### PR TITLE
ci: only report coverage when node-version is 18

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,10 +18,6 @@ jobs:
             matrix:
                 node-version: [16, 18]
 
-        env:
-            TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-            TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-
         steps:
             - name: Checkout
               uses: actions/checkout@v3
@@ -58,6 +54,7 @@ jobs:
 
             # TODO: cross fork PR will not trigger this action
             - name: 🧬 Report coverage
+              if: matrix.node-version == '18'
               uses: codecov/codecov-action@v3
               env:
                   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

- [x] I am sure that the code is update-to-date with the `dev` branch.
