### PR TITLE
fix: storybook failed because can not override name property

### DIFF
--- a/packages/core/src/docs/data-model/json-x/json-x.ts
+++ b/packages/core/src/docs/data-model/json-x/json-x.ts
@@ -40,7 +40,7 @@ export interface ISubType {
 export { JSONOp as JSONXActions, Path as JSONXPath, json1 as JSON1 };
 
 export class JSONX {
-    static name = 'json-x';
+    // static name = 'json-x';
 
     static uri = 'https://github.com/dream-num/univer#json-x';
 

--- a/packages/core/src/docs/data-model/text-x/__tests__/text-x.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/text-x.spec.ts
@@ -251,5 +251,9 @@ describe('test TextX methods and branches', () => {
 
             expect(TextX.isNoop(textX.serialize())).toBe(false);
         });
+
+        it('textX name should to be text-x', () => {
+            expect(TextX.name).toBe('text-x');
+        });
     });
 });

--- a/packages/core/src/docs/data-model/text-x/text-x.ts
+++ b/packages/core/src/docs/data-model/text-x/text-x.ts
@@ -29,7 +29,7 @@ function onlyHasDataStream(body: IDocumentBody) {
 export type TPriority = 'left' | 'right';
 
 export class TextX {
-    static name = 'text-x';
+    // static name = 'text-x';
 
     static id = 'text-x';
 
@@ -310,3 +310,8 @@ export class TextX {
         return this;
     }
 }
+
+// FIXME: @Jocs, Use to avoid storybook error. and move the static name property to here.
+Object.defineProperty(TextX, 'name', {
+    value: 'text-x',
+});


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
