### PR TITLE
fix: slide&sheet image component-name duplicated 

### DIFF
--- a/packages/slides-ui/src/components/upload-component/component-name.ts
+++ b/packages/slides-ui/src/components/upload-component/component-name.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const COMPONENT_UPLOAD_FILE_MENU = 'COMPONENT_UPLOAD_FILE_MENU';
+export const COMPONENT_UPLOAD_FILE_MENU = 'SLIDE_COMPONENT_UPLOAD_FILE_MENU';
 
 export enum UploadFileType {
     cellImage,


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
