### PR TITLE
fix: the viewport size is too big after cancel filter rule, then viewport main is blank because graphic mem is full.

### DIFF
--- a/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
@@ -73,8 +73,8 @@ export class DocRenderController extends RxDisposable implements IRenderModule {
             top: 0,
             bottom: 0,
             right: 0,
-            isRelativeX: true,
-            isRelativeY: true,
+            explicitViewportWidthSet: false,
+            explicitViewportHeightSet: false,
             isWheelPreventDefaultX: true,
         });
 

--- a/packages/engine-render/src/components/sheets/extensions/background.ts
+++ b/packages/engine-render/src/components/sheets/extensions/background.ts
@@ -15,14 +15,13 @@
  */
 
 import type { IRange, IScale } from '@univerjs/core';
-
 import { expandRangeIfIntersects, fixLineWidthByScale, getColor, inViewRanges } from '../../../basics/tools';
+import { SpreadsheetExtensionRegistry } from '../../extension';
+import { SheetExtension } from './sheet-extension';
 import type { UniverRenderingContext } from '../../../context';
 import type { IDrawInfo } from '../../extension';
-import { SpreadsheetExtensionRegistry } from '../../extension';
 import type { SpreadsheetSkeleton } from '../sheet-skeleton';
 import type { Spreadsheet } from '../spreadsheet';
-import { SheetExtension } from './sheet-extension';
 
 const UNIQUE_KEY = 'DefaultBackgroundExtension';
 

--- a/packages/engine-render/src/components/sheets/extensions/row-header-layout.ts
+++ b/packages/engine-render/src/components/sheets/extensions/row-header-layout.ts
@@ -18,11 +18,11 @@ import type { IScale } from '@univerjs/core';
 
 import { DEFAULT_FONTFACE_PLANE, FIX_ONE_PIXEL_BLUR_OFFSET, MIDDLE_CELL_POS_MAGIC_NUMBER } from '../../../basics/const';
 import { getColor } from '../../../basics/tools';
-import type { UniverRenderingContext } from '../../../context';
 import { SheetRowHeaderExtensionRegistry } from '../../extension';
-import type { SpreadsheetSkeleton } from '../sheet-skeleton';
-import type { IARowCfg, IARowCfgObj, IColumnStyleCfg, IRowStyleCfg } from '../interfaces';
 import { SheetExtension } from './sheet-extension';
+import type { UniverRenderingContext } from '../../../context';
+import type { IARowCfg, IARowCfgObj, IColumnStyleCfg, IRowStyleCfg } from '../interfaces';
+import type { SpreadsheetSkeleton } from '../sheet-skeleton';
 
 const UNIQUE_KEY = 'DefaultRowHeaderLayoutExtension';
 

--- a/packages/engine-render/src/components/sheets/row-header.ts
+++ b/packages/engine-render/src/components/sheets/row-header.ts
@@ -15,11 +15,11 @@
  */
 
 import type { Nullable } from '@univerjs/core';
+import { SheetRowHeaderExtensionRegistry } from '../extension';
+import { SpreadsheetHeader } from './sheet-component';
 import type { IViewportInfo, Vector2 } from '../../basics/vector2';
 import type { UniverRenderingContext } from '../../context';
-import { SheetRowHeaderExtensionRegistry } from '../extension';
 import type { IRowsHeaderCfgParam, RowHeaderLayout } from './extensions/row-header-layout';
