### PR TITLE
fix(ui): cleanup DOMs when dispose

### DIFF
--- a/packages/sheets-ui/src/services/clipboard/clipboard.service.ts
+++ b/packages/sheets-ui/src/services/clipboard/clipboard.service.ts
@@ -116,6 +116,10 @@ export class SheetClipboardService extends Disposable implements ISheetClipboard
         });
         this._usmToHtml = new USMToHtmlService();
         this._copyContentCache = new CopyContentCache();
+
+        this.disposeWithMe(toDisposable(() => {
+            this._htmlToUSM.dispose();
+        }));
     }
 
     copyContentCache(): CopyContentCache {

--- a/packages/sheets-ui/src/services/clipboard/clipboard.service.ts
+++ b/packages/sheets-ui/src/services/clipboard/clipboard.service.ts
@@ -117,9 +117,7 @@ export class SheetClipboardService extends Disposable implements ISheetClipboard
         this._usmToHtml = new USMToHtmlService();
         this._copyContentCache = new CopyContentCache();
 
-        this.disposeWithMe(toDisposable(() => {
-            this._htmlToUSM.dispose();
-        }));
+        this.disposeWithMe(this._htmlToUSM);
     }
 
     copyContentCache(): CopyContentCache {

--- a/packages/sheets-ui/src/services/clipboard/html-to-usm/converter.ts
+++ b/packages/sheets-ui/src/services/clipboard/html-to-usm/converter.ts
@@ -383,6 +383,10 @@ export class HtmlToUSMService {
             }
         }
     }
+
+    dispose() {
+        document.body.removeChild(this.htmlElement);
+    }
 }
 
 /**

--- a/packages/ui/src/views/App.tsx
+++ b/packages/ui/src/views/App.tsx
@@ -83,6 +83,9 @@ export function App(props: IUniverAppProps) {
         return () => {
             // batch unsubscribe
             subscriptions.forEach((subscription) => subscription.unsubscribe());
+
+            // cleanup
+            document.body.removeChild(portalContainer);
         };
     }, [localeService, messageService, mountContainer, portalContainer, themeService.currentTheme$]);
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->


When the univer is destroyed and then re created, there are residual doms that have not been cleaned up


## A description of the proposed changes. 

remove iframe and .univer-theme when univer dispose called

## How to test them.


Replace the file `\examples\src\sheets\main.ts` with the following content and run `setupUniver()` multiple times in the console


```ts
import { LocaleType, LogLevel, Univer } from '@univerjs/core';
import { defaultTheme } from '@univerjs/design';
import { UniverDocsPlugin } from '@univerjs/docs';
import { UniverDocsUIPlugin } from '@univerjs/docs-ui';
import { UniverFormulaEnginePlugin } from '@univerjs/engine-formula';
import { UniverRenderEnginePlugin } from '@univerjs/engine-render';
import { UniverFindReplacePlugin } from '@univerjs/find-replace';
import type { IUniverRPCMainThreadConfig } from '@univerjs/rpc';
import { UniverRPCMainThreadPlugin } from '@univerjs/rpc';
import { UniverSheetsPlugin } from '@univerjs/sheets';
import { UniverSheetsFindReplacePlugin } from '@univerjs/sheets-find-replace';
import { UniverSheetsFormulaPlugin } from '@univerjs/sheets-formula';
import { UniverSheetsNumfmtPlugin } from '@univerjs/sheets-numfmt';
import { UniverSheetsUIPlugin } from '@univerjs/sheets-ui';
import { UniverSheetsZenEditorPlugin } from '@univerjs/sheets-zen-editor';
import { UniverUIPlugin } from '@univerjs/ui';

import { DEFAULT_WORKBOOK_DATA_DEMO } from '../data';
import { DebuggerPlugin } from '../plugins/debugger';
import { locales } from './locales';

const LOAD_LAZY_PLUGINS_TIMEOUT = 1_000;

declare global {
    interface Window {
        univer?: Univer;
        setupUniver?: () => void;
    }
}

const setupUniver = async () => {
    if (window.univer) {
        window.univer.dispose();
    }

    // univer
    const univer = new Univer({
        theme: defaultTheme,
        locale: LocaleType.ZH_CN,
        locales,
        logLevel: LogLevel.VERBOSE,
    });

// core plugins
    univer.registerPlugin(UniverDocsPlugin, {
        hasScroll: false,
    });
    univer.registerPlugin(UniverRenderEnginePlugin);
    univer.registerPlugin(UniverUIPlugin, {
        container: 'app',
        header: true,
        footer: true,
    });

    univer.registerPlugin(UniverDocsUIPlugin);

    univer.registerPlugin(UniverSheetsPlugin, {
        notExecuteFormula: true,
    });
    univer.registerPlugin(UniverSheetsUIPlugin);

// sheet feature plugins

    univer.registerPlugin(UniverSheetsNumfmtPlugin);
    univer.registerPlugin(DebuggerPlugin);
    univer.registerPlugin(UniverSheetsZenEditorPlugin);
    univer.registerPlugin(UniverFormulaEnginePlugin, {
        notExecuteFormula: true,
    });
    univer.registerPlugin(UniverSheetsFormulaPlugin);
    univer.registerPlugin(UniverRPCMainThreadPlugin, {
        workerURL: './worker.js',
    } as IUniverRPCMainThreadConfig);

// find replace
    univer.registerPlugin(UniverFindReplacePlugin);
    univer.registerPlugin(UniverSheetsFindReplacePlugin);

// create univer sheet instance
    univer.createUniverSheet(DEFAULT_WORKBOOK_DATA_DEMO);
    setTimeout(() => {
        import('./lazy').then((lazy) => {
            const plugins = lazy.default();
            plugins.forEach((p) => univer.registerPlugin(p[0], p[1]));
        });
    }, LOAD_LAZY_PLUGINS_TIMEOUT);

    window.univer = univer;
};
window.setupUniver = setupUniver;

setupUniver();

```

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->
