### PR TITLE
feat(doc): move selection by shift + arrow keys

### DIFF
--- a/packages/base-docs/src/Controller/move-cursor.controller.ts
+++ b/packages/base-docs/src/Controller/move-cursor.controller.ts
@@ -128,7 +128,11 @@ export class MoveCursorController extends Disposable {
         let focusOffset = collapsed ? endOffset : rangeDirection === RANGE_DIRECTION.FORWARD ? endOffset : startOffset;
 
         if (direction === Direction.LEFT || direction === Direction.RIGHT) {
+            const dataStreamLength = skeleton.getModel().getBodyModel().getBody().dataStream.length ?? Infinity;
+
             focusOffset = direction === Direction.RIGHT ? ++focusOffset : --focusOffset;
+
+            focusOffset = Math.min(dataStreamLength - 2, Math.max(0, focusOffset));
 
             this._textSelectionManagerService.replace([
                 {

--- a/packages/base-docs/src/Controller/move-cursor.controller.ts
+++ b/packages/base-docs/src/Controller/move-cursor.controller.ts
@@ -148,12 +148,10 @@ export class MoveCursorController extends Disposable {
                 return;
             }
 
-            const cursorList = new NodePositionConvertToCursor(documentOffsetConfig, skeleton).getRangePointData(
+            const newActiveRange = new NodePositionConvertToCursor(documentOffsetConfig, skeleton).getRangePointData(
                 newPos,
                 newPos
-            ).cursorList;
-
-            const newActiveRange = cursorList[0];
+            ).cursorList[0];
 
             // move selection
             this._textSelectionManagerService.replace([

--- a/packages/base-docs/src/Controller/move-cursor.controller.ts
+++ b/packages/base-docs/src/Controller/move-cursor.controller.ts
@@ -7,6 +7,7 @@ import {
     IRenderManagerService,
     ITextSelectionRenderManager,
     NodePositionConvertToCursor,
+    RANGE_DIRECTION,
 } from '@univerjs/base-render';
 import {
     Direction,
@@ -22,7 +23,11 @@ import { Inject } from '@wendellhu/redi';
 import { Subscription } from 'rxjs';
 
 import { getDocObject } from '../Basics/component-tools';
-import { IMoveCursorOperationParams, MoveCursorOperation } from '../commands/operations/cursor.operation';
+import {
+    IMoveCursorOperationParams,
+    MoveCursorOperation,
+    MoveSelectionOperation,
+} from '../commands/operations/cursor.operation';
 import { DocSkeletonManagerService } from '../services/doc-skeleton-manager.service';
 import { TextSelectionManagerService } from '../services/text-selection-manager.service';
 
@@ -52,7 +57,7 @@ export class MoveCursorController extends Disposable {
     private _initialize() {}
 
     private _commandExecutedListener() {
-        const updateCommandList = [MoveCursorOperation.id];
+        const updateCommandList = [MoveCursorOperation.id, MoveSelectionOperation.id];
 
         this.disposeWithMe(
             this._commandService.onCommandExecuted((command: ICommandInfo) => {
@@ -62,9 +67,104 @@ export class MoveCursorController extends Disposable {
 
                 const param = command.params as IMoveCursorOperationParams;
 
-                this._moveCursorFunction(param.direction);
+                switch (command.id) {
+                    case MoveCursorOperation.id: {
+                        return this._moveCursorFunction(param.direction);
+                    }
+
+                    case MoveSelectionOperation.id: {
+                        return this._moveSelectionFunction(param.direction);
+                    }
+
+                    default: {
+                        throw new Error('Unknown command');
+                    }
+                }
             })
         );
+    }
+
+    private _moveSelectionFunction(direction: Direction) {
+        const activeRange = this._textSelectionRenderManager.getActiveRange();
+        const allRanges = this._textSelectionRenderManager.getAllTextRanges();
+
+        const skeleton = this._docSkeletonManagerService.getCurrent()?.skeleton;
+
+        const docObject = this._getDocObject();
+
+        if (activeRange == null || skeleton == null || docObject == null) {
+            return;
+        }
+
+        const { startOffset, endOffset, style, collapsed, direction: rangeDirection } = activeRange;
+
+        if (allRanges.length > 1) {
+            let min = Infinity;
+            let max = -Infinity;
+
+            for (const range of allRanges) {
+                min = Math.min(min, range.startOffset!);
+                max = Math.max(max, range.endOffset!);
+            }
+
+            this._textSelectionManagerService.replace([
+                {
+                    startOffset: direction === Direction.LEFT || direction === Direction.UP ? max : min,
+                    endOffset: direction === Direction.LEFT || direction === Direction.UP ? min : max,
+                    collapsed: false,
+                    style,
+                },
+            ]);
+
+            return;
+        }
+
+        const anchorOffset = collapsed
+            ? startOffset
+            : rangeDirection === RANGE_DIRECTION.FORWARD
+            ? startOffset
+            : endOffset;
+
+        let focusOffset = collapsed ? endOffset : rangeDirection === RANGE_DIRECTION.FORWARD ? endOffset : startOffset;
+
+        if (direction === Direction.LEFT || direction === Direction.RIGHT) {
+            focusOffset = direction === Direction.RIGHT ? ++focusOffset : --focusOffset;
+
+            this._textSelectionManagerService.replace([
+                {
+                    startOffset: anchorOffset,
+                    endOffset: focusOffset,
+                    collapsed: anchorOffset === focusOffset,
+                    style,
+                },
+            ]);
+        } else {
+            const focusSpan = skeleton.findNodeByCharIndex(focusOffset);
+
+            const documentOffsetConfig = docObject.document.getOffsetConfig();
+
+            const newPos = this._getTopOrBottomPosition(skeleton, focusSpan, direction === Direction.DOWN);
+            if (newPos == null) {
+                return;
+            }
+
+            const cursorList = new NodePositionConvertToCursor(documentOffsetConfig, skeleton).getRangePointData(
+                newPos,
+                newPos
+            ).cursorList;
+
+            const newActiveRange = cursorList[0];
+
+            // move selection
+            this._textSelectionManagerService.replace([
+                {
+                    startOffset: anchorOffset,
+                    endOffset: newActiveRange.endOffset,
+                    collapsed: anchorOffset === newActiveRange.endOffset,
+                    style,
+                },
+            ]);
+        }
     }
 
     private _moveCursorFunction(direction: Direction) {
@@ -79,11 +179,7 @@ export class MoveCursorController extends Disposable {
             return;
         }
 
-        const { startOffset, endOffset, style, startNodePosition } = activeRange;
-
-        const preSpan = skeleton.findSpanByPosition(startNodePosition);
-
-        const documentOffsetConfig = docObject.document.getOffsetConfig();
+        const { startOffset, endOffset, style } = activeRange;
 
         if (direction === Direction.LEFT || direction === Direction.RIGHT) {
             let cursor;
@@ -117,6 +213,10 @@ export class MoveCursorController extends Disposable {
                 },
             ]);
         } else {
+            const preSpan = skeleton.findNodeByCharIndex(endOffset);
+
+            const documentOffsetConfig = docObject.document.getOffsetConfig();
+
             const newPos = this._getTopOrBottomPosition(skeleton, preSpan, direction === Direction.DOWN);
             if (newPos == null) {
                 return;
@@ -142,17 +242,11 @@ export class MoveCursorController extends Disposable {
         span: Nullable<IDocumentSkeletonSpan>,
         direction: boolean
     ): Nullable<INodePosition> {
-        // const referenceSpan = docSkeleton.findSpanByPosition(this._currentNodePosition);
-        const selectionRange = this._textSelectionManagerService.getFirst();
-        if (selectionRange == null) {
-            return;
-        }
-        const referenceSpan = docSkeleton.findNodeByCharIndex(selectionRange.startOffset);
-        if (referenceSpan == null || span == null) {
+        if (span == null) {
             return;
         }
 
-        const offsetLeft = this._getSpanLeftOffsetInLine(referenceSpan);
+        const offsetLeft = this._getSpanLeftOffsetInLine(span);
 
         const line = this._getNextOrPrevLine(span, direction);
 
@@ -193,17 +287,16 @@ export class MoveCursorController extends Disposable {
         } = {
             distance: Infinity,
         };
+
         for (const divide of line.divides) {
             const divideLeft = divide.left;
-            for (const span of divide.spanGroup) {
-                const { left, width } = span;
-                const leftSide = divideLeft + left;
-                const rightSide = leftSide + width;
-                if (offsetLeft >= leftSide && offsetLeft <= rightSide) {
-                    return docSkeleton.findPositionBySpan(span);
-                }
 
-                const distance = Math.abs(offsetLeft - (leftSide + rightSide) / 2);
+            for (const span of divide.spanGroup) {
+                const { left } = span;
+                const leftSide = divideLeft + left;
+
+                const distance = Math.abs(offsetLeft - leftSide);
+
                 if (distance < nearestNode.distance) {
                     nearestNode.span = span;
                     nearestNode.distance = distance;

--- a/packages/base-docs/src/DocPlugin.ts
+++ b/packages/base-docs/src/DocPlugin.ts
@@ -33,7 +33,7 @@ import {
 } from './commands/commands/inline-format.command';
 import { SetDocZoomRatioCommand } from './commands/commands/set-doc-zoom-ratio.command';
 import { RichTextEditingMutation } from './commands/mutations/core-editing.mutation';
-import { MoveCursorOperation } from './commands/operations/cursor.operation';
+import { MoveCursorOperation, MoveSelectionOperation } from './commands/operations/cursor.operation';
 import { SetDocZoomRatioOperation } from './commands/operations/set-doc-zoom-ratio.operation';
 import { SetTextSelectionsOperation } from './commands/operations/text-selection.operation';
 import { DeleteLeftInputController } from './Controller/delete-left-input.controller';
@@ -56,6 +56,10 @@ import {
     MoveCursorLeftShortcut,
     MoveCursorRightShortcut,
     MoveCursorUpShortcut,
+    MoveSelectionDownShortcut,
+    MoveSelectionLeftShortcut,
+    MoveSelectionRightShortcut,
+    MoveSelectionUpShortcut,
 } from './shortcuts/cursor.shortcut';
 import { DocCanvasView } from './View/doc-canvas-view';
 
@@ -106,6 +110,7 @@ export class DocPlugin extends Plugin {
         (
             [
                 MoveCursorOperation,
+                MoveSelectionOperation,
                 DeleteLeftCommand,
                 SetInlineFormatBoldCommand,
                 SetInlineFormatItalicCommand,
@@ -135,6 +140,10 @@ export class DocPlugin extends Plugin {
             MoveCursorDownShortcut,
             MoveCursorRightShortcut,
             MoveCursorLeftShortcut,
+            MoveSelectionUpShortcut,
+            MoveSelectionDownShortcut,
+            MoveSelectionLeftShortcut,
+            MoveSelectionRightShortcut,
             DeleteLeftShortcut,
             BreakLineShortcut,
         ].forEach((shortcut) => {

--- a/packages/base-docs/src/commands/operations/cursor.operation.ts
+++ b/packages/base-docs/src/commands/operations/cursor.operation.ts
@@ -20,3 +20,18 @@ export const MoveCursorOperation: IOperation<IMoveCursorOperationParams> = {
         return true;
     },
 };
+
+/**
+ * The operation to move selection in the current document.
+ */
+export const MoveSelectionOperation: IOperation<IMoveCursorOperationParams> = {
+    id: 'doc.operation.move-selection',
+    type: CommandType.OPERATION,
+    handler: (accessor, params) => {
+        if (!params) {
+            return false;
+        }
+
+        return true;
+    },
+};

--- a/packages/base-docs/src/commands/operations/text-selection.operation.ts
+++ b/packages/base-docs/src/commands/operations/text-selection.operation.ts
@@ -17,7 +17,7 @@ export const SetTextSelectionsOperation: IOperation<ISetTextSelectionsOperationP
     handler: (accessor, params) => {
         const textSelectionManagerService = accessor.get(TextSelectionManagerService);
 
-        textSelectionManagerService.replace(params!.ranges);
+        textSelectionManagerService.replaceWithNoRefresh(params!.ranges);
 
         return true;
     },

--- a/packages/base-docs/src/index.ts
+++ b/packages/base-docs/src/index.ts
@@ -27,7 +27,7 @@ export {
     type IRichTextEditingMutationParams,
     RichTextEditingMutation,
 } from './commands/mutations/core-editing.mutation';
-export { MoveCursorOperation } from './commands/operations/cursor.operation';
+export { MoveCursorOperation, MoveSelectionOperation } from './commands/operations/cursor.operation';
 export * from './DocPlugin';
 export { DocSkeletonManagerService } from './services/doc-skeleton-manager.service';
 export { TextSelectionManagerService } from './services/text-selection-manager.service';

--- a/packages/base-docs/src/shortcuts/cursor.shortcut.ts
+++ b/packages/base-docs/src/shortcuts/cursor.shortcut.ts
@@ -1,7 +1,7 @@
-import { IShortcutItem, KeyCode } from '@univerjs/base-ui';
+import { IShortcutItem, KeyCode, MetaKeys } from '@univerjs/base-ui';
 import { Direction, FOCUSING_DOC } from '@univerjs/core';
 
-import { MoveCursorOperation } from '../commands/operations/cursor.operation';
+import { MoveCursorOperation, MoveSelectionOperation } from '../commands/operations/cursor.operation';
 
 export const MoveCursorUpShortcut: IShortcutItem = {
     id: MoveCursorOperation.id,
@@ -33,6 +33,42 @@ export const MoveCursorLeftShortcut: IShortcutItem = {
 export const MoveCursorRightShortcut: IShortcutItem = {
     id: MoveCursorOperation.id,
     binding: KeyCode.ARROW_RIGHT,
+    preconditions: (contextService) => contextService.getContextValue(FOCUSING_DOC),
+    staticParameters: {
+        direction: Direction.RIGHT,
+    },
+};
+
+export const MoveSelectionUpShortcut: IShortcutItem = {
+    id: MoveSelectionOperation.id,
+    binding: KeyCode.ARROW_UP | MetaKeys.SHIFT,
+    preconditions: (contextService) => contextService.getContextValue(FOCUSING_DOC),
+    staticParameters: {
+        direction: Direction.UP,
+    },
+};
+
+export const MoveSelectionDownShortcut: IShortcutItem = {
+    id: MoveSelectionOperation.id,
+    binding: KeyCode.ARROW_DOWN | MetaKeys.SHIFT,
+    preconditions: (contextService) => contextService.getContextValue(FOCUSING_DOC),
+    staticParameters: {
+        direction: Direction.DOWN,
+    },
+};
+
+export const MoveSelectionLeftShortcut: IShortcutItem = {
+    id: MoveSelectionOperation.id,
+    binding: KeyCode.ARROW_LEFT | MetaKeys.SHIFT,
+    preconditions: (contextService) => contextService.getContextValue(FOCUSING_DOC),
+    staticParameters: {
+        direction: Direction.LEFT,
+    },
+};
+
+export const MoveSelectionRightShortcut: IShortcutItem = {
+    id: MoveSelectionOperation.id,
+    binding: KeyCode.ARROW_RIGHT | MetaKeys.SHIFT,
     preconditions: (contextService) => contextService.getContextValue(FOCUSING_DOC),
     staticParameters: {
         direction: Direction.RIGHT,

--- a/packages/base-render/src/Component/Docs/text-selection-render-manager.ts
+++ b/packages/base-render/src/Component/Docs/text-selection-render-manager.ts
@@ -276,12 +276,15 @@ export class TextSelectionRenderManager extends RxDisposable implements ITextSel
         return this._rangeList;
     }
 
-    add(textSelection: Nullable<TextRange>) {
-        if (textSelection == null) {
+    add(textRange: Nullable<TextRange>) {
+        if (textRange == null) {
             return;
         }
 
-        this._addTextRange(textSelection);
+        this._addTextRange(textRange);
+
+        // FIXME: @jocs, why I need to refresh textRange? it already refreshed when create.
+        textRange.refresh();
     }
 
     sync() {
@@ -706,6 +709,7 @@ export class TextSelectionRenderManager extends RxDisposable implements ITextSel
     private _syncDomToSelection() {
         const activeRangeInstance = this.getActiveRangeInstance();
         const anchor = activeRangeInstance?.getAnchor();
+
         if (!anchor || (anchor && !anchor.visible) || this._activeViewport == null) {
             this.focus();
             return;

--- a/packages/base-ui/src/services/shortcut/shortcut.service.ts
+++ b/packages/base-ui/src/services/shortcut/shortcut.service.ts
@@ -59,6 +59,7 @@ export class DesktopShortcutService extends Disposable implements IShortcutServi
         // first map shortcut to a number, so it could be converted and fetched quickly
         const binding = this.getBindingFromItem(shortcut);
         const existing = this._shortCutMapping.get(binding);
+
         if (existing) {
             existing.add(shortcut);
         } else {


### PR DESCRIPTION
- [x] use shift + arrow keys to select content. #354 
- [x] Optimized the algorithm for moving the cursor up and down 