### PR TITLE
fix(sheet): fix rendering issue when vertices of merged cells are hidden

### DIFF
--- a/packages/engine-render/src/components/sheets/extensions/background.ts
+++ b/packages/engine-render/src/components/sheets/extensions/background.ts
@@ -72,6 +72,7 @@ export class Background extends SheetExtension {
 
                 ctx.fillStyle = rgb || getColor([255, 255, 255])!;
                 ctx.beginPath();
+                const mergeFillSet = new Set<string>();
                 backgroundCache.forValue((rowIndex, columnIndex) => {
                     const cellInfo = backgroundPositions?.getValue(rowIndex, columnIndex);
 
@@ -81,7 +82,16 @@ export class Background extends SheetExtension {
                     let { startY, endY, startX, endX } = cellInfo;
                     const { isMerged, isMergedMainCell, mergeInfo } = cellInfo;
                     if (isMerged) {
-                        return true;
+                        const key = `${mergeInfo.startRow}-${mergeInfo.endRow}-${mergeInfo.startColumn}-${mergeInfo.endColumn}`;
+                        if (mergeFillSet.has(key)) {
+                            return true;
+                        } else {
+                            startY = mergeInfo.startY;
+                            endY = mergeInfo.endY;
+                            startX = mergeInfo.startX;
+                            endX = mergeInfo.endX;
+                            mergeFillSet.add(key);
+                        }
                     }
 
                     if (
@@ -106,10 +116,16 @@ export class Background extends SheetExtension {
                     // }
 
                     if (isMergedMainCell) {
-                        startY = mergeInfo.startY;
-                        endY = mergeInfo.endY;
-                        startX = mergeInfo.startX;
-                        endX = mergeInfo.endX;
+                        const key = `${mergeInfo.startRow}-${mergeInfo.endRow}-${mergeInfo.startColumn}-${mergeInfo.endColumn}`;
+                        if (mergeFillSet.has(key)) {
+                            return true;
+                        } else {
+                            startY = mergeInfo.startY;
+                            endY = mergeInfo.endY;
+                            startX = mergeInfo.startX;
+                            endX = mergeInfo.endX;
+                            mergeFillSet.add(key);
+                        }
                     }
 
                     ctx.moveToByPrecision(startX, startY);


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->

close #1215 
修复合并单元格顶点被隐藏后的渲染问题
之前是按照顶点来获取合并单元格要渲染的背景颜色位置
现在改成任一单元格 通过set保证只绘制一次

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->
