### PR TITLE
fix(core): observer remove unregisterOnNextCall

### DIFF
--- a/packages/core/src/observer/__tests__/observable.spec.ts
+++ b/packages/core/src/observer/__tests__/observable.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EventState, Observable, Observer } from '../observable';
+
+describe('EventState', () => {
+    it('should initialize with skipNextObservers set to false', () => {
+        const eventState = new EventState();
+        expect(eventState.skipNextObservers).toBe(false);
+    });
+
+    it('should allow stopPropagation to be set', () => {
+        const eventState = new EventState();
+        eventState.stopPropagation();
+        expect(eventState.isStopPropagation).toBe(true);
+    });
+});
+
+describe('Observer', () => {
+    it('should create an observer with a callback', () => {
+        const callback = (eventData: any, eventState: EventState) => {};
+        const observable = new Observable();
+        const observer = new Observer(callback, observable);
+        expect(observer.callback).toBe(callback);
+        expect(observer.observable).toBe(observable);
+    });
+
+    it('should dispose an observer', () => {
+        const callback = (eventData: any, eventState: EventState) => {};
+        const observable = new Observable();
+        // const observer = new Observer(callback, observable);
+        const observer = observable.add(callback);
+        observer?.dispose();
+        expect(observable.observers.length).toBe(0);
+    });
+});
+
+describe('Observable', () => {
+    it('should add observers', () => {
+        const observable = new Observable();
+        const callback = (eventData: any, eventState: EventState) => {};
+        observable.add(callback);
+        expect(observable.observers.length).toBe(1);
+    });
+
+    it('should notify observers', () => {
+        const observable = new Observable();
+        const callback = (eventData: any, eventState: EventState) => {
+            eventState.lastReturnValue = eventData;
+            return eventData; // Ensure the callback returns the eventData
+        };
+        observable.add(callback);
+        const result = observable.notifyObservers('testData');
+        expect(result?.lastReturnValue).toBe('testData');
+    });
+
+    it('should skip observers when skipNextObservers is set', () => {
+        const observable = new Observable();
+        const callback1 = (eventData: any, eventState: EventState) => {
+            eventState.skipNextObservers = true;
+        };
+        const callback2 = (eventData: any, eventState: EventState) => {
+            eventState.lastReturnValue = 'should not be called';
+        };
+        observable.add(callback1);
+        observable.add(callback2);
+        const result = observable.notifyObservers('testData');
+        expect(result?.lastReturnValue).not.toBe('should not be called');
+    });
+
+    it('should notify observers with promise', async () => {
+        const observable = new Observable();
+        const callback = async (eventData: any, eventState: EventState) => {
+            eventState.lastReturnValue = eventData;
+        };
+        observable.add(callback);
+        const result = await observable.notifyObserversWithPromise('testData');
+        expect(result).toBe('testData');
+    });
+});

--- a/packages/slides/src/views/render/canvas-view.ts
+++ b/packages/slides/src/views/render/canvas-view.ts
@@ -155,8 +155,10 @@ export class CanvasView extends RxDisposable {
 
         const { scene, engine } = currentRender;
 
-        engine.onTransformChangeObservable.addOnce(() => {
+        const observer = engine.onTransformChangeObservable.add(() => {
             this._scrollToCenter();
+            // add once
+            observer?.dispose();
         });
 
         engine.onTransformChangeObservable.add(() => {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->


<!-- A description of the proposed changes. -->

<!-- How to test them. -->
How to test?

```js
const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
univerAPI.getSheetHooks().onCellDrop((cell) => {
    console.log('onCellDrop', cell);
    if (cell?.location.row !== undefined && cell?.location.col !== undefined) {
        const range = activeSheet?.getRange(cell?.location.row, cell?.location.col, 1, 1);
        if (range) {
            range.setValue('Dropped');
        }
    }
});
```
<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
