### PR TITLE
fix(ui): correct the resize listener target in toolbar

### DIFF
--- a/packages/ui/src/views/components/doc-bars/hook.ts
+++ b/packages/ui/src/views/components/doc-bars/hook.ts
@@ -181,8 +181,13 @@ export function useToolbarCollapseObserver(visibleItems: IToolbarRenderHookHandl
 
         resize();
         const observer = new ResizeObserver(() => resize());
-        observer.observe(document.body);
-        return () => observer.unobserve(document.body);
+
+        const toolbarDom = toolbarRef.current!;
+        observer.observe(toolbarDom);
+
+        return () => {
+            observer.unobserve(toolbarDom);
+        };
     }, [visibleItems]);
 
     return {


### PR DESCRIPTION
The `resize()` of the toolbar should not be implemented by listening to `document.body`.
Doing so may cause issues with correctly triggering the resize calculation in scenarios involving toggling visibility, such as when using Univer within Ant Design's Tabs component.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
