### PR TITLE
fix(design): remove duplicate z-index property from Select's dropdown CSS definition

### DIFF
--- a/packages/design/src/components/select/index.module.less
+++ b/packages/design/src/components/select/index.module.less
@@ -232,7 +232,6 @@
         border: 1px solid rgb(var(--border-color));
         border-radius: var(--border-radius-base);
         box-shadow: var(--box-shadow-base);
-        z-index: 100;
         &-hidden {
             display: none;
         }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

- [x] I am sure that the code is update-to-date with the `dev` branch.

fix https://github.com/dream-num/univer-pro/issues/274