### PR TITLE
fix: underline position offset is wrong when has margin top

### DIFF
--- a/packages/base-render/src/components/docs/document.ts
+++ b/packages/base-render/src/components/docs/document.ts
@@ -350,12 +350,14 @@ export class Documents extends DocComponent {
                             rotateTranslateXListApply && this._drawLiquid.translate(rotateTranslateXListApply[i]); // x axis offset
 
                             const divideLength = divides.length;
+
                             for (let i = 0; i < divideLength; i++) {
                                 const divide = divides[i];
                                 const { spanGroup } = divide;
                                 this._drawLiquid.translateSave();
 
                                 this._drawLiquid.translateDivide(divide);
+
                                 for (const span of spanGroup) {
                                     if (!span.content || span.content.length === 0) {
                                         continue;

--- a/packages/base-render/src/components/docs/extensions/font-and-base-line.ts
+++ b/packages/base-render/src/components/docs/extensions/font-and-base-line.ts
@@ -27,6 +27,7 @@ export class FontAndBaseLine extends docExtension {
         const maxLineAsc = asc + lineMarginTop + linePaddingTop;
         const { ts: textStyle, content, fontStyle, bBox } = span;
         const { spanPointWithFont = Vector2.create(0, 0) } = this.extensionOffset;
+
         if (!textStyle) {
             if (content != null) {
                 ctx.fillText(content, spanPointWithFont.x, spanPointWithFont.y);

--- a/packages/base-render/src/components/docs/extensions/line.ts
+++ b/packages/base-render/src/components/docs/extensions/line.ts
@@ -23,7 +23,7 @@ export class Line extends docExtension {
             return;
         }
 
-        const { asc: maxLineAsc = 0, lineHeight = 0 } = line;
+        const { asc: maxLineAsc = 0, lineHeight = 0, marginTop = 0 } = line;
         const { ts: textStyle, left, width, bBox } = span;
         if (!textStyle) {
             return;
@@ -46,13 +46,14 @@ export class Line extends docExtension {
 
         if (underline) {
             const { s: show, cl: colorStyle, t: lineType } = underline;
+
             if (show === BooleanNumber.TRUE) {
                 ctx.beginPath();
                 const color = getColorStyle(colorStyle) || COLOR_BLACK_RGB;
                 ctx.strokeStyle = color;
                 this._setLineType(ctx, lineType || TextDecoration.SINGLE);
 
-                const startY = fixLineWidthByScale(lineHeight + DEFAULT_OFFSET_SPACING - 0.5, scale);
+                const startY = fixLineWidthByScale(lineHeight - marginTop + DEFAULT_OFFSET_SPACING - 0.5, scale);
 
                 const start = calculateRectRotate(
                     originTranslate.addByPoint(left, startY),
@@ -68,6 +69,7 @@ export class Line extends docExtension {
                     vertexAngle,
                     alignOffset
                 );
+
                 ctx.moveTo(start.x, start.y);
                 ctx.lineTo(end.x, end.y);
                 ctx.stroke();


### PR DESCRIPTION
- [x] underline position offset is wrong when line has margin top fix #471 