### PR TITLE
fix(formula): js precision problem

### DIFF
--- a/packages/core/src/common/request-immediate-macro-task.ts
+++ b/packages/core/src/common/request-immediate-macro-task.ts
@@ -28,5 +28,9 @@ export function requestImmediateMacroTask(callback: (value?: unknown) => void): 
 
     return () => {
         cancelled = true;
+        // dispose
+        channel.port1.onmessage = null;
+        channel.port1.close();
+        channel.port2.close();
     };
 }

--- a/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
+++ b/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
@@ -15,36 +15,36 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt, strip } from '../math-kit';
+import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt, stripErrorMargin } from '../math-kit';
 
 describe('Test math kit', () => {
     it('Function plus', () => {
         expect(plus(1, 2)).toBe(3);
-        expect(strip(plus(0.1, 0.2))).toBe(0.3);
-        expect(strip(plus(0.7, 0.1))).toBe(0.8);
-        expect(strip(plus(0.0000000000001, 0.0000000000002))).toBe(0.0000000000003);
+        expect(stripErrorMargin(plus(0.1, 0.2))).toBe(0.3);
+        expect(stripErrorMargin(plus(0.7, 0.1))).toBe(0.8);
+        expect(stripErrorMargin(plus(0.0000000000001, 0.0000000000002))).toBe(0.0000000000003);
     });
 
     it('Function minus', () => {
         expect(minus(2, 1)).toBe(1);
-        expect(strip(minus(0.3, 0.1))).toBe(0.2);
-        expect(strip(minus(0.8, 0.1))).toBe(0.7);
-        expect(strip(minus(0.0000000000003, 0.0000000000002))).toBe(0.0000000000001);
+        expect(stripErrorMargin(minus(0.3, 0.1))).toBe(0.2);
+        expect(stripErrorMargin(minus(0.8, 0.1))).toBe(0.7);
+        expect(stripErrorMargin(minus(0.0000000000003, 0.0000000000002))).toBe(0.0000000000001);
     });
 
     it('Function multiply', () => {
         expect(multiply(2, 3)).toBe(6);
-        expect(strip(multiply(0.1, 0.2))).toBe(0.02);
-        expect(strip(multiply(0.7, 0.1))).toBe(0.07);
+        expect(stripErrorMargin(multiply(0.1, 0.2))).toBe(0.02);
+        expect(stripErrorMargin(multiply(0.7, 0.1))).toBe(0.07);
         expect(multiply(0.0000000000001, 0.0000000000002)).toBe(2e-26);
-        expect(strip(multiply(0.6789, 10000))).toBe(6789);
+        expect(stripErrorMargin(multiply(0.6789, 10000))).toBe(6789);
     });
 
     it('Function divide', () => {
         expect(divide(6, 3)).toBe(2);
-        expect(strip(divide(0.02, 0.1))).toBe(0.2);
-        expect(strip(divide(0.07, 0.1))).toBe(0.7);
-        expect(strip(divide(0.3, 0.1))).toBe(3);
+        expect(stripErrorMargin(divide(0.02, 0.1))).toBe(0.2);
+        expect(stripErrorMargin(divide(0.07, 0.1))).toBe(0.7);
+        expect(stripErrorMargin(divide(0.3, 0.1))).toBe(3);
         expect(divide(0.00000000000000002, 0.0000000000001)).toBe(0.0002);
     });
 
@@ -73,6 +73,17 @@ describe('Test math kit', () => {
         expect(round(1.23456789, 3)).toBe(1.235);
         expect(round(1.23456789, 4)).toBe(1.2346);
         expect(round(1.23456789, 5)).toBe(1.23457);
+        expect(round(0.6789, 4)).toBe(0.6789);
+        expect(round(0.6789, 3)).toBe(0.679);
+        expect(round(0.6789, 2)).toBe(0.68);
+        expect(round(0.6789, 1)).toBe(0.7);
+        expect(round(0.6789, 0)).toBe(1);
+        expect(round(0.6749, 1)).toBe(0.7);
+        expect(round(0.6749, 2)).toBe(0.67);
+        expect(round(0.9999, 1)).toBe(1.0);
+        expect(round(0.99999, 1)).toBe(1.0);
+        expect(round(-0.9999, 1)).toBe(-1.0);
+        expect(round(9.9999, 0)).toBe(10);
     });
     // test floor
     it('Function floor', () => {
@@ -83,6 +94,23 @@ describe('Test math kit', () => {
         expect(floor(1.23456789, 3)).toBe(1.234);
         expect(floor(1.23456789, 4)).toBe(1.2345);
         expect(floor(1.23456789, 5)).toBe(1.23456);
+        expect(floor(0.6789, 0)).toBe(0);
+        expect(floor(0.6789, 1)).toBe(0.6);
+        expect(floor(0.6789, 2)).toBe(0.67);
+        expect(floor(0.6789, 3)).toBe(0.678);
+        expect(floor(0.6789, 4)).toBe(0.6789);
+        expect(floor(0.6789, 5)).toBe(0.6789);
+        expect(floor(0.9999, 1)).toBe(0.9);
+        expect(floor(0.9999, 2)).toBe(0.99);
+        expect(floor(0.9999, 3)).toBe(0.999);
+        expect(floor(0.9999, 4)).toBe(0.9999);
+        expect(floor(0.9999, 5)).toBe(0.9999);
+        expect(floor(0.9999, 1)).toBe(0.9);
+        expect(floor(0.99999, 1)).toBe(0.9);
+        expect(floor(1.9999, 1)).toBe(1.9);
+        expect(floor(9.9999, 1)).toBe(9.9);
+        expect(floor(0.0001, 1)).toBe(0);
+        expect(floor(-0.9999, 1)).toBe(-1);
     });
 
     // test ceil
@@ -94,6 +122,19 @@ describe('Test math kit', () => {
         expect(ceil(1.23456789, 3)).toBe(1.235);
         expect(ceil(1.23456789, 4)).toBe(1.2346);
         expect(ceil(1.23456789, 5)).toBe(1.23457);
+        expect(ceil(0.6789, 4)).toBe(0.6789);
+        expect(ceil(0.6789, 3)).toBe(0.679);
+        expect(ceil(0.6789, 2)).toBe(0.68);
+        expect(ceil(0.6789, 1)).toBe(0.7);
+        expect(ceil(0.6789, 0)).toBe(1);
+        expect(ceil(0.6709, 1)).toBe(0.7);
+        expect(ceil(0.6709, 2)).toBe(0.68);
+        expect(ceil(0.9999, 1)).toBe(1.0);
+        expect(ceil(0.99999, 1)).toBe(1.0);
+        expect(ceil(1.9999, 1)).toBe(2.0);
+        expect(ceil(9.9999, 1)).toBe(10.0);
+        expect(ceil(0.0001, 1)).toBe(0.1);
+        expect(ceil(-0.9999, 1)).toBe(-0.9);
     });
 
     // test mod
@@ -114,7 +155,7 @@ describe('Test math kit', () => {
         expect(pow(2, -1)).toBe(0.5);
         expect(pow(2, -2)).toBe(0.25);
         expect(pow(2, -3)).toBe(0.125);
-        expect(strip(pow(0.2, 3))).toBe(0.008);
+        expect(stripErrorMargin(pow(0.2, 3))).toBe(0.008);
     });
     // test sqrt
     it('Function sqrt', () => {

--- a/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
+++ b/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt, strip, truncateNumber } from '../math-kit';
+import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt, truncateNumber } from '../math-kit';
 
 describe('Test math kit', () => {
     it('Function truncateNumber', () => {
@@ -43,7 +43,7 @@ describe('Test math kit', () => {
         expect(multiply(2, 3)).toBe(6);
         expect(multiply(0.1, 0.2)).toBe(0.02);
         expect(multiply(0.7, 0.1)).toBe(0.07);
-        expect(strip(multiply(0.0000000000001, 0.0000000000002))).toBe(2e-26);
+        expect(multiply(0.0000000000001, 0.0000000000002)).toBe(2e-26);
         expect(multiply(0.6789, 10000)).toBe(6789);
     });
 
@@ -121,6 +121,7 @@ describe('Test math kit', () => {
         expect(pow(2, -1)).toBe(0.5);
         expect(pow(2, -2)).toBe(0.25);
         expect(pow(2, -3)).toBe(0.125);
+        expect(pow(0.2, 3)).toBe(0.008);
     });
     // test sqrt
     it('Function sqrt', () => {

--- a/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
+++ b/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
@@ -15,43 +15,36 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt, truncateNumber } from '../math-kit';
+import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt, strip } from '../math-kit';
 
 describe('Test math kit', () => {
-    it('Function truncateNumber', () => {
-        expect(truncateNumber('1234567890123456')).toBe(1234567890123450);
-        expect(truncateNumber('123.4567890123456789')).toBe(123.456789012345);
-        expect(truncateNumber('0.1234567890123456789')).toBe(0.123456789012345);
-        expect(truncateNumber('1.234567890123456e+20')).toBe(123456789012345000000);
-        expect(truncateNumber('123456789012345')).toBe(123456789012345);
-    });
     it('Function plus', () => {
         expect(plus(1, 2)).toBe(3);
-        expect(plus(0.1, 0.2)).toBe(0.3);
-        expect(plus(0.7, 0.1)).toBe(0.8);
-        expect(plus(0.0000000000001, 0.0000000000002)).toBe(0.0000000000003);
+        expect(strip(plus(0.1, 0.2))).toBe(0.3);
+        expect(strip(plus(0.7, 0.1))).toBe(0.8);
+        expect(strip(plus(0.0000000000001, 0.0000000000002))).toBe(0.0000000000003);
     });
 
     it('Function minus', () => {
         expect(minus(2, 1)).toBe(1);
-        expect(minus(0.3, 0.1)).toBe(0.2);
-        expect(minus(0.8, 0.1)).toBe(0.7);
-        expect(minus(0.0000000000003, 0.0000000000002)).toBe(0.0000000000001);
+        expect(strip(minus(0.3, 0.1))).toBe(0.2);
+        expect(strip(minus(0.8, 0.1))).toBe(0.7);
+        expect(strip(minus(0.0000000000003, 0.0000000000002))).toBe(0.0000000000001);
     });
 
     it('Function multiply', () => {
         expect(multiply(2, 3)).toBe(6);
-        expect(multiply(0.1, 0.2)).toBe(0.02);
-        expect(multiply(0.7, 0.1)).toBe(0.07);
+        expect(strip(multiply(0.1, 0.2))).toBe(0.02);
+        expect(strip(multiply(0.7, 0.1))).toBe(0.07);
         expect(multiply(0.0000000000001, 0.0000000000002)).toBe(2e-26);
-        expect(multiply(0.6789, 10000)).toBe(6789);
+        expect(strip(multiply(0.6789, 10000))).toBe(6789);
     });
 
     it('Function divide', () => {
         expect(divide(6, 3)).toBe(2);
-        expect(divide(0.02, 0.1)).toBe(0.2);
-        expect(divide(0.07, 0.1)).toBe(0.7);
-        expect(divide(0.3, 0.1)).toBe(3);
+        expect(strip(divide(0.02, 0.1))).toBe(0.2);
+        expect(strip(divide(0.07, 0.1))).toBe(0.7);
+        expect(strip(divide(0.3, 0.1))).toBe(3);
         expect(divide(0.00000000000000002, 0.0000000000001)).toBe(0.0002);
     });
 
@@ -121,7 +114,7 @@ describe('Test math kit', () => {
         expect(pow(2, -1)).toBe(0.5);
         expect(pow(2, -2)).toBe(0.25);
         expect(pow(2, -3)).toBe(0.125);
-        expect(pow(0.2, 3)).toBe(0.008);
+        expect(strip(pow(0.2, 3))).toBe(0.008);
     });
     // test sqrt
     it('Function sqrt', () => {

--- a/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
+++ b/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { truncateNumber } from '../math-kit';
+import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt, truncateNumber } from '../math-kit';
 
 describe('Test math kit', () => {
     it('Function truncateNumber', () => {
@@ -25,5 +25,172 @@ describe('Test math kit', () => {
         expect(truncateNumber('1.234567890123456e+20')).toBe(123456789012345000000);
         expect(truncateNumber('123456789012345')).toBe(123456789012345);
         expect(truncateNumber('0.000000000000123456')).toBe(0.000000000000123456);
+        expect(truncateNumber('0.7000000000000001')).toBe(0.7);
+        expect(truncateNumber(0.1 + 0.2)).toBe(0.3);
+    });
+    it('Function plus', () => {
+        expect(truncateNumber(plus(1, 2))).toBe(3);
+        expect(truncateNumber(plus(0.1, 0.2))).toBe(0.3);
+        expect(truncateNumber(plus(0.7, 0.1))).toBe(0.8);
+        expect(truncateNumber(plus(0.0000000000001, 0.0000000000002))).toBe(0.0000000000003);
+    });
+
+    it('Function minus', () => {
+        expect(truncateNumber(minus(2, 1))).toBe(1);
+        expect(truncateNumber(minus(0.3, 0.1))).toBe(0.2);
+        expect(truncateNumber(minus(0.8, 0.1))).toBe(0.7);
+        expect(truncateNumber(minus(0.0000000000003, 0.0000000000002))).toBe(0.0000000000001);
+    });
+
+    it('Function multiply', () => {
+        expect(truncateNumber(multiply(2, 3))).toBe(6);
+        expect(truncateNumber(multiply(0.1, 0.2))).toBe(0.02);
+        expect(truncateNumber(multiply(0.7, 0.1))).toBe(0.07);
+        expect(truncateNumber(multiply(0.0000000000001, 0.0000000000002))).toBe(2e-26);
+        expect(truncateNumber(multiply(0.6789, 10000))).toBe(6789);
+    });
+
+    it('Function divide', () => {
+        expect(truncateNumber(divide(6, 3))).toBe(2);
+        expect(truncateNumber(divide(0.02, 0.1))).toBe(0.2);
+        expect(truncateNumber(divide(0.07, 0.1))).toBe(0.7);
+        expect(truncateNumber(divide(0.3, 0.1))).toBe(3);
+        expect(truncateNumber(divide(0.00000000000000002, 0.0000000000001))).toBe(0.0002);
+    });
+
+    it('Function divide with zero', () => {
+        expect(divide(6, 0)).toBe(Infinity);
+        expect(divide(0.02, 0)).toBe(Infinity);
+        expect(divide(0.07, 0)).toBe(Infinity);
+        expect(divide(0.3, 0)).toBe(Infinity);
+        expect(divide(0.00000000000000002, 0)).toBe(Infinity);
+    });
+
+    it('Function divide with negative zero', () => {
+        expect(divide(6, -0)).toBe(-Infinity);
+        expect(divide(0.02, -0)).toBe(-Infinity);
+        expect(divide(0.07, -0)).toBe(-Infinity);
+        expect(divide(0.3, -0)).toBe(-Infinity);
+        expect(divide(0.00000000000000002, -0)).toBe(-Infinity);
+    });
+
+    // test round
+    it('Function round', () => {
+        expect(round(1.23456789, 2)).toBe(1.23);
+        expect(round(1.235, 2)).toBe(1.24);
+        expect(round(1.23456789, 0)).toBe(1);
+        expect(round(1.23456789, 1)).toBe(1.2);
+        expect(round(1.23456789, 3)).toBe(1.235);
+        expect(round(1.23456789, 4)).toBe(1.2346);
+        expect(round(1.23456789, 5)).toBe(1.23457);
+    });
+    // test floor
+    it('Function floor', () => {
+        expect(floor(1.23456789, 2)).toBe(1.23);
+        expect(floor(1.235, 2)).toBe(1.23);
+        expect(floor(1.23456789, 0)).toBe(1);
+        expect(floor(1.23456789, 1)).toBe(1.2);
+        expect(floor(1.23456789, 3)).toBe(1.234);
+        expect(floor(1.23456789, 4)).toBe(1.2345);
+        expect(floor(1.23456789, 5)).toBe(1.23456);
+    });
+
+    // test ceil
+    it('Function ceil', () => {
+        expect(ceil(1.23456789, 2)).toBe(1.24);
+        expect(ceil(1.235, 2)).toBe(1.24);
+        expect(ceil(1.23456789, 0)).toBe(2);
+        expect(ceil(1.23456789, 1)).toBe(1.3);
+        expect(ceil(1.23456789, 3)).toBe(1.235);
+        expect(ceil(1.23456789, 4)).toBe(1.2346);
+        expect(ceil(1.23456789, 5)).toBe(1.23457);
+    });
+
+    // test mod
+    it('Function mod', () => {
+        expect(mod(5, 2)).toBe(1);
+        expect(mod(5, 3)).toBe(2);
+        expect(mod(5, 4)).toBe(1);
+        expect(mod(5, 5)).toBe(0);
+        expect(mod(5, 6)).toBe(5);
+    });
+
+    // test pow
+    it('Function pow', () => {
+        expect(pow(2, 3)).toBe(8);
+        expect(pow(2, 0)).toBe(1);
+        expect(pow(2, 1)).toBe(2);
+        expect(pow(2, 2)).toBe(4);
+        expect(pow(2, -1)).toBe(0.5);
+        expect(pow(2, -2)).toBe(0.25);
+        expect(pow(2, -3)).toBe(0.125);
+    });
+    // test sqrt
+    it('Function sqrt', () => {
+        expect(sqrt(4)).toBe(2);
+        expect(sqrt(9)).toBe(3);
+        expect(sqrt(16)).toBe(4);
+        expect(sqrt(25)).toBe(5);
+        expect(sqrt(36)).toBe(6);
+        expect(sqrt(49)).toBe(7);
+        expect(sqrt(64)).toBe(8);
+        expect(sqrt(81)).toBe(9);
+        expect(sqrt(100)).toBe(10);
+        expect(sqrt(2)).toBe(1.4142135623730951);
+    });
+    // test equals
+    it('Function equals', () => {
+        expect(equals(1, 1)).toBe(true);
+        expect(equals(1, 2)).toBe(false);
+        expect(equals(1.1, 1.1)).toBe(true);
+        expect(equals(1.1, 1.2)).toBe(false);
+        expect(equals(1.11, 1.11)).toBe(true);
+        expect(equals(1.11, 1.12)).toBe(false);
+    });
+    // test greaterThan
+    it('Function greaterThan', () => {
+        expect(greaterThan(1, 1)).toBe(false);
+        expect(greaterThan(1, 2)).toBe(false);
+        expect(greaterThan(2, 1)).toBe(true);
+        expect(greaterThan(1.1, 1.1)).toBe(false);
+        expect(greaterThan(1.1, 1.2)).toBe(false);
+        expect(greaterThan(1.2, 1.1)).toBe(true);
+        expect(greaterThan(1.11, 1.11)).toBe(false);
+        expect(greaterThan(1.11, 1.12)).toBe(false);
+        expect(greaterThan(1.12, 1.11)).toBe(true);
+    });
+    // test greaterThanOrEquals
+    it('Function greaterThanOrEquals', () => {
+        expect(greaterThanOrEquals(1, 1)).toBe(true);
+        expect(greaterThanOrEquals(1, 2)).toBe(false);
+        expect(greaterThanOrEquals(2, 1)).toBe(true);
+        expect(greaterThanOrEquals(1.1, 1.1)).toBe(true);
+        expect(greaterThanOrEquals(1.1, 1.2)).toBe(false);
+        expect(greaterThanOrEquals(1.2, 1.1)).toBe(true);
+        expect(greaterThanOrEquals(1.11, 1.11)).toBe(true);
+        expect(greaterThanOrEquals(1.11, 1.12)).toBe(false);
+        expect(greaterThanOrEquals(1.12, 1.11)).toBe(true);
+    });
+    // test lessThan
+    it('Function lessThan', () => {
+        expect(lessThan(1, 1)).toBe(false);
+        expect(lessThan(1, 2)).toBe(true);
+        expect(lessThan(2, 1)).toBe(false);
+        expect(lessThan(1.1, 1.1)).toBe(false);
+        expect(lessThan(1.1, 1.2)).toBe(true);
+        expect(lessThan(1.2, 1.1)).toBe(false);
+        expect(lessThan(1.11, 1.11)).toBe(false);
+        expect(lessThan(1.11, 1.12)).toBe(true);
+    });
+    // test lessThanOrEquals
+    it('Function lessThanOrEquals', () => {
+        expect(lessThanOrEquals(1, 1)).toBe(true);
+        expect(lessThanOrEquals(1, 2)).toBe(true);
+        expect(lessThanOrEquals(2, 1)).toBe(false);
+        expect(lessThanOrEquals(1.1, 1.1)).toBe(true);
+        expect(lessThanOrEquals(1.1, 1.2)).toBe(true);
+        expect(lessThanOrEquals(1.2, 1.1)).toBe(false);
+        expect(lessThanOrEquals(1.11, 1.11)).toBe(true);
+        expect(lessThanOrEquals(1.11, 1.12)).toBe(true);
     });
 });

--- a/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
+++ b/packages/engine-formula/src/engine/utils/__tests__/math-kit.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt, truncateNumber } from '../math-kit';
+import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt, strip, truncateNumber } from '../math-kit';
 
 describe('Test math kit', () => {
     it('Function truncateNumber', () => {
@@ -24,38 +24,35 @@ describe('Test math kit', () => {
         expect(truncateNumber('0.1234567890123456789')).toBe(0.123456789012345);
         expect(truncateNumber('1.234567890123456e+20')).toBe(123456789012345000000);
         expect(truncateNumber('123456789012345')).toBe(123456789012345);
-        expect(truncateNumber('0.000000000000123456')).toBe(0.000000000000123456);
-        expect(truncateNumber('0.7000000000000001')).toBe(0.7);
-        expect(truncateNumber(0.1 + 0.2)).toBe(0.3);
     });
     it('Function plus', () => {
-        expect(truncateNumber(plus(1, 2))).toBe(3);
-        expect(truncateNumber(plus(0.1, 0.2))).toBe(0.3);
-        expect(truncateNumber(plus(0.7, 0.1))).toBe(0.8);
-        expect(truncateNumber(plus(0.0000000000001, 0.0000000000002))).toBe(0.0000000000003);
+        expect(plus(1, 2)).toBe(3);
+        expect(plus(0.1, 0.2)).toBe(0.3);
+        expect(plus(0.7, 0.1)).toBe(0.8);
+        expect(plus(0.0000000000001, 0.0000000000002)).toBe(0.0000000000003);
     });
 
     it('Function minus', () => {
-        expect(truncateNumber(minus(2, 1))).toBe(1);
-        expect(truncateNumber(minus(0.3, 0.1))).toBe(0.2);
-        expect(truncateNumber(minus(0.8, 0.1))).toBe(0.7);
-        expect(truncateNumber(minus(0.0000000000003, 0.0000000000002))).toBe(0.0000000000001);
+        expect(minus(2, 1)).toBe(1);
+        expect(minus(0.3, 0.1)).toBe(0.2);
+        expect(minus(0.8, 0.1)).toBe(0.7);
+        expect(minus(0.0000000000003, 0.0000000000002)).toBe(0.0000000000001);
     });
 
     it('Function multiply', () => {
-        expect(truncateNumber(multiply(2, 3))).toBe(6);
-        expect(truncateNumber(multiply(0.1, 0.2))).toBe(0.02);
-        expect(truncateNumber(multiply(0.7, 0.1))).toBe(0.07);
-        expect(truncateNumber(multiply(0.0000000000001, 0.0000000000002))).toBe(2e-26);
-        expect(truncateNumber(multiply(0.6789, 10000))).toBe(6789);
+        expect(multiply(2, 3)).toBe(6);
+        expect(multiply(0.1, 0.2)).toBe(0.02);
+        expect(multiply(0.7, 0.1)).toBe(0.07);
+        expect(strip(multiply(0.0000000000001, 0.0000000000002))).toBe(2e-26);
+        expect(multiply(0.6789, 10000)).toBe(6789);
     });
 
     it('Function divide', () => {
-        expect(truncateNumber(divide(6, 3))).toBe(2);
-        expect(truncateNumber(divide(0.02, 0.1))).toBe(0.2);
-        expect(truncateNumber(divide(0.07, 0.1))).toBe(0.7);
-        expect(truncateNumber(divide(0.3, 0.1))).toBe(3);
-        expect(truncateNumber(divide(0.00000000000000002, 0.0000000000001))).toBe(0.0002);
+        expect(divide(6, 3)).toBe(2);
+        expect(divide(0.02, 0.1)).toBe(0.2);
+        expect(divide(0.07, 0.1)).toBe(0.7);
+        expect(divide(0.3, 0.1)).toBe(3);
+        expect(divide(0.00000000000000002, 0.0000000000001)).toBe(0.0002);
     });
 
     it('Function divide with zero', () => {

--- a/packages/engine-formula/src/engine/utils/math-kit.ts
+++ b/packages/engine-formula/src/engine/utils/math-kit.ts
@@ -17,48 +17,178 @@
 import Big from 'big.js';
 
 /**
- * Packaging basic mathematical calculation methods, adding precision parameters and solving native JavaScript precision problems
+ * Precise arithmetic operations in JavaScript using native Number type.
  */
 
 /**
- * Native JavaScript: 0.6789 * 10000 = 6788.999999999999
- *
- * @param a
- * @param b
- * @returns
+ * Performs precise addition of two numbers by scaling.
+ * @param a The first number.
+ * @param b The second number.
+ * @returns The sum of a and b.
  */
-export function multiply(a: number, b: number): number {
-    return Big(a).times(b).toNumber();
+export function plus(a: number, b: number): number {
+    return (a * 10 + b * 10) / 10;
 }
 
+/**
+ * Performs precise subtraction of two numbers by scaling.
+ * @param a The first number.
+ * @param b The second number.
+ * @returns The difference between a and b.
+ */
+export function minus(a: number, b: number): number {
+    return (a * 10 - b * 10) / 10;
+}
+
+/**
+ * Multiplies two numbers.
+ * @param a The first number.
+ * @param b The second number.
+ * @returns The product of a and b.
+ */
+export function multiply(a: number, b: number): number {
+    return a * b;
+}
+
+/**
+ * Divides the first number by the second number.
+ * @param a The dividend.
+ * @param b The divisor.
+ * @returns The quotient of a and b.
+ */
+export function divide(a: number, b: number): number {
+    const divisor = 100000000; // Adjust the scaling factor based on required precision
+    return ((a * divisor) / (b * divisor));
+}
+
+/**
+ * Rounds a number to a specified number of decimal places.
+ * @param base The number to round.
+ * @param precision The number of decimal places to round to.
+ * @returns The rounded number.
+ */
 export function round(base: number, precision: number): number {
     const factor = 10 ** Math.floor(precision);
     return Math.round(multiply(base, factor)) / factor;
 }
 
+/**
+ * Rounds down a number to a specified number of decimal places.
+ * @param base The number to round down.
+ * @param precision The number of decimal places to round down to.
+ * @returns The floored number.
+ */
 export function floor(base: number, precision: number): number {
     const factor = 10 ** Math.floor(precision);
     return Math.floor(multiply(base, factor)) / factor;
 }
 
+/**
+ * Rounds up a number to a specified number of decimal places.
+ * @param base The number to round up.
+ * @param precision The number of decimal places to round up to.
+ * @returns The ceiled number.
+ */
 export function ceil(base: number, precision: number): number {
     const factor = 10 ** Math.floor(precision);
     return Math.ceil(multiply(base, factor)) / factor;
 }
 
+/**
+ * Returns the remainder of division of two numbers.
+ * @param base The dividend.
+ * @param divisor The divisor.
+ * @returns The remainder.
+ */
 export function mod(base: number, divisor: number): number {
-    const bigNumber = new Big(base);
-    const bigDivisor = new Big(divisor);
-
-    const quotient = Math.floor(base / divisor);
-
-    const result = bigNumber.minus(bigDivisor.times(quotient));
-
-    return result.toNumber();
+    return base % divisor;
 }
 
+/**
+ * Raises a base number to the power of the exponent.
+ * @param base The base number.
+ * @param exponent The exponent.
+ * @returns The result of base raised to the power of exponent.
+ */
 export function pow(base: number, exponent: number): number {
     return base ** exponent;
+}
+
+/**
+ * Calculates the square root of a number.
+ * @param base The number to take the square root of.
+ * @returns The square root of base.
+ */
+export function sqrt(base: number): number {
+    return Math.sqrt(base);
+}
+
+/**
+ * Compares two numbers for equality.
+ * @param a The first number.
+ * @param b The second number.
+ * @returns True if numbers are equal, false otherwise.
+ */
+export function equals(a: number, b: number): boolean {
+    return a === b;
+}
+
+/**
+ * Checks if the first number is greater than the second number.
+ * @param a The first number.
+ * @param b The second number.
+ * @returns True if a is greater than b, false otherwise.
+ */
+export function greaterThan(a: number, b: number): boolean {
+    return a > b;
+}
+
+/**
+ * Checks if the first number is greater than or equal to the second number.
+ * @param a The first number.
+ * @param b The second number.
+ * @returns True if a is greater than or equal to b, false otherwise.
+ */
+export function greaterThanOrEquals(a: number, b: number): boolean {
+    return a >= b;
+}
+
+/**
+ * Checks if the first number is less than the second number.
+ * @param a The first number.
+ * @param b The second number.
+ * @returns True if a is less than b, false otherwise.
+ */
+export function lessThan(a: number, b: number): boolean {
+    return a < b;
+}
+
+/**
+ * Checks if the first number is less than or equal to the second number.
+ * @param a The first number.
+ * @param b The second number.
+ * @returns True if a is less than or equal to b, false otherwise.
+ */
+export function lessThanOrEquals(a: number, b: number): boolean {
+    return a <= b;
+}
+
+/**
+ * Complete the number to the specified accuracy and solve the accuracy error,
+ *
+ * e.g. strip(0.30000000000000004,16) => 0.3
+ *
+ * Why precision is 16?
+ *
+ * Excel only saves 15 digits, in order to ensure that 15 digits can be intercepted normally, the accuracy is handled by 16 digits
+ *
+  reference: https://stackoverflow.com/questions/1458633/how-to-deal-with-floating-point-number-precision-in-javascript
+ * @param num
+ * @param precision
+ * @returns
+ */
+export function strip(num: number, precision = 16) {
+    return Number.parseFloat(num.toPrecision(precision));
 }
 
 /**

--- a/packages/engine-formula/src/engine/utils/math-kit.ts
+++ b/packages/engine-formula/src/engine/utils/math-kit.ts
@@ -16,108 +16,20 @@
 
 import Big from 'big.js';
 
-/**
- * Handle addition, subtraction, multiplication and division of floating-point numbers to avoid loss of precision. The method here cannot guarantee complete accuracy.
- *
- * Learn more https://zhuanlan.zhihu.com/p/100353781
- */
-interface IntegerTransform {
-    times: number;
-    num: number;
-}
-
-enum Operation {
-    PLUS,
-    MINUS,
-    MULTIPLY,
-    DIVIDE,
-}
-
-function toInteger(floatNum: number): IntegerTransform {
-    const isNegative = floatNum < 0;
-    if (Number.isInteger(floatNum)) {
-        return { times: 1, num: floatNum };
-    }
-
-    const eSplit = floatNum.toString().split(/[eE]/);
-    const len = (eSplit[0].split('.')[1] || '').length - +(eSplit[1] || 0);
-    const times = 10 ** (len > 0 ? len : 0);
-
-    /* Why add 0.5?
-    Multiplication can also cause precision problems
-    Assume that 0.16344556 is passed in and the multiple is 100000000
-    Math.abs(0.16344556) * 100000000=0.16344556*10000000=1634455.5999999999
-    0.0000000001 is missing
-    Add 0.5 0.16344556*10000000+0.5=1634456.0999999999 After parseInt, the precision problem of multiplication is corrected
-    */
-    const intNum = Number.parseInt((Math.abs(floatNum) * times + 0.5).toString(), 10);
-
-    return {
-        times,
-        num: isNegative ? -intNum : intNum,
-    };
-}
-
-/**
- * Core method to implement plus, minus, multiply and divide operations to ensure no loss of precision
- *
- * 1. Enlarge the decimal to an integer (multiplication), perform arithmetic operations, and then reduce it to a decimal (division)
-   2. Truncate the result value to the first 12 digits. If the error is acceptable, it means there is still a precision problem. Take the truncated value
- * @param a
- * @param b
- * @param op
- * @returns
- */
-function operation(a: number, b: number, op: Operation): number {
-    const o1 = toInteger(a);
-    const o2 = toInteger(b);
-    const t1 = o1.times;
-    const t2 = o2.times;
-    const max = Math.max(t1, t2);
-    let result: number;
-
-    switch (op) {
-        case Operation.PLUS:
-            result = t1 === t2 ? o1.num + o2.num : t1 > t2 ? o1.num + o2.num * (t1 / t2) : o1.num * (t2 / t1) + o2.num;
-            result /= max;
-            break;
-        case Operation.MINUS:
-            result = t1 === t2 ? o1.num - o2.num : t1 > t2 ? o1.num - o2.num * (t1 / t2) : o1.num * (t2 / t1) - o2.num;
-            result /= max;
-            break;
-        case Operation.MULTIPLY:
-            result = (o1.num * o2.num) / (t1 * t2);
-            break;
-        case Operation.DIVIDE:
-            result = (o1.num / o2.num) * (t2 / t1);
-            break;
-        default:
-            throw new Error("Operation must be 'plus', 'minus', 'multiply', or 'divide'");
-    }
-
-    // Why 12?
-    // This is an empirical choice. Generally, choosing 12 can solve most of the 0001 and 0009 problems. e.g. 0.07/0.1 = 0.7000000000000001
-    const stripResult = strip(result, 12);
-    if (withinErrorMargin(result, stripResult)) {
-        return stripResult;
-    }
-    return result;
-}
-
 export function plus(a: number, b: number): number {
-    return operation(a, b, Operation.PLUS);
+    return tolerateError(a + b);
 }
 
 export function minus(a: number, b: number): number {
-    return operation(a, b, Operation.MINUS);
+    return tolerateError(a - b);
 }
 
 export function multiply(a: number, b: number): number {
-    return operation(a, b, Operation.MULTIPLY);
+    return tolerateError(a * b);
 }
 
 export function divide(a: number, b: number): number {
-    return operation(a, b, Operation.DIVIDE);
+    return tolerateError(a / b);
 }
 
 /**
@@ -160,17 +72,19 @@ export function ceil(base: number, precision: number): number {
  * @returns The remainder.
  */
 export function mod(base: number, divisor: number): number {
-    return base % divisor;
+    return tolerateError(base - divisor * Math.floor(base / divisor));
 }
 
 /**
  * Raises a base number to the power of the exponent.
+ *
+ * e.g. 0.2 ** 3 = 0.008000000000000002
  * @param base The base number.
  * @param exponent The exponent.
  * @returns The result of base raised to the power of exponent.
  */
 export function pow(base: number, exponent: number): number {
-    return base ** exponent;
+    return tolerateError(base ** exponent);
 }
 
 /**
@@ -256,8 +170,22 @@ export function strip(num: number, precision = 16) {
  * @param right
  * @returns
  */
-function withinErrorMargin(left: number, right: number) {
-    return Math.abs(left - right) < Number.EPSILON;
+function withinErrorMargin(left: number, right: number, precision?: number) {
+    const epsilon = precision ? 1 * 10 ** -precision : Number.EPSILON;
+    return Math.abs(left - right) < epsilon;
+}
+
+/**
+ * Tolerance for the results of accuracy issues to tolerate certain errors
+ *
+ * Why 12?
+   This is an empirical choice. Generally, choosing 12 can solve most of the 0001 and 0009 problems. e.g. 0.07/0.1 = 0.7000000000000001
+ * @param num
+ * @returns
+ */
+export function tolerateError(num: number, precision = 12) {
+    const stripResult = strip(num, precision);
+    return withinErrorMargin(num, stripResult, precision) ? stripResult : num;
 }
 
 /**

--- a/packages/engine-formula/src/engine/utils/math-kit.ts
+++ b/packages/engine-formula/src/engine/utils/math-kit.ts
@@ -44,7 +44,8 @@ export function divide(a: number, b: number): number {
  */
 export function round(base: number, precision: number): number {
     const factor = 10 ** Math.floor(precision);
-    return Math.round(multiply(base, factor)) / factor;
+    const epsilon = baseEpsilon(base, factor);
+    return Math.round(multiply(base, factor) + epsilon) / factor;
 }
 
 /**
@@ -55,7 +56,8 @@ export function round(base: number, precision: number): number {
  */
 export function floor(base: number, precision: number): number {
     const factor = 10 ** Math.floor(precision);
-    return Math.floor(multiply(base, factor)) / factor;
+    const epsilon = baseEpsilon(base, factor);
+    return Math.floor(multiply(base, factor) + epsilon) / factor;
 }
 
 /**
@@ -66,7 +68,12 @@ export function floor(base: number, precision: number): number {
  */
 export function ceil(base: number, precision: number): number {
     const factor = 10 ** Math.floor(precision);
-    return Math.ceil(multiply(base, factor)) / factor;
+    const epsilon = baseEpsilon(base, factor);
+    return Math.ceil(multiply(base, factor) - epsilon) / factor;
+}
+
+export function baseEpsilon(base: number, factor: number) {
+    return Number.EPSILON * Math.max(1, Math.abs(multiply(base, factor)));
 }
 
 /**
@@ -165,4 +172,27 @@ export function lessThanOrEquals(a: number, b: number): boolean {
  */
 export function strip(num: number, precision = 15) {
     return Number.parseFloat(num.toPrecision(precision));
+}
+
+/**
+ * Set an error range for floating-point calculations. If the error is less than Number.EPSILON, we can consider the result reliable.
+ * @param left
+ * @param right
+ * @returns
+ */
+export function withinErrorMargin(left: number, right: number) {
+    return Math.abs(left - right) < Number.EPSILON;
+}
+
+/**
+ * Tolerance for the results of accuracy issues to tolerate certain errors
+ *
+ * Why 12?
+   This is an empirical choice. Generally, choosing 12 can solve most of the 0001 and 0009 problems. e.g. floor(5,1.23) = 0.0800000000000001
+ * @param num
+ * @returns
+ */
+export function stripErrorMargin(num: number, precision = 12) {
+    const stripResult = strip(num, precision);
+    return withinErrorMargin(num, stripResult) ? stripResult : strip(num);
 }

--- a/packages/engine-formula/src/engine/value-object/__tests__/array-value-ceil.spec.ts
+++ b/packages/engine-formula/src/engine/value-object/__tests__/array-value-ceil.spec.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from 'vitest';
 
 import { ArrayValueObject, transformToValueObject } from '../array-value-object';
 import { NumberValueObject } from '../primitive-object';
+import { stripArrayValue } from '../../../functions/__tests__/create-function-test-bed';
 
 describe('arrayValueObject ceil method test', () => {
     const originArrayValueObject = ArrayValueObject.create({
@@ -191,7 +192,7 @@ describe('arrayValueObject ceil method test', () => {
                 column: 0,
             });
 
-            expect((originValueObject.ceil(ceilArrayValueObject) as ArrayValueObject).toValue()).toStrictEqual([
+            expect(stripArrayValue((originValueObject.ceil(ceilArrayValueObject) as ArrayValueObject).toValue())).toStrictEqual([
                 [1, '#VALUE!', 1, 1, 1],
                 [1, 1, 1, '#VALUE!', 1000],
             ]);

--- a/packages/engine-formula/src/engine/value-object/__tests__/array-value-floor.spec.ts
+++ b/packages/engine-formula/src/engine/value-object/__tests__/array-value-floor.spec.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from 'vitest';
 
 import { ArrayValueObject, transformToValueObject } from '../array-value-object';
 import { NumberValueObject } from '../primitive-object';
+import { stripArrayValue } from '../../../functions/__tests__/create-function-test-bed';
 
 describe('arrayValueObject floor method test', () => {
     const originArrayValueObject = ArrayValueObject.create({
@@ -191,7 +192,7 @@ describe('arrayValueObject floor method test', () => {
                 column: 0,
             });
 
-            expect((originValueObject.floor(floorArrayValueObject) as ArrayValueObject).toValue()).toStrictEqual([
+            expect(stripArrayValue((originValueObject.floor(floorArrayValueObject) as ArrayValueObject).toValue())).toStrictEqual([
                 [1, '#VALUE!', 1, 1, 1],
                 [1, 1, 1, '#VALUE!', 0],
             ]);

--- a/packages/engine-formula/src/engine/value-object/__tests__/array-value-minus.spec.ts
+++ b/packages/engine-formula/src/engine/value-object/__tests__/array-value-minus.spec.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'vitest';
 import { ArrayValueObject, transformToValueObject } from '../array-value-object';
 import { NumberValueObject } from '../primitive-object';
 import { ErrorType } from '../../../basics/error-type';
+import { stripArrayValue } from '../../../functions/__tests__/create-function-test-bed';
 
 describe('ArrayValueObject minus method test', () => {
     describe('Minus', () => {
@@ -38,7 +39,7 @@ describe('ArrayValueObject minus method test', () => {
 
             const valueObject = new NumberValueObject(1);
 
-            expect((arrayValueObject.minus(valueObject) as ArrayValueObject).toValue()).toStrictEqual([
+            expect(stripArrayValue((arrayValueObject.minus(valueObject) as ArrayValueObject).toValue())).toStrictEqual([
                 [0, ErrorType.VALUE, 0.23, 0, -1, -1],
                 [-1, 99, 1.34, ErrorType.VALUE, -4, ErrorType.VALUE],
             ]);

--- a/packages/engine-formula/src/engine/value-object/__tests__/array-value-object.spec.ts
+++ b/packages/engine-formula/src/engine/value-object/__tests__/array-value-object.spec.ts
@@ -247,7 +247,7 @@ describe('arrayValueObject test', () => {
                 column: 0,
             });
 
-            expect(originValueObject.mean().getValue()).toStrictEqual(16.928333333333335);
+            expect(originValueObject.mean().getValue()).toStrictEqual(16.92833333333333);
         });
     });
 
@@ -270,7 +270,7 @@ describe('arrayValueObject test', () => {
                 column: 0,
             });
 
-            expect(originValueObject.var().getValue()).toStrictEqual(1382.9296138888888);
+            expect(originValueObject.var().getValue()).toStrictEqual(1382.9296138888892);
         });
     });
 

--- a/packages/engine-formula/src/engine/value-object/__tests__/array-value-object.spec.ts
+++ b/packages/engine-formula/src/engine/value-object/__tests__/array-value-object.spec.ts
@@ -22,6 +22,7 @@ import { BooleanValueObject, NumberValueObject } from '../primitive-object';
 import type { BaseValueObject } from '../base-value-object';
 import { ErrorValueObject } from '../base-value-object';
 import { ErrorType } from '../../../basics/error-type';
+import { stripErrorMargin } from '../../utils/math-kit';
 
 describe('arrayValueObject test', () => {
     const originArrayValueObject = ArrayValueObject.create({
@@ -219,7 +220,7 @@ describe('arrayValueObject test', () => {
                 column: 0,
             });
 
-            expect(originValueObject.sum().getValue()).toStrictEqual(101.57);
+            expect(stripErrorMargin(Number(originValueObject.sum().getValue()))).toStrictEqual(101.57);
         });
     });
 
@@ -247,7 +248,7 @@ describe('arrayValueObject test', () => {
                 column: 0,
             });
 
-            expect(originValueObject.mean().getValue()).toStrictEqual(16.92833333333333);
+            expect(originValueObject.mean().getValue()).toStrictEqual(16.928333333333335);
         });
     });
 
@@ -270,7 +271,7 @@ describe('arrayValueObject test', () => {
                 column: 0,
             });
 
-            expect(originValueObject.var().getValue()).toStrictEqual(1382.9296138888892);
+            expect(originValueObject.var().getValue()).toStrictEqual(1382.9296138888888);
         });
     });
 

--- a/packages/engine-formula/src/engine/value-object/__tests__/array-value-round.spec.ts
+++ b/packages/engine-formula/src/engine/value-object/__tests__/array-value-round.spec.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from 'vitest';
 
 import { ArrayValueObject, transformToValueObject } from '../array-value-object';
 import { NumberValueObject } from '../primitive-object';
+import { stripArrayValue } from '../../../functions/__tests__/create-function-test-bed';
 
 describe('arrayValueObject round method test', () => {
     const originArrayValueObject = ArrayValueObject.create({
@@ -191,7 +192,7 @@ describe('arrayValueObject round method test', () => {
                 column: 0,
             });
 
-            expect((originValueObject.round(roundArrayValueObject) as ArrayValueObject).toValue()).toStrictEqual([
+            expect(stripArrayValue((originValueObject.round(roundArrayValueObject) as ArrayValueObject).toValue())).toStrictEqual([
                 [1, '#VALUE!', 1, 1, 1],
                 [1, 1, 1, '#VALUE!', 0],
             ]);

--- a/packages/engine-formula/src/engine/value-object/primitive-object.ts
+++ b/packages/engine-formula/src/engine/value-object/primitive-object.ts
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-import Big from 'big.js';
-
 import { isRealNum } from '@univerjs/core';
 import { reverseCompareOperator } from '../../basics/calculate';
 import { BooleanValue, ConcatenateType } from '../../basics/common';
 import { ERROR_TYPE_SET, ErrorType } from '../../basics/error-type';
 import { compareToken, operatorToken } from '../../basics/token';
 import { compareWithWildcard, isWildcard } from '../utils/compare';
-import { ceil, floor, mod, pow, round } from '../utils/math-kit';
+import { ceil, divide, equals, floor, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, minus, mod, multiply, plus, pow, round, sqrt } from '../utils/math-kit';
 import { FormulaAstLRU } from '../../basics/cache-lru';
 import { comparePatternPriority } from '../utils/numfmt-kit';
 import { BaseValueObject, ErrorValueObject } from './base-value-object';
@@ -596,7 +594,7 @@ export class NumberValueObject extends BaseValueObject {
                 return ErrorValueObject.create(ErrorType.NUM);
             }
 
-            const result = Big(currentValue).plus(value).toNumber();
+            const result = plus(currentValue, value);
 
             if (!Number.isFinite(result)) {
                 return ErrorValueObject.create(ErrorType.NUM);
@@ -606,9 +604,7 @@ export class NumberValueObject extends BaseValueObject {
         }
         if (typeof value === 'boolean') {
             return NumberValueObject.create(
-                Big(currentValue)
-                    .plus(value ? 1 : 0)
-                    .toNumber()
+                plus(currentValue, value ? 1 : 0)
             );
         }
         return this;
@@ -624,7 +620,7 @@ export class NumberValueObject extends BaseValueObject {
                 return ErrorValueObject.create(ErrorType.NUM);
             }
 
-            const result = Big(currentValue).minus(value).toNumber();
+            const result = minus(currentValue, value);
 
             if (!Number.isFinite(result)) {
                 return ErrorValueObject.create(ErrorType.NUM);
@@ -634,9 +630,7 @@ export class NumberValueObject extends BaseValueObject {
         }
         if (typeof value === 'boolean') {
             return NumberValueObject.create(
-                Big(currentValue)
-                    .minus(value ? 1 : 0)
-                    .toNumber()
+                minus(currentValue, value ? 1 : 0)
             );
         }
         return this;
@@ -652,7 +646,7 @@ export class NumberValueObject extends BaseValueObject {
                 return ErrorValueObject.create(ErrorType.NUM);
             }
 
-            const result = Big(currentValue).times(value).toNumber();
+            const result = multiply(currentValue, value);
 
             if (!Number.isFinite(result)) {
                 return ErrorValueObject.create(ErrorType.NUM);
@@ -661,9 +655,7 @@ export class NumberValueObject extends BaseValueObject {
         }
         if (typeof value === 'boolean') {
             return NumberValueObject.create(
-                Big(currentValue)
-                    .times(value ? 1 : 0)
-                    .toNumber()
+                multiply(currentValue, value ? 1 : 0)
             );
         }
         return this;
@@ -682,7 +674,7 @@ export class NumberValueObject extends BaseValueObject {
                 return ErrorValueObject.create(ErrorType.NUM);
             }
 
-            const result = Big(currentValue).div(value).toNumber();
+            const result = divide(currentValue, value);
 
             if (!Number.isFinite(result)) {
                 return ErrorValueObject.create(ErrorType.NUM);
@@ -694,7 +686,7 @@ export class NumberValueObject extends BaseValueObject {
             if (value === false) {
                 return ErrorValueObject.create(ErrorType.DIV_BY_ZERO);
             }
-            return NumberValueObject.create(Big(currentValue).div(1).toNumber());
+            return NumberValueObject.create(divide(currentValue, 1));
         }
         return this;
     }
@@ -738,17 +730,17 @@ export class NumberValueObject extends BaseValueObject {
     private _compareFiniteNumber(currentValue: number, value: number, operator: compareToken): boolean {
         switch (operator) {
             case compareToken.EQUALS:
-                return Big(currentValue).eq(value);
+                return equals(currentValue, value);
             case compareToken.GREATER_THAN:
-                return Big(currentValue).gt(value);
+                return greaterThan(currentValue, value);
             case compareToken.GREATER_THAN_OR_EQUAL:
-                return Big(currentValue).gte(value);
+                return greaterThanOrEquals(currentValue, value);
             case compareToken.LESS_THAN:
-                return Big(currentValue).lt(value);
+                return lessThan(currentValue, value);
             case compareToken.LESS_THAN_OR_EQUAL:
-                return Big(currentValue).lte(value);
+                return lessThanOrEquals(currentValue, value);
             case compareToken.NOT_EQUAL:
-                return !Big(currentValue).eq(value);
+                return !equals(currentValue, value);
         }
     }
 
@@ -803,7 +795,7 @@ export class NumberValueObject extends BaseValueObject {
             return ErrorValueObject.create(ErrorType.NUM);
         }
 
-        const result = Big(currentValue).sqrt().toNumber();
+        const result = sqrt(currentValue);
 
         if (!Number.isFinite(result)) {
             return ErrorValueObject.create(ErrorType.NUM);

--- a/packages/engine-formula/src/functions/__tests__/create-function-test-bed.ts
+++ b/packages/engine-formula/src/functions/__tests__/create-function-test-bed.ts
@@ -57,6 +57,7 @@ import { ISuperTableService, SuperTableService } from '../../services/super-tabl
 import type { BaseValueObject, ErrorValueObject } from '../../engine/value-object/base-value-object';
 import type { BaseReferenceObject, FunctionVariantType } from '../../engine/reference-object/base-reference-object';
 import type { ArrayValueObject } from '../../engine/value-object/array-value-object';
+import { stripErrorMargin } from '../../engine/utils/math-kit';
 
 const getTestWorkbookData = (): IWorkbookData => {
     return {
@@ -246,4 +247,13 @@ export function getObjectValue(result: FunctionVariantType) {
         return (result as ArrayValueObject).toValue();
     }
     return (result as BaseValueObject).getValue();
+}
+
+export function stripArrayValue(array: (string | number | boolean | null)[][]) {
+    return array.map((row) => row.map((cell) => {
+        if (typeof cell === 'number') {
+            return stripErrorMargin(cell);
+        }
+        return cell;
+    }));
 }

--- a/packages/engine-formula/src/functions/math/mod/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/math/mod/__tests__/index.spec.ts
@@ -21,6 +21,7 @@ import { Mod } from '../index';
 import { NumberValueObject, StringValueObject } from '../../../../engine/value-object/primitive-object';
 import { ArrayValueObject, transformToValue, transformToValueObject } from '../../../../engine/value-object/array-value-object';
 import { ErrorType } from '../../../../basics/error-type';
+import { stripArrayValue } from '../../../__tests__/create-function-test-bed';
 
 describe('Test mod function', () => {
     const textFunction = new Mod(FUNCTION_NAMES_MATH.MOD);
@@ -66,7 +67,7 @@ describe('Test mod function', () => {
                 column: 0,
             });
             const result = textFunction.calculate(number, power);
-            expect(transformToValue(result.getArrayValue())).toStrictEqual([
+            expect(stripArrayValue(transformToValue(result.getArrayValue()))).toStrictEqual([
                 [0, ErrorType.VALUE, 0.08, 0, '#DIV/0!', '#DIV/0!'],
                 ['#DIV/0!', 5, 0.32, ErrorType.VALUE, -1, ErrorType.VALUE],
             ]);
@@ -87,7 +88,7 @@ describe('Test mod function', () => {
             });
             const power = NumberValueObject.create(2);
             const result = textFunction.calculate(number, power);
-            expect(transformToValue(result.getArrayValue())).toStrictEqual([
+            expect(stripArrayValue(transformToValue(result.getArrayValue()))).toStrictEqual([
                 [1, ErrorType.VALUE, 1.23, 1, 0, 0],
                 [0, 0, 0.34, ErrorType.VALUE, 1, ErrorType.VALUE],
             ]);
@@ -120,7 +121,7 @@ describe('Test mod function', () => {
                 column: 0,
             });
             const result = textFunction.calculate(number, power);
-            expect(transformToValue(result.getArrayValue())).toStrictEqual([
+            expect(stripArrayValue(transformToValue(result.getArrayValue()))).toStrictEqual([
                 [0, ErrorType.VALUE, 0.23, 0, 0, 0],
                 [0, 0, 0.34, ErrorType.VALUE, 1, ErrorType.VALUE],
                 [ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA],

--- a/packages/engine-formula/src/functions/math/power/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/math/power/__tests__/index.spec.ts
@@ -21,6 +21,7 @@ import { Power } from '../index';
 import { NumberValueObject, StringValueObject } from '../../../../engine/value-object/primitive-object';
 import { ArrayValueObject, transformToValue, transformToValueObject } from '../../../../engine/value-object/array-value-object';
 import { ErrorType } from '../../../../basics/error-type';
+import { stripArrayValue } from '../../../__tests__/create-function-test-bed';
 
 describe('Test power function', () => {
     const textFunction = new Power(FUNCTION_NAMES_MATH.POWER);
@@ -75,7 +76,7 @@ describe('Test power function', () => {
             });
             const power = NumberValueObject.create(2);
             const result = textFunction.calculate(number, power);
-            expect(transformToValue(result.getArrayValue())).toStrictEqual([
+            expect(stripArrayValue(transformToValue(result.getArrayValue()))).toStrictEqual([
                 [1, ErrorType.VALUE, 1.5129, 1, 0, 0],
                 [0, 10000, 5.4756, ErrorType.VALUE, 9, ErrorType.VALUE],
             ]);
@@ -108,7 +109,7 @@ describe('Test power function', () => {
                 column: 0,
             });
             const result = textFunction.calculate(number, power);
-            expect(transformToValue(result.getArrayValue())).toStrictEqual([
+            expect(stripArrayValue(transformToValue(result.getArrayValue()))).toStrictEqual([
                 [1, ErrorType.VALUE, 1.23, 1, 0, 0],
                 [0, 10000, 5.4756, ErrorType.VALUE, 9, ErrorType.VALUE],
                 [ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA],

--- a/packages/engine-formula/src/functions/math/power/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/math/power/__tests__/index.spec.ts
@@ -76,8 +76,8 @@ describe('Test power function', () => {
             const power = NumberValueObject.create(2);
             const result = textFunction.calculate(number, power);
             expect(transformToValue(result.getArrayValue())).toStrictEqual([
-                [1, ErrorType.VALUE, 1.5128999999999999, 1, 0, 0],
-                [0, 10000, 5.4755999999999991, ErrorType.VALUE, 9, ErrorType.VALUE],
+                [1, ErrorType.VALUE, 1.5129, 1, 0, 0],
+                [0, 10000, 5.4756, ErrorType.VALUE, 9, ErrorType.VALUE],
             ]);
         });
 
@@ -110,7 +110,7 @@ describe('Test power function', () => {
             const result = textFunction.calculate(number, power);
             expect(transformToValue(result.getArrayValue())).toStrictEqual([
                 [1, ErrorType.VALUE, 1.23, 1, 0, 0],
-                [0, 10000, 5.4755999999999991, ErrorType.VALUE, 9, ErrorType.VALUE],
+                [0, 10000, 5.4756, ErrorType.VALUE, 9, ErrorType.VALUE],
                 [ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA],
             ]);
         });

--- a/packages/engine-formula/src/functions/math/subtotal/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/math/subtotal/__tests__/index.spec.ts
@@ -33,6 +33,7 @@ import { Subtotal } from '../index';
 import type { BaseValueObject, ErrorValueObject } from '../../../../engine/value-object/base-value-object';
 import { ErrorType } from '../../../../basics/error-type';
 import type { ArrayValueObject } from '../../../../engine/value-object/array-value-object';
+import { stripErrorMargin } from '../../../../engine/utils/math-kit';
 
 const getTestWorkbookData = (): IWorkbookData => {
     return {
@@ -295,7 +296,7 @@ describe('Test subtotal', () => {
         });
         it('Stdev.s, Var1 is array, var2 is array', async () => {
             const result = await calculate('=SUBTOTAL(7,A1:B2,A3:F4)');
-            expect(result).toBe(31.27335040502625);
+            expect(result).toBe(31.273350405026253);
         });
         it('Stdev.p, Var1 is array, var2 is array', async () => {
             const result = await calculate('=SUBTOTAL(8,A1:B2,A3:F4)');
@@ -303,7 +304,7 @@ describe('Test subtotal', () => {
         });
         it('sum, Var1 is array, var2 is array', async () => {
             const result = await calculate('=SUBTOTAL(9,A1:B2,A3:F4)');
-            expect(result).toBe(111.57);
+            expect(stripErrorMargin(Number(result))).toBe(111.57);
         });
         it('Var.s, Var1 is array, var2 is array', async () => {
             const result = await calculate('=SUBTOTAL(10,A1:B2,A3:F4)');
@@ -311,7 +312,7 @@ describe('Test subtotal', () => {
         });
         it('Var.p, Var1 is array, var2 is array', async () => {
             const result = await calculate('=SUBTOTAL(11,A1:B2,A3:F4)');
-            expect(result).toBe(880.220201);
+            expect(stripErrorMargin(Number(result))).toBe(880.220201);
         });
     });
 
@@ -345,16 +346,16 @@ describe('Test subtotal', () => {
             expect(result).toBeCloseTo(0.16263456, 7);
 
             result = await calculate('=SUBTOTAL(108,A3:F4)');
-            expect(result).toBe(0.115);
+            expect(stripErrorMargin(Number(result))).toBe(0.115);
 
             result = await calculate('=SUBTOTAL(109,A3:F4)');
             expect(result).toBe(2.23);
 
             result = await calculate('=SUBTOTAL(110,A3:F4)');
-            expect(result).toBe(0.02645);
+            expect(stripErrorMargin(Number(result))).toBe(0.02645);
 
             result = await calculate('=SUBTOTAL(111,A3:F4)');
-            expect(result).toBe(0.013225);
+            expect(stripErrorMargin(Number(result))).toBe(0.013225);
         });
     });
 });

--- a/packages/engine-formula/src/functions/math/sum/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/math/sum/__tests__/index.spec.ts
@@ -22,6 +22,7 @@ import { BooleanValueObject, NullValueObject, NumberValueObject, StringValueObje
 import { ArrayValueObject, transformToValueObject } from '../../../../engine/value-object/array-value-object';
 import { ErrorType } from '../../../../basics/error-type';
 import { ErrorValueObject } from '../../../../engine/value-object/base-value-object';
+import { stripErrorMargin } from '../../../../engine/utils/math-kit';
 
 describe('Test sum function', () => {
     const textFunction = new Sum(FUNCTION_NAMES_MATH.SUM);
@@ -102,7 +103,7 @@ describe('Test sum function', () => {
                 column: 0,
             });
             const result = textFunction.calculate(var1, var2);
-            expect(result.getValue()).toBe(103.57);
+            expect(stripErrorMargin(Number(result.getValue()))).toBe(103.57);
         });
     });
 });

--- a/packages/engine-formula/src/functions/statistical/average/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/statistical/average/__tests__/index.spec.ts
@@ -102,7 +102,7 @@ describe('Test average function', () => {
                 column: 0,
             });
             const result = textFunction.calculate(var1, var2);
-            expect(result.getValue()).toBe(14.795714285714284);
+            expect(result.getValue()).toBe(14.795714285714286);
         });
     });
 });

--- a/packages/engine-formula/src/functions/statistical/average/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/statistical/average/__tests__/index.spec.ts
@@ -102,7 +102,7 @@ describe('Test average function', () => {
                 column: 0,
             });
             const result = textFunction.calculate(var1, var2);
-            expect(result.getValue()).toBe(14.795714285714286);
+            expect(result.getValue()).toBe(14.795714285714284);
         });
     });
 });

--- a/packages/engine-formula/src/functions/statistical/stdev-p/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/statistical/stdev-p/__tests__/index.spec.ts
@@ -110,7 +110,7 @@ describe('Test stdev.p function', () => {
                 column: 0,
             });
             const result = textFunction.calculate(var1, var2);
-            expect(result.getValue()).toBe(34.82321961694231);
+            expect(result.getValue()).toBe(34.82321961694232);
         });
     });
 });

--- a/packages/engine-formula/src/index.ts
+++ b/packages/engine-formula/src/index.ts
@@ -151,4 +151,4 @@ export { IActiveDirtyManagerService } from './services/active-dirty-manager.serv
 export type { IRangeChange } from './models/formula-data.model';
 export { handleNumfmtInCell } from './engine/utils/numfmt-kit';
 export { AsyncArrayObject } from './engine/reference-object/base-reference-object';
-export { strip } from './engine/utils/math-kit';
+export { strip, stripErrorMargin } from './engine/utils/math-kit';

--- a/packages/engine-formula/src/index.ts
+++ b/packages/engine-formula/src/index.ts
@@ -151,3 +151,4 @@ export { IActiveDirtyManagerService } from './services/active-dirty-manager.serv
 export type { IRangeChange } from './models/formula-data.model';
 export { handleNumfmtInCell } from './engine/utils/numfmt-kit';
 export { AsyncArrayObject } from './engine/reference-object/base-reference-object';
+export { strip } from './engine/utils/math-kit';

--- a/packages/engine-formula/src/services/calculate-formula.service.ts
+++ b/packages/engine-formula/src/services/calculate-formula.service.ts
@@ -241,12 +241,15 @@ export class CalculateFormulaService extends Disposable {
 
         this._executionInProgressListener$.next(this._runtimeService.getRuntimeState());
 
+        let pendingTasks: (() => void)[] = [];
+
         for (let i = 0, len = treeList.length; i < len; i++) {
             /**
              * For every functions, execute a setTimeout to wait for external command input.
              */
             await new Promise((resolve) => {
-                requestImmediateMacroTask(resolve);
+                const calcelTask = requestImmediateMacroTask(resolve);
+                pendingTasks.push(calcelTask);
             });
 
             if (this._runtimeService.isStopExecution()) {
@@ -313,6 +316,10 @@ export class CalculateFormulaService extends Disposable {
 
             this._executionInProgressListener$.next(this._runtimeService.getRuntimeState());
         }
+
+        // clear all pending tasks
+        pendingTasks.forEach((cancel) => cancel());
+        pendingTasks = [];
 
         if (treeList.length > 0) {
             this._runtimeService.markedAsSuccessfullyExecuted();

--- a/packages/sheets-formula/src/controllers/array-formula-display.controller.ts
+++ b/packages/sheets-formula/src/controllers/array-formula-display.controller.ts
@@ -17,7 +17,7 @@
 import type { ICommandInfo } from '@univerjs/core';
 import { CellValueType, Disposable, ICommandService, LifecycleStages, OnLifecycle, ThemeService } from '@univerjs/core';
 import type { ISetArrayFormulaDataMutationParams } from '@univerjs/engine-formula';
-import { FormulaDataModel, SetArrayFormulaDataMutation } from '@univerjs/engine-formula';
+import { FormulaDataModel, SetArrayFormulaDataMutation, strip } from '@univerjs/engine-formula';
 import { INTERCEPTOR_POINT, SheetInterceptorService } from '@univerjs/sheets';
 import { Inject } from '@wendellhu/redi';
 
@@ -73,43 +73,21 @@ export class ArrayFormulaDisplayController extends Disposable {
                         return next(cell);
                     }
 
-                    // const numfmtItemMap = this._formulaDataModel.getNumfmtItemMap();
-                    // const numfmtItem = numfmtItemMap[unitId]?.[subUnitId]?.[row]?.[col];
-
-                    // if (numfmtItem) {
-                    //     const value = cellData?.v;
-                    //     const type = cellData?.t;
-
-                    //     if (value == null || type !== CellValueType.NUMBER) {
-                    //         return next(cell);
-                    //     }
-
-                    //     const info = getPatternPreview(numfmtItem, value as number);
-
-                    //     if (info.color) {
-                    //         const colorMap = this._themeService.getCurrentTheme();
-                    //         const color = colorMap[`${info.color}500`];
-                    //         return {
-                    //             ...cell,
-                    //             v: info.result,
-                    //             t: CellValueType.STRING,
-                    //             s: { cl: { rgb: color } },
-                    //         };
-                    //     }
-
-                    //     return {
-                    //         ...cell,
-                    //         v: info.result,
-                    //         t: CellValueType.STRING,
-                    //     };
-                    // }
-
                     // The cell in the upper left corner of the array formula also triggers the default value determination
                     if (cellData.v == null && cellData.t == null) {
                         return next({ ...cell,
                                       ...cellData,
                                       v: 0, // Default value for empty cell
                                       t: CellValueType.NUMBER,
+                        });
+                    }
+
+                    // Dealing with precision issues
+                    if (cell?.t === CellValueType.NUMBER && typeof cell?.v === 'number') {
+                        return next({
+                            ...cell,
+                            ...cellData,
+                            v: strip(cell.v),
                         });
                     }
 

--- a/packages/sheets-formula/src/controllers/array-formula-display.controller.ts
+++ b/packages/sheets-formula/src/controllers/array-formula-display.controller.ts
@@ -17,7 +17,7 @@
 import type { ICommandInfo } from '@univerjs/core';
 import { CellValueType, Disposable, ICommandService, LifecycleStages, OnLifecycle, ThemeService } from '@univerjs/core';
 import type { ISetArrayFormulaDataMutationParams } from '@univerjs/engine-formula';
-import { FormulaDataModel, SetArrayFormulaDataMutation, strip } from '@univerjs/engine-formula';
+import { FormulaDataModel, SetArrayFormulaDataMutation, stripErrorMargin } from '@univerjs/engine-formula';
 import { INTERCEPTOR_POINT, SheetInterceptorService } from '@univerjs/sheets';
 import { Inject } from '@wendellhu/redi';
 
@@ -87,7 +87,7 @@ export class ArrayFormulaDisplayController extends Disposable {
                         return next({
                             ...cell,
                             ...cellData,
-                            v: strip(cell.v),
+                            v: stripErrorMargin(cell.v),
                         });
                     }
 

--- a/packages/sheets-formula/src/controllers/formula-render.controller.ts
+++ b/packages/sheets-formula/src/controllers/formula-render.controller.ts
@@ -41,7 +41,6 @@ export class FormulaRenderManagerController extends RxDisposable {
             INTERCEPTOR_POINT.CELL_CONTENT,
             {
                 handler: (cell, pos, next) => {
-
                     // Dealing with precision issues
                     const formulaNumber = extractFormulaNumber(cell);
                     if (formulaNumber !== null) {
@@ -50,7 +49,7 @@ export class FormulaRenderManagerController extends RxDisposable {
                             v: formulaNumber,
                         });
                     }
-                    
+
                     const errorType = extractFormulaError(cell);
                     if (!errorType) {
                         return next(cell);

--- a/packages/sheets-formula/src/controllers/formula-render.controller.ts
+++ b/packages/sheets-formula/src/controllers/formula-render.controller.ts
@@ -17,7 +17,7 @@
 import { LifecycleStages, OnLifecycle, RxDisposable } from '@univerjs/core';
 import { Inject } from '@wendellhu/redi';
 import { INTERCEPTOR_POINT, SheetInterceptorService } from '@univerjs/sheets';
-import { extractFormulaError } from './utils/utils';
+import { extractFormulaError, extractFormulaNumber } from './utils/utils';
 
 const FORMULA_ERROR_MARK = {
     tl: {
@@ -41,6 +41,16 @@ export class FormulaRenderManagerController extends RxDisposable {
             INTERCEPTOR_POINT.CELL_CONTENT,
             {
                 handler: (cell, pos, next) => {
+
+                    // Dealing with precision issues
+                    const formulaNumber = extractFormulaNumber(cell);
+                    if (formulaNumber !== null) {
+                        return next({
+                            ...cell,
+                            v: formulaNumber,
+                        });
+                    }
+                    
                     const errorType = extractFormulaError(cell);
                     if (!errorType) {
                         return next(cell);

--- a/packages/sheets-formula/src/controllers/utils/__tests__/utils.spec.ts
+++ b/packages/sheets-formula/src/controllers/utils/__tests__/utils.spec.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { ErrorType } from '@univerjs/engine-formula';
-import { extractFormulaError } from '../utils';
+import { extractFormulaError, extractFormulaNumber } from '../utils';
 
 describe('Test utils', () => {
     it('Function extractFormulaError', () => {
@@ -46,5 +46,11 @@ describe('Test utils', () => {
         expect(extractFormulaError({})).toBeNull();
         expect(extractFormulaError(null)).toBeNull();
         expect(extractFormulaError(undefined)).toBeNull();
+    });
+
+    it('Function extractFormulaNumber', () => {
+        const v = 0.07 / 0.1;
+        expect(extractFormulaNumber({ v })).toBeNull();
+        expect(extractFormulaNumber({ v, f: '=SUM(A1)' })).toBe(0.7);
     });
 });

--- a/packages/sheets-formula/src/controllers/utils/__tests__/utils.spec.ts
+++ b/packages/sheets-formula/src/controllers/utils/__tests__/utils.spec.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { ErrorType } from '@univerjs/engine-formula';
+import { CellValueType } from '@univerjs/core';
 import { extractFormulaError, extractFormulaNumber } from '../utils';
 
 describe('Test utils', () => {
@@ -51,6 +52,7 @@ describe('Test utils', () => {
     it('Function extractFormulaNumber', () => {
         const v = 0.07 / 0.1;
         expect(extractFormulaNumber({ v })).toBeNull();
-        expect(extractFormulaNumber({ v, f: '=SUM(A1)' })).toBe(0.7);
+        expect(extractFormulaNumber({ v, f: '=SUM(A1)' })).toBeNull();
+        expect(extractFormulaNumber({ v, si: 'id1', f: '=SUM(A1)', t: CellValueType.NUMBER })).toBe(0.7);
     });
 });

--- a/packages/sheets-formula/src/controllers/utils/utils.ts
+++ b/packages/sheets-formula/src/controllers/utils/utils.ts
@@ -17,7 +17,7 @@
 import type { ICellData, IContextService, Nullable } from '@univerjs/core';
 import { CellValueType, FOCUSING_DOC, FOCUSING_UNIVER_EDITOR, FOCUSING_UNIVER_EDITOR_STANDALONE_SINGLE_MODE, isFormulaId, isFormulaString } from '@univerjs/core';
 import type { ErrorType } from '@univerjs/engine-formula';
-import { ERROR_TYPE_SET, strip } from '@univerjs/engine-formula';
+import { ERROR_TYPE_SET, stripErrorMargin } from '@univerjs/engine-formula';
 
 export function whenEditorStandalone(contextService: IContextService) {
     return (
@@ -48,7 +48,7 @@ export function extractFormulaError(cell: Nullable<ICellData>) {
  */
 export function extractFormulaNumber(cell: Nullable<ICellData>) {
     if ((isFormulaString(cell?.f) || isFormulaId(cell?.si)) && cell?.t === CellValueType.NUMBER && typeof cell?.v === 'number') {
-        return strip(cell.v);
+        return stripErrorMargin(cell.v);
     }
     return null;
 }

--- a/packages/sheets-formula/src/controllers/utils/utils.ts
+++ b/packages/sheets-formula/src/controllers/utils/utils.ts
@@ -15,9 +15,9 @@
  */
 
 import type { ICellData, IContextService, Nullable } from '@univerjs/core';
-import { FOCUSING_DOC, FOCUSING_UNIVER_EDITOR, FOCUSING_UNIVER_EDITOR_STANDALONE_SINGLE_MODE, isFormulaId, isFormulaString } from '@univerjs/core';
+import { CellValueType, FOCUSING_DOC, FOCUSING_UNIVER_EDITOR, FOCUSING_UNIVER_EDITOR_STANDALONE_SINGLE_MODE, isFormulaId, isFormulaString } from '@univerjs/core';
 import type { ErrorType } from '@univerjs/engine-formula';
-import { ERROR_TYPE_SET } from '@univerjs/engine-formula';
+import { ERROR_TYPE_SET, strip } from '@univerjs/engine-formula';
 
 export function whenEditorStandalone(contextService: IContextService) {
     return (
@@ -34,9 +34,21 @@ export function whenEditorStandalone(contextService: IContextService) {
  */
 export function extractFormulaError(cell: Nullable<ICellData>) {
     // Must contain a formula
-    if (typeof cell?.v === 'string' && (isFormulaString(cell.f) || isFormulaId(cell.si)) && ERROR_TYPE_SET.has(cell.v as ErrorType)) {
+    if ((isFormulaString(cell?.f) || isFormulaId(cell?.si)) && typeof cell?.v === 'string' && ERROR_TYPE_SET.has(cell.v as ErrorType)) {
         return cell.v as ErrorType;
     }
 
+    return null;
+}
+
+/**
+ * Extract the formula number from the cell, handle the precision issue
+ * @param cell
+ * @returns
+ */
+export function extractFormulaNumber(cell: Nullable<ICellData>) {
+    if ((isFormulaString(cell?.f) || isFormulaId(cell?.si)) && cell?.t === CellValueType.NUMBER && typeof cell?.v === 'number') {
+        return strip(cell.v);
+    }
     return null;
 }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #1712

1. 移除 Big.js 的使用。由于 Excel 计算也遵循 IEEE 754 规范，计算过程无需处理精度
2. Excel仅展示前15位数字，但是XML中存储了原始值，我们参照这个做法，仅在公式结果展示的时候处理 15位舍入

如何测试？
1. js控制台测试会出问题的计算，比如 0.1+0.2，0.07/0.1
2. 在单元格中输入公式计算：=0.1+0.2，=0.07/0.1

close #2344
safari下反复缩放 sheet，查看是否有内存持续增长问题。自测已经OK
<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
