### PR TITLE
refactor(i18n): redesign i18n

### DIFF
--- a/examples/univer-sheet-ts/src/locales.ts
+++ b/examples/univer-sheet-ts/src/locales.ts
@@ -1,0 +1,21 @@
+import { zh as DocPluginZh } from '@univerjs/base-docs';
+import { zh as SheetPluginZh } from '@univerjs/base-sheets';
+import { zh as UIPluginZh } from '@univerjs/base-ui';
+import { zh as FindPluginZh } from '@univerjs/sheets-plugin-find';
+import { zh as ImportXlsxPluginZh } from '@univerjs/sheets-plugin-import-xlsx';
+import { zh as NumberfmtPluginZh } from '@univerjs/sheets-plugin-numfmt';
+import { zh as DocUIPluginZh } from '@univerjs/ui-plugin-docs';
+import { zh as SheetUIPluginZh } from '@univerjs/ui-plugin-sheets';
+
+export const locales = {
+    zh: {
+        ...DocPluginZh,
+        ...SheetPluginZh,
+        ...UIPluginZh,
+        ...FindPluginZh,
+        ...ImportXlsxPluginZh,
+        ...NumberfmtPluginZh,
+        ...DocUIPluginZh,
+        ...SheetUIPluginZh,
+    },
+};

--- a/examples/univer-sheet-ts/src/main.tsx
+++ b/examples/univer-sheet-ts/src/main.tsx
@@ -1,20 +1,32 @@
-import { DocPlugin } from '@univerjs/base-docs';
+import { DocPlugin, zh as DocPluginZh } from '@univerjs/base-docs';
 import { RenderEngine } from '@univerjs/base-render';
-import { SheetPlugin } from '@univerjs/base-sheets';
-import { UIPlugin } from '@univerjs/base-ui';
+import { SheetPlugin, zh as SheetPluginZh } from '@univerjs/base-sheets';
+import { UIPlugin, zh as UIPluginZh } from '@univerjs/base-ui';
 import { DEFAULT_WORKBOOK_DATA_DEMO } from '@univerjs/common-plugin-data';
 import { LocaleType, Univer } from '@univerjs/core';
-import { FindPlugin } from '@univerjs/sheets-plugin-find';
+import { FindPlugin, zh as FindPluginZh } from '@univerjs/sheets-plugin-find';
 import { DEFAULT_FORMULA_DATA_DEMO, FormulaPlugin } from '@univerjs/sheets-plugin-formula';
 import { ImagePlugin } from '@univerjs/sheets-plugin-image';
-import { ImportXlsxPlugin } from '@univerjs/sheets-plugin-import-xlsx';
-import { NumfmtPlugin } from '@univerjs/sheets-plugin-numfmt';
-import { DocUIPlugin } from '@univerjs/ui-plugin-docs';
-import { SheetUIPlugin } from '@univerjs/ui-plugin-sheets';
+import { ImportXlsxPlugin, zh as ImportXlsxPluginZh } from '@univerjs/sheets-plugin-import-xlsx';
+import { NumfmtPlugin, zh as NumberfmtPluginZh } from '@univerjs/sheets-plugin-numfmt';
+import { DocUIPlugin, zh as DocUIPluginZh } from '@univerjs/ui-plugin-docs';
+import { SheetUIPlugin, zh as SheetUIPluginZh } from '@univerjs/ui-plugin-sheets';
 
 // univer
 const univer = new Univer({
     locale: LocaleType.EN,
+    locales: {
+        zh: {
+            ...DocPluginZh,
+            ...SheetPluginZh,
+            ...UIPluginZh,
+            ...FindPluginZh,
+            ...ImportXlsxPluginZh,
+            ...NumberfmtPluginZh,
+            ...DocUIPluginZh,
+            ...SheetUIPluginZh,
+        },
+    },
 });
 
 // core plugins
@@ -45,7 +57,7 @@ univer.createUniverSheet(DEFAULT_WORKBOOK_DATA_DEMO);
 // use for console test
 declare global {
     interface Window {
-        univer?: any;
+        univer?: Univer;
     }
 }
 

--- a/examples/univer-sheet-ts/src/main.tsx
+++ b/examples/univer-sheet-ts/src/main.tsx
@@ -1,32 +1,23 @@
-import { DocPlugin, zh as DocPluginZh } from '@univerjs/base-docs';
+import { DocPlugin } from '@univerjs/base-docs';
 import { RenderEngine } from '@univerjs/base-render';
