### PR TITLE
fix(docs-drawing): fix crash when editing text after inserting images and opening the sidebar

### DIFF
--- a/packages/docs-drawing-ui/src/views/doc-image-panel/DocDrawingPanel.tsx
+++ b/packages/docs-drawing-ui/src/views/doc-image-panel/DocDrawingPanel.tsx
@@ -26,10 +26,6 @@ export const DocDrawingPanel = () => {
     const drawingManagerService = useDependency(IDrawingManagerService);
     const focusDrawings = drawingManagerService.getFocusDrawings();
 
-    if (focusDrawings == null || focusDrawings.length === 0) {
-        return;
-    }
-
     const [drawings, setDrawings] = useState<IDrawingParam[]>(focusDrawings);
 
     useEffect(() => {
@@ -42,7 +38,7 @@ export const DocDrawingPanel = () => {
         };
     }, []);
 
-    return (
+    return !!drawings?.length && (
         <div className={styles.imageCommonPanel}>
             <DrawingCommonPanel drawings={drawings} />
             <DocDrawingAnchor drawings={drawings} />


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
