### PR TITLE
fix(sheet): cell custom supports updating from mutation

### DIFF
--- a/packages/core/src/types/interfaces/i-cell-data.ts
+++ b/packages/core/src/types/interfaces/i-cell-data.ts
@@ -60,7 +60,7 @@ export interface ICellData {
     /**
      * User stored custom fields
      */
-    custom?: { [key: string]: any };
+    custom?: Nullable<Record<string, any>>;
 }
 
 export interface ICellMarksStyle {

--- a/packages/sheets/src/commands/commands/__tests__/set-range-values.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-range-values.command.spec.ts
@@ -170,6 +170,51 @@ describe('Test set range values commands', () => {
                 expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
             });
 
+            it('will set range values when there is a selected range, includes custom property', async () => {
+                function getParams() {
+                    const params: ISetRangeValuesCommandParams = {
+                        value: {
+                            v: 'a1',
+                            custom: {
+                                id: 1,
+                            },
+                        },
+                    };
+
+                    return params;
+                }
+
+                function getResultParams() {
+                    const params: ISetRangeValuesCommandParams = {
+                        value: {
+                            v: 'a1',
+                            t: CellValueType.STRING,
+                            custom: {
+                                id: 1,
+                            },
+                        },
+                    };
+
+                    return params;
+                }
+
+                expect(await commandService.executeCommand(SetRangeValuesCommand.id, getParams())).toBeTruthy();
+                expect(getValue()).toStrictEqual(getResultParams().value);
+                // undo
+                expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
+                expect(getValue()).toStrictEqual({
+                    v: 'A1',
+                    t: CellValueType.STRING,
+                });
+
+                // redo
+                expect(await commandService.executeCommand(RedoCommand.id)).toBeTruthy();
+                expect(getValue()).toStrictEqual(getResultParams().value);
+
+                // reset
+                expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
+            });
+
             it('will tile all values when there is a selected range', async () => {
                 function getParams() {
                     const params: ISetRangeValuesCommandParams = {

--- a/packages/sheets/src/commands/mutations/set-range-values.mutation.ts
+++ b/packages/sheets/src/commands/mutations/set-range-values.mutation.ts
@@ -138,6 +138,10 @@ function setNull(value: Nullable<ICellData>) {
         value.s = null;
     }
 
+    if (value.custom === undefined) {
+        value.custom = null;
+    }
+
     return value;
 }
 
@@ -237,6 +241,10 @@ export const SetRangeValuesMutation: IMutation<ISetRangeValuesMutationParams, bo
                     if (!newVal.p && oldVal.p) {
                         mergeRichTextStyle(oldVal.p, newVal.s ? (newVal.s as Nullable<IStyleData>) : null);
                     }
+                }
+
+                if (newVal.custom !== undefined) {
+                    oldVal.custom = newVal.custom;
                 }
 
                 cellMatrix.setValue(row, col, Tools.removeNull(oldVal));
@@ -349,7 +357,7 @@ export function transformNormalKey(
     if (!newStyle || !Object.keys(newStyle).length) {
         return oldStyle;
     }
-    const backupStyle: { [key: string]: any } = oldStyle || {};
+    const backupStyle: Record<string, any> = oldStyle || {};
 
     for (const k in newStyle) {
         if (k === 'bd') {
@@ -402,7 +410,7 @@ export function mergeStyle(
     // don't operate
     if (newStyle === undefined) return oldStyle;
 
-    const backupStyle: { [key: string]: any } = Tools.deepClone(oldStyle) || {};
+    const backupStyle: Record<string, any> = Tools.deepClone(oldStyle) || {};
     if (!backupStyle) return;
     for (const k in newStyle) {
         if (isRichText && ['bd', 'tr', 'td', 'ht', 'vt', 'tb', 'pd'].includes(k)) {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->

<!-- A description of the proposed changes. -->
cell custom supports updating from mutation
<!-- How to test them. -->
如何测试？

打开浏览器控制台，打开Uniscript脚本编辑器，输入
```js
const range = univerAPI.getActiveWorkbook()?.getActiveSheet()?.getRange(1, 1, 1, 1);
if(range){
    range.setValue({
        v: 1,
        // custom 对象中可以放置任何 JSON 内容
        custom:{
            id: 1
        }
    })

    console.info(range.getCellData())
}
```

可以看到打印出的结果中包含自定义的数据即成功
![image](https://github.com/dream-num/univer/assets/26371161/17356d5f-5925-4f55-b3f6-8e293d915480)

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->
