### PR TITLE
fix(conditional-formatting): disregarding computation beyond the tabl…

### DIFF
--- a/packages/sheets-conditional-formatting/src/services/__test__/test.util.ts
+++ b/packages/sheets-conditional-formatting/src/services/__test__/test.util.ts
@@ -43,6 +43,8 @@ const TEST_WORKBOOK_DATA_DEMO: () => IWorkbookData = () => ({
                 4: { 0: { v: 1, t: 2 }, 1: { v: 2, t: 2 }, 2: { v: 3, t: 2 }, 3: { v: 4, t: 2 }, 4: { v: 5, t: 2 }, 5: { v: 6, t: 2 }, 6: { v: 7, t: 2 } },
                 5: { 0: { v: 1, t: 2 }, 1: { v: 2, t: 2 }, 2: { v: 3, t: 2 }, 3: { v: 4, t: 2 }, 4: { v: 5, t: 2 }, 5: { v: 6, t: 2 }, 6: { v: 7, t: 2 } },
             },
+            rowCount: 6,
+            columnCount: 8,
         },
     },
     locale: LocaleType.ZH_CN,
@@ -85,7 +87,7 @@ export const createTestBed = (dependencies?: Dependency[]) => {
             this._injector.add([ConditionalFormattingFormulaService]);
             this._injector.add([ConditionalFormattingRuleModel]);
             this._injector.add([ConditionalFormattingViewModel]);
-            this._injector.add([IActiveDirtyManagerService, { useFactory: () => ({ register: () => {} } as any) }]);
+            this._injector.add([IActiveDirtyManagerService, { useFactory: () => ({ register: () => { } } as any) }]);
             this._injector.get(ConditionalFormattingService);
         }
     }

--- a/packages/sheets-conditional-formatting/src/services/calculate-unit/data-bar.ts
+++ b/packages/sheets-conditional-formatting/src/services/calculate-unit/data-bar.ts
@@ -19,7 +19,7 @@ import { CFRuleType } from '../../base/const';
 import type { IDataBarRenderParams } from '../../render/type';
 import type { IConditionFormattingRule, IDataBar } from '../../models/type';
 import { ConditionalFormattingFormulaService, FormulaResultStatus } from '../conditional-formatting-formula.service';
-import { getValueByType, isNullable } from './utils';
+import { filterRange, getValueByType, isNullable } from './utils';
 import type { ICalculateUnit } from './type';
 import { EMPTY_STYLE } from './type';
 
