### PR TITLE
feat(core): add registerPlugin config types

### DIFF
--- a/examples/src/docs/main.ts
+++ b/examples/src/docs/main.ts
@@ -52,9 +52,7 @@ univer.registerPlugin(UniverUIPlugin, {
     header: true,
     toolbar: true,
 });
-univer.registerPlugin(UniverDocsPlugin, {
-    standalone: true,
-});
+univer.registerPlugin(UniverDocsPlugin);
 univer.registerPlugin(UniverDocsUIPlugin, {
     container: 'univerdoc',
     layout: {

--- a/packages/core/src/basics/univer.ts
+++ b/packages/core/src/basics/univer.ts
@@ -239,7 +239,7 @@ export class Univer extends PluginHolder {
     // #region register plugins
 
     /** Register a plugin into univer. */
-    registerPlugin<T extends Plugin>(plugin: PluginCtor<T>, config?: any): void {
+    registerPlugin<T extends PluginCtor<Plugin>>(plugin: T, config?: ConstructorParameters<T>[0]): void {
         if (plugin.type === PluginType.Univer) {
             this._registerUniverPlugin(plugin, config);
         } else if (plugin.type === PluginType.Sheet) {

--- a/packages/engine-formula/src/plugin.ts
+++ b/packages/engine-formula/src/plugin.ts
@@ -59,7 +59,7 @@ const PLUGIN_NAME = 'base-formula-engine';
 
 interface IUniverFormulaEngine {
     notExecuteFormula?: boolean;
-    function: Array<[Ctor<BaseFunction>, IFunctionNames]>;
+    function?: Array<[Ctor<BaseFunction>, IFunctionNames]>;
 }
 
 export class UniverFormulaEnginePlugin extends Plugin {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

- [x] I am sure that the code is update-to-date with the `dev` branch.

<!-- Associate an issue with the pull request. -->
<!-- Feel free to delete this if there is no related issue. -->

<!-- A description of the proposed changes. -->

1. Add type checking for `Plugin` parameters
```ts
univer.registerPlugin(UniverUIPlugin, {
  container: "app",
  header: true,
  toolbar: true,
  footor: true, // Error, 'footor' does not exist in type <...>. Did you mean to write 'footer'?
})
```

2. `IUniverFormulaEngine.config`  can be optional
```ts
// packages/engine-formula/src/plugin.ts#L95
useFactory: () => this._injector.createInstance(FormulaController, this._config?.function)
```
3. `standalone` is a deprecated property in `UniverDocsPlugin`

<!-- How to test them. -->
