### PR TITLE
feat: add string interpolation support for locale service

### DIFF
--- a/packages/core/src/services/locale/__tests__/locale.service.spec.ts
+++ b/packages/core/src/services/locale/__tests__/locale.service.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LocaleService } from '../locale.service';
+import { LocaleType } from '../../../types/enum/locale-type';
+
+describe('LocaleService', () => {
+    let localeService: LocaleService;
+    const testLocales = {
+        [LocaleType.ZH_CN]: {
+            greeting: '你好',
+            farewell: '再见',
+            nested: {
+                welcome: '欢迎光临',
+            },
+            withParams: '你好, {0}!',
+        },
+        [LocaleType.EN_US]: {
+            greeting: 'Hello',
+            farewell: 'Goodbye',
+            nested: {
+                welcome: 'Welcome',
+            },
+            withParams: 'Hello, {0}!',
+        },
+    };
+
+    beforeEach(() => {
+        localeService = new LocaleService();
+        localeService.load(testLocales);
+    });
+
+    it('should translate simple keys', () => {
+        expect(localeService.t('greeting')).toBe('你好');
+        localeService.setLocale(LocaleType.EN_US);
+        expect(localeService.t('greeting')).toBe('Hello');
+    });
+
+    it('should translate nested keys', () => {
+        expect(localeService.t('nested.welcome')).toBe('欢迎光临');
+        localeService.setLocale(LocaleType.EN_US);
+        expect(localeService.t('nested.welcome')).toBe('Welcome');
+    });
+
+    it('should handle parameters within translations', () => {
+        expect(localeService.t('withParams', '世界')).toBe('你好, 世界!');
+        localeService.setLocale(LocaleType.EN_US);
+        expect(localeService.t('withParams', 'World')).toBe('Hello, World!');
+    });
+
+    it('should return the key if translation is not found', () => {
+        expect(localeService.t('nonExistentKey')).toBe('nonExistentKey');
+    });
+
+    it('should throw an error if locales are not initialized', () => {
+        const newLocaleService = new LocaleService();
+        const t = () => {
+            newLocaleService.t('greeting');
+        };
+        expect(t).toThrowError('Locale not initialized');
+    });
+});

--- a/packages/core/src/services/locale/locale.service.ts
+++ b/packages/core/src/services/locale/locale.service.ts
@@ -53,7 +53,7 @@ export class LocaleService extends Disposable {
         function resolveKeyPath(obj: ILanguagePack | ILanguagePack[], keys: string[]): string | ILanguagePack | ILanguagePack[] | null {
             const currentKey = keys.shift();
 
-            if (currentKey && currentKey in obj) {
+            if (currentKey && obj && currentKey in obj) {
                 const nextObj = (obj as ILanguagePack)[currentKey];
 
                 if (keys.length > 0 && (typeof nextObj === 'object' || Array.isArray(nextObj))) {

--- a/packages/core/src/services/locale/locale.service.ts
+++ b/packages/core/src/services/locale/locale.service.ts
@@ -47,6 +47,29 @@ export class LocaleService extends Disposable {
         this._locales = Tools.deepMerge(this._locales ?? {}, locales);
     }
 
+    /**
+     * Translate a key to the current locale
+     * @param {string} key the key to translate
+     * @param {string[]} args optional arguments to replace in the translated string
+     * @returns {string} the translated string
+     * @example
+     * const locales = {
+     *   [LocaleType.EN_US]: {
+     *     foo: {
+     *       bar: 'Hello'
+     *    }
+     * }
+     * t('foo.bar') => 'Hello'
+     *
+     * @example
+     * const locales = {
+     *   [LocaleType.EN_US]: {
+     *     foo: {
+     *       bar: 'Hello {0}'
+     *    }
+     * }
+     * t('foo.bar', 'World') => 'Hello World'
+     */
     t = (key: string, ...args: string[]): string => {
         if (!this._locales) throw new Error('Locale not initialized');
 
@@ -66,12 +89,10 @@ export class LocaleService extends Disposable {
             return null;
         }
 
-        // 使用点分隔符拆分key
         const keys = key.split('.');
         const resolvedValue = resolveKeyPath(this._locales[this._currentLocale], keys);
 
         if (typeof resolvedValue === 'string') {
-            // 如果找到的是字符串，进行插值
             let result = resolvedValue;
             args.forEach((arg, index) => {
                 result = result.replace(`{${index}}`, arg);


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

- [x] I am sure that the code is update-to-date with the `dev` branch.


## Usage

```typescript
const locales = {
  welcome: 'hello, {0}'
}

console.log(t('welcome', 'world')) // 'hello, world'
```