### PR TITLE
fix(sheets): boolean should store as number

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,13 +4,17 @@
  https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
 -->
 
-- [ ] I am sure that the code is update-to-date with the `dev` branch.
-
-<!-- Associate an issue with the pull request. -->
+<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
 <!-- Feel free to delete this if there is no related issue. -->
 
-close #
+close #xxx, #yyy, #zzzz
 
 <!-- A description of the proposed changes. -->
 
 <!-- How to test them. -->
+
+<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
+<!-- BREAKING CHANGE:
+Before:
+
+After: -->

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,7 +126,7 @@ export {
 } from './sheets/sheet-snapshot-utils';
 export { SheetViewModel } from './sheets/view-model';
 export { getWorksheetUID, Workbook } from './sheets/workbook';
-export { Worksheet } from './sheets/worksheet';
+export { Worksheet, extractPureTextFromCell } from './sheets/worksheet';
 export * from './slides/domain';
 export * from './types/const';
 export * from './types/enum';

--- a/packages/core/src/sheets/__tests__/worksheet.spec.ts
+++ b/packages/core/src/sheets/__tests__/worksheet.spec.ts
@@ -22,6 +22,7 @@ import { LocaleType } from '../../types/enum/locale-type';
 import { extractPureTextFromCell, type Worksheet } from '../worksheet';
 import { type IRange, RANGE_TYPE } from '../../types/interfaces/i-range';
 import { DisposableCollection } from '../../shared/lifecycle';
+import { CellValueType } from '../../types/enum';
 import { createCoreTestBed } from './create-core-test-bed';
 
 describe('test worksheet', () => {
@@ -252,5 +253,12 @@ describe('test "extractPureTextFromCell"', () => {
         expect(extractPureTextFromCell({ v: false })).toBe('FALSE');
         expect(extractPureTextFromCell({ v: true })).toBe('TRUE');
         expect(extractPureTextFromCell({ v: 1 })).toBe('1');
+    });
+
+    describe('test "CellType"', () => {
+        it('should return boolean literal when cell type is boolean', () => {
+            expect(extractPureTextFromCell({ t: CellValueType.BOOLEAN, v: 1 })).toBe('TRUE');
+            expect(extractPureTextFromCell({ t: CellValueType.BOOLEAN, v: 0 })).toBe('FALSE');
+        });
     });
 });

--- a/packages/core/src/sheets/worksheet.ts
+++ b/packages/core/src/sheets/worksheet.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { CellValueType } from '@univerjs/protocol';
 import type { Nullable } from '../shared';
 import { ObjectMatrix, Rectangle, Tools } from '../shared';
 import { createRowColIter } from '../shared/row-col-iter';
@@ -634,9 +635,23 @@ export interface ICell {
  * @param cell
  * @returns pure text in this cell
  */
-export function extractPureTextFromCell(cell: ICellData): Nullable<string> {
-    const rawValue = cell?.p?.body?.dataStream ?? cell?.v;
-    if (typeof rawValue === 'number') return `${rawValue}`;
+export function extractPureTextFromCell(cell: ICellData): string {
+    const richTextValue = cell.p?.body?.dataStream;
+    if (richTextValue) return richTextValue;
+
+    const rawValue = cell.v;
+
+    if (typeof rawValue === 'string') {
+        if (cell.t === CellValueType.BOOLEAN) return rawValue.toUpperCase();
+        return rawValue;
+    };
+
+    if (typeof rawValue === 'number') {
+        if (cell.t === CellValueType.BOOLEAN) return rawValue ? 'TRUE' : 'FALSE';
+        return rawValue.toString();
+    };
+
     if (typeof rawValue === 'boolean') return rawValue ? 'TRUE' : 'FALSE';
-    return rawValue;
+
+    return '';
 }

--- a/packages/core/src/sheets/worksheet.ts
+++ b/packages/core/src/sheets/worksheet.ts
@@ -15,6 +15,7 @@
  */
 
 import { CellValueType } from '@univerjs/protocol';
+
 import type { Nullable } from '../shared';
 import { ObjectMatrix, Rectangle, Tools } from '../shared';
 import { createRowColIter } from '../shared/row-col-iter';

--- a/packages/engine-render/src/components/sheets/sheet-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet-skeleton.ts
@@ -41,6 +41,7 @@ import {
     CellValueType,
     DEFAULT_EMPTY_DOCUMENT_VALUE,
     DocumentDataModel,
+    extractPureTextFromCell,
     getColorStyle,
     HorizontalAlign,
     IContextService,
@@ -57,7 +58,6 @@ import {
 
 import { Inject } from '@wendellhu/redi';
 import { distinctUntilChanged, startWith } from 'rxjs';
-import { extractPureTextFromCell } from '@univerjs/core/sheets/worksheet.js';
 import { BORDER_TYPE, COLOR_BLACK_RGB, MAXIMUM_ROW_HEIGHT } from '../../basics/const';
 import { getRotateOffsetAndFarthestHypotenuse } from '../../basics/draw';
 import type { IDocumentSkeletonColumn } from '../../basics/i-document-skeleton-cached';

--- a/packages/engine-render/src/components/sheets/sheet-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet-skeleton.ts
@@ -57,6 +57,7 @@ import {
 
 import { Inject } from '@wendellhu/redi';
 import { distinctUntilChanged, startWith } from 'rxjs';
+import { extractPureTextFromCell } from '@univerjs/core/sheets/worksheet.js';
 import { BORDER_TYPE, COLOR_BLACK_RGB, MAXIMUM_ROW_HEIGHT } from '../../basics/const';
 import { getRotateOffsetAndFarthestHypotenuse } from '../../basics/draw';
 import type { IDocumentSkeletonColumn } from '../../basics/i-document-skeleton-cached';
@@ -1088,7 +1089,7 @@ export class SpreadsheetSkeleton extends Skeleton {
             const textStyle = this._getFontFormat(style);
             fontString = getFontStyleString(textStyle, this._localService).fontCache;
 
-            documentModel = this._getDocumentDataByStyle(cell.v.toString(), textStyle, {
+            documentModel = this._getDocumentDataByStyle(extractPureTextFromCell(cell), textStyle, {
                 ...cellOtherConfig,
                 textRotation,
                 cellValueType: cell.t!,

--- a/packages/sheets/src/commands/mutations/set-range-values.mutation.ts
+++ b/packages/sheets/src/commands/mutations/set-range-values.mutation.ts
@@ -192,7 +192,12 @@ export const SetRangeValuesMutation: IMutation<ISetRangeValuesMutationParams, bo
 
                 // Set to null, clear content
                 if (newVal.v !== undefined) {
-                    oldVal.v = type === CellValueType.NUMBER ? Number(newVal.v) : newVal.v;
+                    oldVal.v = type === CellValueType.NUMBER
+                        ? Number(newVal.v)
+                        : type === CellValueType.BOOLEAN
+                            // if the value is a boolean, we should store it as 1 or 0
+                            ? (newVal.v!.toString()).toUpperCase() === 'TRUE' ? 1 : 0
+                            : newVal.v;
                 }
 
                 if (oldVal.v !== undefined) {


### PR DESCRIPTION
close #1534

BREAKING CHANGE:
Before:
Boolean values ("TRUE" "FALSE") were stored in the IWorkbooData as strings.
After:
Boolean values would be store as number (0, 1).

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

- [ ] I am sure that the code is update-to-date with the `dev` branch.

<!-- Associate an issue with the pull request. -->
<!-- Feel free to delete this if there is no related issue. -->

<!-- A description of the proposed changes. -->

<!-- How to test them. -->
