### PR TITLE
fix: can not select text when the last page ends with table

### DIFF
--- a/packages/engine-render/src/components/docs/layout/tools.ts
+++ b/packages/engine-render/src/components/docs/layout/tools.ts
@@ -447,6 +447,13 @@ export function updateBlockIndex(pages: IDocumentSkeletonPage[], start: number =
             preSectionStartIndex = section.ed;
         }
 
+        // Some tables may across pages, so we need to calculate the page's end index by the tables.
+        for (const table of skeTables.values()) {
+            const { ed } = table;
+
+            preSectionStartIndex = Math.max(preSectionStartIndex, ed);
+        }
+
         page.st = pageStartIndex + 1;
         page.ed = preSectionStartIndex >= page.st ? preSectionStartIndex : page.st;
         page.height = contentHeight;


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close https://github.com/dream-num/univer-pro/issues/1946

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
