### PR TITLE
feat(render-engine): facade adds onCellPointerOver,onCellDragOver,onCellDrop

### DIFF
--- a/examples/public/sheets/index.html
+++ b/examples/public/sheets/index.html
@@ -24,7 +24,10 @@
     </head>
 
     <body style="overflow: hidden">
-        <div id="app" style="height: 100%"></div>
+        <button draggable="true" title="draggable" style="height: 30px">
+            button
+        </button>
+        <div id="app" style="height: 80%"></div>
 
         <script src="./main.js"></script>
     </body>

--- a/examples/public/sheets/index.html
+++ b/examples/public/sheets/index.html
@@ -24,10 +24,7 @@
     </head>
 
     <body style="overflow: hidden">
-        <button draggable="true" title="draggable" style="height: 30px">
-            button
-        </button>
-        <div id="app" style="height: 80%"></div>
+        <div id="app" style="height: 100%"></div>
 
         <script src="./main.js"></script>
     </body>

--- a/packages/engine-render/src/base-object.ts
+++ b/packages/engine-render/src/base-object.ts
@@ -19,7 +19,7 @@ import { Disposable, Observable } from '@univerjs/core';
 
 import type { EVENT_TYPE } from './basics/const';
 import { CURSOR_TYPE, RENDER_CLASS_TYPE } from './basics/const';
-import type { IMouseEvent, IPointerEvent, IWheelEvent } from './basics/i-events';
+import type { IDragEvent, IMouseEvent, IPointerEvent, IWheelEvent } from './basics/i-events';
 import type { IObjectFullState, ITransformChangeState } from './basics/interfaces';
 import { TRANSFORM_CHANGE_OBSERVABLE_TYPE } from './basics/interfaces';
 import { generateRandomKey, toPx } from './basics/tools';
