### PR TITLE
chore(lint): add import sorting rules & magic number warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         es2021: true,
     },
     parser: '@typescript-eslint/parser',
-    plugins: ['@typescript-eslint', 'prettier', 'import', 'import-newlines', 'unused-imports'],
+    plugins: ['@typescript-eslint', 'prettier', 'import', 'import-newlines', 'unused-imports', 'simple-import-sort'],
     extends: [
         'airbnb-base', // https://www.npmjs.com/package/eslint-config-airbnb-base
         'airbnb-typescript/base', // https://www.npmjs.com/package/eslint-config-airbnb-typescript
@@ -104,6 +104,9 @@ module.exports = {
         'no-unsafe-optional-chaining': 'off',
         '@typescript-eslint/consistent-type-assertions': 'off',
         '@typescript-eslint/no-redeclare': 'off', // dependency interface and dependency token share the same name
+        'no-magic-numbers': ['warn'],
+        'simple-import-sort/imports': 'error',
+        'simple-import-sort/exports': 'error',
     },
     // https://www.npmjs.com/package/eslint-import-resolver-typescript
     settings: {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "eslint-import-resolver-typescript": "^3.5.3",
         "eslint-plugin-import-newlines": "^1.3.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-unused-imports": "^2.0.0",
         "execa": "^4.1.0",
         "find-process": "^1.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^4.2.1
         version: 4.2.1(eslint-config-prettier@8.6.0)(eslint@8.35.0)(prettier@2.3.2)
+      eslint-plugin-simple-import-sort:
+        specifier: ^10.0.0
+        version: 10.0.0(eslint@8.35.0)
       eslint-plugin-unused-imports:
         specifier: ^2.0.0
         version: 2.0.0(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.35.0)
@@ -6117,6 +6120,14 @@ packages:
       eslint-config-prettier: 8.6.0(eslint@8.35.0)
       prettier: 2.3.2
       prettier-linter-helpers: 1.0.0
+    dev: true
+
+  /eslint-plugin-simple-import-sort@10.0.0(eslint@8.35.0):
+    resolution: {integrity: sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==}
+    peerDependencies:
+      eslint: '>=5.0.0'
+    dependencies:
+      eslint: 8.35.0
     dev: true
 
   /eslint-plugin-unused-imports@2.0.0(@typescript-eslint/eslint-plugin@5.54.0)(eslint@8.35.0):


### PR DESCRIPTION
New dependencies:
- simple-import-sort