@@ -31,8 +31,8 @@ export const dataBarCellCalculateUnit: ICalculateUnit = {
 
         const { worksheet } = context;
         const matrix = new ObjectMatrix<number>();
-
-        rule.ranges.forEach((range) => {
+        const ranges = filterRange(rule.ranges, worksheet.getMaxRows() - 1, worksheet.getMaxColumns() - 1);
+        ranges.forEach((range) => {
             Range.foreach(range, (row, col) => {
                 const cell = worksheet?.getCellRaw(row, col);
                 const v = cell && cell.v;
@@ -44,7 +44,7 @@ export const dataBarCellCalculateUnit: ICalculateUnit = {
         });
 
         const computeResult = new ObjectMatrix<IDataBarRenderParams>();
-        rule.ranges.forEach((range) => {
+        ranges.forEach((range) => {
             Range.foreach(range, (row, col) => {
                 computeResult.setValue(row, col, EMPTY_STYLE as IDataBarRenderParams);
             });

--- a/packages/sheets-conditional-formatting/src/services/calculate-unit/highlight-cell.ts
+++ b/packages/sheets-conditional-formatting/src/services/calculate-unit/highlight-cell.ts
@@ -21,7 +21,7 @@ import { deserializeRangeWithSheet, ERROR_TYPE_SET, generateStringWithSequence, 
 import { CFNumberOperator, CFRuleType, CFSubRuleType, CFTextOperator, CFTimePeriodOperator } from '../../base/const';
 import type { IAverageHighlightCell, IConditionFormattingRule, IFormulaHighlightCell, IHighlightCell, INumberHighlightCell, IRankHighlightCell, ITextHighlightCell, ITimePeriodHighlightCell } from '../../models/type';
 import { ConditionalFormattingFormulaService, FormulaResultStatus } from '../conditional-formatting-formula.service';
-import { compareWithNumber, getCellValue, isFloatsEqual, isNullable, serialTimeToTimestamp } from './utils';
+import { compareWithNumber, filterRange, getCellValue, isFloatsEqual, isNullable, serialTimeToTimestamp } from './utils';
 import type { ICalculateUnit } from './type';
 import { EMPTY_STYLE } from './type';
 
@@ -30,13 +30,14 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
     handle: async (rule: IConditionFormattingRule, context) => {
         const ruleConfig = rule.rule as IHighlightCell;
         const { worksheet } = context;
+        const ranges = filterRange(rule.ranges, worksheet.getMaxRows() - 1, worksheet.getMaxColumns() - 1);
 
         const getCache = () => {
             switch (ruleConfig.subType) {
-                case CFSubRuleType.average:{
+                case CFSubRuleType.average: {
                     let sum = 0;
                     let count = 0;
-                    rule.ranges.forEach((range) => {
+                    ranges.forEach((range) => {
                         Range.foreach(range, (row, col) => {
                             const cell = worksheet?.getCellRaw(row, col);
                             const v = getCellValue(cell || undefined);
@@ -49,9 +50,9 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
                     return { average: sum / count };
                 }
                 case CFSubRuleType.uniqueValues:
-                case CFSubRuleType.duplicateValues:{
+                case CFSubRuleType.duplicateValues: {
                     const cacheMap: Map<any, number> = new Map();
-                    rule.ranges.forEach((range) => {
+                    ranges.forEach((range) => {
                         Range.foreach(range, (row, col) => {
                             const cell = worksheet?.getCellRaw(row, col);
                             const v = getCellValue(cell || undefined);
@@ -67,9 +68,9 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
                     });
                     return { count: cacheMap };
                 }
-                case CFSubRuleType.rank:{
+                case CFSubRuleType.rank: {
                     const allValue: number[] = [];
-                    rule.ranges.forEach((range) => {
+                    ranges.forEach((range) => {
                         Range.foreach(range, (row, col) => {
                             const cell = worksheet?.getCellRaw(row, col);
                             const v = getCellValue(cell || undefined);
@@ -89,7 +90,7 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
                         return { rank: allValue[Math.max(targetIndex - 1, 0)] };
                     }
                 }
-                case CFSubRuleType.formula:{
+                case CFSubRuleType.formula: {
                     const subRuleConfig = ruleConfig as IFormulaHighlightCell;
                     const lexerTreeBuilder = context.accessor.get(LexerTreeBuilder);
                     const formulaString = subRuleConfig.value;
@@ -108,7 +109,7 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
         const check = (row: number, col: number) => {
             const cellValue = worksheet?.getCellRaw(row, col);
             switch (ruleConfig.subType) {
-                case CFSubRuleType.number:{
+                case CFSubRuleType.number: {
                     const v = cellValue && Number(cellValue.v);
                     if (isNullable(v) || Number.isNaN(v) || cellValue?.t !== CellValueType.NUMBER) {
                         return false;
@@ -116,48 +117,48 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
                     const subRuleConfig = ruleConfig as INumberHighlightCell;
                     return compareWithNumber({ operator: subRuleConfig.operator, value: subRuleConfig.value || 0 }, v || 0);
                 }
-                case CFSubRuleType.text:{
+                case CFSubRuleType.text: {
                     const subRuleConfig = ruleConfig as ITextHighlightCell;
                     const value = getCellValue(cellValue!);
                     const v = value === null ? '' : String(value);
                     const condition = subRuleConfig.value || '';
                     switch (subRuleConfig.operator) {
-                        case CFTextOperator.beginsWith:{
+                        case CFTextOperator.beginsWith: {
                             return v.startsWith(condition);
                         }
-                        case CFTextOperator.containsBlanks:{
+                        case CFTextOperator.containsBlanks: {
                             return /^\s*$/.test(v);
                         }
-                        case CFTextOperator.notContainsBlanks:{
+                        case CFTextOperator.notContainsBlanks: {
                             return !/^\s*$/.test(v);
                         }
-                        case CFTextOperator.containsErrors:{
+                        case CFTextOperator.containsErrors: {
                             return (ERROR_TYPE_SET as Set<unknown>).has(v);
                         }
-                        case CFTextOperator.notContainsErrors:{
+                        case CFTextOperator.notContainsErrors: {
                             return !(ERROR_TYPE_SET as Set<unknown>).has(v);
                         }
-                        case CFTextOperator.containsText:{
+                        case CFTextOperator.containsText: {
                             return v.indexOf(condition) > -1;
                         }
-                        case CFTextOperator.notContainsText:{
+                        case CFTextOperator.notContainsText: {
                             return v.indexOf(condition) === -1;
                         }
-                        case CFTextOperator.endsWith:{
+                        case CFTextOperator.endsWith: {
                             return v.endsWith(condition);
                         }
-                        case CFTextOperator.equal:{
+                        case CFTextOperator.equal: {
                             return v === condition;
                         }
-                        case CFTextOperator.notEqual:{
+                        case CFTextOperator.notEqual: {
                             return v !== condition;
                         }
-                        default:{
+                        default: {
                             return false;
                         }
                     }
                 }
-                case CFSubRuleType.timePeriod:{
+                case CFSubRuleType.timePeriod: {
                     const value = getCellValue(cellValue!);
                     if (isNullable(value) || Number.isNaN(Number(value)) || cellValue?.t !== CellValueType.NUMBER) {
                         return false;
@@ -165,66 +166,66 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
                     const subRuleConfig = ruleConfig as ITimePeriodHighlightCell;
                     const v = serialTimeToTimestamp(Number(value));
                     switch (subRuleConfig.operator) {
-                        case CFTimePeriodOperator.last7Days:{
+                        case CFTimePeriodOperator.last7Days: {
                             const start = dayjs().subtract(7, 'day').valueOf();
                             const end = dayjs().valueOf();
                             return v >= start && v <= end;
                         }
-                        case CFTimePeriodOperator.lastMonth:{
+                        case CFTimePeriodOperator.lastMonth: {
                             const preMonth = dayjs().subtract(1, 'month');
                             const start = preMonth.startOf('month').valueOf();
                             const end = preMonth.endOf('month').valueOf();
                             return v >= start && v <= end;
                         }
-                        case CFTimePeriodOperator.lastWeek:{
+                        case CFTimePeriodOperator.lastWeek: {
                             const start = dayjs().subtract(1, 'week').valueOf();
                             const end = dayjs().valueOf();
                             return v >= start && v <= end;
                         }
-                        case CFTimePeriodOperator.nextMonth:{
+                        case CFTimePeriodOperator.nextMonth: {
                             const nextMonth = dayjs().add(1, 'month');
                             const start = nextMonth.startOf('month').valueOf();
                             const end = nextMonth.endOf('month').valueOf();
                             return v >= start && v <= end;
                         }
-                        case CFTimePeriodOperator.nextWeek:{
+                        case CFTimePeriodOperator.nextWeek: {
                             const week = dayjs();
                             const nextWeek = week.add(1, 'week');
                             const start = nextWeek.startOf('week').valueOf();
                             const end = nextWeek.endOf('week').valueOf();
                             return v >= start && v <= end;
                         }
-                        case CFTimePeriodOperator.thisMonth:{
+                        case CFTimePeriodOperator.thisMonth: {
                             const start = dayjs().startOf('month').valueOf();
                             const end = dayjs().endOf('month').valueOf();
                             return v >= start && v <= end;
                         }
-                        case CFTimePeriodOperator.thisWeek:{
+                        case CFTimePeriodOperator.thisWeek: {
                             const start = dayjs().startOf('week').valueOf();
                             const end = dayjs().endOf('week').valueOf();
                             return v >= start && v <= end;
                         }
-                        case CFTimePeriodOperator.tomorrow:{
+                        case CFTimePeriodOperator.tomorrow: {
                             const start = dayjs().startOf('day').add(1, 'day').valueOf();
                             const end = dayjs().endOf('day').add(1, 'day').valueOf();
                             return v >= start && v <= end;
                         }
-                        case CFTimePeriodOperator.yesterday:{
+                        case CFTimePeriodOperator.yesterday: {
                             const start = dayjs().startOf('day').subtract(1, 'day').valueOf();
                             const end = dayjs().endOf('day').subtract(1, 'day').valueOf();
                             return v >= start && v <= end;
                         }
-                        case CFTimePeriodOperator.today:{
+                        case CFTimePeriodOperator.today: {
                             const start = dayjs().startOf('day').valueOf();
                             const end = dayjs().endOf('day').valueOf();
                             return v >= start && v <= end;
                         }
-                        default:{
+                        default: {
                             return false;
                         }
                     }
                 }
-                case CFSubRuleType.average:{
+                case CFSubRuleType.average: {
                     const value = cellValue && cellValue.v;
                     const v = Number(value);
                     if (isNullable(value) || Number.isNaN(v) || cellValue?.t !== CellValueType.NUMBER) {
@@ -234,30 +235,30 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
                     const average = cache?.average!;
 
                     switch (subRuleConfig.operator) {
-                        case CFNumberOperator.greaterThan:{
+                        case CFNumberOperator.greaterThan: {
                             return v > average;
                         }
-                        case CFNumberOperator.greaterThanOrEqual:{
+                        case CFNumberOperator.greaterThanOrEqual: {
                             return v >= average;
                         }
-                        case CFNumberOperator.lessThan:{
+                        case CFNumberOperator.lessThan: {
                             return v < average;
                         }
-                        case CFNumberOperator.lessThanOrEqual:{
+                        case CFNumberOperator.lessThanOrEqual: {
                             return v <= average;
                         }
-                        case CFNumberOperator.equal:{
+                        case CFNumberOperator.equal: {
                             return isFloatsEqual(v, average);
                         }
-                        case CFNumberOperator.notEqual:{
+                        case CFNumberOperator.notEqual: {
                             return !isFloatsEqual(v, average);
                         }
-                        default:{
+                        default: {
                             return false;
                         }
                     }
                 }
-                case CFSubRuleType.rank:{
+                case CFSubRuleType.rank: {
                     const value = getCellValue(cellValue!);
 
                     const v = Number(value);
@@ -274,7 +275,7 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
                         return v >= targetValue;
                     }
                 }
-                case CFSubRuleType.uniqueValues:{
+                case CFSubRuleType.uniqueValues: {
                     const value = getCellValue(cellValue!);
 
                     if (isNullable(value)) {
@@ -283,7 +284,7 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
                     const uniqueCache = cache!.count!;
                     return uniqueCache.get(value) === 1;
                 }
-                case CFSubRuleType.duplicateValues:{
+                case CFSubRuleType.duplicateValues: {
                     const value = getCellValue(cellValue!);
 
                     if (isNullable(value)) {
@@ -292,7 +293,7 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
                     const uniqueCache = cache!.count!;
                     return uniqueCache.get(value) !== 1;
                 }
-                case CFSubRuleType.formula:{
+                case CFSubRuleType.formula: {
                     if (!cache?.sequenceNodes) {
                         return false;
                     }
@@ -336,7 +337,7 @@ export const highlightCellCalculateUnit: ICalculateUnit = {
             }
         };
         const computeResult = new ObjectMatrix<IStyleBase>();
-        rule.ranges.forEach((range) => {
+        ranges.forEach((range) => {
             Range.foreach(range, (row, col) => {
                 if (check(row, col)) {
                     computeResult.setValue(row, col, ruleConfig.style);

--- a/packages/sheets-conditional-formatting/src/services/calculate-unit/icon-set.ts
+++ b/packages/sheets-conditional-formatting/src/services/calculate-unit/icon-set.ts
@@ -21,7 +21,7 @@ import { CFRuleType } from '../../base/const';
 import type { IIconSetRenderParams } from '../../render/type';
 import type { IConditionFormattingRule, IIconSet } from '../../models/type';
 import { ConditionalFormattingFormulaService, FormulaResultStatus } from '../conditional-formatting-formula.service';
-import { compareWithNumber, getOppositeOperator, getValueByType, isNullable } from './utils';
+import { compareWithNumber, filterRange, getOppositeOperator, getValueByType, isNullable } from './utils';
 import type { ICalculateUnit } from './type';
 import { EMPTY_STYLE } from './type';
 
@@ -33,8 +33,9 @@ export const iconSetCalculateUnit: ICalculateUnit = {
 
         const { worksheet } = context;
         const matrix = new ObjectMatrix<number>();
+        const ranges = filterRange(rule.ranges, worksheet.getMaxRows() - 1, worksheet.getMaxColumns() - 1);
 
-        rule.ranges.forEach((range) => {
+        ranges.forEach((range) => {
             Range.foreach(range, (row, col) => {
                 const cell = worksheet?.getCellRaw(row, col);
                 const v = cell && cell.v;
@@ -46,7 +47,7 @@ export const iconSetCalculateUnit: ICalculateUnit = {
         });
 
         const computeResult = new ObjectMatrix<IIconSetRenderParams >();
-        rule.ranges.forEach((range) => {
+        ranges.forEach((range) => {
             Range.foreach(range, (row, col) => {
                 computeResult.setValue(row, col, EMPTY_STYLE as IIconSetRenderParams);
             });

--- a/packages/sheets-conditional-formatting/src/services/calculate-unit/utils.ts
+++ b/packages/sheets-conditional-formatting/src/services/calculate-unit/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ICellData } from '@univerjs/core';
+import type { ICellData, IRange } from '@univerjs/core';
 import { BooleanNumber, CellValueType, ColorKit, ObjectMatrix, Range } from '@univerjs/core';
 import { BooleanValue } from '@univerjs/engine-formula';
 import type { IConditionFormattingRule, IValueConfig } from '../../models/type';
@@ -88,9 +88,9 @@ export const serialTimeToTimestamp = (value: number) => {
     dt.setUTCHours(hh, mm, ss);
     return dt.getTime();
 };
-export const getValueByType = (value: IValueConfig, matrix: ObjectMatrix< number>, context: IContext & { cfId: string }) => {
+export const getValueByType = (value: IValueConfig, matrix: ObjectMatrix<number>, context: IContext & { cfId: string }) => {
     switch (value.type) {
-        case CFValueType.max:{
+        case CFValueType.max: {
             let max = 0;
             matrix.forValue((row, col, value) => {
                 if (value > max) {
@@ -102,7 +102,7 @@ export const getValueByType = (value: IValueConfig, matrix: ObjectMatrix< number
                 result: max,
             };
         }
-        case CFValueType.min:{
+        case CFValueType.min: {
             let min: number | undefined;
             matrix.forValue((row, col, value) => {
                 if (min === undefined) {
@@ -117,7 +117,7 @@ export const getValueByType = (value: IValueConfig, matrix: ObjectMatrix< number
                 result: min,
             };
         }
-        case CFValueType.percent:{
+        case CFValueType.percent: {
             let max: number | undefined;
             let min: number | undefined;
             matrix.forValue((row, col, value) => {
@@ -140,7 +140,7 @@ export const getValueByType = (value: IValueConfig, matrix: ObjectMatrix< number
                 result: length * (v / 100) + (min || 0),
             };
         }
-        case CFValueType.percentile:{
+        case CFValueType.percentile: {
             const list = matrix.toNativeArray().sort((a, b) => a - b);
             const v = Math.max(Math.min(Number(value.value) || 0, 100), 0);
             const index = (list.length - 1) * v / 100;
@@ -153,7 +153,7 @@ export const getValueByType = (value: IValueConfig, matrix: ObjectMatrix< number
             };
         }
 
-        case CFValueType.formula:{
+        case CFValueType.formula: {
             const { accessor, unitId, subUnitId, cfId } = context;
             const formulaText = String(value.value);
             const conditionalFormattingFormulaService = accessor.get(ConditionalFormattingFormulaService);
@@ -161,7 +161,7 @@ export const getValueByType = (value: IValueConfig, matrix: ObjectMatrix< number
             const result = conditionalFormattingFormulaService.getFormulaResult(unitId, subUnitId, formulaText);
             return result;
         }
-        case CFValueType.num:{
+        case CFValueType.num: {
             const v = Number(value.value);
             return {
                 status: FormulaResultStatus.SUCCESS,
@@ -186,9 +186,9 @@ export const getCacheStyleMatrix = <S = any>(unitId: string, subUnitId: string, 
     });
     return matrix;
 };
-export const compareWithNumber = (config: { operator: CFNumberOperator;value: number | [number, number] }, v: number) => {
+export const compareWithNumber = (config: { operator: CFNumberOperator; value: number | [number, number] }, v: number) => {
     switch (config.operator) {
-        case CFNumberOperator.between:{
+        case CFNumberOperator.between: {
             if (typeof config.value !== 'object' || !(config.value as unknown as Array<number>).length) {
                 return;
             }
@@ -196,7 +196,7 @@ export const compareWithNumber = (config: { operator: CFNumberOperator;value: nu
             const end = Math.max(...config.value as [number, number]);
             return v >= start && v <= end;
         }
-        case CFNumberOperator.notBetween:{
+        case CFNumberOperator.notBetween: {
             if (typeof config.value !== 'object' || !(config.value as unknown as Array<number>).length) {
                 return;
             }
@@ -204,56 +204,56 @@ export const compareWithNumber = (config: { operator: CFNumberOperator;value: nu
             const end = Math.max(...config.value as [number, number]);
             return !(v >= start && v <= end);
         }
-        case CFNumberOperator.equal:{
+        case CFNumberOperator.equal: {
             const condition = (config.value || 0) as number;
             return isFloatsEqual(condition, v);
         }
-        case CFNumberOperator.notEqual:{
+        case CFNumberOperator.notEqual: {
             const condition = (config.value || 0) as number;
             return !isFloatsEqual(condition, v);
         }
-        case CFNumberOperator.greaterThan:{
+        case CFNumberOperator.greaterThan: {
             const condition = (config.value || 0) as number;
             return v > condition;
         }
-        case CFNumberOperator.greaterThanOrEqual:{
+        case CFNumberOperator.greaterThanOrEqual: {
             const condition = (config.value || 0) as number;
             return v >= condition;
         }
-        case CFNumberOperator.lessThan:{
+        case CFNumberOperator.lessThan: {
             const condition = (config.value || 0) as number;
             return v < condition;
         }
-        case CFNumberOperator.lessThanOrEqual:{
+        case CFNumberOperator.lessThanOrEqual: {
             const condition = (config.value || 0) as number;
             return v <= condition;
         }
-        default:{
+        default: {
             return false;
         }
     }
 };
 export const getOppositeOperator = (operator: CFNumberOperator) => {
     switch (operator) {
-        case CFNumberOperator.greaterThan:{
+        case CFNumberOperator.greaterThan: {
             return CFNumberOperator.lessThanOrEqual;
         }
-        case CFNumberOperator.greaterThanOrEqual:{
+        case CFNumberOperator.greaterThanOrEqual: {
             return CFNumberOperator.lessThan;
         }
-        case CFNumberOperator.lessThan:{
+        case CFNumberOperator.lessThan: {
             return CFNumberOperator.greaterThanOrEqual;
         }
-        case CFNumberOperator.lessThanOrEqual:{
+        case CFNumberOperator.lessThanOrEqual: {
             return CFNumberOperator.greaterThan;
         }
     }
     return operator;
 };
 
-export const getColorScaleFromValue = (colorList: { color: ColorKit;value: number }[], value: number) => {
+export const getColorScaleFromValue = (colorList: { color: ColorKit; value: number }[], value: number) => {
     interface IRgbColor {
-        b: number; g: number;r: number;a?: number;
+        b: number; g: number; r: number; a?: number;
     }
     const prefixRgba = (rgb: IRgbColor): Required<IRgbColor> => {
         if (rgb.a !== undefined) {
@@ -286,4 +286,17 @@ export const getColorScaleFromValue = (colorList: { color: ColorKit;value: numbe
     } else {
         return colorList[colorList.length - 1].color.toRgbString();
     }
+};
+
+
+export const filterRange = (ranges: IRange[], maxRow: number, maxCol: number): IRange[] => {
+    return ranges.map((range) => {
+        if (range.startColumn > maxCol || range.startRow > maxRow) {
+            return null as unknown as IRange;
+        }
+        const _range = { ...range };
+        _range.endRow = Math.min(_range.endRow, maxRow);
+        _range.endColumn = Math.min(_range.endColumn, maxCol);
+        return _range;
+    }).filter((range) => !!range);
 };


### PR DESCRIPTION
Here's the corrected and improved version of your text:

"Establishing an extra-large conditional formatting region, then assessing whether the conditional formatting renders correctly.

The rationale for this modification is:

Assuming a subtable occupies a 10x10 region, but a 100x100 conditional formatting region has been configured. During computation, the conditional formatting should exclude the area exceeding the 10x10 region.

When setting an exceedingly large range on the panel, there is no need for an error message."