### PR TITLE
fix: the selection range is wrong when format range across list

### DIFF
--- a/packages/base-docs/src/commands/commands/inline-format.command.ts
+++ b/packages/base-docs/src/commands/commands/inline-format.command.ts
@@ -157,6 +157,7 @@ export const SetInlineFormatCommand: ICommand<ISetInlineFormatCommandParams> = {
             };
 
             const len = startOffset - memoryCursor.cursor;
+
             if (len !== 0) {
                 doMutation.params!.mutations.push({
                     t: 'r',

--- a/packages/base-render/src/components/docs/doc-skeleton.ts
+++ b/packages/base-render/src/components/docs/doc-skeleton.ts
@@ -181,7 +181,7 @@ export class DocumentSkeleton extends Skeleton {
         const { span, divide, line, column, section, page } = nodes;
 
         return {
-            span: divide.spanGroup.indexOf(span),
+            span: divide.spanGroup.filter((span) => span.spanType !== SpanType.LIST).indexOf(span),
             divide: line.divides.indexOf(divide),
             line: column.lines.indexOf(line),
             column: section.columns.indexOf(column),


### PR DESCRIPTION
- [x] the selection range is wrong when format range across list