@@ -71,6 +71,14 @@ export abstract class BaseObject extends Disposable {
     onPointerOverObserver = new Observable<IPointerEvent | IMouseEvent>();
 
     onPointerEnterObserver = new Observable<IPointerEvent | IMouseEvent>();
+
+    onDragLeaveObserver = new Observable<IDragEvent | IMouseEvent>();
+
+    onDragOverObserver = new Observable<IDragEvent | IMouseEvent>();
+
+    onDragEnterObserver = new Observable<IDragEvent | IMouseEvent>();
+
+    onDropObserver = new Observable<IDragEvent | IMouseEvent>();
 
     onIsAddedToParentObserver = new Observable<any>();
 
@@ -670,9 +678,40 @@ export abstract class BaseObject extends Disposable {
         return true;
     }
 
+    triggerDragLeave(evt: IDragEvent | IMouseEvent) {
+        if (!this.onDragLeaveObserver.notifyObservers(evt)?.stopPropagation) {
+            this._parent?.triggerDragLeave(evt);
+            return false;
+        }
+        return true;
+    }
+
+    triggerDragOver(evt: IDragEvent | IMouseEvent) {
+        if (!this.onDragOverObserver.notifyObservers(evt)?.stopPropagation) {
+            this._parent?.triggerDragOver(evt);
+            return false;
+        }
+        return true;
+    }
+
+    triggerDragEnter(evt: IDragEvent | IMouseEvent) {
+        if (!this.onDragEnterObserver.notifyObservers(evt)?.stopPropagation) {
+            this._parent?.triggerDragEnter(evt);
+            return false;
+        }
+        return true;
+    }
+
+    triggerDrop(evt: IDragEvent | IMouseEvent) {
+        if (!this.onDropObserver.notifyObservers(evt)?.stopPropagation) {
+            this._parent?.triggerDrop(evt);
+            return false;
+        }
+        return true;
+    }
+
     override dispose() {
         super.dispose();
-
         this.onTransformChangeObservable.clear();
         this.onPointerDownObserver.clear();
         this.onPointerMoveObserver.clear();
@@ -682,6 +721,10 @@ export abstract class BaseObject extends Disposable {
         this.onPointerLeaveObserver.clear();
         this.onPointerOverObserver.clear();
         this.onPointerEnterObserver.clear();
+        this.onDragLeaveObserver.clear();
+        this.onDragOverObserver.clear();
+        this.onDragEnterObserver.clear();
+        this.onDropObserver.clear();
         this.onDblclickObserver.clear();
         this.onTripleClickObserver.clear();
         this.onIsAddedToParentObserver.clear();

--- a/packages/engine-render/src/basics/i-events.ts
+++ b/packages/engine-render/src/basics/i-events.ts
@@ -301,6 +301,17 @@ export interface IPointerEvent extends IMouseEvent {
 }
 
 /**
+ * Native friendly interface for DragEvent Object
+ */
+export interface IDragEvent extends IMouseEvent {
+    // Properties
+    /**
+     * Holds the drag operation's data
+     */
+    dataTransfer: DataTransfer;
+}
+
+/**
  * Native friendly interface for WheelEvent Object
  */
 export interface IWheelEvent extends IMouseEvent {

--- a/packages/engine-render/src/engine.ts
+++ b/packages/engine-render/src/engine.ts
@@ -249,7 +249,6 @@ export class Engine extends ThinEngine<Scene> {
         canvasEle.removeEventListener('drop', this._dropEvent);
         canvasEle.removeEventListener(this._getWheelEventName(), this._pointerWheelEvent);
 
-
         this._activeRenderLoops = [];
         this.getCanvas().dispose();
         // this._canvas = null; // 不应该这么做, 上面已经调用了 _canvas 的 dispose 方法
@@ -765,7 +764,6 @@ export class Engine extends ThinEngine<Scene> {
             // Store previous values for event
             const deviceEvent = evt as IPointerEvent;
             deviceEvent.deviceType = deviceType;
-
 
             deviceEvent.currentState = 6;
 

--- a/packages/engine-render/src/scene.ts
+++ b/packages/engine-render/src/scene.ts
@@ -20,7 +20,7 @@ import { BehaviorSubject } from 'rxjs';
 
 import type { BaseObject } from './base-object';
 import { CURSOR_TYPE, RENDER_CLASS_TYPE } from './basics/const';
-import type { IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from './basics/i-events';
+import type { IDragEvent, IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from './basics/i-events';
 import type { IObjectFullState, ISceneTransformState, ITransformChangeState } from './basics/interfaces';
 import { TRANSFORM_CHANGE_OBSERVABLE_TYPE } from './basics/interfaces';
 import { precisionTo, requestNewFrame } from './basics/tools';
@@ -870,6 +870,50 @@ export class Scene extends ThinScene {
             this._parent.classType === RENDER_CLASS_TYPE.SCENE_VIEWER
         ) {
             (this._parent as SceneViewer)?.triggerPointerEnter(evt);
+            return false;
+        }
+        return true;
+    }
+
+    override triggerDragLeave(evt: IDragEvent) {
+        if (
+            !this.onDragLeaveObserver.notifyObservers(evt)?.stopPropagation &&
+            this._parent.classType === RENDER_CLASS_TYPE.SCENE_VIEWER
+        ) {
+            (this._parent as SceneViewer)?.triggerDragLeave(evt);
+            return false;
+        }
+        return true;
+    }
+
+    override triggerDragOver(evt: IDragEvent) {
+        if (
+            !this.onDragOverObserver.notifyObservers(evt)?.stopPropagation &&
+            this._parent.classType === RENDER_CLASS_TYPE.SCENE_VIEWER
+        ) {
+            (this._parent as SceneViewer)?.triggerDragOver(evt);
+            return false;
+        }
+        return true;
+    }
+
+    override triggerDragEnter(evt: IDragEvent) {
+        if (
+            !this.onDragEnterObserver.notifyObservers(evt)?.stopPropagation &&
+            this._parent.classType === RENDER_CLASS_TYPE.SCENE_VIEWER
+        ) {
+            (this._parent as SceneViewer)?.triggerDragEnter(evt);
+            return false;
+        }
+        return true;
+    }
+
+    override triggerDrop(evt: IDragEvent) {
+        if (
+            !this.onDropObserver.notifyObservers(evt)?.stopPropagation &&
+            this._parent.classType === RENDER_CLASS_TYPE.SCENE_VIEWER
+        ) {
+            (this._parent as SceneViewer)?.triggerDrop(evt);
             return false;
         }
         return true;

--- a/packages/engine-render/src/thin-scene.ts
+++ b/packages/engine-render/src/thin-scene.ts
@@ -20,7 +20,7 @@ import { Disposable, Observable } from '@univerjs/core';
 import type { BaseObject } from './base-object';
 import type { CURSOR_TYPE, EVENT_TYPE } from './basics/const';
 import { RENDER_CLASS_TYPE } from './basics/const';
-import type { IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from './basics/i-events';
+import type { IDragEvent, IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from './basics/i-events';
 import type { ITransformChangeState } from './basics/interfaces';
 import { Transform } from './basics/transform';
 import type { Vector2 } from './basics/vector2';
@@ -40,6 +40,14 @@ export abstract class ThinScene extends Disposable {
     onPointerEnterObserver = new Observable<IPointerEvent | IMouseEvent>();
 
     onPointerLeaveObserver = new Observable<IPointerEvent | IMouseEvent>();
+
+    onDragEnterObserver = new Observable<IDragEvent>();
+
+    onDragOverObserver = new Observable<IDragEvent>();
+
+    onDragLeaveObserver = new Observable<IDragEvent>();
+
+    onDropObserver = new Observable<IDragEvent>();
 
     onDblclickObserver = new Observable<IPointerEvent | IMouseEvent>();
 
@@ -182,6 +190,14 @@ export abstract class ThinScene extends Disposable {
 
     abstract triggerPointerEnter(evt: IPointerEvent | IMouseEvent): void;
 
+    abstract triggerDragEnter(evt: IDragEvent | IMouseEvent): void;
+
+    abstract triggerDragOver(evt: IDragEvent | IMouseEvent): void;
+
+    abstract triggerDragLeave(evt: IDragEvent | IMouseEvent): void;
+
+    abstract triggerDrop(evt: IDragEvent | IMouseEvent): void;
+
     abstract render(parentCtx?: UniverRenderingContext): void;
 
     abstract getParent(): any;
@@ -194,6 +210,10 @@ export abstract class ThinScene extends Disposable {
         this.onPointerUpObserver.clear();
         this.onPointerEnterObserver.clear();
         this.onPointerLeaveObserver.clear();
+        this.onDragEnterObserver.clear();
+        this.onDragOverObserver.clear();
+        this.onDragLeaveObserver.clear();
+        this.onDropObserver.clear();
         this.onDblclickObserver.clear();
         this.onTripleClickObserver.clear();
         this.onMouseWheelObserver.clear();

--- a/packages/facade/src/apis/sheets/__tests__/f-sheet-hooks.spec.ts
+++ b/packages/facade/src/apis/sheets/__tests__/f-sheet-hooks.spec.ts
@@ -21,11 +21,34 @@ import type { Injector } from '@wendellhu/redi';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Subject } from 'rxjs';
 
-import type { IHoverCellPosition } from '@univerjs/sheets-ui';
-import { HoverManagerService } from '@univerjs/sheets-ui';
+import type { IDragCellPosition, IHoverCellPosition } from '@univerjs/sheets-ui';
+import { DragManagerService, HoverManagerService } from '@univerjs/sheets-ui';
 import type { FUniver } from '../../facade';
 import { createFacadeTestBed } from '../../__tests__/create-test-bed';
 import { FSheetHooks } from '../f-sheet-hooks';
+
+class MockDataTransfer implements DataTransfer {
+    effectAllowed: 'none' | 'copy' | 'link' | 'move' | 'all' | 'copyLink' | 'copyMove' | 'linkMove' | 'uninitialized';
+    files: FileList;
+    items: DataTransferItemList;
+    types: readonly string[];
+    clearData(format?: string | undefined): void {
+        throw new Error('Method not implemented.');
+    }
+
+    getData(format: string): string {
+        throw new Error('Method not implemented.');
+    }
+
+    setData(format: string, data: string): void {
+        throw new Error('Method not implemented.');
+    }
+
+    dropEffect: 'none' | 'copy' | 'link' | 'move' = 'none';
+    setDragImage(image: Element, x: number, y: number): void {
+        throw new Error('Method not implemented.');
+    }
+}
 
 describe('Test FSheetHooks', () => {
     let get: Injector['get'];
@@ -46,7 +69,11 @@ describe('Test FSheetHooks', () => {
         endColumn: number
     ) => Nullable<IStyleData>;
     let mockHoverManagerService: Partial<HoverManagerService>;
-    let currentCell$: Subject<Nullable<IHoverCellPosition>>;
+    let mockDragManagerService: Partial<DragManagerService>;
+    let hoverCurrentCell$: Subject<Nullable<IHoverCellPosition>>;
+    let hoverCurrentPosition$: Subject<Nullable<IHoverCellPosition>>;
+    let dragCurrentCell$: Subject<Nullable<IDragCellPosition>>;
+    let dragEndCell$: Subject<Nullable<IDragCellPosition>>;
     let sheetHooks: FSheetHooks;
     let workbook: Workbook;
 
@@ -56,15 +83,26 @@ describe('Test FSheetHooks', () => {
 
     beforeEach(() => {
         // Initialize the subject
-        currentCell$ = new Subject<Nullable<IHoverCellPosition>>();
+        hoverCurrentCell$ = new Subject<Nullable<IHoverCellPosition>>();
+        hoverCurrentPosition$ = new Subject<Nullable<IHoverCellPosition>>();
+        dragCurrentCell$ = new Subject<Nullable<IDragCellPosition>>();
+        dragEndCell$ = new Subject<Nullable<IDragCellPosition>>();
 
         // Create a mock HoverManagerService with currentCell$
         mockHoverManagerService = {
-            currentCell$: currentCell$.asObservable(),
+            currentCell$: hoverCurrentCell$.asObservable(),
+            currentPosition$: hoverCurrentPosition$.asObservable(),
+        };
+
+        // Create a mock DragManagerService with currentCell$
+        mockDragManagerService = {
+            currentCell$: dragCurrentCell$.asObservable(),
+            endCell$: dragEndCell$.asObservable(),
         };
 
         const testBed = createFacadeTestBed(undefined, [
             [HoverManagerService, { useValue: mockHoverManagerService }],
+            [DragManagerService, { useValue: mockDragManagerService }],
         ]);
         get = testBed.get;
         injector = testBed.injector;
@@ -109,6 +147,18 @@ describe('Test FSheetHooks', () => {
     });
 
     it('Test onCellPointerMove', () => {
+        sheetHooks.onCellPointerMove((cellPos) => {
+            expect(cellPos).toEqual({ location: { workbook, worksheet, unitId: workbook.getUnitId(), subUnitId: worksheet.getSheetId(), row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 } });
+        });
+
+        // Trigger the Observable to emit a new value
+        const worksheet = workbook.getActiveSheet();
+        const unitId = workbook.getUnitId();
+        const subUnitId = worksheet.getSheetId();
+        hoverCurrentPosition$.next({ location: { workbook, worksheet, unitId, subUnitId, row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 } });
+    });
+
+    it('Test onCellPointerOver', () => {
         sheetHooks.onCellPointerOver((cellPos) => {
             expect(cellPos).toEqual({ location: { workbook, worksheet, unitId: workbook.getUnitId(), subUnitId: worksheet.getSheetId(), row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 } });
         });
@@ -117,6 +167,30 @@ describe('Test FSheetHooks', () => {
         const worksheet = workbook.getActiveSheet();
         const unitId = workbook.getUnitId();
         const subUnitId = worksheet.getSheetId();
-        currentCell$.next({ location: { workbook, worksheet, unitId, subUnitId, row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 } });
+        hoverCurrentCell$.next({ location: { workbook, worksheet, unitId, subUnitId, row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 } });
+    });
+
+    it('Test onCellDragOver', () => {
+        sheetHooks.onCellDragOver((cellPos) => {
+            expect(cellPos).toEqual({ location: { workbook, worksheet, unitId: workbook.getUnitId(), subUnitId: worksheet.getSheetId(), row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 }, dataTransfer: new MockDataTransfer() });
+        });
+
+        // Trigger the Observable to emit a new value
+        const worksheet = workbook.getActiveSheet();
+        const unitId = workbook.getUnitId();
+        const subUnitId = worksheet.getSheetId();
+        dragCurrentCell$.next({ location: { workbook, worksheet, unitId, subUnitId, row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 }, dataTransfer: new MockDataTransfer() });
+    });
+
+    it('Test onCellDrop', () => {
+        sheetHooks.onCellDrop((cellPos) => {
+            expect(cellPos).toEqual({ location: { workbook, worksheet, unitId: workbook.getUnitId(), subUnitId: worksheet.getSheetId(), row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 }, dataTransfer: new MockDataTransfer() });
+        });
+
+        // Trigger the Observable to emit a new value
+        const worksheet = workbook.getActiveSheet();
+        const unitId = workbook.getUnitId();
+        const subUnitId = worksheet.getSheetId();
+        dragEndCell$.next({ location: { workbook, worksheet, unitId, subUnitId, row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 }, dataTransfer: new MockDataTransfer() });
     });
 });

--- a/packages/facade/src/apis/sheets/__tests__/f-sheet-hooks.spec.ts
+++ b/packages/facade/src/apis/sheets/__tests__/f-sheet-hooks.spec.ts
@@ -109,7 +109,7 @@ describe('Test FSheetHooks', () => {
     });
 
     it('Test onCellPointerMove', () => {
-        sheetHooks.onCellPointerMove((cellPos) => {
+        sheetHooks.onCellPointerOver((cellPos) => {
             expect(cellPos).toEqual({ location: { workbook, worksheet, unitId: workbook.getUnitId(), subUnitId: worksheet.getSheetId(), row: 0, col: 0 }, position: { startX: 0, endX: 1, startY: 0, endY: 1 } });
         });
 

--- a/packages/facade/src/apis/sheets/f-sheet-hooks.ts
+++ b/packages/facade/src/apis/sheets/f-sheet-hooks.ts
@@ -18,21 +18,50 @@ import { type Nullable, toDisposable } from '@univerjs/core';
 import type { IDisposable } from '@wendellhu/redi';
 import { Inject } from '@wendellhu/redi';
 
-import type { IHoverCellPosition } from '@univerjs/sheets-ui';
-import { HoverManagerService } from '@univerjs/sheets-ui';
+import type { IDragCellPosition, IHoverCellPosition } from '@univerjs/sheets-ui';
+import { DragManagerService, HoverManagerService } from '@univerjs/sheets-ui';
 
 export class FSheetHooks {
     constructor(
-        @Inject(HoverManagerService) private readonly _hoverManagerService: HoverManagerService
-    ) {
+        @Inject(HoverManagerService) private readonly _hoverManagerService: HoverManagerService,
+        @Inject(DragManagerService) private readonly _dragManagerService: DragManagerService
+    ) { 
         // empty
     }
 
     /**
-     * Subscribe to the location information of the currently hovered cell
-     * @returns a disposable object that can be used to unsubscribe from the event
+     * The onCellPointerMove event is fired when a pointing device is moved into a cell's hit test boundaries.
+     * @param callback Callback function that will be called when the event is fired
+     * @returns A disposable object that can be used to unsubscribe from the event
      */
     onCellPointerMove(callback: (cellPos: Nullable<IHoverCellPosition>) => void): IDisposable {
+        return toDisposable(this._hoverManagerService.currentPosition$.subscribe(callback));
+    }
+
+    /**
+     * The onCellPointerOver event is fired when a pointing device is moved into a cell's hit test boundaries.
+     * @param callback Callback function that will be called when the event is fired
+     * @returns A disposable object that can be used to unsubscribe from the event
+     */
+    onCellPointerOver(callback: (cellPos: Nullable<IHoverCellPosition>) => void): IDisposable {
         return toDisposable(this._hoverManagerService.currentCell$.subscribe(callback));
+    }
+
+    /**
+     * The onCellDragOver event is fired when an element or text selection is being dragged into a cell's hit test boundaries.
+     * @param callback Callback function that will be called when the event is fired
+     * @returns A disposable object that can be used to unsubscribe from the event
+     */
+    onCellDragOver(callback: (cellPos: Nullable<IDragCellPosition>) => void): IDisposable {
+        return toDisposable(this._dragManagerService.currentCell$.subscribe(callback));
+    }
+
+    /**
+     * The onCellDrop event is fired when an element or text selection is being dropped on the cell
+     * @param callback Callback function that will be called when the event is fired
+     * @returns A disposable object that can be used to unsubscribe from the event
+     */
+    onCellDrop(callback: (cellPos: Nullable<IDragCellPosition>) => void) {
+        return toDisposable(this._dragManagerService.endCell$.subscribe(callback));
     }
 }

--- a/packages/facade/src/apis/sheets/f-sheet-hooks.ts
+++ b/packages/facade/src/apis/sheets/f-sheet-hooks.ts
@@ -25,7 +25,7 @@ export class FSheetHooks {
     constructor(
         @Inject(HoverManagerService) private readonly _hoverManagerService: HoverManagerService,
         @Inject(DragManagerService) private readonly _dragManagerService: DragManagerService
-    ) { 
+    ) {
         // empty
     }
 

--- a/packages/facade/src/apis/sheets/f-sheet-hooks.ts
+++ b/packages/facade/src/apis/sheets/f-sheet-hooks.ts
@@ -30,7 +30,7 @@ export class FSheetHooks {
     }
 
     /**
-     * The onCellPointerMove event is fired when a pointing device is moved into a cell's hit test boundaries.
+     * The onCellPointerMove event is fired when a pointer changes coordinates.
      * @param callback Callback function that will be called when the event is fired
      * @returns A disposable object that can be used to unsubscribe from the event
      */
@@ -39,7 +39,7 @@ export class FSheetHooks {
     }
 
     /**
-     * The onCellPointerOver event is fired when a pointing device is moved into a cell's hit test boundaries.
+     * The onCellPointerOver event is fired when a pointer is moved into a cell's hit test boundaries.
      * @param callback Callback function that will be called when the event is fired
      * @returns A disposable object that can be used to unsubscribe from the event
      */
@@ -57,7 +57,7 @@ export class FSheetHooks {
     }
 
     /**
-     * The onCellDrop event is fired when an element or text selection is being dropped on the cell
+     * The onCellDrop event is fired when an element or text selection is being dropped on the cell.
      * @param callback Callback function that will be called when the event is fired
      * @returns A disposable object that can be used to unsubscribe from the event
      */

--- a/packages/facade/src/apis/sheets/f-sheet-hooks.ts
+++ b/packages/facade/src/apis/sheets/f-sheet-hooks.ts
@@ -61,7 +61,7 @@ export class FSheetHooks {
      * @param callback Callback function that will be called when the event is fired
      * @returns A disposable object that can be used to unsubscribe from the event
      */
-    onCellDrop(callback: (cellPos: Nullable<IDragCellPosition>) => void) {
+    onCellDrop(callback: (cellPos: Nullable<IDragCellPosition>) => void): IDisposable {
         return toDisposable(this._dragManagerService.endCell$.subscribe(callback));
     }
 }

--- a/packages/sheets-formula/src/views/more-functions/MoreFunctions.tsx
+++ b/packages/sheets-formula/src/views/more-functions/MoreFunctions.tsx
@@ -29,7 +29,7 @@ export function MoreFunctions() {
     const workbook = useActiveWorkbook();
     const [selectFunction, setSelectFunction] = useState<boolean>(true);
     const [inputParams, setInputParams] = useState<boolean>(false);
-    const [params, setParams] = useState<string[]>([]);
+    // const [params, setParams] = useState<string[]>([]); // TODO@Dushusir: bind setParams to InputParams's onChange
     const [functionInfo, setFunctionInfo] = useState<IFunctionInfo | null>(null);
 
     const localeService = useDependency(LocaleService);
@@ -52,7 +52,7 @@ export function MoreFunctions() {
     return (
         <div className={styles.formulaMoreFunctions}>
             {selectFunction && <SelectFunction onChange={setFunctionInfo} />}
-            {inputParams && <InputParams functionInfo={functionInfo} onChange={setParams} />}
+            {inputParams && <InputParams functionInfo={functionInfo} onChange={() => {}} />}
             <div className={styles.formulaMoreFunctionsOperation}>
                 {/* TODO@Dushusir: open input params after range selector refactor */}
                 {inputParams && (

--- a/packages/sheets-ui/src/common/utils.ts
+++ b/packages/sheets-ui/src/common/utils.ts
@@ -204,7 +204,6 @@ export function transformPosition2Offset(x: number, y: number, scene: Scene, ske
     };
 }
 
-
 export function getHoverCellPosition(currentRender: IRender, workbook: Workbook, worksheet: Worksheet, skeletonParam: ISheetSkeletonManagerParam, offsetX: number, offsetY: number) {
     const { scene } = currentRender;
 

--- a/packages/sheets-ui/src/controllers/drag-render.controller.ts
+++ b/packages/sheets-ui/src/controllers/drag-render.controller.ts
@@ -16,13 +16,15 @@
 
 import type { Workbook } from '@univerjs/core';
 import { Disposable, IUniverInstanceService, LifecycleStages, OnLifecycle, UniverInstanceType } from '@univerjs/core';
-import { IRenderController, IRenderManagerService } from '@univerjs/engine-render';
+import type { IRenderContext, IRenderController } from '@univerjs/engine-render';
+import { IRenderManagerService } from '@univerjs/engine-render';
 import { Inject } from '@wendellhu/redi';
 import { DragManagerService } from '../services/drag-manager.service';
 
 @OnLifecycle(LifecycleStages.Rendered, DragRenderController)
-export class DragRenderController extends Disposable  implements IRenderController {
+export class DragRenderController extends Disposable implements IRenderController {
     constructor(
+        private readonly _context: IRenderContext<Workbook>,
         @IRenderManagerService private _renderManagerService: IRenderManagerService,
         @Inject(DragManagerService) private _dragManagerService: DragManagerService,
         @IUniverInstanceService private _univerInstanceService: IUniverInstanceService

--- a/packages/sheets-ui/src/controllers/drag-render.controller.ts
+++ b/packages/sheets-ui/src/controllers/drag-render.controller.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Workbook } from '@univerjs/core';
+import { Disposable, IUniverInstanceService, LifecycleStages, OnLifecycle, UniverInstanceType } from '@univerjs/core';
+import { IRenderController, IRenderManagerService } from '@univerjs/engine-render';
+import { Inject } from '@wendellhu/redi';
+import { DragManagerService } from '../services/drag-manager.service';
+
+@OnLifecycle(LifecycleStages.Rendered, DragRenderController)
+export class DragRenderController extends Disposable  implements IRenderController {
+    constructor(
+        @IRenderManagerService private _renderManagerService: IRenderManagerService,
+        @Inject(DragManagerService) private _dragManagerService: DragManagerService,
+        @IUniverInstanceService private _univerInstanceService: IUniverInstanceService
+    ) {
+        super();
+
+        this._initDragEvent();
+    }
+
+    private _initDragEvent() {
+        const scene = this._getCurrentScene();
+
+        if (!scene) {
+            return;
+        }
+
+        const dragOverObserver = scene.onDragOverObserver.add((evt) => {
+            this._dragManagerService.onDragOver(evt);
+        });
+
+        const dropObserver = scene.onDropObserver.add((evt) => {
+            this._dragManagerService.onDrop(evt);
+        });
+
+        this.disposeWithMe({
+            dispose() {
+                scene.onDragOverObserver.remove(dragOverObserver);
+                scene.onDropObserver.remove(dropObserver);
+            },
+        });
+    }
+
+    private _getCurrentScene() {
+        return this._renderManagerService.getRenderById(
+            this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId()
+        )?.scene;
+    }
+}

--- a/packages/sheets-ui/src/index.ts
+++ b/packages/sheets-ui/src/index.ts
@@ -81,8 +81,10 @@ export { SheetSkeletonManagerService } from './services/sheet-skeleton-manager.s
 export { UniverSheetsUIPlugin } from './sheets-ui-plugin';
 export { SheetCanvasView } from './views/sheet-canvas-view';
 export { HoverManagerService } from './services/hover-manager.service';
+export { DragManagerService } from './services/drag-manager.service';
 export { CellAlertManagerService, CellAlertType, type ICellAlert } from './services/cell-alert-manager.service';
 export { HoverRenderController } from './controllers/hover-render.controller';
+export { DragRenderController } from './controllers/drag-render.controller';
 export { SHEET_VIEW_KEY } from './common/keys';
 export { SheetCanvasPopManagerService, type ICanvasPopup } from './services/canvas-pop-manager.service';
 export { mergeSetRangeValues } from './services/clipboard/utils';
@@ -91,3 +93,4 @@ export type { IDiscreteRange } from './controllers/utils/range-tools';
 export { virtualizeDiscreteRanges, rangeToDiscreteRange } from './controllers/utils/range-tools';
 export { type IHoverCellPosition } from './services/hover-manager.service';
 export { AutoHeightController } from './controllers/auto-height.controller';
+export { type IDragCellPosition } from './services/drag-manager.service';

--- a/packages/sheets-ui/src/index.ts
+++ b/packages/sheets-ui/src/index.ts
@@ -94,3 +94,4 @@ export { virtualizeDiscreteRanges, rangeToDiscreteRange } from './controllers/ut
 export { type IHoverCellPosition } from './services/hover-manager.service';
 export { AutoHeightController } from './controllers/auto-height.controller';
 export { type IDragCellPosition } from './services/drag-manager.service';
+export { SheetMenuPosition } from './controllers/menu/menu';

--- a/packages/sheets-ui/src/sheets-ui-plugin.ts
+++ b/packages/sheets-ui/src/sheets-ui-plugin.ts
@@ -72,6 +72,8 @@ import { SheetContextMenuRenderController } from './controllers/render-controlle
 import { EditorBridgeRenderController } from './controllers/render-controllers/editor-bridge.render-controller';
 import { AutoFillController } from './controllers/auto-fill.controller';
 import { FormatPainterController } from './controllers/format-painter/format-painter.controller';
+import { DragRenderController } from './controllers/drag-render.controller';
+import { DragManagerService } from './services/drag-manager.service';
 
 export class UniverSheetsUIPlugin extends Plugin {
     static override pluginName = 'SHEET_UI_PLUGIN';
@@ -109,6 +111,7 @@ export class UniverSheetsUIPlugin extends Plugin {
                 [IStatusBarService, { useClass: StatusBarService }],
                 [IMarkSelectionService, { useClass: MarkSelectionService }],
                 [HoverManagerService],
+                [DragManagerService],
                 [SheetCanvasPopManagerService],
                 [CellAlertManagerService],
 
@@ -160,6 +163,7 @@ export class UniverSheetsUIPlugin extends Plugin {
             ForceStringAlertRenderController,
             MarkSelectionRenderController,
             HoverRenderController,
+            DragRenderController,
             ForceStringRenderController,
             CellCustomRenderController,
             SheetContextMenuRenderController,


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
- [x] render engine adds drag event
- [x] facade adds onCellPointerOver,onCellDragOver,onCellDrop
- [x] univer.ai docs PR https://github.com/dream-num/univer.ai/pull/133

<!-- A description of the proposed changes. -->

<!-- How to test them. -->
如何测试？

分别在控制台粘贴以下代码测试 API，测试一个刷新一次页面
```js
window.univerAPI.getSheetHooks().onCellPointerMove((cell) => {
    // 拿到当前鼠标指向的单元格
    console.log(cell?.location.row, cell?.location.col);
  })
```
鼠标hover在sheet区域，跟随鼠标移动触发
```js
window.univerAPI.getSheetHooks().onCellPointerOver((cell) => {
    // 拿到当前鼠标指向的单元格
    console.log(cell?.location.row, cell?.location.col);
  })
```
鼠标hover在sheet区域，打中不同单元格时才触发
```js
window.univerAPI.getSheetHooks().onCellDragOver((cell) => {
    // 拿到当前鼠标指向的单元格
    console.log(cell?.location.row, cell?.location.col);
  })
```
从外部拖拽一个可拖拽元素（比如本地记事本的文本）到sheet区域，打中不同单元格时触发
```js
window.univerAPI.getSheetHooks().onCellDrop((cell) => {
    // 拿到当前鼠标指向的单元格
    console.log(cell?.location.row, cell?.location.col);
  })
```
从外部拖拽一个可拖拽元素（比如本地记事本的文本）到sheet区域，松开鼠标时触发
<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->
