### PR TITLE
feat(facade): add set font apis and get cell model data api

### DIFF
--- a/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
+++ b/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
@@ -173,6 +173,24 @@ describe('Test FRange', () => {
         expect(getStyleByPosition(3, 4, 3, 4)?.bg?.rgb).toBe('red');
     });
 
+    it('Range getCellData', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+        activeSheet?.getRange(0, 0)?.setValue(1);
+        const range = activeSheet?.getRange(0, 0);
+        expect(range?.getCellData()?.v).toBe(1);
+    });
+
+    it('Range getCellStyleData', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+        activeSheet?.getRange(0, 0)?.setValue(1);
+        activeSheet?.getRange(0, 0)?.setBackgroundColor('red');
+        const range = activeSheet?.getRange(0, 0);
+        expect(range?.getCellStyleData()?.bg?.rgb).toBe('red');
+
+        activeSheet?.getRange(0, 0, 2, 2)?.setFontWeight('bold');
+        expect(range?.getCellStyleData()?.bl).toBe(1);
+    });
+
     it('Range setFontWeight', () => {
         const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
 
@@ -205,5 +223,88 @@ describe('Test FRange', () => {
         expect(getStyleByPosition(0, 2, 0, 2)?.bl).toBe(undefined);
         expect(getStyleByPosition(1, 1, 1, 1)?.bl).toBe(undefined);
         expect(getStyleByPosition(1, 2, 1, 2)?.bl).toBe(undefined);
+    });
+
+    it('Range setFontStyle', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+
+        // change A1 Font Style
+        const range = activeSheet?.getRange(0, 0);
+        expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(undefined);
+        range?.setFontStyle('italic');
+        expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(1);
+        range?.setFontStyle('normal');
+        expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(0);
+        range?.setFontStyle(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(undefined);
+
+        // change A1:B2 Font Style
+        const range2 = activeSheet?.getRange(0, 0, 2, 2);
+        range2?.setFontStyle('italic');
+        expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(1);
+        expect(getStyleByPosition(0, 1, 0, 1)?.it).toBe(1);
+        expect(getStyleByPosition(1, 0, 1, 0)?.it).toBe(1);
+        expect(getStyleByPosition(1, 1, 1, 1)?.it).toBe(1);
+
+        range2?.setFontStyle('normal');
+        expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(0);
+        expect(getStyleByPosition(0, 1, 0, 1)?.it).toBe(0);
+        expect(getStyleByPosition(1, 0, 1, 0)?.it).toBe(0);
+        expect(getStyleByPosition(1, 1, 1, 1)?.it).toBe(0);
+
+        range2?.setFontStyle(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(undefined);
+        expect(getStyleByPosition(0, 1, 0, 1)?.it).toBe(undefined);
+        expect(getStyleByPosition(1, 0, 1, 0)?.it).toBe(undefined);
+        expect(getStyleByPosition(1, 1, 1, 1)?.it).toBe(undefined);
+    });
+
+    it('Range setFontLine', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+
+        // change A1 Font Line
+        const range = activeSheet?.getRange(0, 0);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ul?.s).toBe(undefined);
+        range?.setFontLine('underline');
+        expect(getStyleByPosition(0, 0, 0, 0)?.ul?.s).toBe(1);
+        range?.setFontLine('line-through');
+        expect(getStyleByPosition(0, 0, 0, 0)?.st?.s).toBe(1);
+        range?.setFontLine('none');
+        expect(getStyleByPosition(0, 0, 0, 0)?.ul?.s).toBe(0);
+        expect(getStyleByPosition(0, 0, 0, 0)?.st?.s).toBe(0);
+        range?.setFontLine(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ul).toBe(undefined);
+        expect(getStyleByPosition(0, 0, 0, 0)?.st).toBe(undefined);
+
+        // change A1:B2 Font Line
+        const range2 = activeSheet?.getRange(0, 0, 2, 2);
+        range2?.setFontLine('underline');
+        expect(getStyleByPosition(0, 0, 0, 0)?.ul?.s).toBe(1);
+        expect(getStyleByPosition(0, 1, 0, 1)?.ul?.s).toBe(1);
+        expect(getStyleByPosition(1, 0, 1, 0)?.ul?.s).toBe(1);
+        expect(getStyleByPosition(1, 1, 1, 1)?.ul?.s).toBe(1);
+
+        range2?.setFontLine('line-through');
+        expect(getStyleByPosition(0, 0, 0, 0)?.st?.s).toBe(1);
+        expect(getStyleByPosition(0, 1, 0, 1)?.st?.s).toBe(1);
+        expect(getStyleByPosition(1, 0, 1, 0)?.st?.s).toBe(1);
+        expect(getStyleByPosition(1, 1, 1, 1)?.st?.s).toBe(1);
+
+        range2?.setFontLine('none');
+        expect(getStyleByPosition(0, 0, 0, 0)?.ul?.s).toBe(0);
+        expect(getStyleByPosition(0, 1, 0, 1)?.ul?.s).toBe(0);
+        expect(getStyleByPosition(1, 0, 1, 0)?.ul?.s).toBe(0);
+        expect(getStyleByPosition(1, 1, 1, 1)?.ul?.s).toBe(0);
+
+        range2?.setFontLine(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ul).toBe(undefined);
+        expect(getStyleByPosition(0, 1, 0, 1)?.ul).toBe(undefined);
+        expect(getStyleByPosition(1, 0, 1, 0)?.ul).toBe(undefined);
+        expect(getStyleByPosition(1, 1, 1, 1)?.ul).toBe(undefined);
+
+        expect(getStyleByPosition(0, 0, 0, 0)?.st).toBe(undefined);
+        expect(getStyleByPosition(0, 1, 0, 1)?.st).toBe(undefined);
+        expect(getStyleByPosition(1, 0, 1, 0)?.st).toBe(undefined);
+        expect(getStyleByPosition(1, 1, 1, 1)?.st).toBe(undefined);
     });
 });

