### PR TITLE
fix: perf improving in set style cache

### DIFF
--- a/packages/core/src/shared/array-search.ts
+++ b/packages/core/src/shared/array-search.ts
@@ -77,6 +77,13 @@ export function orderSearchArray(arr: number[], pos: number) {
     return cur_index;
 }
 
+/**
+ * return the first index which arr[index] > num
+ * ex: searchArray([1, 3, 5, 7, 9], 7) = 4
+ * @param arr
+ * @param num
+ * @returns {number} index
+ */
 export function searchArray(arr: number[], num: number) {
     let index: number = arr.length - 1;
     if (num < 0) {

--- a/packages/core/src/shared/object-matrix.ts
+++ b/packages/core/src/shared/object-matrix.ts
@@ -342,7 +342,7 @@ export class ObjectMatrix<T> {
         return false;
     }
 
-    getValue(row: number, column: number): T {
+    getValue(row: number, column: number): Nullable<T> {
         return this._matrix?.[row]?.[column];
     }
 

--- a/packages/core/src/shared/object-matrix.ts
+++ b/packages/core/src/shared/object-matrix.ts
@@ -517,7 +517,7 @@ export class ObjectMatrix<T> {
             }
 
             cols.forEach((column) => {
-                array[row][column] = this.getValue(row, column);
+                array[row][column] = this.getValue(row, column)!;
             });
         });
         return array;

--- a/packages/core/src/shared/rectangle.ts
+++ b/packages/core/src/shared/rectangle.ts
@@ -56,6 +56,16 @@ export class Rectangle {
         );
     }
 
