### PR TITLE
fix: if textRuns doesn't intersect, they shouldn't be merged

### DIFF
--- a/packages/base-docs/src/commands/mutations/__tests__/apply-utils.spec.ts
+++ b/packages/base-docs/src/commands/mutations/__tests__/apply-utils.spec.ts
@@ -368,5 +368,31 @@ describe('example', () => {
             expect(body?.textRuns[1].ts?.bl).toBe(BooleanNumber.FALSE);
             expect(body?.textRuns[2].ts?.bl).toBe(BooleanNumber.FALSE);
         });
+
+        it(`If textRuns doesn't intersect, they shouldn't be merged`, async () => {
+            const updateTextRuns = [
+                {
+                    st: 0,
+                    ed: 10,
+                    ts: {
+                        bl: BooleanNumber.FALSE,
+                    },
+                },
+            ];
+            insertTextRuns(
+                body as IDocumentBody,
+                {
+                    textRuns: updateTextRuns,
+                } as unknown as IDocumentBody,
+                10,
+                25
+            );
+
+            expect(body?.textRuns.length).toBe(4);
+            expect(body?.textRuns[0].ts?.bl).toBe(BooleanNumber.FALSE);
+            expect(body?.textRuns[1].ts?.bl).toBe(BooleanNumber.FALSE);
+            expect(body?.textRuns[2].ts?.bl).toBe(BooleanNumber.FALSE);
+            expect(body?.textRuns[3].ts?.bl).toBe(BooleanNumber.FALSE);
+        });
     });
 });

--- a/packages/base-docs/src/commands/mutations/functions/common.ts
+++ b/packages/base-docs/src/commands/mutations/functions/common.ts
@@ -13,6 +13,13 @@ import {
     sortRulesFactory,
 } from '@univerjs/core';
 
+function hasIntersectionBetweenTextRuns(textRun1: ITextRun, textRun2: ITextRun) {
+    const { st: firstSt, ed: firstEd } = textRun1;
+    const { st: secondSt, ed: secondEd } = textRun2;
+
+    return firstEd >= secondSt && secondEd >= firstSt;
+}
+
 export function normalizeTextRuns(textRuns: ITextRun[]) {
     const results: ITextRun[] = [];
 
@@ -29,7 +36,7 @@ export function normalizeTextRuns(textRuns: ITextRun[]) {
         }
 
         const peak = results.pop()!;
-        if (isSameStyleTextRun(textRun, peak)) {
+        if (isSameStyleTextRun(textRun, peak) && hasIntersectionBetweenTextRuns(peak, textRun)) {
             results.push({
                 ...textRun,
                 st: peak.st,


### PR DESCRIPTION
- [x]  if textRuns doesn't intersect, they shouldn't be merged