### PR TITLE
feat(sheet): performan the expand range

### DIFF
--- a/packages/sheets/src/basics/__tests__/expand.data.ts
+++ b/packages/sheets/src/basics/__tests__/expand.data.ts
@@ -1,0 +1,2247 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IWorkbookData } from '@univerjs/core';
+import { LocaleType } from '@univerjs/core';
+
+export const snapshot: IWorkbookData = {
+    id: 'YSvbxFMCTxugbku-IWNyxQ',
+    sheetOrder: [
+        'U_wr1DEF84N_mbesFNmxR',
+    ],
+    name: 'New Sheet By Univer',
+    appVersion: '1',
+    locale: LocaleType.EN_US,
+    styles: {
+        '152X2f': {
+            bd: {
+                b: {
+                    s: 1,
+                    cl: {
+                        rgb: '#b2b2b2',
+                    },
+                },
+                l: {
+                    s: 1,
+                    cl: {
+                        rgb: '#b2b2b2',
+                    },
+                },
+                r: {
+                    s: 1,
+                    cl: {
+                        rgb: '#b2b2b2',
+                    },
+                },
+                t: {
+                    s: 1,
+                    cl: {
+                        rgb: '#b2b2b2',
+                    },
+                },
+            },
+            bg: {
+                rgb: '#f4f4f5',
+            },
+            vt: 2,
+        },
+        '7FmyNp': {
+            n: {
+                pattern: 'yyyy/m/d',
+            },
+            bl: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ff: '等线',
+            fs: 11,
+            ht: 0,
+            it: 0,
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            pd: {
+                b: 1,
+                l: 2,
+                r: 2,
+                t: 0,
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tb: 1,
+            td: 0,
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            vt: 2,
+        },
+        '7XO3nr': {
+            bd: {
+                b: {
+                    s: 1,
+                    cl: {
+                        rgb: '#b2b2b2',
+                    },
+                },
+                l: {
+                    s: 1,
+                    cl: {
+                        rgb: '#b2b2b2',
+                    },
+                },
+                r: {
+                    s: 1,
+                    cl: {
+                        rgb: '#b2b2b2',
+                    },
+                },
+                t: {
+                    s: 1,
+                    cl: {
+                        rgb: '#b2b2b2',
+                    },
+                },
+            },
+            bg: {
+                rgb: '#eceeff',
+            },
+            bl: 1,
+            vt: 2,
+        },
+        '9SFcMu': {
+            bl: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ff: '等线',
+            fs: 11,
+            ht: 0,
+            it: 0,
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            pd: {
+                b: 1,
+                l: 2,
+                r: 2,
+                t: 0,
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tb: 1,
+            td: 0,
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            vt: 2,
+        },
+        EyKJCZ: {
+            bg: {
+                rgb: 'rgb(255,255,0)',
+            },
+            bl: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ff: '等线',
+            fs: 11,
+            ht: 0,
+            it: 0,
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            pd: {
+                b: 1,
+                l: 2,
+                r: 2,
+                t: 0,
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tb: 1,
+            td: 0,
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            vt: 2,
+        },
+        FyTrrV: {
+            bl: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ff: '等线',
+            fs: 11,
+            ht: 2,
+            it: 0,
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            pd: {
+                b: 1,
+                l: 2,
+                r: 2,
+                t: 0,
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tb: 1,
+            td: 0,
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            vt: 2,
+        },
+        IrI1it: {
+            n: {
+                pattern: 'yyyy/mm/dd',
+            },
+            bl: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ff: '等线',
+            fs: 11,
+            ht: 0,
+            it: 0,
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            pd: {
+                b: 1,
+                l: 2,
+                r: 2,
+                t: 0,
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tb: 1,
+            td: 0,
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            vt: 2,
+        },
+        OdkELx: {
+            bg: {
+                rgb: 'rgb(68,114,196)',
+            },
+            bl: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ff: '等线',
+            fs: 11,
+            ht: 0,
+            it: 0,
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            pd: {
+                b: 1,
+                l: 2,
+                r: 2,
+                t: 0,
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tb: 1,
+            td: 0,
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            vt: 2,
+        },
+        VYPA_J: {
+            bg: {
+                rgb: 'rgb(255,0,0)',
+            },
+            bl: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ff: '等线',
+            fs: 11,
+            ht: 2,
+            it: 0,
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            pd: {
+                b: 1,
+                l: 2,
+                r: 2,
+                t: 0,
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tb: 0,
+            td: 0,
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            vt: 2,
+        },
+        bB0NY3: {
+            bl: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ff: '等线',
+            fs: 11,
+            ht: 0,
+            it: 0,
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            pd: {
+                b: 1,
+                l: 2,
+                r: 2,
+                t: 0,
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tb: 0,
+            td: 0,
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            vt: 2,
+        },
+        grdSj3: {
+            bd: null,
+            bg: {
+                rgb: '#1d32e9',
+            },
+            bl: 1,
+            cl: {
+                rgb: '#FFFFFF',
+            },
+            vt: 2,
+        },
+        vRtCqS: {
+            ff: 'Arial',
+            fs: 10,
+            it: 0,
+            bl: 0,
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            td: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ht: 0,
+            vt: 0,
+            tb: 3,
+            pd: {
+                t: 0,
+                b: 1,
+                l: 2,
+                r: 2,
+            },
+        },
+        b_xNmg: {
+            ff: '等线',
+            fs: 11,
+            it: 0,
+            bl: 0,
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tr: {
+                a: 0,
+            },
+            td: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ht: 0,
+            vt: 2,
+            tb: 3,
+            pd: {
+                t: 0,
+                b: 1,
+                l: 2,
+                r: 2,
+            },
+        },
+        'TL-w0i': {
+            ff: 'Arial',
+            fs: 10,
+            it: 0,
+            bl: 0,
+            ul: {
+                s: 0,
+            },
+            st: {
+                s: 0,
+            },
+            ol: {
+                s: 0,
+            },
+            tr: {
+                a: 0,
+                v: 0,
+            },
+            td: 0,
+            ht: 0,
+            vt: 0,
+            tb: 0,
+            pd: {
+                t: 0,
+                b: 1,
+                l: 2,
+                r: 2,
+            },
+        },
+        '9EuDtV': {
+            ff: 'Arial',
+            fs: 10,
+            it: 0,
+            bl: 0,
+            ul: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            st: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            ol: {
+                s: 0,
+                cl: {
+                    rgb: 'rgb(0,0,0)',
+                },
+            },
+            tr: {
+                a: 0,
+            },
+            td: 0,
+            cl: {
+                rgb: 'rgb(0,0,0)',
+            },
+            ht: 0,
+            vt: 0,
+            tb: 3,
+            pd: {
+                t: 0,
+                b: 1,
+                l: 2,
+                r: 2,
+            },
+        },
+    },
+    sheets: {
+        U_wr1DEF84N_mbesFNmxR: {
+            id: 'U_wr1DEF84N_mbesFNmxR',
+            name: '工作表2',
+            rowCount: 998,
+            columnCount: 20,
+            freeze: {
+                xSplit: 0,
+                ySplit: 0,
+                startRow: -1,
+                startColumn: -1,
+            },
+            hidden: 0,
+            rowData: {
+                2: {
+                    h: 24,
+                    ah: 24,
+                    hd: 0,
+                },
+                6: {
+                    h: 28,
+                    hd: 0,
+                },
+                7: {
+                    h: 28,
+                    hd: 0,
+                },
+                8: {
+                    h: 28,
+                    hd: 0,
+                },
+                9: {
+                    h: 28,
+                    hd: 0,
+                },
+                10: {
+                    h: 28,
+                    ah: 24,
+                    hd: 0,
+                },
+                11: {
+                    h: 28,
+                    ah: 24,
+                    hd: 0,
+                },
+                12: {
+                    h: 28,
+                    hd: 0,
+                },
+                13: {
+                    h: 28,
+                    hd: 0,
+                },
+                14: {
+                    h: 28,
+                    hd: 0,
+                },
+                15: {
+                    h: 28,
+                    hd: 0,
+                },
+                16: {
+                    h: 28,
+                    hd: 0,
+                },
+                17: {
+                    h: 28,
+                    hd: 0,
+                },
+                18: {
+                    h: 28,
+                    hd: 0,
+                },
+                19: {
+                    h: 28,
+                    hd: 0,
+                },
+                20: {
+                    h: 28,
+                    hd: 0,
+                },
+                21: {
+                    h: 28,
+                    hd: 0,
+                },
+                27: {
+                    hd: 0,
+                    h: 28,
+                },
+                28: {
+                    hd: 0,
+                    h: 24,
+                    ah: 24,
+                },
+                29: {
+                    hd: 0,
+                    h: 24,
+                },
+                30: {
+                    hd: 0,
+                    h: 24,
+                },
+                41: {
+                    hd: 0,
+                    h: 28,
+                },
+                42: {
+                    hd: 0,
+                    h: 24,
+                },
+                43: {
+                    hd: 0,
+                    h: 28,
+                },
+                44: {
+                    hd: 0,
+                    h: 28,
+                },
+            },
+            tabColor: '',
+            mergeData: [
+                {
+                    startRow: 11,
+                    endRow: 13,
+                    startColumn: 11,
+                    endColumn: 13,
+                },
+                {
+                    startRow: 18,
+                    endRow: 19,
+                    startColumn: 13,
+                    endColumn: 17,
+                },
+                {
+                    startRow: 11,
+                    endRow: 12,
+                    startColumn: 3,
+                    endColumn: 5,
+                    rangeType: 0,
+                },
+                {
+                    startRow: 3,
+                    endRow: 7,
+                    startColumn: 7,
+                    endColumn: 7,
+                    rangeType: 0,
+                },
+                {
+                    startRow: 28,
+                    endRow: 29,
+                    startColumn: 7,
+                    endColumn: 8,
+                    rangeType: 0,
+                },
+                {
+                    startRow: 42,
+                    endRow: 43,
+                    startColumn: 5,
+                    endColumn: 7,
+                },
+                {
+                    startRow: 28,
+                    endRow: 29,
+                    startColumn: 17,
+                    endColumn: 19,
+                },
+                {
+                    startRow: 30,
+                    endRow: 30,
+                    startColumn: 13,
+                    endColumn: 17,
+                },
+            ],
+            rowHeader: {
+                width: 46,
+                hidden: 0,
+            },
+            scrollTop: 0,
+            zoomRatio: 1,
+            columnData: {
+                4: {
+                    w: 88,
+                    hd: 0,
+                },
+                5: {
+                    w: 88,
+                    hd: 0,
+                },
+                6: {
+                    w: 88,
+                    hd: 0,
+                },
+                7: {
+                    w: 69,
+                    hd: 0,
+                },
+                8: {
+                    w: 88,
+                    hd: 0,
+                },
+                9: {
+                    w: 88,
+                    hd: 0,
+                },
+                10: {
+                    w: 88,
+                    hd: 0,
+                },
+                11: {
+                    w: 88,
+                    hd: 0,
+                },
+                12: {
+                    w: 88,
+                    hd: 0,
+                },
+                13: {
+                    w: 88,
+                    hd: 0,
+                },
+                14: {
+                    w: 88,
+                    hd: 0,
+                },
+                15: {
+                    w: 88,
+                    hd: 0,
+                },
+                16: {
+                    w: 88,
+                    hd: 0,
+                },
+                17: {
+                    w: 88,
+                    hd: 0,
+                },
+                18: {
+                    w: 88,
+                    hd: 0,
+                },
+                19: {
+                    w: 88,
+                    hd: 0,
+                },
+                20: {
+                    w: 88,
+                    hd: 0,
+                },
+            },
+            scrollLeft: 0,
+            rightToLeft: 0,
+            columnHeader: {
+                height: 20,
+                hidden: 0,
+            },
+            showGridlines: 1,
+            defaultRowHeight: 24,
+            defaultColumnWidth: 88,
+            cellData: {
+                2: {
+                    8: {
+                        v: 111,
+                        t: 2,
+                    },
+                },
+                3: {
+                    7: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                },
+                6: {
+                    5: {
+                        v: '北部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '辽宁',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {},
+                    8: {
+                        v: 'vegetable',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '西红柿',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 86,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                7: {
+                    5: {
+                        v: '西部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '河南',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {},
+                    8: {
+                        v: 'fruit',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '葡萄',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 26,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                8: {
+                    5: {
+                        v: '西部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '河南',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '洛阳',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'vegetable',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '茄子',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 36,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                9: {
+                    5: {
+                        v: '西部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '陕西',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '咸阳',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'fruit',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '梨子',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 88,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                10: {
+                    2: {
+                        v: 111,
+                        t: 2,
+                    },
+                    3: {
+                        v: 111,
+                        t: 2,
+                    },
+                    5: {
+                        v: '东部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '广西',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '南宁',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'fruit',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '梨子',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 6,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: 111,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                11: {
+                    2: {
+                        v: 11,
+                        t: 2,
+                    },
+                    3: {
+                        s: 'bB0NY3',
+                    },
+                    4: {},
+                    5: {},
+                    6: {
+                        v: '黑龙江',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '哈尔滨',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'vegetable',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '黄瓜',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 95,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: 11,
+                        t: 2,
+                        s: 'FyTrrV',
+                    },
+                    12: {
+                        s: 'FyTrrV',
+                    },
+                    13: {
+                        s: 'FyTrrV',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                12: {
+                    3: {},
+                    4: {},
+                    5: {},
+                    6: {
+                        v: '辽宁',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '鞍山',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'vegetable',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '西红柿',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 10,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        s: 'FyTrrV',
+                    },
+                    12: {
+                        s: 'FyTrrV',
+                    },
+                    13: {
+                        s: 'FyTrrV',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                13: {
+                    5: {
+                        v: '北部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '辽宁',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '鞍山',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'fruit',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '葡萄',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 7,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        s: 'FyTrrV',
+                    },
+                    12: {
+                        s: 'FyTrrV',
+                    },
+                    13: {
+                        s: 'FyTrrV',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                14: {
+                    5: {
+                        v: '东部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '福建',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '厦门',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'fruit',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '橘子',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 0,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: 11,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                15: {
+                    5: {
+                        v: '西部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '陕西',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '西安',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'vegetable',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '西红柿',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 34,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                16: {
+                    5: {
+                        v: '东部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '福建',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '泉州',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'vegetable',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '西红柿',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 56,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: 11,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                17: {
+                    5: {
+                        v: '北部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '辽宁',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '鞍山',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'vegetable',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '白菜',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 16,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                18: {
+                    5: {
+                        v: '西部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '河南',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '郑州',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'fruit',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '橘子',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 90,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '　',
+                        t: 1,
+                        s: 'VYPA_J',
+                    },
+                    14: {
+                        s: 'VYPA_J',
+                    },
+                    15: {
+                        s: 'VYPA_J',
+                    },
+                    16: {
+                        s: 'VYPA_J',
+                    },
+                    17: {
+                        s: 'VYPA_J',
+                    },
+                },
+                19: {
+                    5: {
+                        v: '东部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '福建',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '厦门',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'vegetable',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '西红柿',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 89,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        s: 'VYPA_J',
+                    },
+                    14: {
+                        s: 'VYPA_J',
+                    },
+                    15: {
+                        s: 'VYPA_J',
+                    },
+                    16: {
+                        s: 'VYPA_J',
+                    },
+                    17: {
+                        s: 'VYPA_J',
+                    },
+                },
+                20: {
+                    5: {
+                        v: '北部',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '黑龙江',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '齐齐哈尔',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: 'vegetable',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '土豆',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: 65,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                21: {
+                    5: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    6: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    7: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    8: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    9: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    10: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    11: {
+                        v: '',
+                        t: 1,
+                        s: 'bB0NY3',
+                    },
+                    12: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    13: {
+                        v: 111,
+                        t: 2,
+                        s: 'bB0NY3',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                    17: {
+                        v: '',
+                        t: 1,
+                        s: '9SFcMu',
+                    },
+                },
+                27: {
+                    6: {
+                        v: '陕西',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    7: {
+                        v: '西安',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'TL-w0i',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'TL-w0i',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: 'TL-w0i',
+                    },
+                    16: {
+                        v: 111,
+                        t: 2,
+                        s: '9EuDtV',
+                    },
+                    17: {
+                        v: 111,
+                        t: 2,
+                        s: '9EuDtV',
+                    },
+                    18: {
+                        v: '',
+                        t: 1,
+                        s: '9EuDtV',
+                    },
+                    19: {
+                        v: '东部',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    20: {
+                        v: '陕西',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                },
+                28: {
+                    6: {
+                        v: '福建',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    7: {
+                        v: '',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    9: {
+                        v: 11,
+                        t: 2,
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'TL-w0i',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'TL-w0i',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: 'TL-w0i',
+                    },
+                    16: {
+                        v: 11,
+                        t: 2,
+                        s: '9EuDtV',
+                    },
+                    17: {
+                        s: 'b_xNmg',
+                    },
+                    18: {
+                        s: 'b_xNmg',
+                    },
+                    19: {
+                        s: 'b_xNmg',
+                    },
+                    20: {
+                        v: '福建',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                },
+                29: {
+                    6: {
+                        v: '辽宁',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    7: {},
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: 'TL-w0i',
+                    },
+                    14: {
+                        v: '',
+                        t: 1,
+                        s: 'TL-w0i',
+                    },
+                    15: {
+                        v: '',
+                        t: 1,
+                        s: 'TL-w0i',
+                    },
+                    16: {
+                        v: '',
+                        t: 1,
+                        s: '9EuDtV',
+                    },
+                    17: {
+                        s: 'b_xNmg',
+                    },
+                    18: {
+                        s: 'b_xNmg',
+                    },
+                    19: {
+                        s: 'b_xNmg',
+                    },
+                    20: {
+                        v: '辽宁',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                },
+                30: {
+                    6: {
+                        v: '河南',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    7: {
+                        v: '郑州',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    13: {
+                        v: '',
+                        t: 1,
+                        s: '9EuDtV',
+                    },
+                    14: {
+                        s: '9EuDtV',
+                    },
+                    15: {
+                        s: '9EuDtV',
+                    },
+                    16: {
+                        s: '9EuDtV',
+                    },
+                    17: {
+                        s: '9EuDtV',
+                    },
+                    18: {
+                        v: '',
+                        t: 1,
+                        s: '9EuDtV',
+                    },
+                    19: {
+                        v: '北部',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    20: {
+                        v: '河南',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                },
+                41: {
+                    4: {
+                        v: 111,
+                        t: 2,
+                        s: 'vRtCqS',
+                    },
+                    5: {
+                        v: 111,
+                        t: 2,
+                        s: 'vRtCqS',
+                    },
+                    6: {
+                        v: '',
+                        t: 1,
+                        s: 'vRtCqS',
+                    },
+                    7: {
+                        v: '东部',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    8: {
+                        v: '陕西',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                },
+                42: {
+                    4: {
+                        v: 11,
+                        t: 2,
+                        s: 'vRtCqS',
+                    },
+                    5: {
+                        v: '',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    6: {
+                        s: 'b_xNmg',
+                    },
+                    7: {
+                        s: 'b_xNmg',
+                    },
+                    8: {
+                        v: '福建',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                },
+                43: {
+                    4: {
+                        v: '',
+                        t: 1,
+                        s: 'vRtCqS',
+                    },
+                    5: {
+                        s: 'b_xNmg',
+                    },
+                    6: {
+                        s: 'b_xNmg',
+                    },
+                    7: {
+                        s: 'b_xNmg',
+                    },
+                    8: {
+                        v: '辽宁',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                },
+                44: {
+                    4: {
+                        v: '',
+                        t: 1,
+                        s: 'vRtCqS',
+                    },
+                    5: {
+                        v: '',
+                        t: 1,
+                        s: 'vRtCqS',
+                    },
+                    6: {
+                        v: '',
+                        t: 1,
+                        s: 'vRtCqS',
+                    },
+                    7: {
+                        v: '北部',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                    8: {
+                        v: '河南',
+                        t: 1,
+                        s: 'b_xNmg',
+                    },
+                },
+            },
+        },
+    },
+    resources: [
+        {
+            data: '{}',
+            name: 'SHEET_THREAD_COMMENT_PLUGIN',
+        },
+        {
+            data: '{}',
+            name: 'SHEET_WORKSHEET_PROTECTION_PLUGIN',
+        },
+        {
+            data: '{}',
+            name: 'SHEET_WORKSHEET_PROTECTION_POINT_PLUGIN',
+        },
+        {
+            data: '',
+            name: 'SHEET_RANGE_PROTECTION_PLUGIN',
+        },
+        {
+            data: '',
+            name: 'SHEET_CONDITIONAL_FORMATTING_PLUGIN',
+        },
+        {
+            data: '{}',
+            name: 'SHEET_HYPER_LINK_PLUGIN',
+        },
+        {
+            data: '',
+            name: 'SHEET_DRAWING_PLUGIN',
+        },
+        {
+            data: "{\"dataFieldManagerConfig\":{\"YSvbxFMCTxugbku-IWNyxQ\":{\"collections\":{\"6A9814C2\":{\"fields\":{\"87333\":{\"id\":\"87333\",\"name\":\"省份\",\"hexCode\":\"6B6\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!A1:A34\"},\"90719\":{\"id\":\"90719\",\"name\":\"城市\",\"hexCode\":\"4F5\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!C1:C34\"},\"483B3\":{\"id\":\"483B3\",\"name\":\"省份\",\"hexCode\":\"32C\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!B1:B34\"},\"9F632\":{\"id\":\"9F632\",\"name\":\"类别\",\"hexCode\":\"E0A\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!D1:D34\"},\"F5D56\":{\"id\":\"F5D56\",\"name\":\"商品\",\"hexCode\":\"BBF\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!E1:E34\"},\"51E60\":{\"id\":\"51E60\",\"name\":\"数量\",\"hexCode\":\"2F9\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!F1:F34\"},\"EE056\":{\"id\":\"EE056\",\"name\":\" 销售日期\",\"hexCode\":\"4E3\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!G1:G34\"}},\"fieldIds\":[\"87333\",\"483B3\",\"90719\",\"9F632\",\"F5D56\",\"51E60\",\"EE056\"],\"displayNameRecord\":{\"87333\":\"省份\",\"90719\":\"城市\",\"483B3\":\"省份(1)\",\"9F632\":\"类别\",\"F5D56\":\"商品\",\"51E60\":\"数量\",\"EE056\":\" 销售日期\"},\"customFields\":[],\"dataRecordCount\":33,\"range\":{\"range\":{\"startRow\":0,\"startColumn\":0,\"endRow\":33,\"endColumn\":6,\"rangeType\":0,\"unitId\":\"YSvbxFMCTxugbku-IWNyxQ\",\"sheetId\":\"J5WIXlyBa4F-jGg7lMoZ2\"},\"unitId\":\"YSvbxFMCTxugbku-IWNyxQ\",\"sheetName\":\"Sheet1\",\"subUnitId\":\"J5WIXlyBa4F-jGg7lMoZ2\"}}},\"dataFields\":{\"87333\":{\"id\":\"87333\",\"name\":\"省份\",\"hexCode\":\"6B6\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!A1:A34\"},\"90719\":{\"id\":\"90719\",\"name\":\"城市\",\"hexCode\":\"4F5\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!C1:C34\"},\"483B3\":{\"id\":\"483B3\",\"name\":\"省份\",\"hexCode\":\"32C\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!B1:B34\"},\"9F632\":{\"id\":\"9F632\",\"name\":\"类别\",\"hexCode\":\"E0A\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!D1:D34\"},\"F5D56\":{\"id\":\"F5D56\",\"name\":\"商品\",\"hexCode\":\"BBF\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!E1:E34\"},\"51E60\":{\"id\":\"51E60\",\"name\":\"数量\",\"hexCode\":\"2F9\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!F1:F34\"},\"EE056\":{\"id\":\"EE056\",\"name\":\" 销售日期\",\"hexCode\":\"4E3\",\"rangeKey\":\"'[YSvbxFMCTxugbku-IWNyxQ]Sheet1'!G1:G34\"}}}},\"pivotTableConfigs\":{\"YSvbxFMCTxugbku-IWNyxQ\":{\"J5WIXlyBa4F-jGg7lMoZ2\":{\"6A9814C2\":{\"targetCellInfo\":{\"row\":5,\"col\":12,\"unitId\":\"YSvbxFMCTxugbku-IWNyxQ\",\"subUnitId\":\"J5WIXlyBa4F-jGg7lMoZ2\",\"sheetName\":\"Sheet1\"},\"sourceRangeInfo\":{\"range\":{\"startRow\":0,\"startColumn\":0,\"endRow\":33,\"endColumn\":6,\"rangeType\":0,\"unitId\":\"YSvbxFMCTxugbku-IWNyxQ\",\"sheetId\":\"J5WIXlyBa4F-jGg7lMoZ2\"},\"unitId\":\"YSvbxFMCTxugbku-IWNyxQ\",\"sheetName\":\"Sheet1\",\"subUnitId\":\"J5WIXlyBa4F-jGg7lMoZ2\"},\"fieldsConfig\":{\"columnFields\":[],\"dimension\":{\"16\":{\"id\":\"16\",\"dataFieldId\":\"87333\",\"displayName\":\"省份\",\"sourceName\":\"省份\"}},\"measure\":{},\"filterFields\":[],\"hiddenFields\":[],\"rowFields\":[\"16\"],\"valueFields\":[],\"layout\":3,\"valueIndex\":-1,\"valuePosition\":-1,\"collapseInfo\":{},\"options\":{\"pageWrap\":1,\"pageOverThenDown\":false}},\"isEmpty\":false}}}}}",
+            name: 'SHEET_PIVOT_TABLE_PLUGIN',
+        },
+        {
+            data: '',
+            name: 'SHEET_DEFINED_NAME_PLUGIN',
+        },
+        {
+            data: '{}',
+            name: 'SHEET_DATA_VALIDATION_PLUGIN',
+        },
+        {
+            data: '{"J5WIXlyBa4F-jGg7lMoZ2":{"ref":{"startRow":0,"startColumn":0,"endRow":33,"endColumn":6,"rangeType":0},"filterColumns":[],"cachedFilteredOut":[]}}',
+            name: 'SHEET_FILTER_PLUGIN',
+        },
+    ],
+    rev: 44,
+};

--- a/packages/sheets/src/basics/__tests__/expand.spec.ts
+++ b/packages/sheets/src/basics/__tests__/expand.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Workbook } from '@univerjs/core';
+import { createCoreTestBed } from '@univerjs/core/sheets/__tests__/create-core-test-bed.js';
+import { expandToContinuousRange } from '../expand-range';
+import { snapshot } from './expand.data';
+
+// the work book can be get 'unit=YSvbxFMCTxugbku-IWNyxQ&type=2&subunit=U_wr1DEF84N_mbesFNmxR' in pro
+describe('Test expandToContinuousRange', () => {
+    let workbook: Workbook;
+    const directions = {
+        left: true,
+        right: true,
+        up: true,
+        down: true,
+    };
+
+    beforeEach(() => {
+        const testBed = createCoreTestBed(snapshot);
+        workbook = testBed.sheet;
+    });
+    it('Test expandToContinuousRange all', () => {
+        const range = {
+            startRow: 13,
+            startColumn: 7,
+            endRow: 13,
+            endColumn: 7,
+        };
+        const result = expandToContinuousRange(range, directions, workbook.getActiveSheet());
+        const { startRow, startColumn, endColumn, endRow } = result;
+        expect(startRow).toEqual(3);
+        expect(startColumn).toEqual(3);
+        expect(endColumn).toEqual(17);
+        expect(endRow).toEqual(21);
+    });
+    it('can not expand', () => {
+        const range = {
+            startRow: 28,
+            startColumn: 9,
+            endRow: 28,
+            endColumn: 9,
+        };
+        const result = expandToContinuousRange(range, directions, workbook.getActiveSheet());
+        const { startRow, startColumn, endColumn, endRow } = result;
+        expect(startRow).toEqual(range.startRow);
+        expect(startColumn).toEqual(range.startColumn);
+        expect(endColumn).toEqual(range.endColumn);
+        expect(endRow).toEqual(range.endRow);
+    });
+
+    it('Test expandToContinuousRange with range', () => {
+        const range = {
+            startRow: 8,
+            startColumn: 7,
+            endRow: 12,
+            endColumn: 8,
+        };
+        const result = expandToContinuousRange(range, directions, workbook.getActiveSheet());
+        const { startRow, startColumn, endColumn, endRow } = result;
+        expect(startRow).toEqual(3);
+        expect(startColumn).toEqual(3);
+        expect(endColumn).toEqual(17);
+        expect(endRow).toEqual(21);
+    });
+
+    it('expand to right', () => {
+        const range = {
+            startRow: 29,
+            startColumn: 16,
+            endRow: 29,
+            endColumn: 16,
+        };
+        const result = expandToContinuousRange(range, directions, workbook.getActiveSheet());
+        const { startRow, startColumn, endColumn, endRow } = result;
+        expect(startRow).toEqual(27);
+        expect(startColumn).toEqual(16);
+        expect(endColumn).toEqual(19);
+        expect(endRow).toEqual(29);
+    });
+    it('expand to left', () => {
+        const range = {
+            startRow: 41,
+            startColumn: 8,
+            endRow: 41,
+            endColumn: 8,
+        };
+        const result = expandToContinuousRange(range, directions, workbook.getActiveSheet());
+        const { startRow, startColumn, endColumn, endRow } = result;
+        expect(startRow).toEqual(41);
+        expect(startColumn).toEqual(5);
+        expect(endColumn).toEqual(8);
+        expect(endRow).toEqual(44);
+    });
+
+    it('expand to empty span', () => {
+        const range = {
+            startRow: 41,
+            startColumn: 4,
+            endRow: 41,
+            endColumn: 4,
+        };
+        const result = expandToContinuousRange(range, directions, workbook.getActiveSheet());
+        const { startRow, startColumn, endColumn, endRow } = result;
+        expect(startRow).toEqual(41);
+        expect(startColumn).toEqual(4);
+        expect(endColumn).toEqual(7);
+        expect(endRow).toEqual(43);
+    });
+});

--- a/packages/sheets/src/basics/expand-range.ts
+++ b/packages/sheets/src/basics/expand-range.ts
@@ -1,0 +1,403 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ICellData, IRange, Worksheet } from '@univerjs/core';
+import { createRowColIter, ObjectMatrix, Rectangle } from '@univerjs/core';
+
+export interface IExpandParams {
+    left?: boolean;
+    right?: boolean;
+    up?: boolean;
+    down?: boolean;
+}
+
+type IMatrixWithSpanInfo = ICellData & {
+    spanAnchor?: {
+        startRow: number;
+        startColumn: number;
+        endRow: number;
+        endColumn: number;
+    };
+};
+
+interface IExpandedRangeResult {
+    spanAnchor: IRange | null;
+    hasValue: boolean;
+    range: IRange;
+}
+
+function cellHasValue(cell: ICellData | undefined): boolean {
+    if (cell === undefined || cell === null) {
+        return false;
+    }
+    return (cell.v !== undefined && cell.v !== null && cell.v !== '') || cell.p !== undefined;
+}
+
+function hasValueFromMatrixWithSpanInfo(cell: IMatrixWithSpanInfo | undefined, matrix: ObjectMatrix<IMatrixWithSpanInfo>): boolean {
+    if (cell && cell.spanAnchor) {
+        return cellHasValue(matrix.getValue(cell.spanAnchor.startRow, cell.spanAnchor.startColumn));
+    }
+    return cellHasValue(cell);
+}
+function getMatrixWithSpanInfo(worksheet: Worksheet, startRow: number, startColumn: number, endRow: number, endColumn: number): ObjectMatrix<IMatrixWithSpanInfo> {
+    const matrix = worksheet.getCellMatrix();
+
+    // get all merged cells
+    const mergedCellsInRange = worksheet.getSnapshot().mergeData.filter((rect) =>
+        Rectangle.intersects({ startRow, startColumn, endRow, endColumn }, rect)
+    );
+
+    // iterate all cells in the range
+    const returnCellMatrix = new ObjectMatrix<IMatrixWithSpanInfo>();
+
+    matrix.forValue((row, col) => {
+        const v = matrix.getValue(row, col);
+        if (v) {
+            returnCellMatrix.setValue(row, col, v);
+        }
+    });
+    mergedCellsInRange.forEach((mergedCell) => {
+        const { startColumn, startRow, endColumn, endRow } = mergedCell;
+        createRowColIter(startRow, endRow, startColumn, endColumn).forEach((row, col) => {
+            if (row === startRow && col === startColumn) {
+                returnCellMatrix.setValue(row, col, {
+                    ...matrix.getValue(row, col),
+                    spanAnchor: { startRow, endRow, startColumn, endColumn },
+                });
+            }
+
+            if (row !== startRow || col !== startColumn) {
+                returnCellMatrix.realDeleteValue(row, col);
+                returnCellMatrix.setValue(row, col, {
+                    spanAnchor: { startRow, endRow, startColumn, endColumn },
+                });
+            }
+        });
+    });
+    return returnCellMatrix;
+}
+
+// do not delete following code， it may be used in the future
+// function getMergeRange(startRow: number, startColumn: number, endRow: number, endColumn: number, allMatrixWithSpan: ObjectMatrix<IMatrixWithSpanInfo>): IRange {
+//     let isSearching = true;
+//     let left = startColumn;
+//     let right = endColumn;
+//     let up = startRow;
+//     let down = endRow;
+
+//     while (isSearching) {
+//         isSearching = false;
+//         // left
+//         for (let i = startRow; i < endRow; i++) {
+//             const cell = allMatrixWithSpan.getValue(i, startColumn);
+//             if (cell && cell.spanAnchor) {
+//                 left = Math.min(left, cell.spanAnchor.startColumn);
+//                 right = Math.max(right, cell.spanAnchor.endColumn);
+//                 up = Math.min(up, cell.spanAnchor.startRow);
+//                 down = Math.max(down, cell.spanAnchor.endRow);
+//             }
+//         }
+//         // right
+//         for (let i = startRow; i < endRow; i++) {
+//             const cell = allMatrixWithSpan.getValue(i, endColumn);
+//             if (cell && cell.spanAnchor) {
+//                 left = Math.min(left, cell.spanAnchor.startColumn);
+//                 right = Math.max(right, cell.spanAnchor.endColumn);
+//                 up = Math.min(up, cell.spanAnchor.startRow);
+//                 down = Math.max(down, cell.spanAnchor.endRow);
+//             }
+//         }
+//         // up
+//         for (let i = startColumn; i < endColumn; i++) {
+//             const cell = allMatrixWithSpan.getValue(startRow, i);
+//             if (cell && cell.spanAnchor) {
+//                 left = Math.min(left, cell.spanAnchor.startColumn);
+//                 right = Math.max(right, cell.spanAnchor.endColumn);
+//                 up = Math.min(up, cell.spanAnchor.startRow);
+//                 down = Math.max(down, cell.spanAnchor.endRow);
+//             }
+//         }
+//         // down
+//         for (let i = startColumn; i < endColumn; i++) {
+//             const cell = allMatrixWithSpan.getValue(endRow, i);
+//             if (cell && cell.spanAnchor) {
+//                 left = Math.min(left, cell.spanAnchor.startColumn);
+//                 right = Math.max(right, cell.spanAnchor.endColumn);
+//                 up = Math.min(up, cell.spanAnchor.startRow);
+//                 down = Math.max(down, cell.spanAnchor.endRow);
+//             }
+//         }
+
+//         if (startColumn !== left || startRow !== up || endColumn !== right || endRow !== down) {
+//             isSearching = true;
+//             startColumn = left;
+//             startRow = up;
+//             endColumn = right;
+//             endRow = down;
+//         }
+//     }
+
+//     return {
+//         startRow: up,
+//         startColumn: left,
+//         endRow: down,
+//         endColumn: right,
+//     };
+// }
+
+function getExpandedRangeLeft(range: IRange, allMatrixWithSpan: ObjectMatrix<IMatrixWithSpanInfo>, leftOffset: number, isWorksheetHasSpan: boolean): IExpandedRangeResult {
+    const { startRow, startColumn, endRow } = range;
+
+    let spanAnchor: IRange | null = null;
+    let hasValue = false;
+    for (let i = startRow; i <= endRow; i++) {
+        const cell = allMatrixWithSpan.getValue(i, startColumn - leftOffset);
+        hasValue = hasValue || hasValueFromMatrixWithSpanInfo(cell, allMatrixWithSpan);
+        if (!isWorksheetHasSpan && hasValue) {
+            break;
+        }
+        if (cell && cell.spanAnchor) {
+            if (!spanAnchor) {
+                spanAnchor = {
+                    startRow: cell.spanAnchor.startRow,
+                    startColumn: cell.spanAnchor.startColumn,
+                    endRow: cell.spanAnchor.endRow,
+                    endColumn: cell.spanAnchor.endColumn,
+                };
+            } else {
+                spanAnchor = {
+                    startRow: Math.min(cell.spanAnchor.startRow, spanAnchor.startRow),
+                    startColumn: Math.min(cell.spanAnchor.startColumn, spanAnchor.startColumn),
+                    endRow: Math.max(cell.spanAnchor.endRow, spanAnchor.endRow),
+                    endColumn: Math.max(cell.spanAnchor.endColumn, spanAnchor.endColumn),
+                };
+            }
+        }
+    }
+
+    if (hasValue) {
+        range.startColumn = range.startColumn - leftOffset;
+        return {
+            spanAnchor,
+            hasValue: true,
+            range,
+        };
+    }
+    return {
+        spanAnchor: null,
+        hasValue: false,
+        range,
+    };
+}
+function getExpandedRangeRight(range: IRange, allMatrixWithSpan: ObjectMatrix<IMatrixWithSpanInfo>, rightOffset: number, isWorksheetHasSpan: boolean): IExpandedRangeResult {
+    const { startRow, endColumn, endRow } = range;
+    let spanAnchor: IRange | null = null;
+    let hasValue = false;
+
+    for (let i = startRow; i <= endRow; i++) {
+        const cell = allMatrixWithSpan.getValue(i, endColumn + rightOffset);
+        hasValue = hasValue || hasValueFromMatrixWithSpanInfo(cell, allMatrixWithSpan);
+        if (!isWorksheetHasSpan && hasValue) {
+            break;
+        }
+        if (cell && cell.spanAnchor) {
+            if (!spanAnchor) {
+                spanAnchor = {
+                    startRow: cell.spanAnchor.startRow,
+                    startColumn: cell.spanAnchor.startColumn,
+                    endRow: cell.spanAnchor.endRow,
+                    endColumn: cell.spanAnchor.endColumn,
+                };
+            } else {
+                spanAnchor = {
+                    startRow: Math.min(cell.spanAnchor.startRow, spanAnchor.startRow),
+                    startColumn: Math.min(cell.spanAnchor.startColumn, spanAnchor.startColumn),
+                    endRow: Math.max(cell.spanAnchor.endRow, spanAnchor.endRow),
+                    endColumn: Math.max(cell.spanAnchor.endColumn, spanAnchor.endColumn),
+                };
+            }
+        }
+    }
+
+    if (hasValue) {
+        range.endColumn = range.endColumn + rightOffset;
+        return {
+            spanAnchor,
+            hasValue: true,
+            range,
+        };
+    }
+
+    return {
+        spanAnchor: null,
+        hasValue: false,
+        range,
+    };
+}
+
+function getExpandedRangeUp(range: IRange, allMatrixWithSpan: ObjectMatrix<IMatrixWithSpanInfo>, upOffset: number, isWorksheetHasSpan: boolean): IExpandedRangeResult {
+    const { startRow, startColumn, endColumn } = range;
+    let spanAnchor: IRange | null = null;
+    let hasValue = false;
+    for (let i = startColumn; i <= endColumn; i++) {
+        const cell = allMatrixWithSpan.getValue(startRow - upOffset, i);
+        hasValue = hasValue || hasValueFromMatrixWithSpanInfo(cell, allMatrixWithSpan);
+        if (!isWorksheetHasSpan && hasValue) {
+            break;
+        }
+        if (cell && cell.spanAnchor) {
+            if (!spanAnchor) {
+                spanAnchor = {
+                    startRow: cell.spanAnchor.startRow,
+                    startColumn: cell.spanAnchor.startColumn,
+                    endRow: cell.spanAnchor.endRow,
+                    endColumn: cell.spanAnchor.endColumn,
+                };
+            } else {
+                spanAnchor = {
+                    startRow: Math.min(cell.spanAnchor.startRow, spanAnchor.startRow),
+                    startColumn: Math.min(cell.spanAnchor.startColumn, spanAnchor.startColumn),
+                    endRow: Math.max(cell.spanAnchor.endRow, spanAnchor.endRow),
+                    endColumn: Math.max(cell.spanAnchor.endColumn, spanAnchor.endColumn),
+                };
+            }
+        }
+    }
+
+    if (hasValue) {
+        range.startRow = range.startRow - upOffset;
+        return {
+            spanAnchor,
+            hasValue: true,
+            range,
+        };
+    }
+    return {
+        spanAnchor: null,
+        hasValue: false,
+        range,
+    };
+}
+
+function getExpandedRangeDown(range: IRange, allMatrixWithSpan: ObjectMatrix<IMatrixWithSpanInfo>, downOffset: number, isWorksheetHasSpan: boolean): IExpandedRangeResult {
+    const { startColumn, endColumn, endRow } = range;
+    let spanAnchor: IRange | null = null;
+    let hasValue = false;
+    for (let i = startColumn; i <= endColumn; i++) {
+        const cell = allMatrixWithSpan.getValue(endRow + downOffset, i);
+        hasValue = hasValue || hasValueFromMatrixWithSpanInfo(cell, allMatrixWithSpan);
+        if (!isWorksheetHasSpan && hasValue) {
+            break;
+        }
+        if (cell && cell.spanAnchor) {
+            if (!spanAnchor) {
+                spanAnchor = {
+                    startRow: cell.spanAnchor.startRow,
+                    startColumn: cell.spanAnchor.startColumn,
+                    endRow: cell.spanAnchor.endRow,
+                    endColumn: cell.spanAnchor.endColumn,
+                };
+            } else {
+                spanAnchor = {
+                    startRow: Math.min(cell.spanAnchor.startRow, spanAnchor.startRow),
+                    startColumn: Math.min(cell.spanAnchor.startColumn, spanAnchor.startColumn),
+                    endRow: Math.max(cell.spanAnchor.endRow, spanAnchor.endRow),
+                    endColumn: Math.max(cell.spanAnchor.endColumn, spanAnchor.endColumn),
+                };
+            }
+        }
+    }
+
+    if (hasValue) {
+        range.endRow = range.endRow + downOffset;
+        return {
+            spanAnchor,
+            hasValue: true,
+            range,
+        };
+    }
+    return {
+        spanAnchor: null,
+        hasValue: false,
+        range,
+    };
+}
+
+export function expandToContinuousRange(startRange: IRange, directions: IExpandParams, worksheet: Worksheet): IRange {
+    const maxRow = worksheet.getMaxRows();
+    const maxColumn = worksheet.getMaxColumns();
+    const allMatrixWithSpan = getMatrixWithSpanInfo(worksheet, 0, 0, maxRow - 1, maxColumn - 1);
+
+    const worksheetHasSpan = worksheet.getSnapshot().mergeData.length > 0;
+    const { left, right, up, down } = directions;
+    let changed = true;
+    let destRange = { ...startRange };
+    const spanAnchors: IRange[] = [];
+
+    while (changed) {
+        changed = false;
+        if (up && destRange.startRow !== 0) {
+            const { hasValue, range, spanAnchor } = getExpandedRangeUp(destRange, allMatrixWithSpan, 1, worksheetHasSpan);
+            if (spanAnchor) {
+                spanAnchors.push(spanAnchor);
+            }
+            if (hasValue) {
+                destRange = range;
+                changed = true;
+                continue;
+            }
+        }
+        if (down && destRange.endRow !== maxRow - 1) {
+            const { hasValue, range, spanAnchor } = getExpandedRangeDown(destRange, allMatrixWithSpan, 1, worksheetHasSpan);
+            if (spanAnchor) {
+                spanAnchors.push(spanAnchor);
+            }
+
+            if (hasValue) {
+                destRange = range;
+                changed = true;
+                continue;
+            }
+        }
+        if (left && destRange.startColumn !== 0) {
+            const { hasValue, range, spanAnchor } = getExpandedRangeLeft(destRange, allMatrixWithSpan, 1, worksheetHasSpan);
+            if (spanAnchor) {
+                spanAnchors.push(spanAnchor);
+            }
+            if (hasValue) {
+                destRange = range;
+                changed = true;
+                continue;
+            }
+        }
+        if (right && destRange.endColumn !== maxColumn - 1) {
+            const { hasValue, range, spanAnchor } = getExpandedRangeRight(destRange, allMatrixWithSpan, 1, worksheetHasSpan);
+            if (spanAnchor) {
+                spanAnchors.push(spanAnchor);
+            }
+            if (hasValue) {
+                destRange = range;
+                changed = true;
+                continue;
+            }
+        }
+    }
+    if (spanAnchors.length > 0) {
+        destRange = Rectangle.union(destRange, ...spanAnchors);
+    }
+
+    return destRange;
+}

--- a/packages/sheets/src/basics/expand-range.ts
+++ b/packages/sheets/src/basics/expand-range.ts
@@ -335,7 +335,21 @@ function getExpandedRangeDown(range: IRange, allMatrixWithSpan: ObjectMatrix<IMa
         range,
     };
 }
+// the demo unit=YSvbxFMCTxugbku-IWNyxQ&type=2&subunit=U_wr1DEF84N_mbesFNmxR in pro
+// The excel behavior rules:
+// 1. If the range has a span, the range should expand to whole span range.
+// 2. If range left, right, up, down has value, the range should expand to the cell which has value.
+// 3. If the range has no value, the range should not expand.
+// 4. If the merge has span, the every cell value in span should be the anchor of the span range.
+// 5. The span range should be not part in the result range.
 
+/**
+ *  Expand the range to a continuous range, it uses when Ctrl + A , or only one cell selected to add a pivot table adn so on.
+ * @param {IRange} startRange The start range.
+ * @param {IExpandParams} directions The directions to expand.
+ * @param {Worksheet} worksheet The worksheet working on.
+ * @returns {IRange} The expanded range.
+ */
 export function expandToContinuousRange(startRange: IRange, directions: IExpandParams, worksheet: Worksheet): IRange {
     const maxRow = worksheet.getMaxRows();
     const maxColumn = worksheet.getMaxColumns();

--- a/packages/sheets/src/index.ts
+++ b/packages/sheets/src/index.ts
@@ -102,7 +102,7 @@ export { MergeCellController, MERGE_CELL_INTERCEPTOR_CHECK } from './controllers
 export { AddMergeRedoSelectionsOperationFactory, AddMergeUndoSelectionsOperationFactory } from './commands/utils/handle-merge-operation';
 
 export type { FormatType } from './services/numfmt/type';
-export { expandToContinuousRange } from './basics/utils';
+export { expandToContinuousRange } from './basics/expand-range';
 
 // permission
 export { defaultWorksheetPermissionPoint, getAllWorksheetPermissionPoint, getAllWorksheetPermissionPointByPointPanel } from './services/permission';


### PR DESCRIPTION
-  if the sheet has none span, we can ignore span check logic
- we treat the span merge cells has same value just like the [left, top] cell
- we should check the span which may be added in the most left , top, right, bottom, so that can avoid the part of span be added in result range.

# Here is performance compare:
the count is how many times we called ` matrix.getValue(row, col)`
before:
<img width="362" alt="Image" src="https://github.com/user-attachments/assets/0948ee3b-c531-4f58-a250-dc04326ece65">
after with span check:
<img width="277" alt="Image" src="https://github.com/user-attachments/assets/8849954a-f850-4166-b5b0-240cc077e2b9">
without checked span:
<img width="367" alt="Image" src="https://github.com/user-attachments/assets/836696dc-8112-4e04-88b4-67a5796de4c6">