-import { SheetPlugin, zh as SheetPluginZh } from '@univerjs/base-sheets';
-import { UIPlugin, zh as UIPluginZh } from '@univerjs/base-ui';
+import { SheetPlugin } from '@univerjs/base-sheets';
+import { UIPlugin } from '@univerjs/base-ui';
 import { DEFAULT_WORKBOOK_DATA_DEMO } from '@univerjs/common-plugin-data';
 import { LocaleType, Univer } from '@univerjs/core';
-import { FindPlugin, zh as FindPluginZh } from '@univerjs/sheets-plugin-find';
+import { FindPlugin } from '@univerjs/sheets-plugin-find';
 import { DEFAULT_FORMULA_DATA_DEMO, FormulaPlugin } from '@univerjs/sheets-plugin-formula';
 import { ImagePlugin } from '@univerjs/sheets-plugin-image';
-import { ImportXlsxPlugin, zh as ImportXlsxPluginZh } from '@univerjs/sheets-plugin-import-xlsx';
-import { NumfmtPlugin, zh as NumberfmtPluginZh } from '@univerjs/sheets-plugin-numfmt';
-import { DocUIPlugin, zh as DocUIPluginZh } from '@univerjs/ui-plugin-docs';
-import { SheetUIPlugin, zh as SheetUIPluginZh } from '@univerjs/ui-plugin-sheets';
+import { ImportXlsxPlugin } from '@univerjs/sheets-plugin-import-xlsx';
+import { NumfmtPlugin } from '@univerjs/sheets-plugin-numfmt';
+import { DocUIPlugin } from '@univerjs/ui-plugin-docs';
+import { SheetUIPlugin } from '@univerjs/ui-plugin-sheets';
+
+import { locales } from './locales';
 
 // univer
 const univer = new Univer({
     locale: LocaleType.EN,
-    locales: {
-        zh: {
-            ...DocPluginZh,
-            ...SheetPluginZh,
-            ...UIPluginZh,
-            ...FindPluginZh,
-            ...ImportXlsxPluginZh,
-            ...NumberfmtPluginZh,
-            ...DocUIPluginZh,
-            ...SheetUIPluginZh,
-        },
-    },
+    locales,
 });
 
 // core plugins

