### PR TITLE
fix(core,base-sheets): fix undo and redo

### DIFF
--- a/packages/base-sheets/src/Controller/Selection/SelectionManager.ts
+++ b/packages/base-sheets/src/Controller/Selection/SelectionManager.ts
@@ -17,6 +17,7 @@ import {
     DEFAULT_SELECTION,
     DEFAULT_CELL,
     IGridRange,
+    ActionOperationType,
 } from '@univerjs/core';
 import { ACTION_NAMES, ISelectionsConfig } from '../../Basics';
 import { ISelectionModelValue, ISetSelectionValueActionData, SetSelectionValueAction } from '../../Model/Action/SetSelectionValueAction';
@@ -311,6 +312,8 @@ export class SelectionManager {
             sheetId: this._worksheet.getSheetId(),
             actionName: SetSelectionValueAction.NAME,
             selections: models,
+            // The operation of selecting cells is not undoable, so set the UNDO_ACTION bit to 0
+            operation: ActionOperationType.DEFAULT_ACTION & ~ActionOperationType.UNDO_ACTION,
         };
 
         action = ActionOperation.make<ISetSelectionValueActionData>(action).removeUndo().getAction();

--- a/packages/core/src/Command/Command.ts
+++ b/packages/core/src/Command/Command.ts
@@ -64,6 +64,12 @@ export class Command {
         })();
     }
 
+    canUndo(): boolean {
+        return this._actionList.some((action) =>
+            ActionOperation.hasUndo(action.getDoActionData())
+        );
+    }
+
     redo(): void {
         this._actionList.forEach((action) => {
             if (ActionOperation.hasUndo(action.getDoActionData())) {

--- a/packages/core/src/Command/UndoManager.ts
+++ b/packages/core/src/Command/UndoManager.ts
@@ -14,7 +14,9 @@ export class UndoManager {
     }
 
     push(command: Command): void {
-        this._redoStack.push(command);
+        if (command.canUndo()) {
+            this._redoStack.push(command);
+        }
     }
 
     undo(): Command | undefined {

--- a/packages/core/src/Sheets/Apply/SetRangeData.ts
+++ b/packages/core/src/Sheets/Apply/SetRangeData.ts
@@ -80,17 +80,14 @@ export function SetRangeDataApply(unit: CommandUnit, data: ISetRangeDataActionDa
             }
 
             // update other value TODO: move
-            if (value.p != null) {
-                cell.p = value.p;
-            }
-            if (value.v != null) {
-                cell.v = value.v;
-            }
-            if (value.m != null) {
-                cell.m = value.m;
-            } else {
-                cell.m = String(cell.v);
-            }
+            // if (value.p != null) {
+            //     cell.p = value.p;
+            // }
+
+            // When undoing, the cell may have a null value state before it
+            cell.v = value.v || '';
+            cell.m = value.m || String(cell.v);
+
             if (value.t != null) {
                 cell.t = value.t;
             }

--- a/packages/core/src/Sheets/Domain/Range.ts
+++ b/packages/core/src/Sheets/Domain/Range.ts
@@ -12,7 +12,12 @@ import {
     SetRangeStyleAction,
 } from '../Action';
 
-import { CommandManager, ISheetActionData, Command } from '../../Command';
+import {
+    CommandManager,
+    ISheetActionData,
+    Command,
+    ActionOperationType,
+} from '../../Command';
 
 import { DEFAULT_RANGE, DEFAULT_STYLES, ACTION_NAMES } from '../../Const';
 
@@ -3134,6 +3139,8 @@ export class Range {
                     [startColumn]: value,
                 },
             },
+            // set the operation type for modifying cell data to default (it includes undo)
+            operation: ActionOperationType.DEFAULT_ACTION,
         };
         const command = new Command(
             {


### PR DESCRIPTION
Special Note: 
Due to the setting of `end_of_line: lf` in editorconfig, there are many invalid changes in `packages/base-sheets/src/Controller/Selection/SelectionManager.ts` and `packages/core/src/Sheets/Domain/Range.ts` files point, hereby explain to modify the position of the line number::

`packages/base-sheets/src/Controller/Selection/SelectionManager.ts`：`20 and 316`
`packages/core/src/Sheets/Domain/Range.ts`:  `15~20  and 3142~3143`

#23 