### PR TITLE
fix: fix issue where custom menu items are hidden by default when `hidden$` is not configured

### DIFF
--- a/packages/ui/src/components/menu/desktop/Menu.tsx
+++ b/packages/ui/src/components/menu/desktop/Menu.tsx
@@ -25,7 +25,7 @@ import {
 import { CheckMarkSingle, MoreSingle } from '@univerjs/icons';
 import clsx from 'clsx';
 import React, { useMemo, useState } from 'react';
-import { combineLatest, isObservable, map } from 'rxjs';
+import { combineLatest, isObservable, map, Observable } from 'rxjs';
 
 import type {
     IDisplayMenuItem,
@@ -91,7 +91,7 @@ function MenuWrapper(props: IBaseMenuProps) {
                 const filteredGroup: Record<string, IDisplayMenuItem<IMenuItem>[]> = {};
 
                 Object.entries(group).forEach(([key, items]) => {
-                    const hiddenObservables = items.map((item) => item.hidden$).filter((item) => !!item);
+                    const hiddenObservables = items.map((item) => item.hidden$ ?? new Observable<boolean>((subscriber) => subscriber.next(false)));
 
                     combineLatest(hiddenObservables)
                         .pipe(


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #3120

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