-import { SpreadsheetHeader } from './sheet-component';
 import type { SpreadsheetSkeleton } from './sheet-skeleton';
 
 export class SpreadsheetRowHeader extends SpreadsheetHeader {

--- a/packages/engine-render/src/engine.ts
+++ b/packages/engine-render/src/engine.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import type { Nullable } from '@univerjs/core';
 import { toDisposable, Tools } from '@univerjs/core';
-
 import { Observable, shareReplay, Subject } from 'rxjs';
-import type { CURSOR_TYPE } from './basics/const';
-import type { IKeyboardEvent, IPointerEvent } from './basics/i-events';
+
+import type { Nullable } from '@univerjs/core';
 import { DeviceType, PointerInput } from './basics/i-events';
-import type { ITimeMetric } from './basics/interfaces';
 import { TRANSFORM_CHANGE_OBSERVABLE_TYPE } from './basics/interfaces';
-import type { IBasicFrameInfo } from './basics/performance-monitor';
 import { PerformanceMonitor } from './basics/performance-monitor';
 import { getPointerPrefix, getSizeForDom, IsSafari, requestNewFrame } from './basics/tools';
 import { Canvas, CanvasRenderMode } from './canvas';
-import type { Scene } from './scene';
-import { ThinEngine } from './thin-engine';
 import { observeClientRect } from './floating/util';
+import { ThinEngine } from './thin-engine';
+import type { CURSOR_TYPE } from './basics/const';
+import type { IKeyboardEvent, IPointerEvent } from './basics/i-events';
+import type { ITimeMetric } from './basics/interfaces';
+import type { IBasicFrameInfo } from './basics/performance-monitor';
+import type { Scene } from './scene';
 
 export class Engine extends ThinEngine<Scene> {
     renderEvenInBackground = true;

--- a/packages/engine-render/src/layer.ts
+++ b/packages/engine-render/src/layer.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { Nullable } from '@univerjs/core';
 import { Disposable, requestImmediateMacroTask, sortRules, toDisposable } from '@univerjs/core';
+import type { Nullable } from '@univerjs/core';
 
 import { BaseObject } from './base-object';
 import { RENDER_CLASS_TYPE } from './basics/const';

--- a/packages/engine-render/src/render-manager/render-manager.service.ts
+++ b/packages/engine-render/src/render-manager/render-manager.service.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import type { Dependency, DependencyIdentifier, IDisposable, Nullable, UnitModel, UnitType } from '@univerjs/core';
 import { createIdentifier, Disposable, Inject, Injector, IUniverInstanceService, remove, toDisposable, UniverInstanceType } from '@univerjs/core';
-import type { Observable } from 'rxjs';
 import { BehaviorSubject, Subject } from 'rxjs';
+import type { Dependency, DependencyIdentifier, IDisposable, Nullable, UnitModel, UnitType } from '@univerjs/core';
+import type { Observable } from 'rxjs';
 
+import { Engine } from '../engine';
+import { Scene } from '../scene';
+import { type IRender, RenderUnit } from './render-unit';
 import type { BaseObject } from '../base-object';
 import type { DocComponent } from '../components/docs/doc-component';
 import type { SheetComponent } from '../components/sheets/sheet-component';
 import type { Slide } from '../components/slides/slide';
-import { Engine } from '../engine';
-import { Scene } from '../scene';
-import { type IRender, RenderUnit } from './render-unit';
 
 export type RenderComponentType = SheetComponent | DocComponent | Slide | BaseObject;
 
@@ -245,7 +245,7 @@ export class RenderManagerService extends Disposable implements IRenderManagerSe
      * @param isMainScene
      * @returns renderUnit:IRender
      */
-    private _createRender(unitId: string, engine: Engine, isMainScene: boolean = true): IRender {
+    protected _createRender(unitId: string, engine: Engine, isMainScene: boolean = true): IRender {
         const existItem = this.getRenderById(unitId);
         let shouldDestroyEngine = true;
 

--- a/packages/engine-render/src/scene.ts
+++ b/packages/engine-render/src/scene.ts
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-import type { IKeyValue, Nullable } from '@univerjs/core';
 import { sortRules, sortRulesByDesc, toDisposable } from '@univerjs/core';
 import { BehaviorSubject } from 'rxjs';
-import type { BaseObject } from './base-object';
+import type { IKeyValue, Nullable } from '@univerjs/core';
 import { CURSOR_TYPE, RENDER_CLASS_TYPE } from './basics/const';
-import type { IDragEvent, IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from './basics/i-events';
-import type { IObjectFullState, ISceneTransformState, ITransformChangeState } from './basics/interfaces';
 import { TRANSFORM_CHANGE_OBSERVABLE_TYPE } from './basics/interfaces';
 import { precisionTo, requestNewFrame } from './basics/tools';
 import { Transform } from './basics/transform';
+import { Layer } from './layer';
+import { InputManager } from './scene.input-manager';
+import { Transformer } from './scene.transformer';
+import { ThinScene } from './thin-scene';
+import type { BaseObject } from './base-object';
+import type { IDragEvent, IKeyboardEvent, IMouseEvent, IPointerEvent, IWheelEvent } from './basics/i-events';
+import type { IObjectFullState, ISceneTransformState, ITransformChangeState } from './basics/interfaces';
 import type { ITransformerConfig } from './basics/transformer-config';
 import type { Vector2 } from './basics/vector2';
 import type { UniverRenderingContext } from './context';
-import { Layer } from './layer';
-import type { SceneViewer } from './scene-viewer';
-import { InputManager } from './scene.input-manager';
-import { Transformer } from './scene.transformer';
-import type { ThinEngine } from './thin-engine';
-import { ThinScene } from './thin-scene';
-import type { Viewport } from './viewport';
 import type { Engine } from './engine';
+import type { SceneViewer } from './scene-viewer';
+import type { ThinEngine } from './thin-engine';
+import type { Viewport } from './viewport';
 
 export class Scene extends ThinScene {
     private _layers: Layer[] = [];

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -381,8 +381,13 @@ export class Viewport {
         this._width = w;
     }
 
-    set height(h: Nullable<number>) {
-        this._height = h;
+    set height(height: Nullable<number>) {
+        const maxHeight = this.scene.getParent().height;
+        if(height !== null && height !== undefined) {
+            this._height = Tools.clamp(height, 0, maxHeight);
+        } else {
+            this._height = height;
+        }
     }
 
     get isActive() {

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -194,10 +194,17 @@ export class Viewport {
 
     private _paddingEndY: number = 0;
 
-    private _explicitViewportWidthSet: boolean = false;
     /**
-     * _isRelativeY true means this height is dynamic decided by canvas size and other viewport height
-     * ex: if freeze horizontally, viewMain _isRelativeY is true, the height of viewMain is decided by canvas height - viewMainTop.height.
+     * Usually for viewport by after freeze, _explicitViewportWidthSet true means viewport's width is specify explicitly.
+     * ex: ViewMainLeft _explicitViewportWidthSet is true when freeze at a certain col, the width of viewMainLeft is decided by freeze line.
+     * Usually this prop is false for viewMain, viewport width is decided by engine size - freeze line
+     */
+    private _explicitViewportWidthSet: boolean = false;
+
+    /**
+     * _explicitViewportHeightSet true means viewport's height is specify explicitly.
+     * Used for viewport by after freeze.
+     * ex: ViewMainTop _explicitViewportHeightSet is true when freeze at a certain row, the height of viewMainTop is decided by freeze line.
      */
     private _explicitViewportHeightSet: boolean = false;
 
@@ -577,7 +584,14 @@ export class Viewport {
      * @returns IViewportScrollPosition
      */
     scrollToViewportPos(pos: Partial<IViewportScrollPosition>, isTrigger = true) {
-        if (!this._scrollBar || this.isActive === false) {
+        // TODO @lumixraku Now scrollManager only call viewportMain@scrollToViewportPos.
+        // this method in other viewports won't get called.
+        // viewport is inactive when it's out of visible area (see #univer-pro/issues/2479)
+        // so there should not return when inactive.
+        // it's not right, this method in other viewport should be called.
+
+        // if (!this._scrollBar || this.isActive === false) {
+        if (!this._scrollBar) {
             return;
         }
         const { viewportScrollX, viewportScrollY } = pos;

--- a/packages/facade/src/apis/__tests__/create-test-bed.ts
+++ b/packages/facade/src/apis/__tests__/create-test-bed.ts
@@ -45,8 +45,8 @@ import {
 } from '@univerjs/sheets';
 import { ConditionalFormattingFormulaService, ConditionalFormattingRuleModel, ConditionalFormattingService, ConditionalFormattingViewModel } from '@univerjs/sheets-conditional-formatting';
 import { DataValidationCacheService, DataValidationCustomFormulaService, DataValidationFormulaService, SheetDataValidationModel, SheetsDataValidationValidatorService } from '@univerjs/sheets-data-validation';
-
 import { UniverSheetsFilterPlugin } from '@univerjs/sheets-filter';
+
 import {
     DescriptionService,
     IDescriptionService,
@@ -61,6 +61,7 @@ import { ISheetSelectionRenderService, SheetRenderController, SheetSelectionRend
 import { IThreadCommentDataSourceService, ThreadCommentDataSourceService, ThreadCommentModel } from '@univerjs/thread-comment';
 import { IPlatformService, IShortcutService, PlatformService, ShortcutService } from '@univerjs/ui';
 import type { Dependency, IWorkbookData, UnitModel } from '@univerjs/core';
+import type { IRender } from '@univerjs/engine-render';
 import { FUniver } from '../facade';
 
 function getTestWorkbookDataDemo(): IWorkbookData {
@@ -120,6 +121,13 @@ export interface ITestBed {
     injector: Injector;
 }
 
+class RenderManagerServiceTestBed extends RenderManagerService {
+    override createRender(unitId: string): IRender {
+        const renderer = this._createRender(unitId, new Engine(100, 100));
+        return renderer;
+    }
+}
+
 export function createFacadeTestBed(workbookData?: IWorkbookData, dependencies?: Dependency[]): ITestBed {
     const univer = new Univer();
     const injector = univer.__getInjector();
@@ -150,7 +158,7 @@ export function createFacadeTestBed(workbookData?: IWorkbookData, dependencies?:
             injector.add([IFunctionService, { useClass: FunctionService }]);
             injector.add([ISocketService, { useClass: WebSocketService }]);
             injector.add([IRenderingEngine, { useFactory: () => new Engine() }]);
-            injector.add([IRenderManagerService, { useClass: RenderManagerService }]);
+            injector.add([IRenderManagerService, { useClass: RenderManagerServiceTestBed }]);
             injector.add([ISheetSelectionRenderService, { useClass: SheetSelectionRenderService }]);
             injector.add([SheetsRenderService]);
             injector.add([IShortcutService, { useClass: ShortcutService }]);

--- a/packages/facade/src/apis/__tests__/facade.spec.ts
+++ b/packages/facade/src/apis/__tests__/facade.spec.ts
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ICellData, Injector, IStyleData, Nullable } from '@univerjs/core';
 import { ICommandService, IUniverInstanceService } from '@univerjs/core';
+import { RegisterFunctionMutation, SetFormulaCalculationStartMutation } from '@univerjs/engine-formula';
+import { IRenderManagerService } from '@univerjs/engine-render';
 import { SetRangeValuesCommand, SetRangeValuesMutation, SetStyleCommand } from '@univerjs/sheets';
 
+import { IDescriptionService } from '@univerjs/sheets-formula';
+import { SHEET_VIEW_KEY } from '@univerjs/sheets-ui';
+import { AddCommentCommand, AddCommentMutation, DeleteCommentCommand, DeleteCommentMutation, DeleteCommentTreeCommand, ResolveCommentMutation, UpdateCommentCommand, UpdateCommentMutation, UpdateCommentRefMutation } from '@univerjs/thread-comment';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ICellData, Injector, IStyleData, Nullable } from '@univerjs/core';
 import type {
     ColumnHeaderLayout,
     RenderComponentType,
@@ -27,14 +32,9 @@ import type {
     SpreadsheetColumnHeader,
     SpreadsheetRowHeader,
 } from '@univerjs/engine-render';
-import { IRenderManagerService } from '@univerjs/engine-render';
-import { SHEET_VIEW_KEY } from '@univerjs/sheets-ui';
-import { RegisterFunctionMutation, SetFormulaCalculationStartMutation } from '@univerjs/engine-formula';
-import { IDescriptionService } from '@univerjs/sheets-formula';
-import { AddCommentCommand, AddCommentMutation, DeleteCommentCommand, DeleteCommentMutation, DeleteCommentTreeCommand, ResolveCommentMutation, UpdateCommentCommand, UpdateCommentMutation, UpdateCommentRefMutation } from '@univerjs/thread-comment';
-import type { FUniver } from '../facade';
 import { createFacadeTestBed } from './create-test-bed';
 import { COLUMN_UNIQUE_KEY, ColumnHeaderCustomExtension, MAIN_UNIQUE_KEY, MainCustomExtension, ROW_UNIQUE_KEY, RowHeaderCustomExtension } from './utils/sheet-extension-util';
+import type { FUniver } from '../facade';
 
 describe('Test FUniver', () => {
     let get: Injector['get'];

--- a/packages/sheets-ui/src/controllers/render-controllers/freeze.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/freeze.render-controller.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { ICommandInfo, IFreeze, IRange, IStyleSheet, IWorksheetData, Nullable, Workbook } from '@univerjs/core';
 import {
     ColorKit,
     createInterceptorKey,
@@ -28,21 +27,7 @@ import {
     ThemeService,
     toDisposable,
 } from '@univerjs/core';
-import type { IMouseEvent, IPointerEvent, IRenderContext, IRenderModule, Viewport } from '@univerjs/engine-render';
 import { CURSOR_TYPE, Rect, SHEET_VIEWPORT_KEY, TRANSFORM_CHANGE_OBSERVABLE_TYPE, Vector2 } from '@univerjs/engine-render';
-import type {
-    IInsertColCommandParams,
-    IInsertRowCommandParams,
-    IMoveColsCommandParams,
-    IMoveRowsCommandParams,
-    IRemoveRowColCommandParams,
-    ISetColHiddenMutationParams,
-    ISetFrozenMutationParams,
-    ISetRowHiddenMutationParams,
-    ISetWorksheetColWidthMutationParams,
-    ISetWorksheetRowAutoHeightMutationParams,
-    ISetWorksheetRowHeightMutationParams,
-} from '@univerjs/sheets';
 import {
     InsertColCommand,
     InsertRangeMoveDownCommand,
@@ -66,16 +51,31 @@ import {
     SheetInterceptorService,
     SheetsSelectionsService,
 } from '@univerjs/sheets';
-
 import { Subscription } from 'rxjs';
+import type { ICommandInfo, IFreeze, IRange, IStyleSheet, IWorksheetData, Nullable, Workbook } from '@univerjs/core';
+import type { IMouseEvent, IPointerEvent, IRenderContext, IRenderModule, Viewport } from '@univerjs/engine-render';
+
+import type {
+    IInsertColCommandParams,
+    IInsertRowCommandParams,
+    IMoveColsCommandParams,
+    IMoveRowsCommandParams,
+    IRemoveRowColCommandParams,
+    ISetColHiddenMutationParams,
+    ISetFrozenMutationParams,
+    ISetRowHiddenMutationParams,
+    ISetWorksheetColWidthMutationParams,
+    ISetWorksheetRowAutoHeightMutationParams,
+    ISetWorksheetRowHeightMutationParams,
+} from '@univerjs/sheets';
 import { ScrollCommand } from '../../commands/commands/set-scroll.command';
 import { SetZoomRatioOperation } from '../../commands/operations/set-zoom-ratio.operation';
 import { SHEET_COMPONENT_HEADER_LAYER_INDEX } from '../../common/keys';
 
-import type { IViewportScrollState } from '../../services/scroll-manager.service';
 import { SheetScrollManagerService } from '../../services/scroll-manager.service';
 import { SheetSkeletonManagerService } from '../../services/sheet-skeleton-manager.service';
 import { getCoordByOffset, getSheetObject } from '../utils/component-tools';
+import type { IViewportScrollState } from '../../services/scroll-manager.service';
 
 enum FREEZE_DIRECTION_TYPE {
     ROW,
@@ -786,7 +786,7 @@ export class HeaderFreezeRenderController extends Disposable implements IRenderM
         );
     }
 
-    // eslint-disable-next-line max-lines-per-function
+    // eslint-disable-next-line max-lines-per-function, complexity
     private _updateViewport(
         row: number = -1,
         column: number = -1,
@@ -1567,7 +1567,8 @@ export class HeaderFreezeRenderController extends Disposable implements IRenderM
     private _getFreeze() {
         const config: IWorksheetData | undefined = this._sheetSkeletonManagerService
             .getCurrent()
-            ?.skeleton.getWorksheetConfig();
+            ?.skeleton
+            .getWorksheetConfig();
 
         if (config == null) {
             return;

--- a/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import type { ICommandInfo, IExecutionOptions, IRange, Nullable, Workbook, Worksheet } from '@univerjs/core';
 import { CommandType, FOCUSING_SHEET, ICommandService, IContextService, Inject, Optional, Rectangle, RxDisposable } from '@univerjs/core';
-import type { IAfterRender$Info, IBasicFrameInfo, IExtendFrameInfo, IRenderContext, IRenderModule, ISummaryFrameInfo, ITimeMetric, IViewportInfos, IWheelEvent, Scene } from '@univerjs/engine-render';
 import {
     PointerInput,
     Rect,
@@ -32,6 +30,8 @@ import {
 import { COMMAND_LISTENER_SKELETON_CHANGE, COMMAND_LISTENER_VALUE_CHANGE, MoveRangeMutation, SetRangeValuesMutation, SetWorksheetActiveOperation } from '@univerjs/sheets';
 import { ITelemetryService } from '@univerjs/telemetry';
 import { Subject, withLatestFrom } from 'rxjs';
+import type { ICommandInfo, IExecutionOptions, IRange, Nullable, Workbook, Worksheet } from '@univerjs/core';
+import type { IAfterRender$Info, IBasicFrameInfo, IExtendFrameInfo, IRenderContext, IRenderModule, ISummaryFrameInfo, ITimeMetric, IViewportInfos, IWheelEvent, Scene } from '@univerjs/engine-render';
 import { SetScrollRelativeCommand } from '../../commands/commands/set-scroll.command';
 
 import {

--- a/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
@@ -251,8 +251,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             bottom: 0,
             right: 0,
             isWheelPreventDefaultX: true,
-            isRelativeX: true,
-            isRelativeY: true,
+            explicitViewportWidthSet: false,
+            explicitViewportHeightSet: false,
             allowCache: true,
             bufferEdgeX,
             bufferEdgeY,
@@ -260,8 +260,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewMainLeftTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN_LEFT_TOP, scene, {
             isWheelPreventDefaultX: true,
             active: false,
-            isRelativeX: false,
-            isRelativeY: false,
+            explicitViewportWidthSet: true,
+            explicitViewportHeightSet: true,
             allowCache: true,
             bufferEdgeX: 0,
             bufferEdgeY: 0,
@@ -270,8 +270,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewMainLeft = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN_LEFT, scene, {
             isWheelPreventDefaultX: true,
             active: false,
-            isRelativeX: false,
-            isRelativeY: true,
+            explicitViewportWidthSet: true,
+            explicitViewportHeightSet: false,
             allowCache: true,
             bufferEdgeX: 0,
             bufferEdgeY,
@@ -280,8 +280,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewMainTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN_TOP, scene, {
             isWheelPreventDefaultX: true,
             active: false,
-            isRelativeX: true,
-            isRelativeY: false,
+            explicitViewportWidthSet: false,
+            explicitViewportHeightSet: true,
             allowCache: true,
             bufferEdgeX,
             bufferEdgeY: 0,
@@ -290,8 +290,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewRowTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_ROW_TOP, scene, {
             active: false,
             isWheelPreventDefaultX: true,
-            isRelativeX: false,
-            isRelativeY: false,
+            explicitViewportWidthSet: true,
+            explicitViewportHeightSet: true,
         });
 
         const viewRowBottom = new Viewport(SHEET_VIEWPORT_KEY.VIEW_ROW_BOTTOM, scene, {
@@ -300,15 +300,15 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             bottom: 0,
             width: rowHeader.width,
             isWheelPreventDefaultX: true,
-            isRelativeX: false,
-            isRelativeY: true,
+            explicitViewportWidthSet: true,
+            explicitViewportHeightSet: false,
         });
 
         const viewColumnLeft = new Viewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_LEFT, scene, {
             active: false,
             isWheelPreventDefaultX: true,
-            isRelativeX: false,
-            isRelativeY: false,
+            explicitViewportWidthSet: true,
+            explicitViewportHeightSet: true,
         });
 
         const viewColumnRight = new Viewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_RIGHT, scene, {
@@ -317,8 +317,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             height: columnHeader.height,
             right: 0,
             isWheelPreventDefaultX: true,
-            isRelativeX: true,
-            isRelativeY: false,
+            explicitViewportWidthSet: false,
+            explicitViewportHeightSet: true,
         });
 
         const viewLeftTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_LEFT_TOP, scene, {
@@ -327,8 +327,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             width: rowHeader.width,
             height: columnHeader.height,
             isWheelPreventDefaultX: true,
-            isRelativeX: false,
-            isRelativeY: false,
+            explicitViewportWidthSet: true,
+            explicitViewportHeightSet: true,
         });
 
         return {

--- a/packages/slides-ui/src/controllers/slide.render-controller.ts
+++ b/packages/slides-ui/src/controllers/slide.render-controller.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import type { EventState, IColorStyle, IPageElement, ISlidePage, Nullable, SlideDataModel, UnitModel } from '@univerjs/core';
 import { debounce, getColorStyle, Inject, Injector, IUniverInstanceService, RxDisposable, UniverInstanceType } from '@univerjs/core';
-import type { BaseObject, IRenderContext, IRenderModule, IWheelEvent } from '@univerjs/engine-render';
 import {
     IRenderManagerService,
     Rect,
@@ -25,8 +23,10 @@ import {
     Slide,
     Viewport,
 } from '@univerjs/engine-render';
-
 import { ObjectProvider, SLIDE_KEY } from '@univerjs/slides';
+import type { EventState, IColorStyle, IPageElement, ISlidePage, Nullable, SlideDataModel, UnitModel } from '@univerjs/core';
+
+import type { BaseObject, IRenderContext, IRenderModule, IWheelEvent } from '@univerjs/engine-render';
 import type { PageID } from '../type';
 
 // export const ICanvasView = createIdentifier<IUniverInstanceService>('univer.slide.canvas-view');
@@ -72,8 +72,8 @@ export class SlideRenderController extends RxDisposable implements IRenderModule
             top: 0,
             bottom: 0,
             right: 0,
-            isRelativeX: true,
-            isRelativeY: true,
+            explicitViewportWidthSet: false,
+            explicitViewportHeightSet: false,
             isWheelPreventDefaultX: true,
         });
         scene.attachControl();
@@ -368,8 +368,8 @@ export class SlideRenderController extends RxDisposable implements IRenderModule
             top: 0,
             bottom: 0,
             right: 0,
-            isRelativeX: true,
-            isRelativeY: true,
+            explicitViewportWidthSet: false,
+            explicitViewportHeightSet: false,
         });
         viewMain.closeClip();
 

--- a/packages/slides/src/views/render/adaptors/docs-adaptor.ts
+++ b/packages/slides/src/views/render/adaptors/docs-adaptor.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import type { EventState, Injector, IPageElement } from '@univerjs/core';
 import { DocumentDataModel, Inject, LocaleService, PageElementType } from '@univerjs/core';
-import type { BaseObject, IDocumentSkeletonDrawing, IPageRenderConfig, IWheelEvent } from '@univerjs/engine-render';
 import {
     Documents,
     DocumentSkeleton,
@@ -30,6 +28,8 @@ import {
     ScrollBar,
     Viewport,
 } from '@univerjs/engine-render';
+import type { EventState, Injector, IPageElement } from '@univerjs/core';
+import type { BaseObject, IDocumentSkeletonDrawing, IPageRenderConfig, IWheelEvent } from '@univerjs/engine-render';
 
 import { CanvasObjectProviderRegistry, ObjectAdaptor } from '../adaptor';
 
@@ -111,8 +111,8 @@ export class DocsAdaptor extends ObjectAdaptor {
             top: 0,
             bottom: 0,
             right: 0,
-            isRelativeX: true,
-            isRelativeY: true,
+            explicitViewportWidthSet: false,
+            explicitViewportHeightSet: false,
             isWheelPreventDefaultX: true,
         });
 

--- a/packages/slides/src/views/render/adaptors/slide-adaptor.ts
+++ b/packages/slides/src/views/render/adaptors/slide-adaptor.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import type { IColorStyle, IPageElement, ISlidePage } from '@univerjs/core';
 import { getColorStyle, Inject, Injector, PageElementType, SlideDataModel } from '@univerjs/core';
-import type { Engine } from '@univerjs/engine-render';
 import { Rect, Scene, Slide, Viewport } from '@univerjs/engine-render';
+import type { IColorStyle, IPageElement, ISlidePage } from '@univerjs/core';
+import type { Engine } from '@univerjs/engine-render';
 
 import { CanvasObjectProviderRegistry, ObjectAdaptor } from '../adaptor';
 import { ObjectProvider } from '../object-provider';
@@ -128,8 +128,8 @@ export class SlideAdaptor extends ObjectAdaptor {
             top: 0,
             bottom: 0,
             right: 0,
-            isRelativeX: true,
-            isRelativeY: true,
+            explicitViewportWidthSet: false,
+            explicitViewportHeightSet: false,
         });
 
         viewMain.closeClip();

--- a/packages/slides/src/views/render/adaptors/spreadsheet-adaptor.ts
+++ b/packages/slides/src/views/render/adaptors/spreadsheet-adaptor.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import type { EventState, ICellData, Injector, IPageElement } from '@univerjs/core';
 import { IContextService, Inject, LocaleService, ObjectMatrix, PageElementType, Styles, Worksheet } from '@univerjs/core';
-import type { IScrollObserverParam, IWheelEvent } from '@univerjs/engine-render';
 import {
     getColor,
     Rect,
@@ -29,6 +27,8 @@ import {
     SpreadsheetSkeleton,
     Viewport,
 } from '@univerjs/engine-render';
+import type { EventState, ICellData, Injector, IPageElement } from '@univerjs/core';
+import type { IScrollObserverParam, IWheelEvent } from '@univerjs/engine-render';
 
 import { CanvasObjectProviderRegistry, ObjectAdaptor } from '../adaptor';
 
@@ -170,8 +170,8 @@ export class SpreadsheetAdaptor extends ObjectAdaptor {
             top: columnHeaderHeightScale,
             bottom: 0,
             right: 0,
-            isRelativeX: true,
-            isRelativeY: true,
+            explicitViewportWidthSet: false,
+            explicitViewportHeightSet: false,
             isWheelPreventDefaultX: true,
         });
         const viewTop = new Viewport(SHEET_VIEW_KEY.VIEW_TOP + id, scene, {
@@ -179,7 +179,7 @@ export class SpreadsheetAdaptor extends ObjectAdaptor {
             height: columnHeaderHeightScale,
             top: 0,
             right: 0,
-            isRelativeX: true,
+            explicitViewportWidthSet: false,
             isWheelPreventDefaultX: true,
         });
         const viewLeft = new Viewport(SHEET_VIEW_KEY.VIEW_LEFT + id, scene, {
@@ -187,7 +187,7 @@ export class SpreadsheetAdaptor extends ObjectAdaptor {
             bottom: 0,
             top: columnHeaderHeightScale,
             width: rowHeaderWidthScale,
-            isRelativeY: true,
+            explicitViewportHeightSet: false,
             isWheelPreventDefaultX: true,
         });
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close https://github.com/dream-num/univer-pro/issues/2479

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
