### PR TITLE
fix: fix the judgment logic of editor returning empty textRun

### DIFF
--- a/packages/sheets-ui/src/controllers/editor/__tests__/end-edit.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/editor/__tests__/end-edit.controller.spec.ts
@@ -301,6 +301,30 @@ describe('Test EndEditController', () => {
             // textRuns works on parts of strings
             const isRichTextRes2 = isRichText(anotherCellBody);
             expect(isRichTextRes2).toBe(true);
+
+            const cellBody2 = {
+                dataStream: 'true\r\n',
+                textRuns: [
+                    {
+                        ts: {},
+                        st: 0,
+                        ed: 0,
+                    },
+                ],
+                paragraphs: [
+                    {
+                        startIndex: 4,
+                        paragraphStyle: {
+                            horizontalAlign: 0,
+                        },
+                    },
+                ],
+                customBlocks: [],
+                customRanges: [],
+            };
+
+            const isRichTextWithCellBody2 = isRichText(cellBody2);
+            expect(isRichTextWithCellBody2).toBe(false);
         });
 
         it('test number can not set style', () => {

--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -1120,7 +1120,7 @@ export function isRichText(body: IDocumentBody): boolean {
             const hasRichTextStyle = Boolean(textRun.ts && Object.keys(textRun.ts).some((property) => {
                 return richTextStyle.includes(property);
             }));
-            return hasRichTextStyle || (textRun.ts && (textRun.ed - textRun.st < bodyNoLineBreak.length));
+            return hasRichTextStyle || (Object.keys(textRun.ts ?? {}).length && (textRun.ed - textRun.st < bodyNoLineBreak.length));
         }) ||
         paragraphs.some((paragraph) => paragraph.bullet) ||
         paragraphs.length >= 2 ||


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close https://github.com/dream-num/univer-pro/issues/2234

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