--- a/packages/base-docs/src/DocPlugin.ts
+++ b/packages/base-docs/src/DocPlugin.ts
@@ -8,7 +8,7 @@ import { BreakLineCommand, CoverCommand, DeleteCommand, DeleteLeftCommand, IMEIn
 import { RichTextEditingMutation } from './commands/mutations/core-editing.mutation';
 import { MoveCursorOperation } from './commands/operations/cursor.operation';
 import { DocumentController } from './Controller/DocumentController';
-import { en, zh } from './Locale';
+import { en } from './Locale';
 import { DocsViewManagerService } from './services/docs-view-manager/docs-view-manager.service';
 import { BreakLineShortcut, DeleteLeftShortcut } from './shortcuts/core-editing.shortcut';
 import { MoveCursorDownShortcut, MoveCursorLeftShortcut, MoveCursorRightShortcut, MoveCursorUpShortcut } from './shortcuts/cursor.shortcut';
@@ -50,7 +50,6 @@ export class DocPlugin extends Plugin<DocPluginObserve> {
     initialize(): void {
         this._localeService.getLocale().load({
             en,
-            zh,
         });
 
         install(this);

--- a/packages/base-docs/src/index.ts
+++ b/packages/base-docs/src/index.ts
@@ -11,5 +11,6 @@ export {
     UpdateCommand,
 } from './commands/commands/core-editing.command';
 export * from './DocPlugin';
+export * from './Locale';
 export { DocsViewManagerService } from './services/docs-view-manager/docs-view-manager.service';
 export { DocsView, DocsViewFactory } from './View/Render/Views/DocsView';

--- a/packages/base-sheets/src/SheetPlugin.ts
+++ b/packages/base-sheets/src/SheetPlugin.ts
@@ -8,7 +8,7 @@ import { SetSelectionsOperation } from './Commands/Operations/selection.operatio
 import { BasicWorkbookController, CountBarController, SheetContainerController } from './Controller';
 import { BasicWorksheetController } from './Controller/BasicWorksheet.controller';
 import { FormulaBarController } from './Controller/FormulaBarController';
-import { en, zh } from './Locale';
+import { en } from './Locale';
 import { BorderStyleManagerService } from './Services/border-style-manager.service';
 import { SelectionManagerService } from './Services/selection-manager.service';
 import { CanvasView } from './View/CanvasView';
@@ -45,7 +45,6 @@ export class SheetPlugin extends Plugin<SheetPluginObserve> {
     initialize(): void {
         this._localeService.getLocale().load({
             en,
-            zh,
         });
 
         install(this);

--- a/packages/base-sheets/src/index.ts
+++ b/packages/base-sheets/src/index.ts
@@ -93,3 +93,4 @@ export { SetWorksheetActivateMutation } from './Commands/Mutations/set-worksheet
 export { SetWorksheetHideMutation } from './Commands/Mutations/set-worksheet-hide.mutation';
 export { SetWorksheetNameMutation } from './Commands/Mutations/set-worksheet-name.mutation';
 export { SetWorksheetOrderMutation } from './Commands/Mutations/set-worksheet-order.mutation';
+export * from './Locale';

--- a/packages/base-slides/src/SlidePlugin.ts
+++ b/packages/base-slides/src/SlidePlugin.ts
@@ -4,7 +4,7 @@ import { Dependency, Inject, Injector } from '@wendellhu/redi';
 
 import { install, SlidePluginObserve, uninstall } from './Basics/Observer';
 import { ToolbarController } from './Controller';
-import { en, zh } from './Locale';
+import { en } from './Locale';
 import { CanvasView } from './View/Render';
 
 export interface ISlidePluginConfig {}
@@ -37,7 +37,6 @@ export class SlidePlugin extends Plugin<SlidePluginObserve> {
     initialize(): void {
         this._localeService.getLocale().load({
             en,
-            zh,
         });
         install(this);
         // this.initConfig();

--- a/packages/base-slides/src/index.ts
+++ b/packages/base-slides/src/index.ts
@@ -1,3 +1,4 @@
 export * from './Controller';
+export * from './Locale';
 export * from './SlidePlugin';
 export * from './View/Render';

--- a/packages/base-ui/src/index.ts
+++ b/packages/base-ui/src/index.ts
@@ -8,6 +8,7 @@ export { IUIController } from './controllers/ui/ui.controller';
 export { IDesktopUIController } from './controllers/ui/ui-desktop.controller';
 export * from './Enum';
 export * from './Helpers';
+export * from './Locale';
 export { CopyCommand, CutCommand, PasteCommand } from './services/clipboard/clipboard.command';
 export { DesktopClipboardService, IClipboardService } from './services/clipboard/clipboard.service';
 export { CopyShortcutItem, CutShortcutItem, PasteShortcutItem } from './services/clipboard/clipboard.shortcut';

--- a/packages/base-ui/src/views/app.tsx
+++ b/packages/base-ui/src/views/app.tsx
@@ -80,7 +80,12 @@ export function App(props: IUniverAppProps) {
          *  after:  {--primary-color:#0188fb;--primary-color-hover:#5391ff;}
          */
         let currentSkin = defaultSkin;
-        currentSkin = Object.fromEntries(Object.keys(defaultSkin).map((item) => [`--${item.replace(/([A-Z0-9])/g, '-$1').toLowerCase()}`, currentSkin[item]]));
+        currentSkin = Object.fromEntries(
+            Object.keys(defaultSkin).map((item) => [
+                `--${item.replace(/([A-Z0-9])/g, '-$1').toLowerCase()}`,
+                currentSkin[item],
+            ])
+        );
         sheet.insertRule(
             `#${'univer-container'} ${JSON.stringify(currentSkin)
                 .replace(/"/g, '')
@@ -97,13 +102,19 @@ export function App(props: IUniverAppProps) {
     const [locale, setLocale] = useState<LocaleType>(localeService.getLocale().getCurrentLocale());
 
     useEffect(() => {
-        localeService.getLocale().locale$.subscribe((locale) => {
+        const listener = localeService.getLocale().locale$.subscribe((locale) => {
             locale && setLocale(locale);
         });
-    });
+
+        return () => {
+            listener.unsubscribe();
+        };
+    }, []);
 
     return (
-        <AppContext.Provider value={{ injector, localeService, locale, componentManager, zIndexManager, observerManager }}>
+        <AppContext.Provider
+            value={{ injector, localeService, locale, componentManager, zIndexManager, observerManager }}
+        >
             {/* TODO: UI here is not fine tuned */}
             <div
                 style={{
@@ -143,13 +154,19 @@ export function App(props: IUniverAppProps) {
                     <Sider style={{ display: props.outerLeft ? 'block' : 'none' }}></Sider>
                     <Layout className={style.mainContent} style={{ position: 'relative' }}>
                         {/* header */}
-                        <Header style={{ display: props.header ? 'block' : 'none' }}>{props.toolbar && <Toolbar></Toolbar>}</Header>
+                        <Header style={{ display: props.header ? 'block' : 'none' }}>
+                            {props.toolbar && <Toolbar></Toolbar>}
+                        </Header>
                         {/* content */}
                         <Layout>
                             <Sider style={{ display: props.innerLeft ? 'block' : 'none' }}>{/* inner left */}</Sider>
                             <Content className={style.contentContainerHorizontal}>
                                 {/* FIXME: context menu component shouldn't have to mount on this position */}
-                                <Container onContextMenu={(e) => e.preventDefault()} className={style.contentInnerRightContainer} ref={containerRef}>
+                                <Container
+                                    onContextMenu={(e) => e.preventDefault()}
+                                    className={style.contentInnerRightContainer}
+                                    ref={containerRef}
+                                >
                                     <ContextMenu />
                                     {/* {config.rightMenu && <RightMenu {...methods.rightMenu}></RightMenu>} */}
                                     {/* {<RichText {...methods.cellEditor}></RichText>} */}
@@ -158,7 +175,10 @@ export function App(props: IUniverAppProps) {
                         </Layout>
                         {/* footer */}
                         <Footer style={{ display: props.footer ? 'block' : 'none' }}>
-                            {footerComponents && Array.from(footerComponents.values()).map((component, index) => React.createElement(component(), { key: `${index}` }))}
+                            {footerComponents &&
+                                Array.from(footerComponents.values()).map((component, index) =>
+                                    React.createElement(component(), { key: `${index}` })
+                                )}
                         </Footer>
                     </Layout>
                 </Layout>

--- a/packages/base-ui/src/views/app.tsx
+++ b/packages/base-ui/src/views/app.tsx
@@ -96,6 +96,12 @@ export function App(props: IUniverAppProps) {
 
     const [locale, setLocale] = useState<LocaleType>(localeService.getLocale().getCurrentLocale());
 
+    useEffect(() => {
+        localeService.getLocale().locale$.subscribe((locale) => {
+            locale && setLocale(locale);
+        });
+    });
+
     return (
         <AppContext.Provider value={{ injector, localeService, locale, componentManager, zIndexManager, observerManager }}>
             {/* TODO: UI here is not fine tuned */}
@@ -125,7 +131,6 @@ export function App(props: IUniverAppProps) {
                     onChange={(e) => {
                         const value = e.target.value as LocaleType;
                         localeService.setLocale(value);
-                        setLocale(value);
                     }}
                 >
                     <option value={LocaleType.EN}>English</option>

--- a/packages/core/src/Basics/Univer.ts
+++ b/packages/core/src/Basics/Univer.ts
@@ -10,6 +10,7 @@ import { DesktopLogService, ILogService } from '../services/log/log.service';
 import { DesktopPermissionService, IPermissionService } from '../services/permission/permission.service';
 import { IUndoRedoService, LocalUndoRedoService } from '../services/undoredo/undoredo.service';
 import { Nullable } from '../Shared';
+import { LocaleType } from '../Types/Enum/LocaleType';
 import { IDocumentData, ISlideData, IUniverData, IWorkbookConfig } from '../Types/Interfaces';
 import { UniverDoc } from './UniverDoc';
 import { UniverObserverImpl } from './UniverObserverImpl';
@@ -31,10 +32,9 @@ export class Univer {
         this._setObserver();
 
         // initialize localization info
-        const { locale } = univerData;
-        if (locale) {
-            this._univerInjector.get(LocaleService).setLocale(locale);
-        }
+        const { locale, locales } = univerData;
+        locales && this._univerInjector.get(LocaleService).load(locales);
+        locale && this._univerInjector.get(LocaleService).setLocale(locale);
     }
 
     private get _currentUniverService(): ICurrentUniverService {
@@ -56,6 +56,10 @@ export class Univer {
         } else {
             throw new Error(`Unimplemented plugin system for business: "${plugin.type}".`);
         }
+    }
+
+    setLocale(locale: LocaleType) {
+        this._univerInjector.get(LocaleService).setLocale(locale);
     }
 
     /** Create a univer sheet instance with internal dependency injection. */

--- a/packages/core/src/Shared/Locale.ts
+++ b/packages/core/src/Shared/Locale.ts
@@ -3,8 +3,8 @@ import { Tools } from './Tools';
 import { IKeyValue, Nullable } from './Types';
 
 export type ILocales = {
-    en: IKeyValue;
-    zh: IKeyValue;
+    en?: IKeyValue;
+    zh?: IKeyValue;
 };
 /**
  * The data structure stored by the Locale class

--- a/packages/core/src/Types/Interfaces/IUniverData.ts
+++ b/packages/core/src/Types/Interfaces/IUniverData.ts
@@ -1,7 +1,9 @@
+import { ILocales } from '../../Shared/Locale';
 import { LocaleType } from '../Enum';
 
 export interface IUniverData {
     locale: LocaleType;
+    locales: ILocales;
     id: string;
 }
 

--- a/packages/core/src/services/locale.service.ts
+++ b/packages/core/src/services/locale.service.ts
@@ -1,6 +1,6 @@
 import { BehaviorSubject, Observable } from 'rxjs';
 
-import { Disposable, toDisposable } from '../Shared/Lifecycle';
+import { Disposable, toDisposable } from '../Shared/lifecycle';
 import { ILocales } from '../Shared/Locale';
 import { Tools } from '../Shared/Tools';
 import { Nullable } from '../Shared/Types';

--- a/packages/core/src/services/locale.service.ts
+++ b/packages/core/src/services/locale.service.ts
@@ -1,26 +1,128 @@
-import { Locale } from '../Shared/Locale';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+import { Disposable, toDisposable } from '../Shared/Lifecycle';
+import { ILocales } from '../Shared/Locale';
+import { Tools } from '../Shared/Tools';
+import { Nullable } from '../Shared/Types';
 import { LocaleType } from '../Types/Enum/LocaleType';
+
+/**
+ * get value from Locale object and key
+ * @param locale - A specified language pack
+ * @param key - Specify key
+ * @returns Get the translation corresponding to the Key
+ *
+ * @private
+ */
+function getValue(locale: ILocales[LocaleType], key: string): Nullable<string | object> {
+    if (!locale) return;
+
+    try {
+        return locale[key] ? locale[key] : key.split('.').reduce((a, b) => a[b], locale);
+    } catch (error) {
+        console.error('Key %s not found', key);
+    }
+}
+
+interface ILanguagePack {
+    [key: string]: string | object;
+}
 
 /**
  * This service provides i18n and timezone / location features to other modules.
  */
-export class LocaleService {
-    private _locale;
+export class LocaleService extends Disposable {
+    currentLocale: LocaleType;
+
+    locales: ILocales;
+
+    readonly locale$: Observable<Nullable<LocaleType>>;
+
+    private readonly _locale$ = new BehaviorSubject<Nullable<LocaleType>>(undefined);
 
     constructor() {
-        this._locale = new Locale();
+        super();
+
+        this.locale$ = this._locale$.asObservable();
+
+        this.disposeWithMe(toDisposable(() => this._locale$.complete()));
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    t(key: string, ...args: any[]): string {
-        return this._locale.get(key);
+    t(key: string): string {
+        return this.get(key);
     }
 
     setLocale(locale: LocaleType): void {
-        this._locale.initialize(locale);
+        this.initialize(locale);
+        this._locale$.next(locale);
     }
 
-    getLocale(): Locale {
-        return this._locale;
+    getLocale() {
+        return this;
+    }
+
+    initialize(locale: Nullable<LocaleType>) {
+        this.currentLocale = locale || LocaleType.EN;
+    }
+
+    /**
+     * Get the formatted message by key
+     *
+     * @example
+     * ```ts
+     * Locale.get('name')
+     * ```
+     *
+     * @param key - The string representing key in Locale data file
+     * @returns Get the translation corresponding to the Key
+     */
+    get(key: string | undefined): string {
+        if (key) {
+            const { locales, currentLocale } = this;
+
+            return (getValue(locales[currentLocale], key) as string) || key;
+        }
+        return String();
+    }
+
+    getObject<T>(key: string): T {
+        const { locales, currentLocale } = this;
+        return getValue(locales[currentLocale], key) as unknown as T;
+    }
+
+    /**
+     * Load more locales after init
+     *
+     * @example
+     * ```ts
+     * Locale.load({zh,en})
+     * ```
+     *
+     * @param locales - Locale object
+     * @returns void
+     *
+     */
+    load(locales: ILocales): void {
+        this.locales = Tools.deepMerge(this.locales ?? {}, locales);
+    }
+
+    /**
+     * change Locale
+     *
+     * @example
+     * Change to Chinese
+     * ```ts
+     * Locale.change(LocaleType.ZH)
+     * ```
+     *
+     * @param locale - Locale Type, see {@link LocaleType}
+     *
+     */
+    change(locale: LocaleType): void {
+        this.currentLocale = locale;
+    }
+
+    getCurrentLocale() {
+        return this.currentLocale;
     }
 }

--- a/packages/sheets-plugin-filter/src/index.ts
+++ b/packages/sheets-plugin-filter/src/index.ts
@@ -1,3 +1,4 @@
 import { FilterPlugin } from './FilterPlugin';
 
 export { FilterPlugin };
+export * from './Locale';

--- a/packages/sheets-plugin-find/src/FindPlugin.ts
+++ b/packages/sheets-plugin-find/src/FindPlugin.ts
@@ -7,7 +7,7 @@ import { FIND_PLUGIN_NAME } from './Const/PLUGIN_NAME';
 import { FindController } from './Controller/FindController';
 import { FindModalController } from './Controller/FindModalController';
 import { TextFinder } from './Domain/TextFind';
-import { en, zh } from './Locale';
+import { en } from './Locale';
 import { FindService } from './services/find.service';
 // import { FindPluginObserve, install } from './Basics/Observer';
 // import { FindModalController } from './Controller/FindModalController';
@@ -57,7 +57,6 @@ export class FindPlugin extends Plugin<FindPluginObserve> {
     initialize(): void {
         this._localeService.getLocale().load({
             en,
-            zh,
         });
 
         this.initController();

--- a/packages/sheets-plugin-find/src/index.ts
+++ b/packages/sheets-plugin-find/src/index.ts
@@ -1,3 +1,4 @@
 import { FindPlugin } from './FindPlugin';
 
 export { FindPlugin };
+export * from './Locale';

--- a/packages/sheets-plugin-formula/src/FormulaPlugin.tsx
+++ b/packages/sheets-plugin-formula/src/FormulaPlugin.tsx
@@ -1,25 +1,24 @@
-import { Dependency, Inject, Injector } from '@wendellhu/redi';
-import { Plugin, PluginType, LocaleService } from '@univerjs/core';
 import { FormulaEngineService } from '@univerjs/base-formula-engine';
-import { CellEditExtensionManager, CellInputExtensionManager, ComponentManager, Icon } from '@univerjs/base-ui';
+import { CellEditExtensionManager, CellInputExtensionManager } from '@univerjs/base-ui';
+import { LocaleService, Plugin, PluginType } from '@univerjs/core';
 import { SheetContainerUIController } from '@univerjs/ui-plugin-sheets';
-import { zh, en } from './Locale';
+import { Dependency, Inject, Injector } from '@wendellhu/redi';
 
-import { IFormulaConfig } from './Basics/Interfaces/IFormula';
 import { FORMULA_PLUGIN_NAME } from './Basics/Const/PLUGIN_NAME';
-import { FormulaController } from './Controller/FormulaController';
-import { firstLoader } from './Controller/FirstLoader';
+import { IFormulaConfig } from './Basics/Interfaces/IFormula';
+import { FormulaPluginObserve, install } from './Basics/Observer';
 import { FormulaCellEditExtensionFactory } from './Basics/Register/FormulaCellEditExtension';
 import { FormulaCellInputExtensionFactory } from './Basics/Register/FormulaCellInputExtension';
-import { FormulaActionExtensionFactory } from './Basics/Register';
-import { FormulaPluginObserve, install } from './Basics/Observer';
-import { SearchFormulaController } from './Controller/SearchFormulaModalController';
+import { firstLoader } from './Controller/FirstLoader';
+import { FormulaController } from './Controller/FormulaController';
 import { FormulaPromptController } from './Controller/FormulaPromptController';
+import { SearchFormulaController } from './Controller/SearchFormulaModalController';
+import { en } from './Locale';
 
 export class FormulaPlugin extends Plugin<FormulaPluginObserve> {
     static override type = PluginType.Sheet;
 
-    protected _formulaActionExtensionFactory: FormulaActionExtensionFactory;
+    // protected _formulaActionExtensionFactory: FormulaActionExtensionFactory;
 
     private _formulaController: FormulaController;
 
@@ -27,11 +26,7 @@ export class FormulaPlugin extends Plugin<FormulaPluginObserve> {
 
     private _formulaPromptController: FormulaPromptController;
 
-    constructor(
-        private _config: IFormulaConfig,
-        @Inject(Injector) override readonly _injector: Injector,
-        @Inject(LocaleService) private readonly _localeService: LocaleService
-    ) {
+    constructor(private _config: IFormulaConfig, @Inject(Injector) override readonly _injector: Injector, @Inject(LocaleService) private readonly _localeService: LocaleService) {
         super(FORMULA_PLUGIN_NAME);
     }
 
@@ -41,7 +36,6 @@ export class FormulaPlugin extends Plugin<FormulaPluginObserve> {
          */
         this._localeService.getLocale().load({
             en,
-            zh,
         });
 
         const sheetContainerUIController = this._injector.get(SheetContainerUIController);
@@ -55,7 +49,6 @@ export class FormulaPlugin extends Plugin<FormulaPluginObserve> {
             this._formulaController.setFormulaEngine(formulaEngineService);
 
             firstLoader(this._formulaController);
-
 
             formulaBar.setFx({
                 onClick: () => {

--- a/packages/sheets-plugin-formula/src/index.ts
+++ b/packages/sheets-plugin-formula/src/index.ts
@@ -3,3 +3,4 @@ import './Model/RegisterAction';
 
 export * from './Basics';
 export * from './FormulaPlugin';
+export * from './Locale';

--- a/packages/sheets-plugin-import-xlsx/src/ImportXlsxPlugin.tsx
+++ b/packages/sheets-plugin-import-xlsx/src/ImportXlsxPlugin.tsx
@@ -4,7 +4,7 @@ import { Inject, Injector } from '@wendellhu/redi';
 import { IMPORT_XLSX_PLUGIN_NAME } from './Basics';
 import { DragAndDropExtensionFactory } from './Basics/Register/DragAndDropExtension';
 import { ImportXlsxController } from './Controller/ImportXlsxController';
-import { en, zh } from './Locale';
+import { en } from './Locale';
 import { UploadService } from './services/upload.service';
 
 export interface IImportXlsxPluginConfig {}
@@ -26,7 +26,6 @@ export class ImportXlsxPlugin extends Plugin<any> {
          */
         this._localeService.getLocale().load({
             en,
-            zh,
         });
 
         // this._importXlsxController = new ImportXlsxController(this);

--- a/packages/sheets-plugin-import-xlsx/src/index.ts
+++ b/packages/sheets-plugin-import-xlsx/src/index.ts
@@ -1,1 +1,2 @@
 export * from './ImportXlsxPlugin';
+export * from './Locale';

--- a/packages/sheets-plugin-numfmt/src/NumfmtPlugin.ts
+++ b/packages/sheets-plugin-numfmt/src/NumfmtPlugin.ts
@@ -6,7 +6,6 @@ import { install, NUMFMT_PLUGIN_NAME, NumfmtActionExtensionFactory, NumfmtPlugin
 import { NumfmtController, NumfmtModalController } from './Controller';
 import { INumfmtPluginConfig } from './Interfaces';
 import en from './Locale/en';
-import zh from './Locale/zh';
 import { NumfmtModel } from './Model';
 import { NumfmtService } from './services/numfmt.service';
 import { INumfmtPluginData } from './Symbol';
@@ -43,7 +42,7 @@ export class NumfmtPlugin extends Plugin<NumfmtPluginObserve> {
 
     override onMounted(): void {
         install(this);
-        this._localeService.getLocale().load({ en, zh });
+        this._localeService.getLocale().load({ en });
         // const actionRegister = this._commandManager.getActionExtensionManager().getRegister();
         // actionRegister.add(this._numfmtActionExtensionFactory);
     }

--- a/packages/sheets-plugin-numfmt/src/index.ts
+++ b/packages/sheets-plugin-numfmt/src/index.ts
@@ -1,3 +1,4 @@
 import './RegisterAction';
 
+export * from './Locale';
 export * from './NumfmtPlugin';

--- a/packages/sheets-plugin-operation/src/OperationPlugin.ts
+++ b/packages/sheets-plugin-operation/src/OperationPlugin.ts
@@ -10,7 +10,7 @@ import { PasteImageExtensionFactory } from './Basics/Register/PasteImageExtensio
 import { PasteOfficeExtensionFactory } from './Basics/Register/PasteOfficeExtension';
 import { OPERATION_PLUGIN } from './Const';
 import { Copy, Paste, UniverCopy, UniverPaste } from './Domain';
-import { en, zh } from './Locale';
+import { en } from './Locale';
 
 interface CopyResolver {
     name: string;
@@ -62,7 +62,6 @@ export class OperationPlugin extends Plugin {
     initialize() {
         this._localeService.getLocale().load({
             en,
-            zh,
         });
 
         this.registerExtension();

--- a/packages/sheets-plugin-operation/src/index.ts
+++ b/packages/sheets-plugin-operation/src/index.ts
@@ -1,1 +1,2 @@
+export * from './Locale';
 export * from './OperationPlugin';

--- a/packages/ui-plugin-docs/src/doc-ui-plugin.ts
+++ b/packages/ui-plugin-docs/src/doc-ui-plugin.ts
@@ -5,7 +5,7 @@ import { DefaultDocUiConfig, IDocUIPluginConfig, installObserver } from './Basic
 import { DOC_UI_PLUGIN_NAME } from './Basics/Const/PLUGIN_NAME';
 import { AppUIController } from './Controller';
 import { DocClipboardController } from './Controller/clipboard.controller';
-import { en, zh } from './Locale';
+import { en } from './Locale';
 import { DocClipboardService, IDocClipboardService } from './services/clipboard/clipboard.service';
 
 export class DocUIPlugin extends Plugin<any> {
@@ -25,7 +25,6 @@ export class DocUIPlugin extends Plugin<any> {
     override onMounted(): void {
         this._localService.getLocale().load({
             en,
-            zh,
         });
 
         installObserver(this);

--- a/packages/ui-plugin-sheets/src/sheet-ui-plugin.ts
+++ b/packages/ui-plugin-sheets/src/sheet-ui-plugin.ts
@@ -12,7 +12,7 @@ import {
 import { AppUIController } from './Controller/AppUIController';
 import { SheetClipboardController } from './Controller/clipboard/clipboard.controller';
 import { DesktopSheetShortcutController } from './Controller/shortcut.controller';
-import { en, zh } from './Locale';
+import { en } from './Locale';
 import { ICellEditorService } from './services/cell-editor/cell-editor.service';
 import { DesktopCellEditorService } from './services/cell-editor/cell-editor-desktop.service';
 import { ISheetClipboardService, SheetClipboardService } from './services/clipboard/clipboard.service';
@@ -48,7 +48,6 @@ export class SheetUIPlugin extends Plugin<SheetUIPluginObserve> {
          * TODO 异步加载
          */
         this._localeService.getLocale().load({
-            zh,
             en,
         });
 

--- a/packages/ui-plugin-slides/src/SlideUIPlugin.ts
+++ b/packages/ui-plugin-slides/src/SlideUIPlugin.ts
@@ -8,7 +8,7 @@ import { DefaultSlideUIConfig, installObserver, ISlideUIPluginConfig, SlideUIPlu
 import { SLIDE_UI_PLUGIN_NAME } from './Basics/Const/PLUGIN_NAME';
 import { IToolbarItemProps } from './Controller';
 import { AppUIController } from './Controller/AppUIController';
-import { en, zh } from './Locale';
+import { en } from './Locale';
 
 export class SlideUIPlugin extends Plugin<SlideUIPluginObserve> {
     static override type = PluginType.Slide;
@@ -39,7 +39,6 @@ export class SlideUIPlugin extends Plugin<SlideUIPluginObserve> {
          * load more Locale object
          */
         this._localeService.getLocale().load({
-            zh,
             en,
         });
 


### PR DESCRIPTION
close #70 

- Default language is set to `en`.
- Exported locale modules for each plugin.
- Provided configuration for injecting language packs.
- Introduced a method to modify the language: `setLocale(locale): void => {}`.

TODO:
1. Specification language codes
zh => zh-CN
en => en-US

2. Drop `Shared/Locale.ts`