### PR TITLE
feat(facade): range API add setFontWeight

### DIFF
--- a/examples/src/uniscript/change-font-style.js
+++ b/examples/src/uniscript/change-font-style.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable */
+
+const activeSheet = univerAPI.getCurrentSheet().getActiveSheet();
+
+// Set A1:B2 to bold
+activeSheet.getRange(0, 0, 2, 2).setFontWeight('bold');
+// Set B2 to normal
+activeSheet.getRange(1, 1, 1, 1).setFontWeight('normal');
+
+setTimeout(() => {
+    // reset A1 to normal
+    activeSheet.getRange(0, 0, 1, 1).setFontWeight(null);
+}, 3000);

--- a/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
+++ b/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
@@ -178,7 +178,7 @@ describe('Test FRange', () => {
     it('Range setFontWeight', () => {
         const activeSheet = univerAPI.getCurrentSheet()?.getActiveSheet();
 
-        // A1 sets the number
+        // change A1 font weight
         const range = activeSheet?.getRange(0, 0, 1, 1);
         expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(undefined);
         range?.setFontWeight('bold');
@@ -188,7 +188,7 @@ describe('Test FRange', () => {
         range?.setFontWeight(null);
         expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(undefined);
 
-        // B1:C2 sets the string
+        // change B1:C2 font weight
         const range2 = activeSheet?.getRange(0, 1, 2, 2);
         range2?.setFontWeight('bold');
         expect(getStyleByPosition(0, 1, 0, 1)?.bl).toBe(1);

--- a/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
+++ b/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
@@ -16,7 +16,7 @@
 
 import type { ICellData, IStyleData, Nullable, Univer } from '@univerjs/core';
 import { ICommandService, IUniverInstanceService } from '@univerjs/core';
-import { SetRangeValuesCommand, SetRangeValuesMutation } from '@univerjs/sheets';
+import { SetRangeValuesCommand, SetRangeValuesMutation, SetStyleCommand } from '@univerjs/sheets';
 import type { Injector } from '@wendellhu/redi';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -50,6 +50,7 @@ describe('Test FRange', () => {
         commandService = get(ICommandService);
         commandService.registerCommand(SetRangeValuesCommand);
         commandService.registerCommand(SetRangeValuesMutation);
+        commandService.registerCommand(SetStyleCommand);
 
         getValueByPosition = (
             startRow: number,
@@ -172,5 +173,39 @@ describe('Test FRange', () => {
         expect(getStyleByPosition(2, 4, 2, 4)?.bg?.rgb).toBe('green');
         expect(getStyleByPosition(3, 3, 3, 3)?.bg?.rgb).toBe('orange');
         expect(getStyleByPosition(3, 4, 3, 4)?.bg?.rgb).toBe('red');
+    });
+
+    it('Range setFontWeight', () => {
+        const activeSheet = univerAPI.getCurrentSheet()?.getActiveSheet();
+
+        // A1 sets the number
+        const range = activeSheet?.getRange(0, 0, 1, 1);
+        expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(undefined);
+        range?.setFontWeight('bold');
+        expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(1);
+        range?.setFontWeight('normal');
+        expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(0);
+        range?.setFontWeight(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(undefined);
+
+        // B1:C2 sets the string
+        const range2 = activeSheet?.getRange(0, 1, 2, 2);
+        range2?.setFontWeight('bold');
+        expect(getStyleByPosition(0, 1, 0, 1)?.bl).toBe(1);
+        expect(getStyleByPosition(0, 2, 0, 2)?.bl).toBe(1);
+        expect(getStyleByPosition(1, 1, 1, 1)?.bl).toBe(1);
+        expect(getStyleByPosition(1, 2, 1, 2)?.bl).toBe(1);
+
+        range2?.setFontWeight('normal');
+        expect(getStyleByPosition(0, 1, 0, 1)?.bl).toBe(0);
+        expect(getStyleByPosition(0, 2, 0, 2)?.bl).toBe(0);
+        expect(getStyleByPosition(1, 1, 1, 1)?.bl).toBe(0);
+        expect(getStyleByPosition(1, 2, 1, 2)?.bl).toBe(0);
+
+        range2?.setFontWeight(null);
+        expect(getStyleByPosition(0, 1, 0, 1)?.bl).toBe(undefined);
+        expect(getStyleByPosition(0, 2, 0, 2)?.bl).toBe(undefined);
+        expect(getStyleByPosition(1, 1, 1, 1)?.bl).toBe(undefined);
+        expect(getStyleByPosition(1, 2, 1, 2)?.bl).toBe(undefined);
     });
 });

--- a/packages/facade/src/apis/sheet/f-range.ts
+++ b/packages/facade/src/apis/sheet/f-range.ts
@@ -15,6 +15,7 @@
  */
 
 import type {
+    BooleanNumber,
     ICellData,
     ICellV,
     IColorStyle,
@@ -26,9 +27,12 @@ import type {
 import { ICommandService } from '@univerjs/core';
 import type { ISetStyleCommandParams } from '@univerjs/sheets';
 import { SetRangeValuesCommand, SetStyleCommand } from '@univerjs/sheets';
+import type { IStyleTypeValue } from '@univerjs/sheets/controllers/basic-worksheet.controller.js';
 import { Inject, Injector } from '@wendellhu/redi';
 
 import { covertCellValue, covertCellValues } from './utils';
+
+type fontWeight = 'bold' | 'normal';
 
 export class FRange {
     constructor(
@@ -107,5 +111,27 @@ export class FRange {
             range: this._range,
             value: realValue,
         });
+    }
+
+    /**
+     * Set the font weight for the given range (normal/bold).
+     * @param fontWeight
+     */
+    setFontWeight(fontWeight: fontWeight | null): void {
+        const value: BooleanNumber | undefined = fontWeight === null ? undefined : fontWeight === 'bold' ? 1 : 0;
+
+        const style: IStyleTypeValue<BooleanNumber | undefined> = {
+            type: 'bl',
+            value,
+        };
+
+        const setStyleParams: ISetStyleCommandParams<BooleanNumber | undefined> = {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: this._worksheet.getSheetId(),
+            range: this._range,
+            style,
+        };
+
+        this._commandService.executeCommand(SetStyleCommand.id, setStyleParams);
     }
 }

--- a/packages/facade/src/apis/sheet/f-range.ts
+++ b/packages/facade/src/apis/sheet/f-range.ts
@@ -25,14 +25,13 @@ import type {
     Worksheet,
 } from '@univerjs/core';
 import { ICommandService } from '@univerjs/core';
-import type { ISetStyleCommandParams } from '@univerjs/sheets';
+import type { ISetStyleCommandParams, IStyleTypeValue } from '@univerjs/sheets';
 import { SetRangeValuesCommand, SetStyleCommand } from '@univerjs/sheets';
-import type { IStyleTypeValue } from '@univerjs/sheets/controllers/basic-worksheet.controller.js';
 import { Inject, Injector } from '@wendellhu/redi';
 
 import { covertCellValue, covertCellValues } from './utils';
 
-type fontWeight = 'bold' | 'normal';
+type FontWeight = 'bold' | 'normal';
 
 export class FRange {
     constructor(
@@ -117,7 +116,7 @@ export class FRange {
      * Set the font weight for the given range (normal/bold).
      * @param fontWeight
      */
-    setFontWeight(fontWeight: fontWeight | null): void {
+    setFontWeight(fontWeight: FontWeight | null): void {
         const value: BooleanNumber | undefined = fontWeight === null ? undefined : fontWeight === 'bold' ? 1 : 0;
 
         const style: IStyleTypeValue<BooleanNumber | undefined> = {

--- a/packages/sheets/src/index.ts
+++ b/packages/sheets/src/index.ts
@@ -118,6 +118,7 @@ export {
 } from './commands/commands/set-row-visible.command';
 export {
     type ISetStyleCommandParams,
+    type IStyleTypeValue,
     ResetBackgroundColorCommand,
     ResetTextColorCommand,
     SetBackgroundColorCommand,


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

- [x] I am sure that the code is update-to-date with the `dev` branch.

<!-- Associate an issue with the pull request. -->
<!-- Feel free to delete this if there is no related issue. -->

#1009 

<!-- A description of the proposed changes. -->

- [x] add range api setFontWeight


```js
const activeSheet = univerAPI.getCurrentSheet().getActiveSheet();

// Set A1:B2 to bold
activeSheet.getRange(0, 0, 2, 2).setFontWeight('bold');
// Set B2 to normal
activeSheet.getRange(1, 1, 1, 1).setFontWeight('normal');
// reset A1 to normal
activeSheet.getRange(0, 0, 1, 1).setFontWeight(null);

```

- [x]  range api test setFontWeight
- [x] add demo to change font Weight

<!-- How to test them. -->