### PR TITLE
feat(facade): add sheet hooks, onCellPointerMove hook

### DIFF
--- a/packages/facade/src/apis/__tests__/create-test-bed.ts
+++ b/packages/facade/src/apis/__tests__/create-test-bed.ts
@@ -102,6 +102,7 @@ export interface ITestBed {
     get: Injector['get'];
     sheet: UnitModel<Workbook>;
     univerAPI: FUniver;
+    injector: Injector;
 }
 
 export function createTestBed(workbookData?: IWorkbookData, dependencies?: Dependency[]): ITestBed {
@@ -172,5 +173,6 @@ export function createTestBed(workbookData?: IWorkbookData, dependencies?: Depen
         get: injector.get.bind(injector),
         sheet,
         univerAPI,
+        injector,
     };
 }

--- a/packages/facade/src/apis/facade.ts
+++ b/packages/facade/src/apis/facade.ts
@@ -40,6 +40,7 @@ import { SHEET_VIEW_KEY } from '@univerjs/sheets-ui';
 import { SetFormulaCalculationStartMutation } from '@univerjs/engine-formula';
 import { FDocument } from './docs/f-document';
 import { FWorkbook } from './sheets/f-workbook';
+import { FSheetHooks } from './sheets/f-sheet-hooks';
 
 export class FUniver {
     /**
@@ -310,6 +311,14 @@ export class FUniver {
         }
 
         return ws;
+    }
+
+    /**
+     * Get sheet hooks
+     * @returns
+     */
+    getSheetHooks() {
+        return this._injector.createInstance(FSheetHooks);
     }
 
     /**

--- a/packages/facade/src/apis/sheets/__tests__/f-sheet-hooks.spec.ts
+++ b/packages/facade/src/apis/sheets/__tests__/f-sheet-hooks.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ICellData, IStyleData, Nullable, UnitModel, Workbook } from '@univerjs/core';
+import { ICommandService, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
+import { SetHorizontalTextAlignCommand, SetRangeValuesCommand, SetRangeValuesMutation, SetStyleCommand, SetTextWrapCommand, SetVerticalTextAlignCommand } from '@univerjs/sheets';
+import type { Injector } from '@wendellhu/redi';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Subject } from 'rxjs';
+
+import type { IHoverCellPosition } from '@univerjs/sheets-ui';
+import { HoverManagerService } from '@univerjs/sheets-ui';
+import type { FUniver } from '../../facade';
+import { createTestBed } from '../../__tests__/create-test-bed';
+import { FSheetHooks } from '../f-sheet-hooks';
+
+describe('Test FSheetHooks', () => {
+    let get: Injector['get'];
+    let injector: Injector;
+    let commandService: ICommandService;
+    let univerAPI: FUniver;
+    let sheet: UnitModel<Workbook>;
+    let getValueByPosition: (
+        startRow: number,
+        startColumn: number,
+        endRow: number,
+        endColumn: number
+    ) => Nullable<ICellData>;
+    let getStyleByPosition: (
+        startRow: number,
+        startColumn: number,
+        endRow: number,
+        endColumn: number
+    ) => Nullable<IStyleData>;
+    let mockHoverManagerService: Partial<HoverManagerService>;
+    let currentCell$: Subject<Nullable<IHoverCellPosition>>;
+    let sheetHooks: FSheetHooks;
+    let workbook: Workbook;
+
+    beforeEach(() => {
+        // Initialize the subject
+        currentCell$ = new Subject<Nullable<IHoverCellPosition>>();
+
+        // Create a mock HoverManagerService with currentCell$
+        mockHoverManagerService = {
+            currentCell$: currentCell$.asObservable(),
+        };
+
+        const testBed = createTestBed(undefined, [
+            [HoverManagerService, { useValue: mockHoverManagerService }],
+        ]);
+        get = testBed.get;
+        injector = testBed.injector;
+        univerAPI = testBed.univerAPI;
+        sheet = testBed.sheet;
+        workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+
+        commandService = get(ICommandService);
+        commandService.registerCommand(SetRangeValuesCommand);
+        commandService.registerCommand(SetRangeValuesMutation);
+        commandService.registerCommand(SetStyleCommand);
+        commandService.registerCommand(SetVerticalTextAlignCommand);
+        commandService.registerCommand(SetHorizontalTextAlignCommand);
+        commandService.registerCommand(SetTextWrapCommand);
+
+        getValueByPosition = (
+            startRow: number,
+            startColumn: number,
+            endRow: number,
+            endColumn: number
+        ): Nullable<ICellData> =>
+            get(IUniverInstanceService)
+                .getUniverSheetInstance('test')
+                ?.getSheetBySheetId('sheet1')
+                ?.getRange(startRow, startColumn, endRow, endColumn)
+                .getValue();
+
+        getStyleByPosition = (
+            startRow: number,
+            startColumn: number,
+            endRow: number,
+            endColumn: number
+        ): Nullable<IStyleData> => {
+            const value = getValueByPosition(startRow, startColumn, endRow, endColumn);
+            const styles = get(IUniverInstanceService).getUniverSheetInstance('test')?.getStyles();
+            if (value && styles) {
+                return styles.getStyleByCell(value);
+            }
+        };
+
+        sheetHooks = injector.createInstance(FSheetHooks);
+    });
+
+    it('Test onCellPointerMove', () => {
+        sheetHooks.onCellPointerMove((cellPos) => {
+            expect(cellPos).toEqual({ location: { workbook, worksheet, unitId: workbook.getUnitId(), subUnitId: worksheet.getSheetId(), row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 } });
+        });
+
+        // Trigger the Observable to emit a new value
+        const worksheet = workbook.getActiveSheet();
+        const unitId = workbook.getUnitId();
+        const subUnitId = worksheet.getSheetId();
+        currentCell$.next({ location: { workbook, worksheet, unitId, subUnitId, row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 } });
+    });
+});

--- a/packages/facade/src/apis/sheets/f-sheet-hooks.ts
+++ b/packages/facade/src/apis/sheets/f-sheet-hooks.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type Nullable, toDisposable } from '@univerjs/core';
+import type { IDisposable } from '@wendellhu/redi';
+import { Inject } from '@wendellhu/redi';
+
+import type { IHoverCellPosition } from '@univerjs/sheets-ui';
+import { HoverManagerService } from '@univerjs/sheets-ui';
+
+export class FSheetHooks {
+    constructor(
+        @Inject(HoverManagerService) private readonly _hoverManagerService: HoverManagerService
+    ) { }
+
+    /**
+     * Subscribe to the location information of the currently hovered cell
+     * @returns
+     */
+    onCellPointerMove(callback: (cellPos: Nullable<IHoverCellPosition>) => void): IDisposable {
+        return toDisposable(this._hoverManagerService.currentCell$.subscribe(callback));
+    }
+}

--- a/packages/sheets-ui/src/index.ts
+++ b/packages/sheets-ui/src/index.ts
@@ -88,3 +88,4 @@ export { mergeSetRangeValues } from './services/clipboard/utils';
 export type { IAutoFillLocation } from './services/auto-fill/type';
 export type { IDiscreteRange } from './controllers/utils/range-tools';
 export { virtualizeDiscreteRanges, rangeToDiscreteRange } from './controllers/utils/range-tools';
+export { type IHoverCellPosition } from './services/hover-manager.service';


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->

close #1176
close #1425
<!-- A description of the proposed changes. -->
通过监听 HoverManagerService 的 currentCell 变化来抛出当前单元格信息，便于用户在外部做拖拽放置
<!-- How to test them. -->

如何测试？
1. 打开uniscript
2. 粘贴以下代码，运行
  ```js
window.univerAPI.getSheetHooks().onCellPointerMove((cell) => {
    const { location, position } = cell
    window.univerAPI?.getActiveWorkbook()?.getActiveSheet()?.getRange(location.row, location.col)?.setBackgroundColor('red');
})
  ```
3. 鼠标在sheet区域内移动，会将经过的单元格设置为红色背景
<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->
