### PR TITLE
fix(sheet): save edit content when select other tab

### DIFF
--- a/packages/engine-formula/src/engine/value-object/primitive-object.ts
+++ b/packages/engine-formula/src/engine/value-object/primitive-object.ts
@@ -534,6 +534,11 @@ export class NumberValueObject extends BaseValueObject {
                 return ErrorValueObject.create(ErrorType.NUM);
             }
 
+            // Parameters in MOD caused an out of range error. Namely, the error occurs when the following is true: (divisor * 1125900000000) is less than or equal to dividend.
+            if (Math.abs(value) * 1125900000000 <= Math.abs(currentValue)) {
+                return ErrorValueObject.create(ErrorType.NUM);
+            }
+
             const result = mod(currentValue, value);
 
             if (!Number.isFinite(result)) {

--- a/packages/engine-formula/src/functions/date/date/index.ts
+++ b/packages/engine-formula/src/functions/date/date/index.ts
@@ -24,11 +24,11 @@ import { NullValueObject, NumberValueObject } from '../../../engine/value-object
 import { BaseFunction } from '../../base-function';
 
 export class DateFunction extends BaseFunction {
-    override calculate(year: BaseValueObject, month: BaseValueObject, day: BaseValueObject) {
-        if (year == null || month == null || day == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 3;
 
+    override maxParams = 3;
+
+    override calculate(year: BaseValueObject, month: BaseValueObject, day: BaseValueObject) {
         if (year.isError()) {
             return year;
         }

--- a/packages/engine-formula/src/functions/date/day/index.ts
+++ b/packages/engine-formula/src/functions/date/day/index.ts
@@ -22,11 +22,11 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Day extends BaseFunction {
-    override calculate(serialNumber: BaseValueObject) {
-        if (serialNumber == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(serialNumber: BaseValueObject) {
         if (serialNumber.isArray()) {
             return serialNumber.map((serialNumberObject) => this._handleSingleObject(serialNumberObject));
         }

--- a/packages/engine-formula/src/functions/date/edate/index.ts
+++ b/packages/engine-formula/src/functions/date/edate/index.ts
@@ -27,11 +27,11 @@ import { BaseFunction } from '../../base-function';
  * TODO@Dushusir: support plaine text date: =EDATE("2020-1-1",1), =EDATE("2020/1/1",1) and other formats
  */
 export class Edate extends BaseFunction {
-    override calculate(startDate: BaseValueObject, months: BaseValueObject) {
-        if (startDate == null || months == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 2;
 
+    override maxParams = 2;
+
+    override calculate(startDate: BaseValueObject, months: BaseValueObject) {
         if (startDate.isError()) {
             return startDate;
         }

--- a/packages/engine-formula/src/functions/date/month/index.ts
+++ b/packages/engine-formula/src/functions/date/month/index.ts
@@ -22,11 +22,11 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Month extends BaseFunction {
-    override calculate(serialNumber: BaseValueObject) {
-        if (serialNumber == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(serialNumber: BaseValueObject) {
         if (serialNumber.isArray()) {
             return serialNumber.map((serialNumberObject) => this._handleSingleObject(serialNumberObject));
         }

--- a/packages/engine-formula/src/functions/date/today/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/date/today/__tests__/index.spec.ts
@@ -18,8 +18,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { FUNCTION_NAMES_DATE } from '../../function-names';
 import { Today } from '../index';
-import { NumberValueObject } from '../../../../engine/value-object/primitive-object';
-import { ErrorType } from '../../../../basics/error-type';
 
 // mock new Date() use V
 const _Date = Date;
@@ -43,11 +41,6 @@ describe('Test today function', () => {
         it('Normal', () => {
             const result = textFunction.calculate();
             expect(result.getValue()).toBe(43831);
-        });
-
-        it('Set a parameter', () => {
-            const result = textFunction.calculate(NumberValueObject.create(1));
-            expect(result.getValue()).toBe(ErrorType.NA);
         });
     });
 });

--- a/packages/engine-formula/src/functions/date/today/index.ts
+++ b/packages/engine-formula/src/functions/date/today/index.ts
@@ -15,18 +15,16 @@
  */
 
 import { DEFAULT_DATE_FORMAT, excelDateSerial } from '../../../basics/date';
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Today extends BaseFunction {
-    override calculate(value?: BaseValueObject) {
-        if (value) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 0;
 
+    override maxParams = 0;
+
+    override calculate(value?: BaseValueObject) {
         const currentSerial = excelDateSerial(new Date());
         const valueObject = NumberValueObject.create(currentSerial);
         valueObject.setPattern(DEFAULT_DATE_FORMAT);

--- a/packages/engine-formula/src/functions/date/year/index.ts
+++ b/packages/engine-formula/src/functions/date/year/index.ts
@@ -22,11 +22,11 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Year extends BaseFunction {
-    override calculate(serialNumber: BaseValueObject) {
-        if (serialNumber == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(serialNumber: BaseValueObject) {
         if (serialNumber.isArray()) {
             return serialNumber.map((serialNumberObject) => this._handleSingleObject(serialNumberObject));
         }

--- a/packages/engine-formula/src/functions/information/isblank/index.ts
+++ b/packages/engine-formula/src/functions/information/isblank/index.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BooleanValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Isblank extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (value.isNull()) {
             return BooleanValueObject.create(true);
         } else if (value.isArray()) {

--- a/packages/engine-formula/src/functions/information/iserr/index.ts
+++ b/packages/engine-formula/src/functions/information/iserr/index.ts
@@ -16,16 +16,16 @@
 
 import { ErrorType } from '../../../basics/error-type';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BooleanValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Iserr extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (value.getValue() === ErrorType.NA) {
             return BooleanValueObject.create(false);
         }

--- a/packages/engine-formula/src/functions/information/iserror/index.ts
+++ b/packages/engine-formula/src/functions/information/iserror/index.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BooleanValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Iserror extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (value.isError()) {
             return BooleanValueObject.create(true);
         } else if (value.isArray()) {

--- a/packages/engine-formula/src/functions/information/iseven/__tests__/iseven.spec.ts
+++ b/packages/engine-formula/src/functions/information/iseven/__tests__/iseven.spec.ts
@@ -15,27 +15,26 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { FUNCTION_NAMES_INFORMATION } from '../function-names';
 
-import { BooleanValueObject, NumberValueObject, StringValueObject } from '../../../engine/value-object/primitive-object';
-import { ErrorType } from '../../../basics/error-type';
-import { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { Isodd } from './isodd';
+import { FUNCTION_NAMES_INFORMATION } from '../../function-names';
+import { BooleanValueObject, NumberValueObject, StringValueObject } from '../../../../engine/value-object/primitive-object';
+import { ErrorType } from '../../../../basics/error-type';
+import { ArrayValueObject } from '../../../../engine/value-object/array-value-object';
+import { Iseven } from '../iseven';
 
-
-describe('Test isodd function', () => {
-    const testFunction = new Isodd(FUNCTION_NAMES_INFORMATION.ISODD);
+describe('Test iseven function', () => {
+    const testFunction = new Iseven(FUNCTION_NAMES_INFORMATION.ISEVEN);
 
     it('should work with different kind of number values', () => {
-        expect(testFunction.calculate(NumberValueObject.create(-1)).getValue()).toBeTruthy();
-        expect(testFunction.calculate(NumberValueObject.create(2.5)).getValue()).toBeFalsy();
-        expect(testFunction.calculate(NumberValueObject.create(5)).getValue()).toBeTruthy();
-        expect(testFunction.calculate(NumberValueObject.create(0)).getValue()).toBeFalsy();
+        expect(testFunction.calculate(NumberValueObject.create(-1)).getValue()).toBeFalsy();
+        expect(testFunction.calculate(NumberValueObject.create(2.5)).getValue()).toBeTruthy();
+        expect(testFunction.calculate(NumberValueObject.create(5)).getValue()).toBeFalsy();
+        expect(testFunction.calculate(NumberValueObject.create(0)).getValue()).toBeTruthy();
     });
 
     it('should convert value first if is it not a number value', () => {
-        expect(testFunction.calculate(StringValueObject.create('123')).getValue()).toBeTruthy();
-        expect(testFunction.calculate(StringValueObject.create('122')).getValue()).toBeFalsy();
+        expect(testFunction.calculate(StringValueObject.create('123')).getValue()).toBeFalsy();
+        expect(testFunction.calculate(StringValueObject.create('122')).getValue()).toBeTruthy();
     });
 
     it('should throw error when value is not convertable to number', () => {

--- a/packages/engine-formula/src/functions/information/iseven/iseven.ts
+++ b/packages/engine-formula/src/functions/information/iseven/iseven.ts
@@ -21,11 +21,11 @@ import { BooleanValueObject } from '../../../engine/value-object/primitive-objec
 import { BaseFunction } from '../../base-function';
 
 export class Iseven extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (value.isArray() || value.isBoolean()) {
             return ErrorValueObject.create(ErrorType.VALUE);
         }

--- a/packages/engine-formula/src/functions/information/islogical/index.ts
+++ b/packages/engine-formula/src/functions/information/islogical/index.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BooleanValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Islogical extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (value.isBoolean()) {
             return BooleanValueObject.create(true);
         } else if (value.isArray()) {

--- a/packages/engine-formula/src/functions/information/isna/index.ts
+++ b/packages/engine-formula/src/functions/information/isna/index.ts
@@ -16,16 +16,16 @@
 
 import { ErrorType } from '../../../basics/error-type';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BooleanValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Isna extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (value.getValue() === ErrorType.NA) {
             return BooleanValueObject.create(true);
         } else if (value.isArray()) {

--- a/packages/engine-formula/src/functions/information/isnontext/index.ts
+++ b/packages/engine-formula/src/functions/information/isnontext/index.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BooleanValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Isnontext extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (!value.isArray() && !value.isString()) {
             return BooleanValueObject.create(true);
         } else if (value.isArray()) {

--- a/packages/engine-formula/src/functions/information/isnumber/index.ts
+++ b/packages/engine-formula/src/functions/information/isnumber/index.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BooleanValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Isnumber extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (value.isNumber()) {
             return BooleanValueObject.create(true);
         } else if (value.isArray()) {

--- a/packages/engine-formula/src/functions/information/isodd/__tests__/isodd.spec.ts
+++ b/packages/engine-formula/src/functions/information/isodd/__tests__/isodd.spec.ts
@@ -15,26 +15,27 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { FUNCTION_NAMES_INFORMATION } from '../../function-names';
 
-import { FUNCTION_NAMES_INFORMATION } from '../function-names';
-import { BooleanValueObject, NumberValueObject, StringValueObject } from '../../../engine/value-object/primitive-object';
-import { ErrorType } from '../../../basics/error-type';
-import { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { Iseven } from './iseven';
+import { BooleanValueObject, NumberValueObject, StringValueObject } from '../../../../engine/value-object/primitive-object';
+import { ErrorType } from '../../../../basics/error-type';
+import { ArrayValueObject } from '../../../../engine/value-object/array-value-object';
+import { Isodd } from '../isodd';
 
-describe('Test iseven function', () => {
-    const testFunction = new Iseven(FUNCTION_NAMES_INFORMATION.ISEVEN);
+
+describe('Test isodd function', () => {
+    const testFunction = new Isodd(FUNCTION_NAMES_INFORMATION.ISODD);
 
     it('should work with different kind of number values', () => {
-        expect(testFunction.calculate(NumberValueObject.create(-1)).getValue()).toBeFalsy();
-        expect(testFunction.calculate(NumberValueObject.create(2.5)).getValue()).toBeTruthy();
-        expect(testFunction.calculate(NumberValueObject.create(5)).getValue()).toBeFalsy();
-        expect(testFunction.calculate(NumberValueObject.create(0)).getValue()).toBeTruthy();
+        expect(testFunction.calculate(NumberValueObject.create(-1)).getValue()).toBeTruthy();
+        expect(testFunction.calculate(NumberValueObject.create(2.5)).getValue()).toBeFalsy();
+        expect(testFunction.calculate(NumberValueObject.create(5)).getValue()).toBeTruthy();
+        expect(testFunction.calculate(NumberValueObject.create(0)).getValue()).toBeFalsy();
     });
 
     it('should convert value first if is it not a number value', () => {
-        expect(testFunction.calculate(StringValueObject.create('123')).getValue()).toBeFalsy();
-        expect(testFunction.calculate(StringValueObject.create('122')).getValue()).toBeTruthy();
+        expect(testFunction.calculate(StringValueObject.create('123')).getValue()).toBeTruthy();
+        expect(testFunction.calculate(StringValueObject.create('122')).getValue()).toBeFalsy();
     });
 
     it('should throw error when value is not convertable to number', () => {

--- a/packages/engine-formula/src/functions/information/isodd/isodd.ts
+++ b/packages/engine-formula/src/functions/information/isodd/isodd.ts
@@ -21,11 +21,11 @@ import { BooleanValueObject } from '../../../engine/value-object/primitive-objec
 import { BaseFunction } from '../../base-function';
 
 export class Isodd extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (value.isArray() || value.isBoolean()) {
             return ErrorValueObject.create(ErrorType.VALUE);
         }

--- a/packages/engine-formula/src/functions/information/isref/index.ts
+++ b/packages/engine-formula/src/functions/information/isref/index.ts
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BooleanValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Isref extends BaseFunction {
+    override minParams = 1;
+
+    override maxParams = 1;
+
     override needsReferenceObject = true;
 
     override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (value.isReferenceObject()) {
             return BooleanValueObject.create(true);
         }

--- a/packages/engine-formula/src/functions/information/istext/index.ts
+++ b/packages/engine-formula/src/functions/information/istext/index.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BooleanValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Istext extends BaseFunction {
-    override calculate(value: BaseValueObject) {
-        if (value == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(value: BaseValueObject) {
         if (value.isString()) {
             return BooleanValueObject.create(true);
         } else if (value.isArray()) {

--- a/packages/engine-formula/src/functions/logical/and/index.ts
+++ b/packages/engine-formula/src/functions/logical/and/index.ts
@@ -21,11 +21,11 @@ import { BooleanValueObject } from '../../../engine/value-object/primitive-objec
 import { BaseFunction } from '../../base-function';
 
 export class And extends BaseFunction {
-    override calculate(...logicalValues: BaseValueObject[]) {
-        if (logicalValues.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...logicalValues: BaseValueObject[]) {
         let result = true;
         let noBoolean = true;
         let errorValue = null;

--- a/packages/engine-formula/src/functions/logical/if/index.ts
+++ b/packages/engine-formula/src/functions/logical/if/index.ts
@@ -22,11 +22,11 @@ import { BooleanValueObject, NullValueObject } from '../../../engine/value-objec
 import { BaseFunction } from '../../base-function';
 
 export class If extends BaseFunction {
-    override calculate(logicalTest: BaseValueObject, valueIfTrue: BaseValueObject, valueIfFalse: BaseValueObject = BooleanValueObject.create(false)) {
-        if (logicalTest == null || valueIfTrue == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 2;
 
+    override maxParams = 3;
+
+    override calculate(logicalTest: BaseValueObject, valueIfTrue: BaseValueObject, valueIfFalse: BaseValueObject = BooleanValueObject.create(false)) {
         if (logicalTest.isError()) {
             return logicalTest;
         }

--- a/packages/engine-formula/src/functions/logical/iferror/index.ts
+++ b/packages/engine-formula/src/functions/logical/iferror/index.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import { expandArrayValueObject } from '../../../engine/utils/array-object';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class Iferror extends BaseFunction {
-    override calculate(value: BaseValueObject, valueIfError: BaseValueObject) {
-        if (value == null || valueIfError == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 2;
 
+    override maxParams = 2;
+
+    override calculate(value: BaseValueObject, valueIfError: BaseValueObject) {
         if (value.isError()) {
             return value;
         }

--- a/packages/engine-formula/src/functions/logical/lambda/index.ts
+++ b/packages/engine-formula/src/functions/logical/lambda/index.ts
@@ -23,6 +23,10 @@ import { BaseFunction } from '../../base-function';
  * Please refer to the lambdaNode; here, it serves the purpose of a placeholder for the formula.
  */
 export class Lambda extends BaseFunction {
+    override minParams = 1;
+
+    override maxParams = 255;
+
     override calculate(...variants: BaseValueObject[]) {
         return ErrorValueObject.create(ErrorType.VALUE);
     }

--- a/packages/engine-formula/src/functions/logical/makearray/index.ts
+++ b/packages/engine-formula/src/functions/logical/makearray/index.ts
@@ -23,11 +23,11 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Makearray extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length !== 3) {
-            return ErrorValueObject.create(ErrorType.VALUE);
-        }
+    override minParams = 3;
 
+    override maxParams = 3;
+
+    override calculate(...variants: BaseValueObject[]) {
         const row = this.getIndexNumValue(variants[0]);
 
         if (typeof row !== 'number') {

--- a/packages/engine-formula/src/functions/logical/or/index.ts
+++ b/packages/engine-formula/src/functions/logical/or/index.ts
@@ -21,11 +21,11 @@ import { BooleanValueObject } from '../../../engine/value-object/primitive-objec
 import { BaseFunction } from '../../base-function';
 
 export class Or extends BaseFunction {
-    override calculate(...logicalValues: BaseValueObject[]) {
-        if (logicalValues.length === 0) {
-            return new ErrorValueObject(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...logicalValues: BaseValueObject[]) {
         let result = false;
         let noBoolean = true;
         let errorValue = null;

--- a/packages/engine-formula/src/functions/lookup/address/index.ts
+++ b/packages/engine-formula/src/functions/lookup/address/index.ts
@@ -24,6 +24,10 @@ import { StringValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Address extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 5;
+
     override calculate(
         rowNumber: BaseValueObject,
         columnNumber: BaseValueObject,
@@ -31,10 +35,6 @@ export class Address extends BaseFunction {
         a1?: BaseValueObject,
         sheetText?: BaseValueObject
     ) {
-        if (rowNumber == null || columnNumber == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (rowNumber.isError()) {
             return rowNumber;
         }

--- a/packages/engine-formula/src/functions/lookup/column/index.ts
+++ b/packages/engine-formula/src/functions/lookup/column/index.ts
@@ -22,6 +22,10 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Column extends BaseFunction {
+    override minParams = 0;
+
+    override maxParams = 1;
+
     override calculate(
         reference?: BaseValueObject
     ) {

--- a/packages/engine-formula/src/functions/lookup/columns/index.ts
+++ b/packages/engine-formula/src/functions/lookup/columns/index.ts
@@ -22,13 +22,13 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Columns extends BaseFunction {
-    override calculate(
-        reference?: BaseValueObject
-    ) {
-        if (reference == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(
+        reference: BaseValueObject
+    ) {
         if (reference.isError()) {
             return reference;
         }

--- a/packages/engine-formula/src/functions/lookup/hlookup/index.ts
+++ b/packages/engine-formula/src/functions/lookup/hlookup/index.ts
@@ -21,16 +21,16 @@ import { ErrorValueObject } from '../../../engine/value-object/base-value-object
 import { BaseFunction } from '../../base-function';
 
 export class Hlookup extends BaseFunction {
+    override minParams = 3;
+
+    override maxParams = 4;
+
     override calculate(
         lookupValue: BaseValueObject,
         tableArray: BaseValueObject,
         rowIndexNum: BaseValueObject,
         rangeLookup?: BaseValueObject
     ) {
-        if (lookupValue == null || tableArray == null || rowIndexNum == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (lookupValue.isError()) {
             return lookupValue;
         }

--- a/packages/engine-formula/src/functions/lookup/index/index.ts
+++ b/packages/engine-formula/src/functions/lookup/index/index.ts
@@ -29,13 +29,13 @@ import { BaseFunction } from '../../base-function';
  *
  */
 export class Index extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 4;
+
     override needsReferenceObject = true;
 
     override calculate(reference: FunctionVariantType, rowNum: FunctionVariantType, columnNum?: FunctionVariantType, areaNum?: FunctionVariantType) {
-        if (reference == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (reference.isError()) {
             return reference;
         }

--- a/packages/engine-formula/src/functions/lookup/index/index.ts
+++ b/packages/engine-formula/src/functions/lookup/index/index.ts
@@ -27,15 +27,17 @@ import { BaseFunction } from '../../base-function';
  *
  * =INDEX(A2:A5,2,1):A1 same as =A1:A3
  *
+ * We refer to Google Sheets and set both rowNum and columnNum to optional
+ *
  */
 export class Index extends BaseFunction {
-    override minParams = 2;
+    override minParams = 1;
 
     override maxParams = 4;
 
     override needsReferenceObject = true;
 
-    override calculate(reference: FunctionVariantType, rowNum: FunctionVariantType, columnNum?: FunctionVariantType, areaNum?: FunctionVariantType) {
+    override calculate(reference: FunctionVariantType, rowNum?: FunctionVariantType, columnNum?: FunctionVariantType, areaNum?: FunctionVariantType) {
         if (reference.isError()) {
             return reference;
         }

--- a/packages/engine-formula/src/functions/lookup/indirect/index.ts
+++ b/packages/engine-formula/src/functions/lookup/indirect/index.ts
@@ -29,15 +29,15 @@ import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-ob
 import { BaseFunction } from '../../base-function';
 
 export class Indirect extends BaseFunction {
+    override minParams = 1;
+
+    override maxParams = 2;
+
     override isAddress() {
         return true;
     }
 
     override calculate(refText: BaseValueObject, a1?: BaseValueObject) {
-        if (refText == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (refText.isError()) {
             return refText;
         }

--- a/packages/engine-formula/src/functions/lookup/lookup/index.ts
+++ b/packages/engine-formula/src/functions/lookup/lookup/index.ts
@@ -23,6 +23,10 @@ import { BaseFunction } from '../../base-function';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
 
 export class Lookup extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 3;
+
     override needsExpandParams = true;
 
     override calculate(
@@ -30,10 +34,6 @@ export class Lookup extends BaseFunction {
         lookupVectorOrArray: ArrayValueObject,
         resultVector?: BaseValueObject
     ) {
-        if (lookupValue == null || lookupVectorOrArray == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (lookupValue.isError()) {
             return lookupValue;
         }

--- a/packages/engine-formula/src/functions/lookup/match/index.ts
+++ b/packages/engine-formula/src/functions/lookup/match/index.ts
@@ -23,15 +23,15 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Match extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 3;
+
     override calculate(
         lookupValue: BaseValueObject,
         lookupArray: ArrayValueObject,
         matchType?: BaseValueObject
     ) {
-        if (lookupValue == null || lookupArray == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (lookupValue.isError()) {
             return lookupValue;
         }

--- a/packages/engine-formula/src/functions/lookup/offset/index.ts
+++ b/packages/engine-formula/src/functions/lookup/offset/index.ts
@@ -24,6 +24,10 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Offset extends BaseFunction {
+    override minParams = 3;
+
+    override maxParams = 5;
+
     override needsReferenceObject = true;
 
     override calculate(
@@ -33,10 +37,6 @@ export class Offset extends BaseFunction {
         height?: FunctionVariantType,
         width?: FunctionVariantType
     ) {
-        if (reference == null || rows == null || columns == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (reference.isError()) {
             return reference;
         }

--- a/packages/engine-formula/src/functions/lookup/row/index.ts
+++ b/packages/engine-formula/src/functions/lookup/row/index.ts
@@ -22,6 +22,10 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Row extends BaseFunction {
+    override minParams = 0;
+
+    override maxParams = 1;
+
     override calculate(
         reference?: BaseValueObject
     ) {

--- a/packages/engine-formula/src/functions/lookup/rows/index.ts
+++ b/packages/engine-formula/src/functions/lookup/rows/index.ts
@@ -22,13 +22,13 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Rows extends BaseFunction {
-    override calculate(
-        reference?: BaseValueObject
-    ) {
-        if (reference == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(
+        reference: BaseValueObject
+    ) {
         if (reference.isError()) {
             return reference;
         }

--- a/packages/engine-formula/src/functions/lookup/vlookup/index.ts
+++ b/packages/engine-formula/src/functions/lookup/vlookup/index.ts
@@ -25,16 +25,16 @@ import { BaseFunction } from '../../base-function';
 import { isSingleValueObject } from '../../../engine/utils/value-object';
 
 export class Vlookup extends BaseFunction {
+    override minParams = 3;
+
+    override maxParams = 4;
+
     override calculate(
         lookupValue: BaseValueObject,
         tableArray: BaseValueObject,
         colIndexNum: BaseValueObject,
         rangeLookup?: BaseValueObject
     ) {
-        if (lookupValue == null || tableArray == null || colIndexNum == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (lookupValue.isError()) {
             return lookupValue;
         }

--- a/packages/engine-formula/src/functions/lookup/xlookup/index.ts
+++ b/packages/engine-formula/src/functions/lookup/xlookup/index.ts
@@ -25,6 +25,10 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Xlookup extends BaseFunction {
+    override minParams = 3;
+
+    override maxParams = 6;
+
     override calculate(
         lookupValue: BaseValueObject,
         lookupArray: ArrayValueObject,
@@ -33,10 +37,6 @@ export class Xlookup extends BaseFunction {
         matchMode?: BaseValueObject,
         searchMode?: BaseValueObject
     ) {
-        if (lookupValue == null || lookupArray == null || returnArray == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (lookupValue.isError()) {
             return lookupValue;
         }

--- a/packages/engine-formula/src/functions/lookup/xmatch/index.ts
+++ b/packages/engine-formula/src/functions/lookup/xmatch/index.ts
@@ -26,16 +26,16 @@ import { BaseFunction } from '../../base-function';
 import { compareToken } from '../../../basics/token';
 
 export class Xmatch extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 4;
+
     override calculate(
         lookupValue: BaseValueObject,
         lookupArray: ArrayValueObject,
         matchMode?: BaseValueObject,
         searchMode?: BaseValueObject
     ) {
-        if (lookupValue == null || lookupArray == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (lookupValue.isError()) {
             return lookupValue;
         }

--- a/packages/engine-formula/src/functions/math/abs/index.ts
+++ b/packages/engine-formula/src/functions/math/abs/index.ts
@@ -20,11 +20,11 @@ import { ErrorValueObject } from '../../../engine/value-object/base-value-object
 import { BaseFunction } from '../../base-function';
 
 export class Abs extends BaseFunction {
-    override calculate(variant: BaseValueObject) {
-        if (variant == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(variant: BaseValueObject) {
         if (variant.isString()) {
             variant = variant.convertToNumberObjectValue();
         }

--- a/packages/engine-formula/src/functions/math/acos/index.ts
+++ b/packages/engine-formula/src/functions/math/acos/index.ts
@@ -20,11 +20,11 @@ import { ErrorValueObject } from '../../../engine/value-object/base-value-object
 import { BaseFunction } from '../../base-function';
 
 export class Acos extends BaseFunction {
-    override calculate(variant: BaseValueObject) {
-        if (variant == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(variant: BaseValueObject) {
         if (variant.isString()) {
             variant = variant.convertToNumberObjectValue();
         }

--- a/packages/engine-formula/src/functions/math/acosh/index.ts
+++ b/packages/engine-formula/src/functions/math/acosh/index.ts
@@ -20,11 +20,11 @@ import { ErrorValueObject } from '../../../engine/value-object/base-value-object
 import { BaseFunction } from '../../base-function';
 
 export class Acosh extends BaseFunction {
-    override calculate(variant: BaseValueObject) {
-        if (variant == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(variant: BaseValueObject) {
         if (variant.isString()) {
             variant = variant.convertToNumberObjectValue();
         }

--- a/packages/engine-formula/src/functions/math/acot/index.ts
+++ b/packages/engine-formula/src/functions/math/acot/index.ts
@@ -21,11 +21,11 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Acot extends BaseFunction {
-    override calculate(variant: BaseValueObject) {
-        if (variant == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(variant: BaseValueObject) {
         if (variant.isString()) {
             variant = variant.convertToNumberObjectValue();
         }

--- a/packages/engine-formula/src/functions/math/mod/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/math/mod/__tests__/index.spec.ts
@@ -32,6 +32,18 @@ describe('Test mod function', () => {
             const result = textFunction.calculate(number, power);
             expect(result.getValue()).toBe(1);
         });
+        it('Number is single cell, power is single cell, the number does not exceed the regulations', () => {
+            const number = NumberValueObject.create(1125899999999);
+            const power = NumberValueObject.create(1);
+            const result = textFunction.calculate(number, power);
+            expect(result.getValue()).toBe(0);
+        });
+        it('Number is single cell, power is single cell, the number exceeds the regulations', () => {
+            const number = NumberValueObject.create(1125900000000);
+            const power = NumberValueObject.create(1);
+            const result = textFunction.calculate(number, power);
+            expect(result.getValue()).toBe(ErrorType.NUM);
+        });
         it('Number is single string number, power is single string number', () => {
             const number = new StringValueObject('5');
             const power = new StringValueObject('2');

--- a/packages/engine-formula/src/functions/math/mod/index.ts
+++ b/packages/engine-formula/src/functions/math/mod/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class Mod extends BaseFunction {
-    override calculate(number: BaseValueObject, divisor: BaseValueObject) {
-        if (number == null || divisor == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 2;
 
+    override maxParams = 2;
+
+    override calculate(number: BaseValueObject, divisor: BaseValueObject) {
         if (number.isString()) {
             number = number.convertToNumberObjectValue();
         }

--- a/packages/engine-formula/src/functions/math/power/index.ts
+++ b/packages/engine-formula/src/functions/math/power/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class Power extends BaseFunction {
-    override calculate(number: BaseValueObject, power: BaseValueObject) {
-        if (number == null || power == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 2;
 
+    override maxParams = 2;
+
+    override calculate(number: BaseValueObject, power: BaseValueObject) {
         if (number.isString()) {
             number = number.convertToNumberObjectValue();
         }

--- a/packages/engine-formula/src/functions/math/product/index.ts
+++ b/packages/engine-formula/src/functions/math/product/index.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Product extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         let accumulatorAll: BaseValueObject = NumberValueObject.create(1);
         for (let i = 0; i < variants.length; i++) {
             let variant = variants[i];

--- a/packages/engine-formula/src/functions/math/product/index.ts
+++ b/packages/engine-formula/src/functions/math/product/index.ts
@@ -15,7 +15,7 @@
  */
 
 import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import type { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 

--- a/packages/engine-formula/src/functions/math/subtotal/index.ts
+++ b/packages/engine-formula/src/functions/math/subtotal/index.ts
@@ -53,19 +53,15 @@ enum FunctionNumIgnoreHidden {
 }
 
 export class Subtotal extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 255;
+
     override needsReferenceObject = true;
 
     override calculate(functionNum: FunctionVariantType, ...refs: FunctionVariantType[]) {
-        if (functionNum == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (functionNum.isError()) {
             return functionNum;
-        }
-
-        if (refs.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
         }
 
         if (functionNum.isReferenceObject()) {

--- a/packages/engine-formula/src/functions/math/sum/index.ts
+++ b/packages/engine-formula/src/functions/math/sum/index.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Sum extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         let accumulatorAll: BaseValueObject = NumberValueObject.create(0);
         for (let i = 0; i < variants.length; i++) {
             let variant = variants[i];

--- a/packages/engine-formula/src/functions/math/sumifs/index.ts
+++ b/packages/engine-formula/src/functions/math/sumifs/index.ts
@@ -23,15 +23,11 @@ import { ErrorValueObject } from '../../../engine/value-object/base-value-object
 import { BaseFunction } from '../../base-function';
 
 export class Sumifs extends BaseFunction {
+    override minParams = 3;
+
+    override maxParams = 255;
+
     override calculate(sumRange: BaseValueObject, ...variants: BaseValueObject[]) {
-        if (sumRange == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
-        if (variants.length < 2) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (sumRange.isError()) {
             return ErrorValueObject.create(ErrorType.NA);
         }

--- a/packages/engine-formula/src/functions/meta/compare/index.ts
+++ b/packages/engine-formula/src/functions/meta/compare/index.ts
@@ -19,6 +19,10 @@ import type { BaseValueObject } from '../../../engine/value-object/base-value-ob
 import { BaseFunction } from '../../base-function';
 
 export class Compare extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 2;
+
     private _compareType: compareToken = compareToken.EQUALS;
 
     setCompareType(token: compareToken) {

--- a/packages/engine-formula/src/functions/meta/cube/index.ts
+++ b/packages/engine-formula/src/functions/meta/cube/index.ts
@@ -22,11 +22,11 @@ import type { ArrayValueObject } from '../../../engine/value-object/array-value-
 import { CubeValueObject } from '../../../engine/value-object/cube-value-object';
 
 export class Cube extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.VALUE);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         const values: ArrayValueObject[] = [];
 
         for (let i = 0; i < variants.length; i++) {

--- a/packages/engine-formula/src/functions/meta/divided/index.ts
+++ b/packages/engine-formula/src/functions/meta/divided/index.ts
@@ -19,6 +19,10 @@ import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-ob
 import { BaseFunction } from '../../base-function';
 
 export class Divided extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 2;
+
     override calculate(variant1: BaseValueObject, variant2: BaseValueObject) {
         if (variant1.isError()) {
             return variant1;

--- a/packages/engine-formula/src/functions/meta/minus/index.ts
+++ b/packages/engine-formula/src/functions/meta/minus/index.ts
@@ -18,6 +18,10 @@ import type { BaseValueObject } from '../../../engine/value-object/base-value-ob
 import { BaseFunction } from '../../base-function';
 
 export class Minus extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 2;
+
     override calculate(variant1: BaseValueObject, variant2: BaseValueObject) {
         if (variant1.isError()) {
             return variant1;

--- a/packages/engine-formula/src/functions/meta/multiply/index.ts
+++ b/packages/engine-formula/src/functions/meta/multiply/index.ts
@@ -18,6 +18,10 @@ import type { BaseValueObject } from '../../../engine/value-object/base-value-ob
 import { BaseFunction } from '../../base-function';
 
 export class Multiply extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 2;
+
     override calculate(variant1: BaseValueObject, variant2: BaseValueObject) {
         if (variant1.isError()) {
             return variant1;

--- a/packages/engine-formula/src/functions/meta/plus/index.ts
+++ b/packages/engine-formula/src/functions/meta/plus/index.ts
@@ -18,6 +18,10 @@ import type { BaseValueObject } from '../../../engine/value-object/base-value-ob
 import { BaseFunction } from '../../base-function';
 
 export class Plus extends BaseFunction {
+    override minParams = 2;
+
+    override maxParams = 2;
+
     override calculate(variant1: BaseValueObject, variant2: BaseValueObject) {
         if (variant1.isError()) {
             return variant1;

--- a/packages/engine-formula/src/functions/statistical/average/index.ts
+++ b/packages/engine-formula/src/functions/statistical/average/index.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Average extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         let accumulatorSum: BaseValueObject = NumberValueObject.create(0);
         let accumulatorCount: BaseValueObject = NumberValueObject.create(0);
         for (let i = 0; i < variants.length; i++) {

--- a/packages/engine-formula/src/functions/statistical/count/index.ts
+++ b/packages/engine-formula/src/functions/statistical/count/index.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Count extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         let accumulatorAll: BaseValueObject = NumberValueObject.create(0);
         for (let i = 0; i < variants.length; i++) {
             const variant = variants[i];

--- a/packages/engine-formula/src/functions/statistical/counta/index.ts
+++ b/packages/engine-formula/src/functions/statistical/counta/index.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Counta extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         let accumulatorAll: BaseValueObject = NumberValueObject.create(0);
         for (let i = 0; i < variants.length; i++) {
             let variant = variants[i];

--- a/packages/engine-formula/src/functions/statistical/max/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/statistical/max/__tests__/index.spec.ts
@@ -120,5 +120,32 @@ describe('Test max function', () => {
             const result = textFunction.calculate(var1, var2);
             expect(result.getValue()).toBe(100);
         });
+
+        it('Var1 is array, var2 is array', () => {
+            const var1 = ArrayValueObject.create({
+                calculateValueList: transformToValueObject([
+                    [null],
+                ]),
+                rowCount: 1,
+                columnCount: 1,
+                unitId: '',
+                sheetId: '',
+                row: 0,
+                column: 0,
+            });
+            const var2 = ArrayValueObject.create({
+                calculateValueList: transformToValueObject([
+                    ['a'],
+                ]),
+                rowCount: 1,
+                columnCount: 1,
+                unitId: '',
+                sheetId: '',
+                row: 0,
+                column: 0,
+            });
+            const result = textFunction.calculate(var1, var2);
+            expect(result.getValue()).toBe(0);
+        });
     });
 });

--- a/packages/engine-formula/src/functions/statistical/max/index.ts
+++ b/packages/engine-formula/src/functions/statistical/max/index.ts
@@ -24,8 +24,7 @@ export class Max extends BaseFunction {
     override maxParams = 255;
 
     override calculate(...variants: BaseValueObject[]) {
-        // Don't use Number.NEGATIVE_INFINITY, the maximum value of a string and a blank cell should be 0
-        let accumulatorAll: BaseValueObject = NumberValueObject.create(0);
+        let accumulatorAll: BaseValueObject = NumberValueObject.create(Number.NEGATIVE_INFINITY);
         for (let i = 0; i < variants.length; i++) {
             let variant = variants[i];
 
@@ -46,6 +45,10 @@ export class Max extends BaseFunction {
             }
 
             accumulatorAll = this._validator(accumulatorAll, variant as BaseValueObject);
+        }
+
+        if (accumulatorAll.getValue() === Number.NEGATIVE_INFINITY) {
+            return NumberValueObject.create(0);
         }
 
         return accumulatorAll;

--- a/packages/engine-formula/src/functions/statistical/max/index.ts
+++ b/packages/engine-formula/src/functions/statistical/max/index.ts
@@ -24,7 +24,8 @@ export class Max extends BaseFunction {
     override maxParams = 255;
 
     override calculate(...variants: BaseValueObject[]) {
-        let accumulatorAll: BaseValueObject = NumberValueObject.create(Number.NEGATIVE_INFINITY);
+        // Don't use Number.NEGATIVE_INFINITY, the maximum value of a string and a blank cell should be 0
+        let accumulatorAll: BaseValueObject = NumberValueObject.create(0);
         for (let i = 0; i < variants.length; i++) {
             let variant = variants[i];
 

--- a/packages/engine-formula/src/functions/statistical/max/index.ts
+++ b/packages/engine-formula/src/functions/statistical/max/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 

--- a/packages/engine-formula/src/functions/statistical/max/index.ts
+++ b/packages/engine-formula/src/functions/statistical/max/index.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
-import { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { type BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Max extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         let accumulatorAll: BaseValueObject = NumberValueObject.create(Number.NEGATIVE_INFINITY);
         for (let i = 0; i < variants.length; i++) {
             let variant = variants[i];

--- a/packages/engine-formula/src/functions/statistical/maxifs/index.ts
+++ b/packages/engine-formula/src/functions/statistical/maxifs/index.ts
@@ -23,15 +23,11 @@ import { ErrorValueObject } from '../../../engine/value-object/base-value-object
 import { BaseFunction } from '../../base-function';
 
 export class Maxifs extends BaseFunction {
+    override minParams = 3;
+
+    override maxParams = 255;
+
     override calculate(maxRange: BaseValueObject, ...variants: BaseValueObject[]) {
-        if (maxRange === null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
-        if (variants.length < 2) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
-
         if (maxRange.isError()) {
             return ErrorValueObject.create(ErrorType.NA);
         }

--- a/packages/engine-formula/src/functions/statistical/min/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/statistical/min/__tests__/index.spec.ts
@@ -120,5 +120,31 @@ describe('Test min function', () => {
             const result = textFunction.calculate(var1, var2);
             expect(result.getValue()).toBe(-3);
         });
+        it('Var1 is array, var2 is array', () => {
+            const var1 = ArrayValueObject.create({
+                calculateValueList: transformToValueObject([
+                    [null],
+                ]),
+                rowCount: 1,
+                columnCount: 1,
+                unitId: '',
+                sheetId: '',
+                row: 0,
+                column: 0,
+            });
+            const var2 = ArrayValueObject.create({
+                calculateValueList: transformToValueObject([
+                    ['a'],
+                ]),
+                rowCount: 1,
+                columnCount: 1,
+                unitId: '',
+                sheetId: '',
+                row: 0,
+                column: 0,
+            });
+            const result = textFunction.calculate(var1, var2);
+            expect(result.getValue()).toBe(0);
+        });
     });
 });

--- a/packages/engine-formula/src/functions/statistical/min/index.ts
+++ b/packages/engine-formula/src/functions/statistical/min/index.ts
@@ -24,7 +24,8 @@ export class Min extends BaseFunction {
     override maxParams = 255;
 
     override calculate(...variants: BaseValueObject[]) {
-        let accumulatorAll: BaseValueObject = NumberValueObject.create(Number.POSITIVE_INFINITY);
+        // Don't use Number.POSITIVE_INFINITY, the minimum value of a string and a blank cell should be 0
+        let accumulatorAll: BaseValueObject = NumberValueObject.create(0);
         for (let i = 0; i < variants.length; i++) {
             let variant = variants[i];
 

--- a/packages/engine-formula/src/functions/statistical/min/index.ts
+++ b/packages/engine-formula/src/functions/statistical/min/index.ts
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
-import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
+import type { BaseValueObject, ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
 
 export class Min extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         let accumulatorAll: BaseValueObject = NumberValueObject.create(Number.POSITIVE_INFINITY);
         for (let i = 0; i < variants.length; i++) {
             let variant = variants[i];

--- a/packages/engine-formula/src/functions/statistical/min/index.ts
+++ b/packages/engine-formula/src/functions/statistical/min/index.ts
@@ -24,8 +24,7 @@ export class Min extends BaseFunction {
     override maxParams = 255;
 
     override calculate(...variants: BaseValueObject[]) {
-        // Don't use Number.POSITIVE_INFINITY, the minimum value of a string and a blank cell should be 0
-        let accumulatorAll: BaseValueObject = NumberValueObject.create(0);
+        let accumulatorAll: BaseValueObject = NumberValueObject.create(Number.POSITIVE_INFINITY);
         for (let i = 0; i < variants.length; i++) {
             let variant = variants[i];
 
@@ -46,6 +45,10 @@ export class Min extends BaseFunction {
             }
 
             accumulatorAll = this._validator(accumulatorAll, variant as BaseValueObject);
+        }
+
+        if (accumulatorAll.getValue() === Number.POSITIVE_INFINITY) {
+            return NumberValueObject.create(0);
         }
 
         return accumulatorAll;

--- a/packages/engine-formula/src/functions/statistical/stdev-p/index.ts
+++ b/packages/engine-formula/src/functions/statistical/stdev-p/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class StdevP extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         const flattenArray = this.flattenArray(variants);
 
         if (flattenArray.isError()) {

--- a/packages/engine-formula/src/functions/statistical/stdev-s/index.ts
+++ b/packages/engine-formula/src/functions/statistical/stdev-s/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class StdevS extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         const flattenArray = this.flattenArray(variants);
 
         if (flattenArray.isError()) {

--- a/packages/engine-formula/src/functions/statistical/stdeva/index.ts
+++ b/packages/engine-formula/src/functions/statistical/stdeva/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class Stdeva extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         const flattenArray = this.flattenArray(variants, false);
 
         if (flattenArray.isError()) {

--- a/packages/engine-formula/src/functions/statistical/stdevpa/index.ts
+++ b/packages/engine-formula/src/functions/statistical/stdevpa/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class Stdevpa extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         const flattenArray = this.flattenArray(variants, false);
 
         if (flattenArray.isError()) {

--- a/packages/engine-formula/src/functions/statistical/var-p/index.ts
+++ b/packages/engine-formula/src/functions/statistical/var-p/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class VarP extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         const flattenArray = this.flattenArray(variants);
 
         if (flattenArray.isError()) {

--- a/packages/engine-formula/src/functions/statistical/var-s/index.ts
+++ b/packages/engine-formula/src/functions/statistical/var-s/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class VarS extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         const flattenArray = this.flattenArray(variants);
 
         if (flattenArray.isError()) {

--- a/packages/engine-formula/src/functions/statistical/vara/index.ts
+++ b/packages/engine-formula/src/functions/statistical/vara/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class Vara extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         const flattenArray = this.flattenArray(variants, false);
 
         if (flattenArray.isError()) {

--- a/packages/engine-formula/src/functions/statistical/varpa/index.ts
+++ b/packages/engine-formula/src/functions/statistical/varpa/index.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
-import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { BaseFunction } from '../../base-function';
 
 export class Varpa extends BaseFunction {
-    override calculate(...variants: BaseValueObject[]) {
-        if (variants.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...variants: BaseValueObject[]) {
         const flattenArray = this.flattenArray(variants, false);
 
         if (flattenArray.isError()) {

--- a/packages/engine-formula/src/functions/text/concatenate/index.ts
+++ b/packages/engine-formula/src/functions/text/concatenate/index.ts
@@ -23,11 +23,11 @@ import { createStringValueObjectByRawValue } from '../../../engine/value-object/
 import { BaseFunction } from '../../base-function';
 
 export class Concatenate extends BaseFunction {
-    override calculate(...textValues: BaseValueObject[]) {
-        if (textValues.length === 0) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 255;
+
+    override calculate(...textValues: BaseValueObject[]) {
         let maxRowLength = 0;
         let maxColumnLength = 0;
 

--- a/packages/engine-formula/src/functions/text/len/index.ts
+++ b/packages/engine-formula/src/functions/text/len/index.ts
@@ -20,11 +20,11 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Len extends BaseFunction {
-    override calculate(text: BaseValueObject) {
-        if (text == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(text: BaseValueObject) {
         if (text.isError()) {
             return text;
         }

--- a/packages/engine-formula/src/functions/text/lenb/index.ts
+++ b/packages/engine-formula/src/functions/text/lenb/index.ts
@@ -21,11 +21,11 @@ import { NumberValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Lenb extends BaseFunction {
-    override calculate(text: BaseValueObject) {
-        if (text == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(text: BaseValueObject) {
         if (text.isError()) {
             return text;
         }

--- a/packages/engine-formula/src/functions/text/lower/index.ts
+++ b/packages/engine-formula/src/functions/text/lower/index.ts
@@ -20,11 +20,11 @@ import { StringValueObject } from '../../../engine/value-object/primitive-object
 import { BaseFunction } from '../../base-function';
 
 export class Lower extends BaseFunction {
-    override calculate(text: BaseValueObject) {
-        if (text == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 1;
 
+    override maxParams = 1;
+
+    override calculate(text: BaseValueObject) {
         if (text.isError()) {
             return text;
         }

--- a/packages/engine-formula/src/functions/text/text/index.ts
+++ b/packages/engine-formula/src/functions/text/text/index.ts
@@ -23,11 +23,11 @@ import { NumberValueObject, StringValueObject } from '../../../engine/value-obje
 import { BaseFunction } from '../../base-function';
 
 export class Text extends BaseFunction {
-    override calculate(text: BaseValueObject, formatText: BaseValueObject) {
-        if (text == null || formatText == null) {
-            return ErrorValueObject.create(ErrorType.NA);
-        }
+    override minParams = 2;
 
+    override maxParams = 2;
+
+    override calculate(text: BaseValueObject, formatText: BaseValueObject) {
         if (text.isError()) {
             return text;
         }

--- a/packages/sheets-filter/src/services/sheet-filter.service.ts
+++ b/packages/sheets-filter/src/services/sheet-filter.service.ts
@@ -147,7 +147,7 @@ export class SheetsFilterService extends Disposable {
                 fromCallback(this._commandService.onCommandExecuted)
                     .pipe(filter(([command]) => command.type === CommandType.MUTATION && FILTER_MUTATIONS.has(command.id))),
 
-                // source2: activte sheet changes
+                // source2: activate sheet changes
                 this._univerInstanceService.getCurrentTypeOfUnit$<Workbook>(UniverInstanceType.UNIVER_SHEET)
                     .pipe(switchMap((workbook) => workbook?.activeSheet$ ?? of(null)))
             ).subscribe(() => this._updateActiveFilterModel()));

--- a/packages/sheets-formula/src/locale/function-list/logical/zh-CN.ts
+++ b/packages/sheets-formula/src/locale/function-list/logical/zh-CN.ts
@@ -173,8 +173,8 @@ export default {
             },
         ],
         functionParameter: {
-            number1: { name: 'rows', detail: '数组中的行数。 必须大于零' },
-            number2: { name: 'cols', detail: '数组中的列数。 必须大于零' },
+            number1: { name: '行数', detail: '数组中的行数。 必须大于零' },
+            number2: { name: '列数', detail: '数组中的列数。 必须大于零' },
             value3: {
                 name: 'lambda',
                 detail: '调用 LAMBDA 来创建数组。 LAMBDA 接受两个参数:row数组的行索引, col数组的列索引',

--- a/packages/sheets-formula/src/services/function-list/logical.ts
+++ b/packages/sheets-formula/src/services/function-list/logical.ts
@@ -210,7 +210,7 @@ export const FUNCTION_LIST_LOGICAL: IFunctionInfo[] = [
                 name: 'formula.functionList.LAMBDA.functionParameter.parameter.name',
                 detail: 'formula.functionList.LAMBDA.functionParameter.parameter.detail',
                 example: '[x, y, …,]',
-                require: 1,
+                require: 0,
                 repeat: 1,
             },
             {

--- a/packages/sheets-formula/src/services/function-list/lookup.ts
+++ b/packages/sheets-formula/src/services/function-list/lookup.ts
@@ -407,7 +407,7 @@ export const FUNCTION_LIST_LOOKUP: IFunctionInfo[] = [
                 name: 'formula.functionList.INDEX.functionParameter.rowNum.name',
                 detail: 'formula.functionList.INDEX.functionParameter.rowNum.detail',
                 example: '1',
-                require: 1,
+                require: 0,
                 repeat: 0,
             },
             {

--- a/packages/sheets-formula/src/services/utils.ts
+++ b/packages/sheets-formula/src/services/utils.ts
@@ -15,7 +15,7 @@
  */
 
 import type { LocaleService } from '@univerjs/core';
-import type { IFunctionInfo } from '@univerjs/engine-formula';
+import type { IFunctionInfo, IFunctionParam } from '@univerjs/engine-formula';
 
 export function getFunctionTypeValues(
     enumObj: any,
@@ -42,4 +42,16 @@ export function getFunctionName(item: IFunctionInfo, localeService: LocaleServic
     }
 
     return functionName;
+}
+
+export function generateParam(param: IFunctionParam) {
+    if (!param.require && !param.repeat) {
+        return `[${param.name}]`;
+    } else if (param.require && !param.repeat) {
+        return param.name;
+    } else if (!param.require && param.repeat) {
+        return `[${param.name},...]`;
+    } else if (param.require && param.repeat) {
+        return `${param.name},...`;
+    }
 }

--- a/packages/sheets-formula/src/views/more-functions/function-help/FunctionHelp.tsx
+++ b/packages/sheets-formula/src/views/more-functions/function-help/FunctionHelp.tsx
@@ -16,14 +16,30 @@
 
 import type { IFunctionParam } from '@univerjs/engine-formula';
 import React from 'react';
+import { generateParam } from '../../../services/utils';
 
 interface IFunctionHelpProps {
     prefix?: string;
     value?: IFunctionParam[];
 }
 
+/**
+ * Determine the parameter format
+ * ┌─────────┬────────┬─────────────┐
+ * │ Require │ Repeat │  Parameter  │
+ * ├─────────┼────────┼─────────────┤
+ * │ 0       │ 0      │ [Number]    │
+ * │ 1       │ 0      │ Number      │
+ * │ 0       │ 1      │ [Number,...] │
+ * │ 1       │ 1      │ Number,...   │
+ * └─────────┴────────┴─────────────┘
+ *
+ * @param props
+ * @returns
+ */
 export function FunctionHelp(props: IFunctionHelpProps) {
     const { prefix, value } = props;
+
     return (
         <div>
             <span>
@@ -33,7 +49,7 @@ export function FunctionHelp(props: IFunctionHelpProps) {
             {value &&
                 value.map((item: IFunctionParam, i: number) => (
                     <span key={i}>
-                        <span>{item.repeat ? `[${item.name},...]` : item.name}</span>
+                        <span>{generateParam(item)}</span>
                         {i === value.length - 1 ? '' : ','}
                     </span>
                 ))}

--- a/packages/sheets-formula/src/views/prompt/help-function/HelpFunction.tsx
+++ b/packages/sheets-formula/src/views/prompt/help-function/HelpFunction.tsx
@@ -24,6 +24,7 @@ import React, { useEffect, useState } from 'react';
 import { IEditorService } from '@univerjs/ui';
 import type { IHelpFunctionOperationParams } from '../../../services/prompt.service';
 import { IFormulaPromptService } from '../../../services/prompt.service';
+import { generateParam } from '../../../services/utils';
 import styles from './index.module.less';
 
 export function HelpFunction() {
@@ -213,7 +214,7 @@ const Help = (props: IHelpProps) => {
                             className={active === i ? styles.formulaHelpFunctionActive : styles.formulaHelpParamActive}
                             onClick={() => onClick(i)}
                         >
-                            {item.repeat ? `[${item.name},...]` : item.name}
+                            {generateParam(item)}
                         </span>
                         {i === value.length - 1 ? '' : ','}
                     </span>

--- a/packages/sheets-ui/src/controllers/editor/end-edit.controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/end-edit.controller.ts
@@ -218,7 +218,8 @@ export class EndEditController extends Disposable {
                  * When closing the editor, switch to the current tab of the editor.
                  */
                 if (workbookId === unitId && sheetId !== worksheetId && this._editorBridgeService.isForceKeepVisible()) {
-                    this._commandService.executeCommand(SetWorksheetActivateCommand.id, {
+                    // SetWorksheetActivateCommand handler uses Promise
+                    await this._commandService.executeCommand(SetWorksheetActivateCommand.id, {
                         subUnitId: sheetId,
                         unitId,
                     });


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->

- [x] 修复选择公式范围时切换到其他工作表，保存数据到了其他工作表问题
如何测试？
1. 新建两个空白工作表 ：工作表1，工作表2
2. 在 工作表1 的 A1单元格编辑 `=`，切换到 工作表2 选择 B1 范围
3. Enter 确定，此时自动切换回 工作表1，并且 A1 的内容更新为 `=工作表2!B1`（之前是数据保存到了 工作表2，[Univer Preview](https://univer-preview.vercel.app/sheets/)）

- [x] 补齐了所有公式参数数量报错提示
如何测试？
比如测试 OFFSET，少于 3 个或者大于 5 个参数都需要报 #N/A 错误。其他公式同理（暂不包含其他类型的错误）

<!-- A description of the proposed changes. -->

<!-- How to test them. -->


<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->
