### PR TITLE
fix(conditional-formatting): viewmodel interception is not required a…

### DIFF
--- a/packages/core/src/shared/after-init-apply.ts
+++ b/packages/core/src/shared/after-init-apply.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { merge, timer } from 'rxjs';
+import { debounceTime, filter, first } from 'rxjs/operators';
+import type { ICommandService } from '../services/command/command.service';
+import { CommandType } from '../services/command/command.service';
+import { fromCallback } from './rxjs';
+
+
+export const afterInitApply = (commandService: ICommandService) => {
+    return new Promise<void>((res) => {
+        merge(
+            fromCallback(commandService.onCommandExecuted).pipe(filter(([info]) => {
+                return info.type === CommandType.MUTATION;
+            })),
+            timer(300)
+        ).pipe(debounceTime(16), first()).subscribe(() => {
+            res();
+        });
+    });
+};

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -41,3 +41,4 @@ export * from './debounce';
 export * from './clipboard';
 export { queryObjectMatrix } from './object-matrix-query';
 export { moveRangeByOffset } from './range';
+export { afterInitApply } from './after-init-apply';

--- a/packages/sheets-conditional-formatting/src/services/__test__/cf.service.spec.ts
+++ b/packages/sheets-conditional-formatting/src/services/__test__/cf.service.spec.ts
@@ -26,6 +26,7 @@ describe('Test conditional formatting service', () => {
     beforeEach(() => {
         testBed && testBed.univer.dispose();
         testBed = createTestBed();
+        (testBed.getConditionalFormattingService() as any)._afterInitApplyPromise = Promise.resolve();
     });
 
     describe('Test highlight', () => {


### PR DESCRIPTION
1. In version 42, for example, 10 custom formula conditional formats were created. 
2. In version 50, snapshot save.
3. In version 51, remove 10 custom formula conditional format 
4. Other actions to version 70. 
5. When the user enters version 70, they will pull the CS of  50-70 and version of snapshot 50.
6. The snapshot of version 50 will have a conditional format, and when applying version 50-70,  deleting the 10 custom formulas.
7. Conditional formatting should not be triggered when applied