### PR TITLE
refactor: rename `UniverDocHyperLinkPlugin` to `UniverDocsHyperLinkPlugin`

### DIFF
--- a/examples/src/docs/main.ts
+++ b/examples/src/docs/main.ts
@@ -25,7 +25,7 @@ import { UniverFormulaEnginePlugin } from '@univerjs/engine-formula';
 import { UniverDebuggerPlugin } from '@univerjs/debugger';
 import { UniverDocsDrawingUIPlugin } from '@univerjs/docs-drawing-ui';
 import { UniverDocsThreadCommentUIPlugin } from '@univerjs/docs-thread-comment-ui';
-import { UniverDocHyperLinkUIPlugin } from '@univerjs/docs-hyper-link-ui';
+import { UniverDocsHyperLinkUIPlugin } from '@univerjs/docs-hyper-link-ui';
 import { DEFAULT_DOCUMENT_DATA_CN } from '../data';
 import { enUS, ruRU, zhCN } from '../locales';
 
@@ -71,7 +71,7 @@ univer.registerPlugin(UniverDocsUIPlugin, {
 
 univer.registerPlugin(UniverDocsDrawingUIPlugin);
 univer.registerPlugin(UniverDocsThreadCommentUIPlugin);
-univer.registerPlugin(UniverDocHyperLinkUIPlugin);
+univer.registerPlugin(UniverDocsHyperLinkUIPlugin);
 
 univer.createUnit(UniverInstanceType.UNIVER_DOC, DEFAULT_DOCUMENT_DATA_CN);
 

--- a/packages/docs-hyper-link-ui/README-zh.md
+++ b/packages/docs-hyper-link-ui/README-zh.md
@@ -22,7 +22,7 @@ pnpm add @univerjs/docs-hyper-link-ui
 
 ### 使用
 ```js
-import { UniverDocHyperLinkUIPlugin} from '@univerjs/docs-hyper-link-ui';
+import { UniverDocsHyperLinkUIPlugin} from '@univerjs/docs-hyper-link-ui';
 
-univer.registerPlugin(UniverDocHyperLinkUIPlugin);
+univer.registerPlugin(UniverDocsHyperLinkUIPlugin);
 ```

--- a/packages/docs-hyper-link-ui/README.md
+++ b/packages/docs-hyper-link-ui/README.md
@@ -22,7 +22,7 @@ pnpm add @univerjs/docs-hyper-link-ui
 
 ### use
 ```js
-import { UniverDocHyperLinkUIPlugin} from '@univerjs/docs-hyper-link-ui';
+import { UniverDocsHyperLinkUIPlugin} from '@univerjs/docs-hyper-link-ui';
 
-univer.registerPlugin(UniverDocHyperLinkUIPlugin);
+univer.registerPlugin(UniverDocsHyperLinkUIPlugin);
 ```

--- a/packages/docs-hyper-link-ui/src/index.ts
+++ b/packages/docs-hyper-link-ui/src/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { UniverDocHyperLinkUIPlugin } from './plugin';
+export { UniverDocsHyperLinkUIPlugin } from './plugin';
 
 // export {} from './'

--- a/packages/docs-hyper-link-ui/src/plugin.ts
+++ b/packages/docs-hyper-link-ui/src/plugin.ts
@@ -17,7 +17,7 @@
 import { DependentOn, Plugin, UniverInstanceType } from '@univerjs/core';
 import type { Dependency } from '@wendellhu/redi';
 import { Inject, Injector } from '@wendellhu/redi';
-import { UniverDocHyperLinkPlugin } from '@univerjs/docs-hyper-link';
+import { UniverDocsHyperLinkPlugin } from '@univerjs/docs-hyper-link';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { DOC_HYPER_LINK_UI_PLUGIN } from './types/const';
 import type { IDocHyperLinkUIConfig } from './controllers/ui.controller';
@@ -27,8 +27,8 @@ import { DocHyperLinkSelectionController } from './controllers/doc-hyper-link-se
 import { DocHyperLinkRenderController } from './controllers/render-controllers/render.controller';
 import { DocHyperLinkClipboardController } from './controllers/doc-hyper-link-clipboard.controller';
 
-@DependentOn(UniverDocHyperLinkPlugin)
-export class UniverDocHyperLinkUIPlugin extends Plugin {
+@DependentOn(UniverDocsHyperLinkPlugin)
+export class UniverDocsHyperLinkUIPlugin extends Plugin {
     static override pluginName = DOC_HYPER_LINK_UI_PLUGIN;
     static override type = UniverInstanceType.UNIVER_DOC;
 

--- a/packages/docs-hyper-link/src/index.ts
+++ b/packages/docs-hyper-link/src/index.ts
@@ -18,7 +18,7 @@ export { DOC_HYPER_LINK_PLUGIN } from './types/const';
 export { DocHyperLinkModel } from './models/hyper-link.model';
 export type { IDocHyperLink } from './types/interfaces/i-doc-hyper-link';
 export { DocHyperLinkType } from './types/enums/doc-hyper-link-type';
-export { UniverDocHyperLinkPlugin } from './plugin';
+export { UniverDocsHyperLinkPlugin } from './plugin';
 // #region - all commands
 
 export { AddDocHyperLinkMutation, type IAddDocHyperLinkMutationParams } from './commands/mutations/add-link.mutation';

--- a/packages/docs-hyper-link/src/plugin.ts
+++ b/packages/docs-hyper-link/src/plugin.ts
@@ -22,7 +22,7 @@ import { DocHyperLinkModel } from './models/hyper-link.model';
 import { DocHyperLinkController } from './controllers/hyper-link.controller';
 import { DocHyperLinkResourceController } from './controllers/resource.controller';
 
-export class UniverDocHyperLinkPlugin extends Plugin {
+export class UniverDocsHyperLinkPlugin extends Plugin {
     static override pluginName = DOC_HYPER_LINK_PLUGIN;
     static override type = UniverInstanceType.UNIVER_DOC;
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