--- a/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
+++ b/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
@@ -196,6 +196,7 @@ describe('Test FRange', () => {
 
         // change A1 font weight
         const range = activeSheet?.getRange(0, 0, 1, 1);
+        range?.setFontWeight(null);
         expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(undefined);
         range?.setFontWeight('bold');
         expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(1);
@@ -230,6 +231,7 @@ describe('Test FRange', () => {
 
         // change A1 Font Style
         const range = activeSheet?.getRange(0, 0);
+        range?.setFontStyle(null);
         expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(undefined);
         range?.setFontStyle('italic');
         expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(1);
@@ -264,6 +266,7 @@ describe('Test FRange', () => {
 
         // change A1 Font Line
         const range = activeSheet?.getRange(0, 0);
+        range?.setFontLine(null);
         expect(getStyleByPosition(0, 0, 0, 0)?.ul?.s).toBe(undefined);
         range?.setFontLine('underline');
         expect(getStyleByPosition(0, 0, 0, 0)?.ul?.s).toBe(1);
@@ -313,6 +316,7 @@ describe('Test FRange', () => {
 
         // change A1 Font Family
         const range = activeSheet?.getRange(0, 0);
+        range?.setFontFamily(null);
         expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe(undefined);
         range?.setFontFamily('Arial');
         expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe('Arial');
@@ -347,6 +351,7 @@ describe('Test FRange', () => {
 
         // change A1 Font Size
         const range = activeSheet?.getRange(0, 0);
+        range?.setFontSize(null);
         expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(undefined);
         range?.setFontSize(12);
         expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(12);
@@ -381,6 +386,7 @@ describe('Test FRange', () => {
 
         // change A1 Font Color
         const range = activeSheet?.getRange(0, 0);
+        range?.setFontColor(null);
         expect(getStyleByPosition(0, 0, 0, 0)?.cl).toBe(undefined);
         range?.setFontColor('red');
         expect(getStyleByPosition(0, 0, 0, 0)?.cl?.rgb).toBe('red');
@@ -408,5 +414,41 @@ describe('Test FRange', () => {
         expect(getStyleByPosition(0, 1, 0, 1)?.cl).toBe(undefined);
         expect(getStyleByPosition(1, 0, 1, 0)?.cl).toBe(undefined);
         expect(getStyleByPosition(1, 1, 1, 1)?.cl).toBe(undefined);
+    });
+
+    it('Range chain call set font styles', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+
+        // set A1 font styles
+        const range = activeSheet?.getRange(0, 0);
+
+        range
+            ?.setFontWeight('bold')
+            .setFontLine('underline')
+            .setFontFamily('Arial')
+            .setFontSize(24)
+            .setFontColor('red');
+
+        expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(1);
+        expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(undefined);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ul?.s).toBe(1);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe('Arial');
+        expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(24);
+        expect(getStyleByPosition(0, 0, 0, 0)?.cl?.rgb).toBe('red');
+
+        // unset A1 font styles
+        range
+            ?.setFontWeight(null)
+            .setFontLine(null)
+            .setFontFamily(null)
+            .setFontSize(null)
+            .setFontColor(null);
+
+        expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(undefined);
+        expect(getStyleByPosition(0, 0, 0, 0)?.it).toBe(undefined);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ul).toBe(undefined);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe(undefined);
+        expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(undefined);
+        expect(getStyleByPosition(0, 0, 0, 0)?.cl).toBe(undefined);
     });
 });

--- a/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
+++ b/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
@@ -174,7 +174,7 @@ describe('Test FRange', () => {
     });
 
     it('Range getCellData', () => {
-        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
         activeSheet?.getRange(0, 0)?.setValue(1);
         const range = activeSheet?.getRange(0, 0);
         expect(range?.getCellData()?.v).toBe(1);

--- a/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
+++ b/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
@@ -307,4 +307,38 @@ describe('Test FRange', () => {
         expect(getStyleByPosition(1, 0, 1, 0)?.st).toBe(undefined);
         expect(getStyleByPosition(1, 1, 1, 1)?.st).toBe(undefined);
     });
+
+    it('Range setFontFamily', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+
+        // change A1 Font Family
+        const range = activeSheet?.getRange(0, 0);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe(undefined);
+        range?.setFontFamily('Arial');
+        expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe('Arial');
+        range?.setFontFamily('宋体');
+        expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe('宋体');
+        range?.setFontFamily(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe(undefined);
+
+        // change A1:B2 Font Family
+        const range2 = activeSheet?.getRange(0, 0, 2, 2);
+        range2?.setFontFamily('Arial');
+        expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe('Arial');
+        expect(getStyleByPosition(0, 1, 0, 1)?.ff).toBe('Arial');
+        expect(getStyleByPosition(1, 0, 1, 0)?.ff).toBe('Arial');
+        expect(getStyleByPosition(1, 1, 1, 1)?.ff).toBe('Arial');
+
+        range2?.setFontFamily('宋体');
+        expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe('宋体');
+        expect(getStyleByPosition(0, 1, 0, 1)?.ff).toBe('宋体');
+        expect(getStyleByPosition(1, 0, 1, 0)?.ff).toBe('宋体');
+        expect(getStyleByPosition(1, 1, 1, 1)?.ff).toBe('宋体');
+
+        range2?.setFontFamily(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.ff).toBe(undefined);
+        expect(getStyleByPosition(0, 1, 0, 1)?.ff).toBe(undefined);
+        expect(getStyleByPosition(1, 0, 1, 0)?.ff).toBe(undefined);
+        expect(getStyleByPosition(1, 1, 1, 1)?.ff).toBe(undefined);
+    });
 });

--- a/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
+++ b/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
@@ -375,4 +375,38 @@ describe('Test FRange', () => {
         expect(getStyleByPosition(1, 0, 1, 0)?.fs).toBe(undefined);
         expect(getStyleByPosition(1, 1, 1, 1)?.fs).toBe(undefined);
     });
+
+    it('Range setFontColor', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+
+        // change A1 Font Color
+        const range = activeSheet?.getRange(0, 0);
+        expect(getStyleByPosition(0, 0, 0, 0)?.cl).toBe(undefined);
+        range?.setFontColor('red');
+        expect(getStyleByPosition(0, 0, 0, 0)?.cl?.rgb).toBe('red');
+        range?.setFontColor('green');
+        expect(getStyleByPosition(0, 0, 0, 0)?.cl?.rgb).toBe('green');
+        range?.setFontColor(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.cl).toBe(undefined);
+
+        // change A1:B2 Font Color
+        const range2 = activeSheet?.getRange(0, 0, 2, 2);
+        range2?.setFontColor('red');
+        expect(getStyleByPosition(0, 0, 0, 0)?.cl?.rgb).toBe('red');
+        expect(getStyleByPosition(0, 1, 0, 1)?.cl?.rgb).toBe('red');
+        expect(getStyleByPosition(1, 0, 1, 0)?.cl?.rgb).toBe('red');
+        expect(getStyleByPosition(1, 1, 1, 1)?.cl?.rgb).toBe('red');
+
+        range2?.setFontColor('green');
+        expect(getStyleByPosition(0, 0, 0, 0)?.cl?.rgb).toBe('green');
+        expect(getStyleByPosition(0, 1, 0, 1)?.cl?.rgb).toBe('green');
+        expect(getStyleByPosition(1, 0, 1, 0)?.cl?.rgb).toBe('green');
+        expect(getStyleByPosition(1, 1, 1, 1)?.cl?.rgb).toBe('green');
+
+        range2?.setFontColor(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.cl).toBe(undefined);
+        expect(getStyleByPosition(0, 1, 0, 1)?.cl).toBe(undefined);
+        expect(getStyleByPosition(1, 0, 1, 0)?.cl).toBe(undefined);
+        expect(getStyleByPosition(1, 1, 1, 1)?.cl).toBe(undefined);
+    });
 });

--- a/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
+++ b/packages/facade/src/apis/sheet/__tests__/f-range.spec.ts
@@ -341,4 +341,38 @@ describe('Test FRange', () => {
         expect(getStyleByPosition(1, 0, 1, 0)?.ff).toBe(undefined);
         expect(getStyleByPosition(1, 1, 1, 1)?.ff).toBe(undefined);
     });
+
+    it('Range setFontSize', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+
+        // change A1 Font Size
+        const range = activeSheet?.getRange(0, 0);
+        expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(undefined);
+        range?.setFontSize(12);
+        expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(12);
+        range?.setFontSize(24);
+        expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(24);
+        range?.setFontSize(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(undefined);
+
+        // change A1:B2 Font Size
+        const range2 = activeSheet?.getRange(0, 0, 2, 2);
+        range2?.setFontSize(12);
+        expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(12);
+        expect(getStyleByPosition(0, 1, 0, 1)?.fs).toBe(12);
+        expect(getStyleByPosition(1, 0, 1, 0)?.fs).toBe(12);
+        expect(getStyleByPosition(1, 1, 1, 1)?.fs).toBe(12);
+
+        range2?.setFontSize(24);
+        expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(24);
+        expect(getStyleByPosition(0, 1, 0, 1)?.fs).toBe(24);
+        expect(getStyleByPosition(1, 0, 1, 0)?.fs).toBe(24);
+        expect(getStyleByPosition(1, 1, 1, 1)?.fs).toBe(24);
+
+        range2?.setFontSize(null);
+        expect(getStyleByPosition(0, 0, 0, 0)?.fs).toBe(undefined);
+        expect(getStyleByPosition(0, 1, 0, 1)?.fs).toBe(undefined);
+        expect(getStyleByPosition(1, 0, 1, 0)?.fs).toBe(undefined);
+        expect(getStyleByPosition(1, 1, 1, 1)?.fs).toBe(undefined);
+    });
 });

--- a/packages/facade/src/apis/sheet/f-range.ts
+++ b/packages/facade/src/apis/sheet/f-range.ts
@@ -407,6 +407,39 @@ export class FRange {
         return this;
     }
 
+    /**
+     * Sets the font color in CSS notation (such as '#ffffff' or 'white').
+     * @param color The font color in CSS notation (such as '#ffffff' or 'white'); a null value resets the color.
+     */
+    setFontColor(color: string | null): this {
+        let style: IStyleTypeValue<IColorStyle | null>;
+
+        if (color === null) {
+            style = {
+                type: 'cl',
+                value: null,
+            };
+        } else {
+            style = {
+                type: 'cl',
+                value: {
+                    rgb: color,
+                },
+            };
+        }
+
+        const setStyleParams: ISetStyleCommandParams<IColorStyle | null> = {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: this._worksheet.getSheetId(),
+            range: this._range,
+            style,
+        };
+
+        this._commandService.executeCommand(SetStyleCommand.id, setStyleParams);
+
+        return this;
+    }
+
     // #endregion editing
 
     /**

--- a/packages/facade/src/apis/sheet/f-range.ts
+++ b/packages/facade/src/apis/sheet/f-range.ts
@@ -386,6 +386,27 @@ export class FRange {
         return this;
     }
 
+    /**
+     * Sets the font size, with the size being the point size to use.
+     * @param size A font size in point size. A null value resets the font size.
+     */
+    setFontSize(size: number | null): this {
+        const style: IStyleTypeValue<number | null> = {
+            type: 'fs',
+            value: size,
+        };
+        const setStyleParams: ISetStyleCommandParams<number | null> = {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: this._worksheet.getSheetId(),
+            range: this._range,
+            style,
+        };
+
+        this._commandService.executeCommand(SetStyleCommand.id, setStyleParams);
+
+        return this;
+    }
+
     // #endregion editing
 
     /**

--- a/packages/facade/src/apis/sheet/f-range.ts
+++ b/packages/facade/src/apis/sheet/f-range.ts
@@ -52,7 +52,7 @@ import {
     transformFacadeVerticalAlignment,
 } from './utils';
 
-type FontWeight = 'bold' | 'normal';
+export type FontWeight = 'bold' | 'normal';
 
 export class FRange {
     constructor(

--- a/packages/facade/src/apis/sheet/f-range.ts
+++ b/packages/facade/src/apis/sheet/f-range.ts
@@ -20,6 +20,8 @@ import type {
     IColorStyle,
     IObjectMatrixPrimitiveType,
     IRange,
+    IStyleData,
+    ITextDecoration,
     Workbook,
     Worksheet,
 } from '@univerjs/core';
@@ -52,7 +54,9 @@ import {
     transformFacadeVerticalAlignment,
 } from './utils';
 
-export type FontWeight = 'bold' | 'normal';
+export type FontLine = 'none' | 'underline' | 'line-through';
+export type FontStyle = 'normal' | 'italic';
+export type FontWeight = 'normal' | 'bold';
 
 export class FRange {
     constructor(
@@ -77,6 +81,28 @@ export class FRange {
 
     getHeight(): number {
         return this._range.endRow - this._range.startRow + 1;
+    }
+
+    /**
+     * Return first cell model data in this range
+     * @returns The cell model data
+     */
+    getCellData(): ICellData | null {
+        return this._worksheet.getCell(this._range.startRow, this._range.startColumn) ?? null;
+    }
+
+    /**
+     * Return first cell style data in this range
+     * @returns The cell style data
+     */
+    getCellStyleData(): IStyleData | null {
+        const cell = this.getCellData();
+        const styles = this._workbook.getStyles();
+        if (cell && styles) {
+            return styles.getStyleByCell(cell) ?? null;
+        }
+
+        return null;
     }
 
     getValue(): CellValue | null {
@@ -209,18 +235,127 @@ export class FRange {
     }
 
     /**
-     * Set the font weight for the given range (normal/bold).
-     * @param fontWeight
+     * Sets the font weight for the given range (normal/bold),
+     * @param fontWeight The font weight, either 'normal' or 'bold'; a null value resets the font weight.
      */
-    setFontWeight(fontWeight: FontWeight | null): void {
-        const value: BooleanNumber | undefined = fontWeight === null ? undefined : fontWeight === 'bold' ? 1 : 0;
+    setFontWeight(fontWeight: FontWeight | null): this {
+        let value: BooleanNumber | null;
+        if (fontWeight === 'bold') {
+            value = BooleanNumber.TRUE;
+        } else if (fontWeight === 'normal') {
+            value = BooleanNumber.FALSE;
+        } else if (fontWeight === null) {
+            value = null;
+        } else {
+            throw new Error('Invalid fontWeight');
+        }
 
-        const style: IStyleTypeValue<BooleanNumber | undefined> = {
+        const style: IStyleTypeValue<BooleanNumber | null> = {
             type: 'bl',
             value,
         };
 
-        const setStyleParams: ISetStyleCommandParams<BooleanNumber | undefined> = {
+        const setStyleParams: ISetStyleCommandParams<BooleanNumber | null> = {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: this._worksheet.getSheetId(),
+            range: this._range,
+            style,
+        };
+
+        this._commandService.executeCommand(SetStyleCommand.id, setStyleParams);
+
+        return this;
+    }
+
+    /**
+     * Sets the font style for the given range ('italic' or 'normal').
+     * @param fontStyle The font style, either 'italic' or 'normal'; a null value resets the font style.
+     */
+    setFontStyle(fontStyle: FontStyle | null): this {
+        let value: BooleanNumber | null;
+        if (fontStyle === 'italic') {
+            value = BooleanNumber.TRUE;
+        } else if (fontStyle === 'normal') {
+            value = BooleanNumber.FALSE;
+        } else if (fontStyle === null) {
+            value = null;
+        } else {
+            throw new Error('Invalid fontStyle');
+        }
+
+        const style: IStyleTypeValue<BooleanNumber | null> = {
+            type: 'it',
+            value,
+        };
+
+        const setStyleParams: ISetStyleCommandParams<BooleanNumber | null> = {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: this._worksheet.getSheetId(),
+            range: this._range,
+            style,
+        };
+
+        this._commandService.executeCommand(SetStyleCommand.id, setStyleParams);
+
+        return this;
+    }
+
+    /**
+     * Sets the font line style of the given range ('underline', 'line-through', or 'none').
+     * @param fontLine The font line style, either 'underline', 'line-through', or 'none'; a null value resets the font line style.
+     */
+    setFontLine(fontLine: FontLine | null): this {
+        if (fontLine === 'underline') {
+            this._setFontUnderline({
+                s: BooleanNumber.TRUE,
+            });
+        } else if (fontLine === 'line-through') {
+            this._setFontStrikethrough({
+                s: BooleanNumber.TRUE,
+            });
+        } else if (fontLine === 'none') {
+            this._setFontUnderline({
+                s: BooleanNumber.FALSE,
+            });
+            this._setFontStrikethrough({
+                s: BooleanNumber.FALSE,
+            });
+        } else if (fontLine === null) {
+            this._setFontUnderline(null);
+            this._setFontStrikethrough(null);
+        } else {
+            throw new Error('Invalid fontLine');
+        }
+        return this;
+    }
+
+    /**
+     * Sets the font underline style of the given ITextDecoration
+     */
+    private _setFontUnderline(value: ITextDecoration | null) {
+        const style: IStyleTypeValue<ITextDecoration | null> = {
+            type: 'ul',
+            value,
+        };
+        const setStyleParams: ISetStyleCommandParams<ITextDecoration | null> = {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: this._worksheet.getSheetId(),
+            range: this._range,
+            style,
+        };
+
+        this._commandService.executeCommand(SetStyleCommand.id, setStyleParams);
+    }
+
+    /**
+     * Sets the font strikethrough style of the given ITextDecoration
+     */
+    private _setFontStrikethrough(value: ITextDecoration | null) {
+        const style: IStyleTypeValue<ITextDecoration | null> = {
+            type: 'st',
+            value,
+        };
+        const setStyleParams: ISetStyleCommandParams<ITextDecoration | null> = {
             unitId: this._workbook.getUnitId(),
             subUnitId: this._worksheet.getSheetId(),
             range: this._range,

--- a/packages/facade/src/apis/sheet/f-range.ts
+++ b/packages/facade/src/apis/sheet/f-range.ts
@@ -412,21 +412,11 @@ export class FRange {
      * @param color The font color in CSS notation (such as '#ffffff' or 'white'); a null value resets the color.
      */
     setFontColor(color: string | null): this {
-        let style: IStyleTypeValue<IColorStyle | null>;
-
-        if (color === null) {
-            style = {
-                type: 'cl',
-                value: null,
-            };
-        } else {
-            style = {
-                type: 'cl',
-                value: {
-                    rgb: color,
-                },
-            };
-        }
+        const value: IColorStyle | null = color === null ? null : { rgb: color };
+        const style: IStyleTypeValue<IColorStyle | null> = {
+            type: 'cl',
+            value,
+        };
 
         const setStyleParams: ISetStyleCommandParams<IColorStyle | null> = {
             unitId: this._workbook.getUnitId(),

--- a/packages/facade/src/apis/sheet/f-range.ts
+++ b/packages/facade/src/apis/sheet/f-range.ts
@@ -65,7 +65,7 @@ export class FRange {
         private readonly _range: IRange,
         @Inject(Injector) private readonly _injector: Injector,
         @ICommandService private readonly _commandService: ICommandService
-    ) {}
+    ) { }
 
     getRow(): number {
         return this._range.startRow;
@@ -363,6 +363,27 @@ export class FRange {
         };
 
         this._commandService.executeCommand(SetStyleCommand.id, setStyleParams);
+    }
+
+    /**
+     * Sets the font family, such as "Arial" or "Helvetica".
+     * @param fontFamily The font family to set; a null value resets the font family.
+     */
+    setFontFamily(fontFamily: string | null): this {
+        const style: IStyleTypeValue<string | null> = {
+            type: 'ff',
+            value: fontFamily,
+        };
+        const setStyleParams: ISetStyleCommandParams<string | null> = {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: this._worksheet.getSheetId(),
+            range: this._range,
+            style,
+        };
+
+        this._commandService.executeCommand(SetStyleCommand.id, setStyleParams);
+
+        return this;
     }
 
     // #endregion editing

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export type { FontWeight } from './apis/sheet/f-range';
 export { FUniver } from './apis/facade';
 export { FRange } from './apis/sheet/f-range';
 export { FSelection } from './apis/sheet/f-selection';

--- a/packages/facade/src/index.ts
+++ b/packages/facade/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export type { FontWeight } from './apis/sheet/f-range';
+export type { FontLine, FontStyle, FontWeight } from './apis/sheet/f-range';
 export { FUniver } from './apis/facade';
 export { FRange } from './apis/sheet/f-range';
 export { FSelection } from './apis/sheet/f-selection';

--- a/packages/sheets/src/commands/mutations/set-range-values.mutation.ts
+++ b/packages/sheets/src/commands/mutations/set-range-values.mutation.ts
@@ -350,15 +350,15 @@ export function mergeStyle(
     // }
 
     if ('cl' in backupStyle) {
-        if ('ul' in backupStyle) {
+        if ('ul' in backupStyle && backupStyle.ul) {
             backupStyle.ul.cl = backupStyle.cl;
         }
 
-        if ('ol' in backupStyle) {
+        if ('ol' in backupStyle && backupStyle.ol) {
             backupStyle.ol.cl = backupStyle.cl;
         }
 
-        if ('st' in backupStyle) {
+        if ('st' in backupStyle && backupStyle.st) {
             backupStyle.st.cl = backupStyle.cl;
         }
     }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

- [x] I am sure that the code is update-to-date with the `dev` branch.

<!-- Associate an issue with the pull request. -->
<!-- Feel free to delete this if there is no related issue. -->

close #1009

<!-- A description of the proposed changes. -->

Add Facade range APIs:

- [x] getCellData

```ts
const activeSheet = univerAPI.getActiveWorkbook().getActiveSheet();


const range = activeSheet.getRange(0, 0);
range.setValue('a');

// 获取单元格数据
const cellData = range .getCellData(); // like { v : "a" }
```

- [x] getCellStyleData


```ts
const activeSheet = univerAPI.getActiveWorkbook().getActiveSheet();

// 获取单元格样式数据
const range = activeSheet.getRange(0, 0);
range.setFontWeight('bold');

const cellStyleData = activeSheet.getRange(0, 0).getCellStyleData(); // reuslt like { bl: 1 }
```


- [x] setFontStyle
- [x] setFontLine
- [x] setFontFamily
- [x] setFontSize
- [x] setFontColor

```ts
const activeSheet = univerAPI.getActiveWorkbook().getActiveSheet();

// 设置单元格样式数据
const range = activeSheet.getRange(0, 0, 2, 2);
range
  .setFontWeight('bold')
  .setFontLine('underline')
  .setFontFamily('Arial')
  .setFontSize(24)
  .setFontColor('red');

//移除单元格样式数据
range
  .setFontWeight(null)
  .setFontLine(null)
  .setFontFamily(null)
  .setFontSize(null)
  .setFontColor(null);
```


<!-- How to test them. -->
