### PR TITLE
ci:fix

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,7 +33,7 @@ jobs:
               run: pnpm build:e2e
 
             - name: Run Playwright Tests
-              run: pnpm exec playwright test
+              run: pnpm test:e2e
 
             - uses: actions/upload-artifact@v3
               if: always()


### PR DESCRIPTION
应该运行 pnpm test:e2e，而不是 pnpm exec playwright test

![CleanShot 2024-04-26 at 10 58 22@2x](https://github.com/dream-num/univer/assets/82451257/6d09e4ff-f23a-4775-8951-701170eef78c)
