### PR TITLE
fix: use new selectionData not workbook._worksheetSelections

### DIFF
--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -829,7 +829,12 @@ export class EditingRenderController extends Disposable implements IRenderModule
                 this._commandService.syncExecuteCommand(SetSelectionsOperation.id, {
                     unitId: this._context.unit.getUnitId(),
                     subUnitId: worksheetId,
-                    selections,
+
+                    // must be a new selectionData
+                    // in selection-manager.service.ts@setSelections
+                    // this._ensureWorkbookSelection(unitIdOrSelections).setSelections
+                    // would clear selection Data on selecitonManagerInstance.
+                    selections: [...selections],
                 });
             }
 

--- a/packages/sheets/src/services/selections/selection-manager.service.ts
+++ b/packages/sheets/src/services/selections/selection-manager.service.ts
@@ -226,10 +226,17 @@ export class WorkbookSelections extends Disposable {
         this._emitOnEnd(selections);
     }
 
+    /**
+     *
+     * @param sheetId
+     * @param selectionDatas
+     * @param type
+     */
     setSelections(sheetId: string, selectionDatas: ISelectionWithStyle[], type: SelectionMoveType = SelectionMoveType.MOVE_END) {
-        const selections = this._ensureSheetSelection(sheetId);
-        selections.length = 0;
-        selections.push(...selectionDatas);
+        // @TODO lumixraku: selectionDatas should not be same variable !!!
+        // but there are some place get selection from this._worksheetSelections and set as 2nd parameter of this function cause problem!!
+        this._ensureSheetSelection(sheetId).length = 0;
+        this._ensureSheetSelection(sheetId).push(...selectionDatas);
 
         // WTF: why we would not refresh in add but in replace?
         if (type === SelectionMoveType.MOVE_START) {
@@ -263,6 +270,12 @@ export class WorkbookSelections extends Disposable {
     }
 
     private _worksheetSelections = new Map<string, ISelectionWithStyle[]>();
+
+    /**
+     * same as _getCurrentSelections, but would set [] if no selection.
+     * @param sheetId
+     * @returns this._worksheetSelections
+     */
     private _ensureSheetSelection(sheetId: string): ISelectionWithStyle[] {
         let worksheetSelection = this._worksheetSelections.get(sheetId);
         if (!worksheetSelection) {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
