### PR TITLE
fix: calculate the document height when text rotated

### DIFF
--- a/packages/base-render/src/basics/draw.ts
+++ b/packages/base-render/src/basics/draw.ts
@@ -209,10 +209,12 @@ export function getRotateOffsetAndFarthestHypotenuse(
 
     const orientation = getRotateOrientation(vertexAngle);
     const linesCount = lines.length;
+
     vertexAngle = Math.abs(vertexAngle);
     const tanTheta = Math.tan(vertexAngle);
     const sinTheta = Math.sin(vertexAngle);
     const cosTheta = Math.cos(vertexAngle);
+
     if (orientation === ORIENTATION_TYPE.UP) {
         let cumRectHeight = 0;
 
@@ -221,7 +223,7 @@ export function getRotateOffsetAndFarthestHypotenuse(
             const { lineHeight: rectHeight = 0 } = line;
             cumRectHeight += i === 0 ? 0 : rectHeight;
 
-            const currentRotateHeight = (rectHeight / tanTheta + rectWidth) * sinTheta;
+            const currentRotateHeight = rectWidth * sinTheta + rectHeight * cosTheta;
 
             rotateTranslateXList.push(cumRectHeight / tanTheta);
 
@@ -279,7 +281,7 @@ export function getRotateOffsetAndFarthestHypotenuse(
             }
         }
 
-        let cumRotateHeightFix = lines[maxOffsetLineIndex].lineHeight || 0;
+        let cumRotateHeightFix = lines[maxOffsetLineIndex]?.lineHeight || 0;
 
         let cumBlowValue = 0;
         for (let i = maxOffsetLineIndex + 1; i <= linesCount - 1; i++) {

--- a/packages/base-render/src/components/sheets/sheet-skeleton.ts
+++ b/packages/base-render/src/components/sheets/sheet-skeleton.ts
@@ -58,12 +58,12 @@ import { BorderCache, IStylesCache } from './interfaces';
 /**
  * Obtain the height and width of a cell's text, taking into account scenarios with rotated text.
  * @param documentSkeleton Data of the document's ViewModel
- * @param angle The rotation angle of an Excel cell, it's **degree**
+ * @param angleInDegree The rotation angle of an Excel cell, it's **degree**
  * @returns
  */
-export function getDocsSkeletonPageSize(documentSkeleton: DocumentSkeleton, angle: number = 0) {
+export function getDocsSkeletonPageSize(documentSkeleton: DocumentSkeleton, angleInDegree: number = 0) {
     const skeletonData = documentSkeleton?.getSkeletonData();
-    angle = degToRad(angle);
+    const angle = degToRad(angleInDegree);
 
     if (!skeletonData) {
         return;

--- a/packages/base-render/src/components/sheets/sheet-skeleton.ts
+++ b/packages/base-render/src/components/sheets/sheet-skeleton.ts
@@ -39,6 +39,7 @@ import { BORDER_TYPE, COLOR_BLACK_RGB, MAXIMUM_ROW_HEIGHT, ORIENTATION_TYPE } fr
 import { getRotateOffsetAndFarthestHypotenuse, getRotateOrientation } from '../../basics/draw';
 import { IDocumentSkeletonColumn } from '../../basics/i-document-skeleton-cached';
 import {
+    degToRad,
     fixLineWidthByScale,
     getCellByIndex,
     getCellInfoInMergeData,
@@ -57,11 +58,12 @@ import { BorderCache, IStylesCache } from './interfaces';
 /**
  * Obtain the height and width of a cell's text, taking into account scenarios with rotated text.
  * @param documentSkeleton Data of the document's ViewModel
- * @param angle The rotation angle of an Excel cell
+ * @param angle The rotation angle of an Excel cell, it's **degree**
  * @returns
  */
 export function getDocsSkeletonPageSize(documentSkeleton: DocumentSkeleton, angle: number = 0) {
     const skeletonData = documentSkeleton?.getSkeletonData();
+    angle = degToRad(angle);
 
     if (!skeletonData) {
         return;
@@ -79,10 +81,12 @@ export function getDocsSkeletonPageSize(documentSkeleton: DocumentSkeleton, angl
 
     const orientation = getRotateOrientation(angle);
     const widthArray: Array<{ rotatedWidth: number; spaceWidth: number }> = [];
+
     columnIterator([lastPage], (column: IDocumentSkeletonColumn) => {
         const { lines, width: columnWidth, spaceWidth } = column;
 
         const { rotatedHeight, rotatedWidth } = getRotateOffsetAndFarthestHypotenuse(lines, columnWidth, angle);
+
         allRotatedHeight += rotatedHeight;
 
         widthArray.push({ rotatedWidth, spaceWidth });
@@ -92,6 +96,7 @@ export function getDocsSkeletonPageSize(documentSkeleton: DocumentSkeleton, angl
     const sinTheta = Math.sin(angle);
 
     const widthCount = widthArray.length;
+
     for (let i = 0; i < widthCount; i++) {
         const { rotatedWidth, spaceWidth } = widthArray[i];
 
@@ -430,6 +435,7 @@ export class SpreadsheetSkeleton extends Skeleton {
 
             let { a: angle } = textRotation as ITextRotation;
             const { v: isVertical = BooleanNumber.FALSE } = textRotation as ITextRotation;
+
             if (isVertical === BooleanNumber.TRUE) {
                 angle = DEFAULT_ROTATE_ANGLE;
             }

--- a/packages/base-render/src/components/sheets/spreadsheet.ts
+++ b/packages/base-render/src/components/sheets/spreadsheet.ts
@@ -493,7 +493,8 @@ export class Spreadsheet extends SheetComponent {
                     }
 
                     // wrap and angle handler
-                    const { documentSkeleton, angle = 0, verticalAlign, horizontalAlign, wrapStrategy } = docsConfig;
+                    const { documentSkeleton, angle = 0, horizontalAlign, wrapStrategy } = docsConfig;
+
                     const cell = spreadsheetSkeleton.getCellData().getValue(row, column);
 
                     const sheetSkeleton = this.getSkeleton();


### PR DESCRIPTION
- [x] When calculating the width and height of the page, need to convert the degree to radian