### PR TITLE
feat(rpc): allow passing an existing Worker

### DIFF
--- a/packages/rpc/src/plugin.ts
+++ b/packages/rpc/src/plugin.ts
@@ -33,7 +33,7 @@ import {
 } from './services/rpc/implementations/web-worker-rpc.service';
 
 export interface IUniverRPCMainThreadConfig {
-    workerURL: string | URL;
+    workerURL: string | URL | Worker;
 }
 
 /**
@@ -51,7 +51,8 @@ export class UniverRPCMainThreadPlugin extends Plugin {
     }
 
     override async onStarting(injector: Injector): Promise<void> {
-        const worker = new Worker(this._config.workerURL);
+        const { workerURL } = this._config;
+        const worker = workerURL instanceof Worker ? workerURL : new Worker(workerURL);
         const messageProtocol = createWebWorkerMessagePortOnMain(worker);
         const dependencies: Dependency[] = [
             [


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

- [x] I am sure that the code is update-to-date with the `dev` branch.

Provide a direct way to pass instance of worker into build tools like Vite and webpack that naturally support web workers

https://vitejs.dev/guide/features#web-workers
https://webpack.js.org/guides/web-workers

## Vite
```diff 
+ import UniverWorker from './worker?worker'

univer.registerPlugin(UniverRPCMainThreadPlugin, {
-    workerURL: './worker.js',
+    workerUrl: new UniverWorker()
} as IUniverRPCMainThreadConfig);
```