+    static simpleRangesIntersect(rangeA: IRange, rangeB: IRange) {
+        const { startRow: startRowA, endRow: endRowA, startColumn: startColumnA, endColumn: endColumnA } = rangeA;
+        const { startRow: startRowB, endRow: endRowB, startColumn: startColumnB, endColumn: endColumnB } = rangeB;
+
+        const rowsOverlap = (startRowA <= endRowB) && (endRowA >= startRowB);
+        const columnsOverlap = (startColumnA <= endColumnB) && (endColumnA >= startColumnB);
+
+        return rowsOverlap && columnsOverlap;
+    }
+
     static intersects(src: IRange, target: IRange): boolean {
         if (src.rangeType === RANGE_TYPE.ROW && target.rangeType === RANGE_TYPE.COLUMN) {
             return true;

--- a/packages/core/src/shared/rectangle.ts
+++ b/packages/core/src/shared/rectangle.ts
@@ -56,7 +56,14 @@ export class Rectangle {
         );
     }
 
-    static simpleRangesIntersect(rangeA: IRange, rangeB: IRange) {
+    /**
+     * Check intersects of normal range(RANGE_TYPE.NORMAL)
+     * For other types of ranges, please consider using the intersects method.
+     * @param rangeA
+     * @param rangeB
+     * @returns boolean
+     */
+    static simpleRangesIntersect(rangeA: IRange, rangeB: IRange): boolean {
         const { startRow: startRowA, endRow: endRowA, startColumn: startColumnA, endColumn: endColumnA } = rangeA;
         const { startRow: startRowB, endRow: endRowB, startColumn: startColumnB, endColumn: endColumnB } = rangeB;
 

--- a/packages/core/src/sheets/span-model.ts
+++ b/packages/core/src/sheets/span-model.ts
@@ -198,6 +198,13 @@ export class SpanModel extends Disposable {
         return ranges;
     }
 
+    /**
+     * @deprecated sigificant performance impact, use _getCellMergeInfo instead.
+     * @param startRow
+     * @param startColumn
+     * @param endRow
+     * @param endColumn
+     */
     public getMergedCellRangeForSkeleton(startRow: number, startColumn: number, endRow: number, endColumn: number) {
         // copy from packages\engine-render\src\components\sheets\sheet-skeleton.ts  _getMergeCells
         const cacheDataMerge: IRange[] = [];

--- a/packages/core/src/sheets/worksheet.ts
+++ b/packages/core/src/sheets/worksheet.ts
@@ -337,7 +337,6 @@ export class Worksheet {
         };
     }
 
-    cellCache: ObjectMatrix<Nullable<ICellDataForSheetInterceptor>> = new ObjectMatrix();
     /**
      * Get cellData, includes cellData, customRender, markers, dataValidate, etc.
      *
@@ -352,13 +351,8 @@ export class Worksheet {
         if (row < 0 || col < 0) {
             return null;
         }
-        // return this._viewModel.getCell(row, col);
-        // const cache = this.cellCache.getValue(row, col);
-        // if (cache) return cache;
 
-        const cell = this._viewModel.getCell(row, col);
-        this.cellCache.setValue(row, col, cell);
-        return cell;
+        return this._viewModel.getCell(row, col);
     }
 
     getCellRaw(row: number, col: number): Nullable<ICellData> {

--- a/packages/core/src/sheets/worksheet.ts
+++ b/packages/core/src/sheets/worksheet.ts
@@ -353,8 +353,8 @@ export class Worksheet {
             return null;
         }
         // return this._viewModel.getCell(row, col);
-        const cache = this.cellCache.getValue(row, col);
-        if (cache) return cache;
+        // const cache = this.cellCache.getValue(row, col);
+        // if (cache) return cache;
 
         const cell = this._viewModel.getCell(row, col);
         this.cellCache.setValue(row, col, cell);

--- a/packages/core/src/sheets/worksheet.ts
+++ b/packages/core/src/sheets/worksheet.ts
@@ -337,6 +337,7 @@ export class Worksheet {
         };
     }
 
+    cellCache: ObjectMatrix<Nullable<ICellDataForSheetInterceptor>> = new ObjectMatrix();
     /**
      * Get cellData, includes cellData, customRender, markers, dataValidate, etc.
      *
@@ -351,8 +352,13 @@ export class Worksheet {
         if (row < 0 || col < 0) {
             return null;
         }
+        // return this._viewModel.getCell(row, col);
+        const cache = this.cellCache.getValue(row, col);
+        if (cache) return cache;
 
-        return this._viewModel.getCell(row, col);
+        const cell = this._viewModel.getCell(row, col);
+        this.cellCache.setValue(row, col, cell);
+        return cell;
     }
 
     getCellRaw(row: number, col: number): Nullable<ICellData> {

--- a/packages/engine-formula/src/engine/reference-object/base-reference-object.ts
+++ b/packages/engine-formula/src/engine/reference-object/base-reference-object.ts
@@ -164,7 +164,7 @@ export class BaseReferenceObject extends ObjectClassType {
                     return callback(ErrorValueObject.create(ErrorType.REF), r, c);
                 }
 
-                const cell = this.getCellData(r, c);
+                const cell = this.getCellData(r, c)!;
                 let result: Nullable<boolean> = false;
                 if (isNullCell(cell)) {
                     result = callback(null, r, c);

--- a/packages/engine-formula/src/functions/meta/compare/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/meta/compare/__tests__/index.spec.ts
@@ -16,14 +16,14 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { ErrorType } from '../../../../basics/error-type';
+import { CELL_INVERTED_INDEX_CACHE } from '../../../../basics/inverted-index-cache';
+import { compareToken } from '../../../../basics/token';
+import { ArrayValueObject, transformToValueObject } from '../../../../engine/value-object/array-value-object';
+import { BooleanValueObject, NullValueObject, NumberValueObject, StringValueObject } from '../../../../engine/value-object/primitive-object';
+import { getObjectValue } from '../../../__tests__/create-function-test-bed';
 import { FUNCTION_NAMES_META } from '../../function-names';
 import { Compare } from '../index';
-import { BooleanValueObject, NullValueObject, NumberValueObject, StringValueObject } from '../../../../engine/value-object/primitive-object';
-import { compareToken } from '../../../../basics/token';
-import { ErrorType } from '../../../../basics/error-type';
-import { ArrayValueObject, transformToValueObject } from '../../../../engine/value-object/array-value-object';
-import { getObjectValue } from '../../../__tests__/create-function-test-bed';
-import { CELL_INVERTED_INDEX_CACHE } from '../../../../basics/inverted-index-cache';
 
 describe('Test compare function', () => {
     const testFunction = new Compare(FUNCTION_NAMES_META.COMPARE);

--- a/packages/engine-render/src/basics/tools.ts
+++ b/packages/engine-render/src/basics/tools.ts
@@ -837,12 +837,14 @@ export function expandRangeIfIntersects(mainRanges: IRange[], ranges: IRange[]) 
     const intersects = [];
     for (const mainRange of mainRanges) {
         for (const range of ranges) {
-            if (Rectangle.intersects(mainRange, range)) {
+            if (Rectangle.simpleRangesIntersect(mainRange, range)) {
                 intersects.push(range);
             }
         }
     }
     // return [...mainRanges, ...intersects];
+    // mainRanges.push(...intersects);
+    // return mainRanges;
     return mainRanges.concat(intersects); // concat is slightly faster than spread
 }
 

--- a/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
+++ b/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
@@ -147,7 +147,10 @@ export class DocumentSkeleton extends Skeleton {
         return this._docViewModel;
     }
 
-    // Layout the document.
+    /**
+     * Layout the document.
+     * PS: This method has significant impact on performance.
+     */
     calculate(bounds?: IViewportInfo) {
         if (!this.dirty) {
             return;

--- a/packages/engine-render/src/components/docs/layout/shaping-engine/font-cache.ts
+++ b/packages/engine-render/src/components/docs/layout/shaping-engine/font-cache.ts
@@ -15,8 +15,8 @@
  */
 
 import type { Nullable } from '@univerjs/core';
-import type { IDocumentSkeletonBoundingBox, IDocumentSkeletonFontStyle } from '../../../../basics/i-document-skeleton-cached';
 import { ptToPixel } from '../../../../basics/tools';
+import type { IDocumentSkeletonBoundingBox, IDocumentSkeletonFontStyle } from '../../../../basics/i-document-skeleton-cached';
 import type { IOpenTypeGlyphInfo } from './text-shaping';
 
 export const DEFAULT_MEASURE_TEXT = '0';

--- a/packages/engine-render/src/components/extension.ts
+++ b/packages/engine-render/src/components/extension.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import type { IDocumentRenderConfig, IRange, IScale, Nullable } from '@univerjs/core';
 import { Registry } from '@univerjs/core';
+import type { IDocumentRenderConfig, IRange, IScale, Nullable } from '@univerjs/core';
 
-import type { BaseObject } from '../base-object';
 import { getScale } from '../basics/tools';
+import type { BaseObject } from '../base-object';
 import type { Vector2 } from '../basics/vector2';
 import type { UniverRenderingContext } from '../context';
 

--- a/packages/engine-render/src/components/sheets/extensions/background.ts
+++ b/packages/engine-render/src/components/sheets/extensions/background.ts
@@ -70,9 +70,7 @@ export class Background extends SheetExtension {
 
             const bgColorMatrix = backgroundCache[rgb];
             ctx.fillStyle = rgb || getColor([255, 255, 255])!;
-
             const backgroundPaths = new Path2D();
-
             const renderBGByCell = (row: number, col: number) => {
                 if (!checkOutOfViewBound && !inViewRanges(viewRanges, row, col)) {
                     return true;
@@ -118,6 +116,7 @@ export class Background extends SheetExtension {
             };
             bgColorMatrix.forValue(renderBGByCell);
             ctx.fill(backgroundPaths);
+            ctx.closePath();
         };
 
         Object.keys(backgroundCache).forEach(renderBGCore);

--- a/packages/engine-render/src/components/sheets/extensions/border.ts
+++ b/packages/engine-render/src/components/sheets/extensions/border.ts
@@ -159,7 +159,7 @@ export class Border extends SheetExtension {
                 return true;
             }
             rowArray.forEach((column) => {
-                const rectangle = overflowCache.getValue(row, column);
+                const rectangle = overflowCache.getValue(row, column)!;
                 const { startColumn, endColumn } = rectangle;
                 if (type === BORDER_TYPE.LEFT && borderColumn > startColumn && borderColumn <= endColumn) {
                     isDraw = true;

--- a/packages/engine-render/src/components/sheets/extensions/font.ts
+++ b/packages/engine-render/src/components/sheets/extensions/font.ts
@@ -248,13 +248,12 @@ export class Font extends SheetExtension {
         };
 
         fontMatrix.forValue(renderFontByCellMatrix);
-        // const fontMatrix: ObjectMatrix<IFontCacheItem> = fontMap[fontFamily];
-        // Object.keys(fontMap).forEach(renderFontCore);
         ctx.restore();
     }
 
     private _renderDocuments(
         ctx: UniverRenderingContext,
+        // docsConfig.documentSkeleton.getSkeletonData().pages[0].sections[0].columns[0].lines[0].divides[0].glyphGroup[0].fontStyle
         docsConfig: IFontCacheItem,
         startX: number,
         startY: number,

--- a/packages/engine-render/src/components/sheets/extensions/font.ts
+++ b/packages/engine-render/src/components/sheets/extensions/font.ts
@@ -54,10 +54,8 @@ export class Font extends SheetExtension {
         moreBoundsInfo: IDrawInfo
     ) {
         const { stylesCache, overflowCache, worksheet } = spreadsheetSkeleton;
-        const { font: fontList } = stylesCache;
-        if (!spreadsheetSkeleton || !worksheet || !fontList) {
-            return;
-        }
+        const { font: fontMap, fontMatrix } = stylesCache;
+        if (!spreadsheetSkeleton || !worksheet || !fontMap) return;
 
         const { rowHeightAccumulation, columnTotalWidth, columnWidthAccumulation, rowTotalHeight } =
             spreadsheetSkeleton;
@@ -73,184 +71,121 @@ export class Font extends SheetExtension {
 
         ctx.save();
         const scale = this._getScale(parentScale);
-        const renderFontCore = (fontFormat: string) => {
-            const fontObjectArray: ObjectMatrix<IFontCacheItem> = fontList[fontFormat];
-
-            // Since the overflow can spill out to both the left and right sides,
-            // we need to consider the content outside the viewBounds.
-            // At the same time, there are also merged cells, so we need to merge the current
-            // viewrange and a single merged area when calculating.
-
-            // Early exit from font condition
-            // if row is not visible
-
-            // If the current cell's style is not set to overflow, and the cell is not within the visible field of view, then exit early.
-            // (the field of view needs to consider the impact of merged cells).
-
-            // If the diffRanges do not intersect with the startRow and endRow on the row, then exit early.
-
-            const { viewRanges = [], checkOutOfViewBound, viewportKey } = moreBoundsInfo;
-
-            const renderFontByCell = (rowIndex: number, columnIndex: number, docsConfig: IFontCacheItem) => {
-                if (!checkOutOfViewBound) {
-                    if (!inViewRanges(viewRanges!, rowIndex, columnIndex)) {
-                        return true;
-                    }
-                }
-                const cellInfo = spreadsheetSkeleton.getCellByIndexWithNoHeader(
-                    rowIndex,
-                    columnIndex
-                );
-                let { startY, endY, startX, endX } = cellInfo;
-                const { isMerged, isMergedMainCell, mergeInfo } = cellInfo;
-
-                {
-                    const visibleRow = spreadsheetSkeleton.worksheet.getRowVisible(rowIndex);
-                    const visibleCol = spreadsheetSkeleton.worksheet.getColVisible(columnIndex);
-                    if (!visibleRow || !visibleCol) return true;
-                }
-                if (isMerged) {
+        const { viewRanges = [], checkOutOfViewBound } = moreBoundsInfo;
+        const renderFontByCellMatrix = (rowIndex: number, columnIndex: number, docsConfig: IFontCacheItem) => {
+            if (!checkOutOfViewBound) {
+                if (!inViewRanges(viewRanges!, rowIndex, columnIndex)) {
                     return true;
                 }
+            }
 
-                // If the merged cell area intersects with the current viewRange,
-                // then merge it into the current viewRange.
-                // After the merge, the font extension within the current viewBounds
-                // also needs to be drawn once.
-                // But at this moment, we cannot assume that it is not within the viewRanges and exit, because there may still be horizontal overflow.
-                // At this moment, we can only exclude the cells that are not within the current row.
+            const cellInfo = spreadsheetSkeleton.getCellByIndexWithNoHeader(
+                rowIndex,
+                columnIndex
+            );
+            let { startY, endY, startX, endX } = cellInfo;
+            const { isMerged, isMergedMainCell, mergeInfo } = cellInfo;
 
-                const mergeTo = diffRanges && diffRanges.length > 0 ? diffRanges : viewRanges;
-                const combineWithMergeRanges = expandRangeIfIntersects([...mergeTo], [mergeInfo]);
-                if (!inRowViewRanges(combineWithMergeRanges, rowIndex)) {
+            if (isMerged) {
+                return true;
+            } else {
+                const visibleRow = spreadsheetSkeleton.worksheet.getRowVisible(rowIndex);
+                const visibleCol = spreadsheetSkeleton.worksheet.getColVisible(columnIndex);
+                if (!visibleRow || !visibleCol) return true;
+            }
+
+            // If the merged cell area intersects with the current viewRange,
+            // then merge it into the current viewRange.
+            // After the merge, the font extension within the current viewBounds
+            // also needs to be drawn once.
+            // But at this moment, we cannot assume that it is not within the viewRanges and exit, because there may still be horizontal overflow.
+            // At this moment, we can only exclude the cells that are not within the current row.
+
+            const mergeTo = diffRanges && diffRanges.length > 0 ? diffRanges : viewRanges;
+            const combineWithMergeRanges = expandRangeIfIntersects([...mergeTo], [mergeInfo]);
+            if (!inRowViewRanges(combineWithMergeRanges, rowIndex)) {
+                return true;
+            }
+
+            if (isMergedMainCell) {
+                startY = mergeInfo.startY;
+                endY = mergeInfo.endY;
+                startX = mergeInfo.startX;
+                endX = mergeInfo.endX;
+            }
+            /**
+             * Incremental content rendering for texture mapping
+             * If the diffRanges do not intersect with the startRow and endRow on the row, then exit early.
+             *
+             * If this cell is not within a merged region, the mergeInfo start and end values are just the cell itself.
+             */
+            if (diffRanges) {
+                if (!this.isRowInRanges(mergeInfo.startRow, mergeInfo.endRow, diffRanges)) {
                     return true;
                 }
+            }
 
-                if (isMergedMainCell) {
-                    startY = mergeInfo.startY;
-                    endY = mergeInfo.endY;
-                    startX = mergeInfo.startX;
-                    endX = mergeInfo.endX;
+            // If the cell is overflowing, but the overflowRectangle has not been set,
+            // then overflowRectangle is set to undefined.
+            const overflowRectangle = overflowCache.getValue(rowIndex, columnIndex);
+            const { horizontalAlign, vertexAngle = 0, centerAngle = 0 } = docsConfig;
+
+            // If it's neither an overflow nor within the current range,
+            // then we can exit early (taking into account the range extension
+            // caused by the merged cells).
+            if (!overflowRectangle && !inViewRanges(combineWithMergeRanges, rowIndex, columnIndex)) {
+                return true;
+            }
+
+            /**
+             * https://github.com/dream-num/univer-pro/issues/334
+             * When horizontal alignment is not set, the default alignment for rotation angles varies to accommodate overflow scenarios.
+             */
+            let horizontalAlignOverFlow = horizontalAlign;
+            if (horizontalAlign === HorizontalAlign.UNSPECIFIED) {
+                if (centerAngle === VERTICAL_ROTATE_ANGLE && vertexAngle === VERTICAL_ROTATE_ANGLE) {
+                    horizontalAlignOverFlow = HorizontalAlign.CENTER;
+                } else if ((vertexAngle > 0 && vertexAngle !== VERTICAL_ROTATE_ANGLE) || vertexAngle === -VERTICAL_ROTATE_ANGLE) {
+                    horizontalAlignOverFlow = HorizontalAlign.RIGHT;
                 }
-                /**
-                 * Incremental content rendering for texture mapping
-                 * If the diffRanges do not intersect with the startRow and endRow on the row, then exit early.
-                 *
-                 * If this cell is not within a merged region, the mergeInfo start and end values are just the cell itself.
-                 */
-                if (diffRanges) {
-                    if (!this.isRowInRanges(mergeInfo.startRow, mergeInfo.endRow, diffRanges)) {
-                        return true;
-                    }
+            }
+
+            const cellData = worksheet.getCell(rowIndex, columnIndex) as ICellDataForSheetInterceptor || {};
+            if (cellData.fontRenderExtension?.isSkip) {
+                return true;
+            }
+
+            ctx.save();
+            ctx.beginPath();
+
+            const rightOffset = cellData.fontRenderExtension?.rightOffset ?? 0;
+            const leftOffset = cellData.fontRenderExtension?.leftOffset ?? 0;
+            let isOverflow = true;
+
+            if (vertexAngle === 0) {
+                startX = startX + leftOffset;
+                endX = endX - rightOffset;
+
+                if (rightOffset !== 0 || leftOffset !== 0) {
+                    isOverflow = false;
                 }
+            }
 
-                // If the cell is overflowing, but the overflowRectangle has not been set,
-                // then overflowRectangle is set to undefined.
-                const overflowRectangle = overflowCache.getValue(rowIndex, columnIndex);
-                const { horizontalAlign, vertexAngle = 0, centerAngle = 0 } = docsConfig;
+            const cellWidth = endX - startX;
+            const cellHeight = endY - startY;
 
-                // If it's neither an overflow nor within the current range,
-                // then we can exit early (taking into account the range extension
-                // caused by the merged cells).
-                if (!overflowRectangle && !inViewRanges(combineWithMergeRanges, rowIndex, columnIndex)) {
-                    return true;
-                }
-
-                /**
-                 * https://github.com/dream-num/univer-pro/issues/334
-                 * When horizontal alignment is not set, the default alignment for rotation angles varies to accommodate overflow scenarios.
-                 */
-                let horizontalAlignOverFlow = horizontalAlign;
-                if (horizontalAlign === HorizontalAlign.UNSPECIFIED) {
-                    if (centerAngle === VERTICAL_ROTATE_ANGLE && vertexAngle === VERTICAL_ROTATE_ANGLE) {
-                        horizontalAlignOverFlow = HorizontalAlign.CENTER;
-                    } else if ((vertexAngle > 0 && vertexAngle !== VERTICAL_ROTATE_ANGLE) || vertexAngle === -VERTICAL_ROTATE_ANGLE) {
-                        horizontalAlignOverFlow = HorizontalAlign.RIGHT;
-                    }
-                }
-
-                const cellData = worksheet.getCell(rowIndex, columnIndex) as ICellDataForSheetInterceptor || {};
-                if (cellData.fontRenderExtension?.isSkip) {
-                    return true;
-                }
-
-                ctx.save();
-                ctx.beginPath();
-
-                const rightOffset = cellData.fontRenderExtension?.rightOffset ?? 0;
-                const leftOffset = cellData.fontRenderExtension?.leftOffset ?? 0;
-                let isOverflow = true;
-
-                if (vertexAngle === 0) {
-                    startX = startX + leftOffset;
-                    endX = endX - rightOffset;
-
-                    if (rightOffset !== 0 || leftOffset !== 0) {
-                        isOverflow = false;
-                    }
-                }
-
-                const cellWidth = endX - startX;
-                const cellHeight = endY - startY;
-
-                /**
-                 * In scenarios with offsets, there is no need to respond to text overflow.
-                 */
-                if (overflowRectangle && isOverflow) {
-                    const { startColumn, startRow, endColumn, endRow } = overflowRectangle;
-                    if (startColumn === endColumn && startColumn === columnIndex) {
-                        ctx.rectByPrecision(
-                            startX + 1 / scale,
-                            startY + 1 / scale,
-                            cellWidth - 2 / scale,
-                            cellHeight - 2 / scale
-                        );
-                        ctx.clip();
-                        // ctx.clearRectForTexture(
-                        //     startX + 1 / scale,
-                        //     startY + 1 / scale,
-                        //     cellWidth - 2 / scale,
-                        //     cellHeight - 2 / scale
-                        // );
-                    } else {
-                        if (horizontalAlignOverFlow === HorizontalAlign.CENTER) {
-                            this._clipRectangleForOverflow(
-                                ctx,
-                                startRow,
-                                endRow,
-                                startColumn,
-                                endColumn,
-                                scale,
-                                rowHeightAccumulation,
-                                columnWidthAccumulation
-                            );
-                        } else if (horizontalAlignOverFlow === HorizontalAlign.RIGHT) {
-                            this._clipRectangleForOverflow(
-                                ctx,
-                                startRow,
-                                rowIndex,
-                                startColumn,
-                                columnIndex,
-                                scale,
-                                rowHeightAccumulation,
-                                columnWidthAccumulation
-                            );
-                        } else {
-                            this._clipRectangleForOverflow(
-                                ctx,
-                                rowIndex,
-                                endRow,
-                                columnIndex,
-                                endColumn,
-                                scale,
-                                rowHeightAccumulation,
-                                columnWidthAccumulation
-                            );
-                        }
-                    }
-                } else {
-                    ctx.rectByPrecision(startX + 1 / scale, startY + 1 / scale, cellWidth - 2 / scale, cellHeight - 2 / scale);
-                    // for normal cell, forbid text overflow cellarea
+            /**
+             * In scenarios with offsets, there is no need to respond to text overflow.
+             */
+            if (overflowRectangle && isOverflow) {
+                const { startColumn, startRow, endColumn, endRow } = overflowRectangle;
+                if (startColumn === endColumn && startColumn === columnIndex) {
+                    ctx.rectByPrecision(
+                        startX + 1 / scale,
+                        startY + 1 / scale,
+                        cellWidth - 2 / scale,
+                        cellHeight - 2 / scale
+                    );
                     ctx.clip();
                     // ctx.clearRectForTexture(
                     //     startX + 1 / scale,
@@ -258,18 +193,63 @@ export class Font extends SheetExtension {
                     //     cellWidth - 2 / scale,
                     //     cellHeight - 2 / scale
                     // );
+                } else {
+                    if (horizontalAlignOverFlow === HorizontalAlign.CENTER) {
+                        this._clipRectangleForOverflow(
+                            ctx,
+                            startRow,
+                            endRow,
+                            startColumn,
+                            endColumn,
+                            scale,
+                            rowHeightAccumulation,
+                            columnWidthAccumulation
+                        );
+                    } else if (horizontalAlignOverFlow === HorizontalAlign.RIGHT) {
+                        this._clipRectangleForOverflow(
+                            ctx,
+                            startRow,
+                            rowIndex,
+                            startColumn,
+                            columnIndex,
+                            scale,
+                            rowHeightAccumulation,
+                            columnWidthAccumulation
+                        );
+                    } else {
+                        this._clipRectangleForOverflow(
+                            ctx,
+                            rowIndex,
+                            endRow,
+                            columnIndex,
+                            endColumn,
+                            scale,
+                            rowHeightAccumulation,
+                            columnWidthAccumulation
+                        );
+                    }
                 }
-                ctx.translate(startX + FIX_ONE_PIXEL_BLUR_OFFSET, startY + FIX_ONE_PIXEL_BLUR_OFFSET);
-                this._renderDocuments(ctx, docsConfig, startX, startY, endX, endY, rowIndex, columnIndex, overflowCache);
+            } else {
+                ctx.rectByPrecision(startX + 1 / scale, startY + 1 / scale, cellWidth - 2 / scale, cellHeight - 2 / scale);
+                // for normal cell, forbid text overflow cellarea
+                ctx.clip();
+                // ctx.clearRectForTexture(
+                //     startX + 1 / scale,
+                //     startY + 1 / scale,
+                //     cellWidth - 2 / scale,
+                //     cellHeight - 2 / scale
+                // );
+            }
+            ctx.translate(startX + FIX_ONE_PIXEL_BLUR_OFFSET, startY + FIX_ONE_PIXEL_BLUR_OFFSET);
+            this._renderDocuments(ctx, docsConfig, startX, startY, endX, endY, rowIndex, columnIndex, overflowCache);
 
-                ctx.closePath();
-                ctx.restore();
-            };
-
-            fontObjectArray.forValue(renderFontByCell);
+            ctx.closePath();
+            ctx.restore();
         };
 
-        Object.keys(fontList).forEach(renderFontCore);
+        fontMatrix.forValue(renderFontByCellMatrix);
+        // const fontMatrix: ObjectMatrix<IFontCacheItem> = fontMap[fontFamily];
+        // Object.keys(fontMap).forEach(renderFontCore);
         ctx.restore();
     }
 

--- a/packages/engine-render/src/components/sheets/extensions/font.ts
+++ b/packages/engine-render/src/components/sheets/extensions/font.ts
@@ -54,8 +54,8 @@ export class Font extends SheetExtension {
         moreBoundsInfo: IDrawInfo
     ) {
         const { stylesCache, overflowCache, worksheet } = spreadsheetSkeleton;
-        const { font: fontMap, fontMatrix } = stylesCache;
-        if (!spreadsheetSkeleton || !worksheet || !fontMap) return;
+        const { fontMatrix } = stylesCache;
+        if (!spreadsheetSkeleton || !worksheet || !fontMatrix) return;
 
         const { rowHeightAccumulation, columnTotalWidth, columnWidthAccumulation, rowTotalHeight } =
             spreadsheetSkeleton;

--- a/packages/engine-render/src/components/sheets/extensions/sheet-extension.ts
+++ b/packages/engine-render/src/components/sheets/extensions/sheet-extension.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { type IRange, Rectangle } from '@univerjs/core';
+import { ObjectMatrix, Rectangle } from '@univerjs/core';
+import type { IRange, ISelectionCellWithMergeInfo } from '@univerjs/core';
 
 import { getCellByIndex } from '../../../basics/tools';
 import { ComponentExtension } from '../../extension';
@@ -32,6 +33,7 @@ export const SHEET_EXTENSION_PREFIX = 'sheet-ext-';
 export class SheetExtension extends ComponentExtension<SpreadsheetSkeleton, SHEET_EXTENSION_TYPE, IRange[]> {
     override type = SHEET_EXTENSION_TYPE.GRID;
 
+    cellCache: ObjectMatrix<ISelectionCellWithMergeInfo> = new ObjectMatrix();
     /**
      * @deprecated The function maybe cause performance issue, use spreadsheetSkeleton.getCellByIndexWithNoHeader instead.
      * Get ISelectionCellWithMergeInfo by cell rowIndex and cell columnIndex.
@@ -51,7 +53,14 @@ export class SheetExtension extends ComponentExtension<SpreadsheetSkeleton, SHEE
         dataMergeCache: IRange[]
     ) {
         // TODO @lumixraku: there are two coords in sheet!! This one does not include rowHeader and columnHeader. Should keep coord to be only one.
-        return getCellByIndex(rowIndex, columnIndex, rowHeightAccumulation, columnWidthAccumulation, dataMergeCache);
+        // return getCellByIndex(rowIndex, columnIndex, rowHeightAccumulation, columnWidthAccumulation, dataMergeCache);
+
+        const cache = this.cellCache.getValue(rowIndex, columnIndex);
+        if (cache) return cache;
+
+        const cell = getCellByIndex(rowIndex, columnIndex, rowHeightAccumulation, columnWidthAccumulation, dataMergeCache);
+        this.cellCache.setValue(rowIndex, columnIndex, cell);
+        return cell;
     }
 
     isRenderDiffRangesByCell(rangeP: IRange, diffRanges?: IRange[]) {

--- a/packages/engine-render/src/components/sheets/extensions/sheet-extension.ts
+++ b/packages/engine-render/src/components/sheets/extensions/sheet-extension.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { ObjectMatrix, Rectangle } from '@univerjs/core';
-import type { IRange, ISelectionCellWithMergeInfo } from '@univerjs/core';
+import { Rectangle } from '@univerjs/core';
+import type { IRange } from '@univerjs/core';
 
 import { getCellByIndex } from '../../../basics/tools';
 import { ComponentExtension } from '../../extension';
@@ -33,7 +33,7 @@ export const SHEET_EXTENSION_PREFIX = 'sheet-ext-';
 export class SheetExtension extends ComponentExtension<SpreadsheetSkeleton, SHEET_EXTENSION_TYPE, IRange[]> {
     override type = SHEET_EXTENSION_TYPE.GRID;
 
-    cellCache: ObjectMatrix<ISelectionCellWithMergeInfo> = new ObjectMatrix();
+    // cellCache: ObjectMatrix<ISelectionCellWithMergeInfo> = new ObjectMatrix();
     /**
      * @deprecated The function maybe cause performance issue, use spreadsheetSkeleton.getCellByIndexWithNoHeader instead.
      * Get ISelectionCellWithMergeInfo by cell rowIndex and cell columnIndex.
@@ -53,13 +53,7 @@ export class SheetExtension extends ComponentExtension<SpreadsheetSkeleton, SHEE
         dataMergeCache: IRange[]
     ) {
         // TODO @lumixraku: there are two coords in sheet!! This one does not include rowHeader and columnHeader. Should keep coord to be only one.
-        // return getCellByIndex(rowIndex, columnIndex, rowHeightAccumulation, columnWidthAccumulation, dataMergeCache);
-
-        const cache = this.cellCache.getValue(rowIndex, columnIndex);
-        if (cache) return cache;
-
         const cell = getCellByIndex(rowIndex, columnIndex, rowHeightAccumulation, columnWidthAccumulation, dataMergeCache);
-        this.cellCache.setValue(rowIndex, columnIndex, cell);
         return cell;
     }
 

--- a/packages/engine-render/src/components/sheets/interfaces.ts
+++ b/packages/engine-render/src/components/sheets/interfaces.ts
@@ -57,6 +57,7 @@ export interface IStylesCache {
     background?: Record<colorString, ObjectMatrix<string>>;
     backgroundPositions?: ObjectMatrix<ISelectionCellWithMergeInfo>;
     font?: Record<string, ObjectMatrix<IFontCacheItem>>;
+    fontMatrix: ObjectMatrix<IFontCacheItem>;
     border?: ObjectMatrix<BorderCache>;
 }
 

--- a/packages/engine-render/src/components/sheets/interfaces.ts
+++ b/packages/engine-render/src/components/sheets/interfaces.ts
@@ -24,9 +24,9 @@ import type {
 } from '@univerjs/core';
 
 import type { BORDER_TYPE } from '../../basics/const';
-import type { DocumentSkeleton } from '../docs/layout/doc-skeleton';
 import type { Canvas } from '../../canvas';
 import type { UniverRenderingContext } from '../../context';
+import type { DocumentSkeleton } from '../docs/layout/doc-skeleton';
 
 export interface BorderCache {
     [key: string]: BorderCacheItem | {};
@@ -52,14 +52,11 @@ export interface IFontCacheItem {
     // content?: string;
 }
 
-type backgroundCache = Record<string, ObjectMatrix<string>>;
-
-type fontCache = Record<string, ObjectMatrix<IFontCacheItem>>;
-
+type colorString = string;
 export interface IStylesCache {
-    background?: backgroundCache;
+    background?: Record<colorString, ObjectMatrix<string>>;
     backgroundPositions?: ObjectMatrix<ISelectionCellWithMergeInfo>;
-    font?: fontCache;
+    font?: Record<string, ObjectMatrix<IFontCacheItem>>;
     border?: ObjectMatrix<BorderCache>;
 }
 

--- a/packages/engine-render/src/components/sheets/sheet-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet-skeleton.ts
@@ -1159,6 +1159,11 @@ export class SpreadsheetSkeleton extends Skeleton {
         });
     }
 
+    /**
+     * This method has significant impact on performance.
+     * @param cell
+     * @param options
+     */
     // eslint-disable-next-line complexity
     private _getCellDocumentModel(
         cell: Nullable<ICellDataForSheetInterceptor>,
@@ -1435,18 +1440,14 @@ export class SpreadsheetSkeleton extends Skeleton {
             dataset_row_st = 0;
             dataset_row_ed = 0;
         } else {
-            if (row_st === -1) {
-                dataset_row_st = 0;
-            } else {
-                dataset_row_st = row_st;
-            }
+            dataset_row_st = Math.max(0, row_st);
 
             if (row_ed === Number.POSITIVE_INFINITY) {
                 dataset_row_ed = rhaLength - 1;
             } else if (row_ed >= rhaLength) {
                 dataset_row_ed = rhaLength - 1;
             } else {
-                dataset_row_ed = row_ed;
+                dataset_row_ed = Math.max(0, row_ed);
             }
         }
 
@@ -1457,18 +1458,14 @@ export class SpreadsheetSkeleton extends Skeleton {
             dataset_col_st = 0;
             dataset_col_ed = 0;
         } else {
-            if (col_st === -1) {
-                dataset_col_st = 0;
-            } else {
-                dataset_col_st = col_st;
-            }
+            dataset_col_st = Math.max(0, col_st);
 
             if (col_ed === Number.POSITIVE_INFINITY) {
                 dataset_col_ed = cwaLength - 1;
             } else if (col_ed >= cwaLength) {
                 dataset_col_ed = cwaLength - 1;
             } else {
-                dataset_col_ed = col_ed;
+                dataset_col_ed = Math.max(0, col_ed);
             }
         }
 
@@ -1718,14 +1715,10 @@ export class SpreadsheetSkeleton extends Skeleton {
             font: {},
             border: new ObjectMatrix<BorderCache>(),
         };
-
         this._cellBgAndBorderCache = new ObjectMatrix<boolean>();
-
         this._overflowCache.reset();
-    }
-
-    resetCache(): void {
-        this._resetCache();
+        // this.cellCache.reset();
+        this.worksheet.cellCache.reset();
     }
 
     private _makeDocumentSkeletonDirty(r: number, c: number): void {
@@ -1765,7 +1758,6 @@ export class SpreadsheetSkeleton extends Skeleton {
         /**
          * TODO: DR-Univer getCellRaw for slide demo, the implementation approach will be changed in the future.
          */
-        // const cell = this.worksheet.getCellRaw(r, c); // getCellRaw would be faster but doesn't contain condition format info.
         const cell = this.worksheet.getCell(row, col) || this.worksheet.getCellRaw(row, col);
         if (!cell) return;
 

--- a/packages/engine-render/src/components/sheets/sheet-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet-skeleton.ts
@@ -381,9 +381,9 @@ export class SpreadsheetSkeleton extends Skeleton {
             fontMatrix: new ObjectMatrix<IFontCacheItem>(),
             border: new ObjectMatrix<BorderCache>(),
         };
-        this._cellBgCacheMatrix = null as unknown as ObjectMatrix<boolean>;
-        this._cellBorderCacheMatrix = null as unknown as ObjectMatrix<boolean>;
-        this._overflowCache = null as unknown as ObjectMatrix<IRange>;
+        this._cellBgCacheMatrix.reset();
+        this._cellBorderCacheMatrix.reset();
+        this._overflowCache.reset();
 
         this._worksheetData = null as unknown as IWorksheetData;
         this._cellData = null as unknown as ObjectMatrix<Nullable<ICellData>>;
@@ -431,19 +431,14 @@ export class SpreadsheetSkeleton extends Skeleton {
     }
 
     getFont(rowIndex: number, columnIndex: number): Nullable<IFontCacheItem> {
-        const fontCache = this.stylesCache.font;
+        const fontCache = this.stylesCache.fontMatrix;
         if (!fontCache) {
             return null;
         }
-
-        for (const font in fontCache) {
-            const fontMatrix = fontCache[font];
-            const fontItem = fontMatrix.getValue(rowIndex, columnIndex);
-            if (fontItem) {
-                return fontItem;
-            }
+        const fontItem = fontCache.getValue(rowIndex, columnIndex);
+        if (fontItem) {
+            return fontItem;
         }
-
         return null;
     }
 
@@ -1810,14 +1805,14 @@ export class SpreadsheetSkeleton extends Skeleton {
         const { documentModel } = modelObject;
         if (documentModel == null) return;
 
-        const { fontString, textRotation, wrapStrategy, verticalAlign, horizontalAlign } = modelObject;
+        const { fontString: _fontString, textRotation, wrapStrategy, verticalAlign, horizontalAlign } = modelObject;
 
-        if (!this._stylesCache.font![fontString]) {
-            this._stylesCache.font![fontString] = new ObjectMatrix();
-        }
+        // if (!this._stylesCache.font![fontString]) {
+        //     this._stylesCache.font![fontString] = new ObjectMatrix();
+        // }
 
-        const fontFamilyMatrix: ObjectMatrix<IFontCacheItem> = this._stylesCache.font![fontString];
-        if (fontFamilyMatrix.getValue(row, col)) return;
+        // const fontFamilyMatrix: ObjectMatrix<IFontCacheItem> = this._stylesCache.font![fontString];
+        // if (fontFamilyMatrix.getValue(row, col)) return;
 
         const documentViewModel = new DocumentViewModel(documentModel);
         if (documentViewModel) {
@@ -1834,7 +1829,7 @@ export class SpreadsheetSkeleton extends Skeleton {
                 wrapStrategy,
             };
             this._stylesCache.fontMatrix.setValue(row, col, config);
-            fontFamilyMatrix.setValue(row, col, config);
+            // fontFamilyMatrix.setValue(row, col, config);
             this._calculateOverflowCell(row, col, config);
         }
     }

--- a/packages/engine-render/src/components/sheets/sheet-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet-skeleton.ts
@@ -1660,6 +1660,7 @@ export class SpreadsheetSkeleton extends Skeleton {
     // }
 
     /**
+     * @deprecated use _getCellMergeInfo instead.
      * get the current row and column segment visible merge data
      * @returns {IRange} The visible merge data
      */
@@ -1687,18 +1688,21 @@ export class SpreadsheetSkeleton extends Skeleton {
 
         if (endColumn === -1 || endRow === -1) return;
 
-        const mergeRanges = this.getCurrentRowColumnSegmentMergeData(this._rowColumnSegment);
-        for (const mergeRange of mergeRanges) {
-            this._setStylesCache(mergeRange.startRow, mergeRange.startColumn, {
-                mergeRange,
-            });
-        }
+        // const mergeRanges = this.getCurrentRowColumnSegmentMergeData(this._rowColumnSegment);
+        // for (const mergeRange of mergeRanges) {
+        //     this._setStylesCache(mergeRange.startRow, mergeRange.startColumn, {
+        //         mergeRange,
+        //     });
+        // }
 
+        // const mergeRange = mergeRanges.length ? mergeRanges[0] : undefined;
         for (let r = startRow; r <= endRow; r++) {
             if (this.worksheet.getRowVisible(r) === false) continue;
 
             for (let c = startColumn; c <= endColumn; c++) {
-                this._setStylesCache(r, c, { cacheItem: { bg: true, border: true } });
+                this._setStylesCache(r, c, {
+                    cacheItem: { bg: true, border: true },
+                });
             }
 
             // Calculate the text length for overflow situations, focusing on the leftmost column within the visible range.
@@ -1852,15 +1856,24 @@ export class SpreadsheetSkeleton extends Skeleton {
         const cell = this.worksheet.getCell(row, col) || this.worksheet.getCellRaw(row, col);
         if (!cell) return;
 
-        const hidden = this.worksheet.getColVisible(col) === false || this.worksheet.getRowVisible(row) === false;
-        if (hidden) {
-            const { isMerged, isMergedMainCell } = this._getCellMergeInfo(row, col);
+        if (!options) {
+            options = { cacheItem: { bg: true, border: true } };
+        }
 
+        const { isMerged, isMergedMainCell, startRow, startColumn, endRow, endColumn } = this._getCellMergeInfo(row, col);
+        if (options) {
+            options.mergeRange = { startRow, startColumn, endRow, endColumn };
+        }
+
+        const hidden = this.worksheet.getColVisible(col) === false || this.worksheet.getRowVisible(row) === false;
+
+        // hiddene and not in mergeRange return.
+        if (hidden) {
+            // If the cell is merged and is not the main cell, the cell is not rendered.
             if (isMerged && !isMergedMainCell) {
-                // If the cell is merged and is not the main cell, the cell is not rendered.
                 return;
+            // If the cell no merged, the cell is not rendered.
             } else if (!isMergedMainCell) {
-                // If the cell no merged, the cell is not rendered.
                 return;
             }
         }

--- a/packages/engine-render/src/components/sheets/sheet-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet-skeleton.ts
@@ -263,13 +263,14 @@ export class SpreadsheetSkeleton extends Skeleton {
     private _stylesCache: IStylesCache = {
         background: {},
         backgroundPositions: new ObjectMatrix<ISelectionCellWithMergeInfo>(),
-        font: {},
-        fontMatrix: new ObjectMatrix<any>(),
+        font: {} as Record<string, ObjectMatrix<IFontCacheItem>>,
+        fontMatrix: new ObjectMatrix<IFontCacheItem>(),
         border: new ObjectMatrix<BorderCache>(),
     };
 
     /** A matrix to store if a (row, column) position has render cache. */
-    private _cellBgAndBorderCache = new ObjectMatrix<boolean>();
+    private _cellBgCacheMatrix = new ObjectMatrix<boolean>();
+    private _cellBorderCacheMatrix = new ObjectMatrix<boolean>();
 
     private _showGridlines: BooleanNumber = BooleanNumber.TRUE;
 
@@ -366,16 +367,22 @@ export class SpreadsheetSkeleton extends Skeleton {
         this._columnTotalWidth = 0;
         this._rowHeaderWidth = 0;
         this._columnHeaderHeight = 0;
-        this._rowColumnSegment = null as any;
+        this._rowColumnSegment = {
+            startRow: -1,
+            endRow: -1,
+            startColumn: -1,
+            endColumn: -1,
+        };
         // this._dataMergeCache = [];
         this._stylesCache = {
             background: {},
             backgroundPositions: new ObjectMatrix<ISelectionCellWithMergeInfo>(),
-            font: {},
-            fontMatrix: new ObjectMatrix<any>(),
+            font: {} as Record<string, ObjectMatrix<IFontCacheItem>>,
+            fontMatrix: new ObjectMatrix<IFontCacheItem>(),
             border: new ObjectMatrix<BorderCache>(),
         };
-        this._cellBgAndBorderCache = null as unknown as ObjectMatrix<boolean>;
+        this._cellBgCacheMatrix = null as unknown as ObjectMatrix<boolean>;
+        this._cellBorderCacheMatrix = null as unknown as ObjectMatrix<boolean>;
         this._overflowCache = null as unknown as ObjectMatrix<IRange>;
 
         this._worksheetData = null as unknown as IWorksheetData;
@@ -1717,44 +1724,125 @@ export class SpreadsheetSkeleton extends Skeleton {
             background: {},
             backgroundPositions: new ObjectMatrix<ISelectionCellWithMergeInfo>(),
             font: {},
-            fontMatrix: new ObjectMatrix<any>(),
+            fontMatrix: new ObjectMatrix<IFontCacheItem>(),
             border: new ObjectMatrix<BorderCache>(),
         };
-        this._cellBgAndBorderCache = new ObjectMatrix<boolean>();
+        this._cellBgCacheMatrix.reset();
+        this._cellBorderCacheMatrix.reset();
         this._overflowCache.reset();
-        this.worksheet.cellCache.reset();
     }
 
     private _makeDocumentSkeletonDirty(row: number, col: number): void {
         if (this._stylesCache.fontMatrix == null) return;
         this._stylesCache.fontMatrix.getValue(row, col)?.documentSkeleton.makeDirty(true); ;
-        // const keys = Object.keys(this._stylesCache.font);
-        // for (const fontString of keys) {
-        //     const fontCache = this._stylesCache.font![fontString];
-        //     if (fontCache != null && fontCache.getValue(r, c)) {
-        //         fontCache.getValue(r, c).documentSkeleton.makeDirty(true);
-        //         return;
-        //     }
-        // }
+    }
+
+    _setBorderStylesCache(row: number, col: number, style: Nullable<IStyleData>, options: {
+        mergeRange?: IRange;
+        cacheItem?: ICacheItem;
+    } | undefined) {
+        // by default, style cache should includes border and background info.
+        const cacheItem = options?.cacheItem || { bg: true, border: true };
+        if (!cacheItem.border) return;
+        const handledThisCell = Tools.isDefine(this._cellBorderCacheMatrix.getValue(row, col));
+        if (handledThisCell) return;
+
+        this._cellBorderCacheMatrix.setValue(row, col, true);
+        if (style && style.bd) {
+            const mergeRange = options?.mergeRange;
+            if (mergeRange) {
+                this._setMergeBorderProps(BORDER_TYPE.TOP, this._stylesCache, mergeRange);
+                this._setMergeBorderProps(BORDER_TYPE.BOTTOM, this._stylesCache, mergeRange);
+                this._setMergeBorderProps(BORDER_TYPE.LEFT, this._stylesCache, mergeRange);
+                this._setMergeBorderProps(BORDER_TYPE.RIGHT, this._stylesCache, mergeRange);
+            } else if (!this.intersectMergeRange(row, col)) {
+                this._setBorderProps(row, col, BORDER_TYPE.TOP, style, this._stylesCache);
+                this._setBorderProps(row, col, BORDER_TYPE.BOTTOM, style, this._stylesCache);
+                this._setBorderProps(row, col, BORDER_TYPE.LEFT, style, this._stylesCache);
+                this._setBorderProps(row, col, BORDER_TYPE.RIGHT, style, this._stylesCache);
+            }
+
+            this._setBorderProps(row, col, BORDER_TYPE.TL_BR, style, this._stylesCache);
+            this._setBorderProps(row, col, BORDER_TYPE.TL_BC, style, this._stylesCache);
+            this._setBorderProps(row, col, BORDER_TYPE.TL_MR, style, this._stylesCache);
+            this._setBorderProps(row, col, BORDER_TYPE.BL_TR, style, this._stylesCache);
+            this._setBorderProps(row, col, BORDER_TYPE.ML_TR, style, this._stylesCache);
+            this._setBorderProps(row, col, BORDER_TYPE.BC_TR, style, this._stylesCache);
+        }
+    }
+
+    _setBgStylesCache(row: number, col: number, style: Nullable<IStyleData>, options: {
+        mergeRange?: IRange;
+        cacheItem?: ICacheItem;
+    } | undefined) {
+        // by default, style cache should includes border and background info.
+        const cacheItem = options?.cacheItem || { bg: true, border: true };
+        if (!cacheItem.bg) return;
+        const handledThisCell = Tools.isDefine(this._cellBgCacheMatrix.getValue(row, col));
+        if (handledThisCell) return;
+
+        this._cellBgCacheMatrix.setValue(row, col, true);
+        if (style && style.bg && style.bg.rgb) {
+            const rgb = style.bg.rgb;
+            if (!this._stylesCache.background![rgb]) {
+                this._stylesCache.background![rgb] = new ObjectMatrix();
+            }
+
+            const bgCache = this._stylesCache.background![rgb];
+            bgCache.setValue(row, col, rgb);
+            const cellInfo = this.getCellByIndexWithNoHeader(row, col);
+            this._stylesCache.backgroundPositions?.setValue(row, col, cellInfo);
+        }
+    }
+
+    _setFontStylesCache(cell: Nullable<ICellData>, row: number, col: number) {
+        if (isNullCell(cell)) return;
+        if (this._stylesCache.fontMatrix.getValue(row, col)) return;
+
+        const modelObject = this._getCellDocumentModel(cell, {
+            displayRawFormula: this._renderRawFormula,
+        });
+        if (modelObject == null) return;
+        const { documentModel } = modelObject;
+        if (documentModel == null) return;
+
+        const { fontString, textRotation, wrapStrategy, verticalAlign, horizontalAlign } = modelObject;
+
+        if (!this._stylesCache.font![fontString]) {
+            this._stylesCache.font![fontString] = new ObjectMatrix();
+        }
+
+        const fontFamilyMatrix: ObjectMatrix<IFontCacheItem> = this._stylesCache.font![fontString];
+        if (fontFamilyMatrix.getValue(row, col)) return;
+
+        const documentViewModel = new DocumentViewModel(documentModel);
+        if (documentViewModel) {
+            const { vertexAngle, centerAngle } = convertTextRotation(textRotation);
+            const documentSkeleton = DocumentSkeleton.create(documentViewModel, this._localService);
+            documentSkeleton.calculate();
+
+            const config: IFontCacheItem = {
+                documentSkeleton,
+                vertexAngle,
+                centerAngle,
+                verticalAlign,
+                horizontalAlign,
+                wrapStrategy,
+            };
+            this._stylesCache.fontMatrix.setValue(row, col, config);
+            fontFamilyMatrix.setValue(row, col, config);
+            this._calculateOverflowCell(row, col, config);
+        }
     }
 
     /**
-     * Set border background and font to this._stylesCache { border font background }
+     * Set border background and font to this._stylesCache
      * @param row {number}
      * @param col {number}
      * @param options {{ mergeRange: IRange; cacheItem: ICacheItem } | undefined}
      */
-    // eslint-disable-next-line complexity
     private _setStylesCache(row: number, col: number, options?: { mergeRange?: IRange; cacheItem?: ICacheItem }): void {
         if (row === -1 || col === -1) {
-            return;
-        }
-
-        // In most cases, this._cellBgAndBorderCache(row, col) has value means this._styles.font has value.
-        // So we can return in advance by cellBgAndBorderCache(row, col)
-        const hasStyleCache = this._cellBgAndBorderCache.getValue(row, col);
-        if (hasStyleCache === true) {
-            this._makeDocumentSkeletonDirty(row, col);
             return;
         }
 
@@ -1777,96 +1865,10 @@ export class SpreadsheetSkeleton extends Skeleton {
             }
         }
 
-        // by default, style cache should includes border and background info.
-        const cacheItem = options?.cacheItem || { bg: true, border: true };
-
         const style = this._styles.getStyleByCell(cell);
-        //#region cache for background
-        if (cacheItem.bg && style && style.bg && style.bg.rgb) {
-            const rgb = style.bg.rgb;
-            if (!this._stylesCache.background![rgb]) {
-                this._stylesCache.background![rgb] = new ObjectMatrix();
-            }
-
-            const bgCache = this._stylesCache.background![rgb];
-            bgCache.setValue(row, col, rgb);
-            const cellInfo = this.getCellByIndexWithNoHeader(row, col);
-            this._stylesCache.backgroundPositions?.setValue(row, col, cellInfo);
-        }
-        //#endregion
-
-        //#region cache for border
-        if (cacheItem.border && style && style.bd) {
-            const mergeRange = options?.mergeRange;
-            if (mergeRange) {
-                this._setMergeBorderProps(BORDER_TYPE.TOP, this._stylesCache, mergeRange);
-                this._setMergeBorderProps(BORDER_TYPE.BOTTOM, this._stylesCache, mergeRange);
-                this._setMergeBorderProps(BORDER_TYPE.LEFT, this._stylesCache, mergeRange);
-                this._setMergeBorderProps(BORDER_TYPE.RIGHT, this._stylesCache, mergeRange);
-            } else if (!this.intersectMergeRange(row, col)) {
-                this._setBorderProps(row, col, BORDER_TYPE.TOP, style, this._stylesCache);
-                this._setBorderProps(row, col, BORDER_TYPE.BOTTOM, style, this._stylesCache);
-                this._setBorderProps(row, col, BORDER_TYPE.LEFT, style, this._stylesCache);
-                this._setBorderProps(row, col, BORDER_TYPE.RIGHT, style, this._stylesCache);
-            }
-
-            this._setBorderProps(row, col, BORDER_TYPE.TL_BR, style, this._stylesCache);
-            this._setBorderProps(row, col, BORDER_TYPE.TL_BC, style, this._stylesCache);
-            this._setBorderProps(row, col, BORDER_TYPE.TL_MR, style, this._stylesCache);
-            this._setBorderProps(row, col, BORDER_TYPE.BL_TR, style, this._stylesCache);
-            this._setBorderProps(row, col, BORDER_TYPE.ML_TR, style, this._stylesCache);
-            this._setBorderProps(row, col, BORDER_TYPE.BC_TR, style, this._stylesCache);
-        }
-
-        // same as: if (!skipBackgroundAndBorder) {...}
-        if (cacheItem.bg || cacheItem.border) {
-            this._cellBgAndBorderCache.setValue(row, col, true);
-        } else {
-            this._cellBgAndBorderCache.setValue(row, col, false);
-        }
-
-        // When execution reaches here, it indicates that this is a new cell, and the _stylesCache.font does not yet record the data for this cell.
-
-        //#region font style
-        if (isNullCell(cell)) return;
-        if (this._stylesCache.fontMatrix.getValue(row, col)) return;
-
-        const modelObject = this._getCellDocumentModel(cell, {
-            displayRawFormula: this._renderRawFormula,
-        });
-        if (modelObject == null) return;
-        const { documentModel } = modelObject;
-        if (documentModel == null) return;
-
-        const { fontString, textRotation, wrapStrategy, verticalAlign, horizontalAlign } = modelObject;
-
-        if (!this._stylesCache.font![fontString]) {
-            this._stylesCache.font![fontString] = new ObjectMatrix();
-        }
-
-        const fontFamilyMatrix: ObjectMatrix<IFontCacheItem> = this._stylesCache.font![fontString];
-        if (fontFamilyMatrix.getValue(row, col)) return;
-
-        const documentViewModel = new DocumentViewModel(documentModel);
-        if (documentViewModel) {
-            // return;
-            const { vertexAngle, centerAngle } = convertTextRotation(textRotation);
-            const documentSkeleton = DocumentSkeleton.create(documentViewModel, this._localService);
-            documentSkeleton.calculate();
-
-            const config: IFontCacheItem = {
-                documentSkeleton,
-                vertexAngle,
-                centerAngle,
-                verticalAlign,
-                horizontalAlign,
-                wrapStrategy,
-            };
-            this._stylesCache.fontMatrix.setValue(row, col, config);
-            fontFamilyMatrix.setValue(row, col, config);
-            this._calculateOverflowCell(row, col, config);
-        }
-        //#endregion
+        this._setBgStylesCache(row, col, style, options);
+        this._setBorderStylesCache(row, col, style, options);
+        this._setFontStylesCache(cell, row, col);
     }
 
     private _updateConfigAndGetDocumentModel(

--- a/packages/engine-render/src/components/sheets/spreadsheet.ts
+++ b/packages/engine-render/src/components/sheets/spreadsheet.ts
@@ -120,10 +120,11 @@ export class Spreadsheet extends SheetComponent {
         this._drawAuxiliary(ctx);
         const parentScale = this.getParentScale();
 
-        const diffRanges = this._refreshIncrementalState && viewportInfo?.diffBounds
-            ? viewportInfo?.diffBounds?.map((bound) => spreadsheetSkeleton.getRowColumnSegmentByViewBound(bound))
+        const diffRanges = this._refreshIncrementalState && viewportInfo.diffBounds
+            ? viewportInfo.diffBounds?.map((bound) => spreadsheetSkeleton.getRowColumnSegmentByViewBound(bound))
             : [];
-        const viewRanges = [spreadsheetSkeleton.getRowColumnSegmentByViewBound(viewportInfo?.cacheBound)];
+
+        const viewRanges = [spreadsheetSkeleton.getRowColumnSegmentByViewBound(viewportInfo.cacheBound)];
         const extensions = this.getExtensionsByOrder();
         // At this moment, ctx.transform is at topLeft of sheet content, cell(0, 0)
 

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import type { EventState, IPosition, IRange, Nullable } from '@univerjs/core';
 import { EventSubject, Tools } from '@univerjs/core';
+import type { EventState, IPosition, IRange, Nullable } from '@univerjs/core';
 
-import type { BaseObject } from './base-object';
 import { RENDER_CLASS_TYPE } from './basics/const';
-import type { IWheelEvent } from './basics/i-events';
 import { PointerInput } from './basics/i-events';
 import { fixLineWidthByScale, toPx } from './basics/tools';
 import { Transform } from './basics/transform';
-import type { IBoundRectNoAngle, IViewportInfo } from './basics/vector2';
 import { Vector2 } from './basics/vector2';
 import { subtractViewportRange } from './basics/viewport-subtract';
 import { Canvas as UniverCanvas } from './canvas';
+import type { BaseObject } from './base-object';
+import type { IWheelEvent } from './basics/i-events';
+import type { IBoundRectNoAngle, IViewportInfo } from './basics/vector2';
 import type { UniverRenderingContext } from './context';
 import type { BaseScrollBar } from './shape/base-scroll-bar';
 import type { ThinScene } from './thin-scene';

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { EventSubject, Tools } from '@univerjs/core';
 import type { EventState, IPosition, IRange, Nullable } from '@univerjs/core';
+import { EventSubject, Tools } from '@univerjs/core';
 
-import { FIX_ONE_PIXEL_BLUR_OFFSET, RENDER_CLASS_TYPE } from './basics/const';
+import type { BaseObject } from './base-object';
+import { RENDER_CLASS_TYPE } from './basics/const';
+import type { IWheelEvent } from './basics/i-events';
 import { PointerInput } from './basics/i-events';
 import { fixLineWidthByScale, toPx } from './basics/tools';
 import { Transform } from './basics/transform';
+import type { IBoundRectNoAngle, IViewportInfo } from './basics/vector2';
 import { Vector2 } from './basics/vector2';
 import { subtractViewportRange } from './basics/viewport-subtract';
 import { Canvas as UniverCanvas } from './canvas';
-import type { BaseObject } from './base-object';
-import type { IWheelEvent } from './basics/i-events';
-import type { IBoundRectNoAngle, IViewportInfo } from './basics/vector2';
 import type { UniverRenderingContext } from './context';
 import type { BaseScrollBar } from './shape/base-scroll-bar';
 import type { ThinScene } from './thin-scene';
@@ -1431,7 +1431,7 @@ export class Viewport {
     }
 
     expandBounds(value: { top: number; left: number; bottom: number; right: number }) {
-        const onePixelFix = FIX_ONE_PIXEL_BLUR_OFFSET * 2;
+        const onePixelFix = 0;//FIX_ONE_PIXEL_BLUR_OFFSET * 2;
         return {
             left: value.left - this.bufferEdgeX - onePixelFix,
             right: value.right + this.bufferEdgeX + onePixelFix,

--- a/packages/sheets-data-validation/src/models/sheet-data-validation-model.ts
+++ b/packages/sheets-data-validation/src/models/sheet-data-validation-model.ts
@@ -159,7 +159,7 @@ export class SheetDataValidationModel extends Disposable {
 
     getRuleIdByLocation(unitId: string, subUnitId: string, row: number, col: number): string | undefined {
         const ruleMatrix = this._ensureRuleMatrix(unitId, subUnitId);
-        return ruleMatrix.getValue(row, col);
+        return ruleMatrix.getValue(row, col)!;
     }
 
     getRuleByLocation(unitId: string, subUnitId: string, row: number, col: number): ISheetDataValidationRule | undefined {

--- a/packages/sheets-data-validation/src/services/dv-custom-formula.service.ts
+++ b/packages/sheets-data-validation/src/services/dv-custom-formula.service.ts
@@ -240,7 +240,7 @@ export class DataValidationCustomFormulaService extends Disposable {
 
         newRanges.forEach((range) => {
             Range.foreach(range, (row, col) => {
-                const oldValue = formulaMap.getValue(row, col) ?? {};
+                const oldValue = formulaMap.getValue(row, col) ?? {} as IDataValidationFormula;
                 if ((oldValue.ruleId !== ruleId)) {
                     const oldRuleFormula = ruleFormulaMap.get(oldValue.ruleId);
                     if (oldRuleFormula?.isTransformable) {

--- a/packages/sheets-hyper-link/src/models/hyper-link.model.ts
+++ b/packages/sheets-hyper-link/src/models/hyper-link.model.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import { Disposable, IUniverInstanceService, ObjectMatrix, UniverInstanceType } from '@univerjs/core';
 import { Subject } from 'rxjs';
 import type { Workbook } from '@univerjs/core';
-import { Disposable, IUniverInstanceService, ObjectMatrix, UniverInstanceType } from '@univerjs/core';
 import type { ICellHyperLink, ICellLinkContent } from '../types/interfaces/i-hyper-link';
 
 type LinkUpdate = {
@@ -210,7 +210,7 @@ export class HyperLinkModel extends Disposable {
 
     getHyperLinkByLocation(unitId: string, subUnitId: string, row: number, column: number): ICellHyperLink | undefined {
         const { matrix } = this._ensureMap(unitId, subUnitId);
-        return matrix.getValue(row, column);
+        return matrix.getValue(row, column)!;
     }
 
     getHyperLinkByLocationSync(unitId: string, subUnitId: string, row: number, column: number) {

--- a/packages/sheets-ui/src/services/hover-manager.service.ts
+++ b/packages/sheets-ui/src/services/hover-manager.service.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import type { ICustomRange, IParagraph, IPosition, ISelectionCellWithMergeInfo, Nullable, Workbook } from '@univerjs/core';
 import { Disposable, HorizontalAlign, IUniverInstanceService, UniverInstanceType, VerticalAlign } from '@univerjs/core';
-import type { ISheetLocation } from '@univerjs/sheets';
-import { BehaviorSubject, distinctUntilChanged, map, Subject } from 'rxjs';
-import type { IBoundRectNoAngle, IFontCacheItem } from '@univerjs/engine-render';
 import { IRenderManagerService } from '@univerjs/engine-render';
+import { BehaviorSubject, distinctUntilChanged, map, Subject } from 'rxjs';
+import type { ICustomRange, IParagraph, IPosition, ISelectionCellWithMergeInfo, Nullable, Workbook } from '@univerjs/core';
+import type { IBoundRectNoAngle, IFontCacheItem, SpreadsheetSkeleton } from '@univerjs/engine-render';
+import type { ISheetLocation } from '@univerjs/sheets';
 import { getHoverCellPosition } from '../common/utils';
-import { SheetSkeletonManagerService } from './sheet-skeleton-manager.service';
 import { SheetScrollManagerService } from './scroll-manager.service';
+import { SheetSkeletonManagerService } from './sheet-skeleton-manager.service';
 import { calculateDocSkeletonRects } from './utils/doc-skeleton-util';
 
 export interface IHoverCellPosition {
@@ -165,10 +165,13 @@ export class HoverManagerService extends Disposable {
         }
 
         const currentRender = this._renderManagerService.getRenderById(workbook.getUnitId());
-        const skeletonParam = currentRender?.with(SheetSkeletonManagerService).getWorksheetSkeleton(worksheet.getSheetId());
-        const scrollManagerService = currentRender?.with(SheetScrollManagerService);
+        if (!currentRender) return null;
+        const skeletonParam = currentRender.with(SheetSkeletonManagerService).getWorksheetSkeleton(worksheet.getSheetId());
+        if (!skeletonParam) return null;
+
+        const scrollManagerService = currentRender.with(SheetScrollManagerService);
         const scrollInfo = scrollManagerService?.getCurrentScrollState();
-        const skeleton = skeletonParam?.skeleton;
+        const skeleton = skeletonParam?.skeleton as SpreadsheetSkeleton;
 
         if (!skeleton || !scrollInfo || !currentRender) return;
 

--- a/packages/sheets/src/basics/expand-range.ts
+++ b/packages/sheets/src/basics/expand-range.ts
@@ -48,7 +48,7 @@ function cellHasValue(cell: ICellData | undefined): boolean {
 
 function hasValueFromMatrixWithSpanInfo(cell: IMatrixWithSpanInfo | undefined, matrix: ObjectMatrix<IMatrixWithSpanInfo>): boolean {
     if (cell && cell.spanAnchor) {
-        return cellHasValue(matrix.getValue(cell.spanAnchor.startRow, cell.spanAnchor.startColumn));
+        return cellHasValue(matrix.getValue(cell.spanAnchor.startRow, cell.spanAnchor.startColumn)!);
     }
     return cellHasValue(cell);
 }
@@ -161,7 +161,7 @@ function getExpandedRangeLeft(range: IRange, allMatrixWithSpan: ObjectMatrix<IMa
     let spanAnchor: IRange | null = null;
     let hasValue = false;
     for (let i = startRow; i <= endRow; i++) {
-        const cell = allMatrixWithSpan.getValue(i, startColumn - leftOffset);
+        const cell = allMatrixWithSpan.getValue(i, startColumn - leftOffset)!;
         hasValue = hasValue || hasValueFromMatrixWithSpanInfo(cell, allMatrixWithSpan);
         if (!isWorksheetHasSpan && hasValue) {
             break;
@@ -205,7 +205,7 @@ function getExpandedRangeRight(range: IRange, allMatrixWithSpan: ObjectMatrix<IM
     let hasValue = false;
 
     for (let i = startRow; i <= endRow; i++) {
-        const cell = allMatrixWithSpan.getValue(i, endColumn + rightOffset);
+        const cell = allMatrixWithSpan.getValue(i, endColumn + rightOffset)!;
         hasValue = hasValue || hasValueFromMatrixWithSpanInfo(cell, allMatrixWithSpan);
         if (!isWorksheetHasSpan && hasValue) {
             break;
@@ -250,7 +250,7 @@ function getExpandedRangeUp(range: IRange, allMatrixWithSpan: ObjectMatrix<IMatr
     let spanAnchor: IRange | null = null;
     let hasValue = false;
     for (let i = startColumn; i <= endColumn; i++) {
-        const cell = allMatrixWithSpan.getValue(startRow - upOffset, i);
+        const cell = allMatrixWithSpan.getValue(startRow - upOffset, i)!;
         hasValue = hasValue || hasValueFromMatrixWithSpanInfo(cell, allMatrixWithSpan);
         if (!isWorksheetHasSpan && hasValue) {
             break;
@@ -294,7 +294,7 @@ function getExpandedRangeDown(range: IRange, allMatrixWithSpan: ObjectMatrix<IMa
     let spanAnchor: IRange | null = null;
     let hasValue = false;
     for (let i = startColumn; i <= endColumn; i++) {
-        const cell = allMatrixWithSpan.getValue(endRow + downOffset, i);
+        const cell = allMatrixWithSpan.getValue(endRow + downOffset, i)!;
         hasValue = hasValue || hasValueFromMatrixWithSpanInfo(cell, allMatrixWithSpan);
         if (!isWorksheetHasSpan && hasValue) {
             break;

--- a/packages/sheets/src/basics/rangeMerge.ts
+++ b/packages/sheets/src/basics/rangeMerge.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { IRange } from '@univerjs/core';
 import { ObjectMatrix, Range } from '@univerjs/core';
+import type { IRange } from '@univerjs/core';
 
 export const createTopMatrixFromRanges = (ranges: IRange[]) => {
     const matrix = new ObjectMatrix<number>();
@@ -96,12 +96,12 @@ const filterLeftMatrix = (topMatrix: ObjectMatrix<number>, range: IRange) => {
 
     for (let col = range.startColumn; col <= range.endColumn; col++) {
         const row = range.endRow + 1;
-        const v = topMatrix.getValue(row, col);
+        const v = topMatrix.getValue(row, col)!;
         if (v > 0) {
             topMatrix.setValue(row, col, 1);
             let nextRow = row + 1;
-            while (topMatrix.getValue(nextRow, col) > 0) {
-                topMatrix.setValue(nextRow, col, topMatrix.getValue(nextRow - 1, col) + 1);
+            while (topMatrix.getValue(nextRow, col)! > 0) {
+                topMatrix.setValue(nextRow, col, topMatrix.getValue(nextRow - 1, col)! + 1);
                 nextRow++;
             }
         }

--- a/packages/sheets/src/basics/utils.ts
+++ b/packages/sheets/src/basics/utils.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { ICellData, IObjectMatrixPrimitiveType, IRange, Nullable, UniverInstanceService, Workbook, Worksheet } from '@univerjs/core';
 import { ObjectMatrix, UniverInstanceType } from '@univerjs/core';
+import type { ICellData, IObjectMatrixPrimitiveType, IRange, Nullable, UniverInstanceService, Workbook, Worksheet } from '@univerjs/core';
 import type { IExpandParams } from '../commands/commands/utils/selection-utils';
 
 export const groupByKey = <T = Record<string, unknown>>(arr: T[], key: string, blankKey = '') => {
@@ -84,7 +84,7 @@ export function expandToContinuousRange(startRange: IRange, directions: IExpandP
                 endColumn: destRange.endColumn,
             };
             for (let col = checkRange.startColumn; col <= checkRange.endColumn; col++) {
-                const cell = allMatrix.getValue(checkRange.startRow, col);
+                const cell = allMatrix.getValue(checkRange.startRow, col)!;
                 if (cellHasValue(cell)) {
                     destRange.startRow = Math.min(checkRange.startRow, destRange.startRow);
                     destRange.startColumn = Math.min(col, destRange.startColumn);
@@ -103,7 +103,7 @@ export function expandToContinuousRange(startRange: IRange, directions: IExpandP
                 endColumn: destRange.endColumn,
             };
             for (let col = checkRange.startColumn; col <= checkRange.endColumn; col++) {
-                const cellValue = allMatrix.getValue(checkRange.startRow, col);
+                const cellValue = allMatrix.getValue(checkRange.startRow, col)!;
                 if (cellHasValue(cellValue)) {
                     destRange.endRow = Math.max(checkRange.endRow, destRange.endRow);
                     destRange.endRow = Math.max(
@@ -126,7 +126,7 @@ export function expandToContinuousRange(startRange: IRange, directions: IExpandP
                 endColumn: destCol,
             };
             for (let row = checkRange.startRow; row <= checkRange.endRow; row++) {
-                const cell = allMatrix.getValue(row, checkRange.startColumn);
+                const cell = allMatrix.getValue(row, checkRange.startColumn)!;
                 if (cellHasValue(cell)) {
                     destRange.startColumn = Math.min(checkRange.startColumn, destRange.startColumn);
                     destRange.startRow = Math.min(row, destRange.startRow);
@@ -145,7 +145,7 @@ export function expandToContinuousRange(startRange: IRange, directions: IExpandP
                 endColumn: destCol,
             };
             for (let row = checkRange.startRow; row <= checkRange.endRow; row++) {
-                const cellValue = allMatrix.getValue(row, checkRange.endColumn);
+                const cellValue = allMatrix.getValue(row, checkRange.endColumn)!;
                 if (cellHasValue(cellValue)) {
                     destRange.endColumn = Math.max(
                         checkRange.endColumn + (cellValue.colSpan !== undefined ? cellValue.colSpan - 1 : 0),


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close  https://github.com/dream-num/univer-pro/issues/2529
close  https://github.com/dream-num/univer/issues/3475

<!-- A description of the proposed changes. -->

Now _getCellDocumentModel() is called too frequenctly.
_getCellDocumentModel() ---> fontString(font family) ---> set font cache matrix by font family.


Each render frame calc fontString(font family) in _getCellDocumentModel in _setStylesCache.
Return condition deps on fontString(font family). That costs a lot of time.

No need to do this. Just using font Matrix.

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
