### PR TITLE
fix(sheets): correct unitId and subUnitId usage in SetStyleCommand

### DIFF
--- a/packages/sheets/src/commands/commands/__tests__/set-style.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-style.command.spec.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { IColorStyle, Injector, ITextDecoration, ITextRotation, Univer, Workbook } from '@univerjs/core';
+import type { ISetStyleCommandParams } from '../set-style.command';
 import {
     BooleanNumber,
     FontItalic,
@@ -28,9 +30,8 @@ import {
     VerticalAlign,
     WrapStrategy,
 } from '@univerjs/core';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { IColorStyle, Injector, ITextDecoration, ITextRotation, Univer, Workbook } from '@univerjs/core';
 
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SheetsSelectionsService } from '../../../services/selections/selection-manager.service';
 import { InsertSheetMutation } from '../../mutations/insert-sheet.mutation';
 import { SetRangeValuesMutation } from '../../mutations/set-range-values.mutation';
@@ -52,7 +53,6 @@ import {
     SetVerticalTextAlignCommand,
 } from '../set-style.command';
 import { createCommandTestBed } from './create-command-test-bed';
-import type { ISetStyleCommandParams } from '../set-style.command';
 
 describe("Test commands used for updating cells' styles", () => {
     let univer: Univer;
@@ -764,10 +764,9 @@ describe("Test commands used for updating cells' styles", () => {
     describe('set style with specific range', () => {
         it('should use the correct unitId and subUnitId when range is provided', async () => {
             const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
-            if (!workbook) throw new Error('Workbook not found');
 
             // Insert a new sheet
-            expect(await commandService.executeCommand(InsertSheetCommand.id, {})).toBeTruthy();
+            expect(await commandService.executeCommand(InsertSheetCommand.id)).toBeTruthy();
 
             const newSheet = workbook.getSheets()[1]; // Get the newly inserted sheet
             const unitId = workbook.getUnitId();

--- a/packages/sheets/src/commands/commands/__tests__/set-style.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-style.command.spec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { IColorStyle, Injector, ITextDecoration, ITextRotation, Univer } from '@univerjs/core';
 import {
     BooleanNumber,
     FontItalic,
@@ -25,14 +24,17 @@ import {
     RANGE_TYPE,
     RedoCommand,
     UndoCommand,
+    UniverInstanceType,
     VerticalAlign,
     WrapStrategy,
 } from '@univerjs/core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { IColorStyle, Injector, ITextDecoration, ITextRotation, Univer, Workbook } from '@univerjs/core';
 
 import { SheetsSelectionsService } from '../../../services/selections/selection-manager.service';
+import { InsertSheetMutation } from '../../mutations/insert-sheet.mutation';
 import { SetRangeValuesMutation } from '../../mutations/set-range-values.mutation';
-import type { ISetStyleCommandParams } from '../set-style.command';
+import { InsertSheetCommand } from '../insert-sheet.command';
 import {
     SetBackgroundColorCommand,
     SetBoldCommand,
@@ -50,6 +52,7 @@ import {
     SetVerticalTextAlignCommand,
 } from '../set-style.command';
 import { createCommandTestBed } from './create-command-test-bed';
+import type { ISetStyleCommandParams } from '../set-style.command';
 
 describe("Test commands used for updating cells' styles", () => {
     let univer: Univer;
@@ -77,6 +80,8 @@ describe("Test commands used for updating cells' styles", () => {
         commandService.registerCommand(SetTextRotationCommand);
         commandService.registerCommand(SetStyleCommand);
         commandService.registerCommand(SetRangeValuesMutation);
+        commandService.registerCommand(InsertSheetCommand);
+        commandService.registerCommand(InsertSheetMutation);
     });
 
     afterEach(() => univer.dispose());
@@ -753,6 +758,55 @@ describe("Test commands used for updating cells' styles", () => {
                 const result = await commandService.executeCommand(SetTextRotationCommand.id);
                 expect(result).toBeFalsy();
             });
+        });
+    });
+
+    describe('set style with specific range', () => {
+        it('should use the correct unitId and subUnitId when range is provided', async () => {
+            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            if (!workbook) throw new Error('Workbook not found');
+
+            // Insert a new sheet
+            expect(await commandService.executeCommand(InsertSheetCommand.id, {})).toBeTruthy();
+
+            const newSheet = workbook.getSheets()[1]; // Get the newly inserted sheet
+            const unitId = workbook.getUnitId();
+            const subUnitId = newSheet.getSheetId();
+
+            const range = { startRow: 0, startColumn: 0, endColumn: 1, endRow: 1, rangeType: RANGE_TYPE.NORMAL };
+
+            const commandParams: ISetStyleCommandParams<IColorStyle> = {
+                range,
+                unitId,
+                subUnitId,
+                style: {
+                    type: 'bg',
+                    value: { rgb: '#FF0000' },
+                },
+            };
+
+            expect(await commandService.executeCommand(SetStyleCommand.id, commandParams)).toBeTruthy();
+
+            // Verify that the background color was set correctly
+            const getBackgroundColor = (row: number, col: number) =>
+                workbook.getSheetBySheetId(subUnitId)!
+                    .getRange(row, col)
+                    .getBackground();
+
+            expect(getBackgroundColor(0, 0)).toBe('#FF0000');
+            expect(getBackgroundColor(0, 1)).toBe('#FF0000');
+            expect(getBackgroundColor(1, 0)).toBe('#FF0000');
+            expect(getBackgroundColor(1, 1)).toBe('#FF0000');
+
+            // undo
+            expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
+            expect(getBackgroundColor(0, 0)).toBe('#fff');
+            expect(getBackgroundColor(1, 1)).toBe('#fff');
+
+            // redo
+            expect(await commandService.executeCommand(RedoCommand.id)).toBeTruthy();
+            expect(getBackgroundColor(0, 0)).toBe('#FF0000');
+            expect(getBackgroundColor(1, 1)).toBe('#FF0000');
         });
     });
 });

--- a/packages/sheets/src/commands/commands/set-style.command.ts
+++ b/packages/sheets/src/commands/commands/set-style.command.ts
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-import type {
-    HorizontalAlign,
-    IAccessor,
-    ICellData,
-    IColorStyle,
-    ICommand,
-    IRange,
-    IStyleData,
-    ITextRotation,
-    VerticalAlign,
-    WrapStrategy,
-} from '@univerjs/core';
 import {
     BooleanNumber,
     CommandType,
@@ -38,13 +26,25 @@ import {
     sequenceExecute,
     Tools,
 } from '@univerjs/core';
+import type {
+    HorizontalAlign,
+    IAccessor,
+    ICellData,
+    IColorStyle,
+    ICommand,
+    IRange,
+    IStyleData,
+    ITextRotation,
+    VerticalAlign,
+    WrapStrategy,
+} from '@univerjs/core';
 
 import { SheetsSelectionsService } from '../../services/selections/selection-manager.service';
 import { SheetInterceptorService } from '../../services/sheet-interceptor/sheet-interceptor.service';
-import type { ISetRangeValuesMutationParams } from '../mutations/set-range-values.mutation';
 import { SetRangeValuesMutation, SetRangeValuesUndoMutationFactory } from '../mutations/set-range-values.mutation';
-import { getSheetCommandTarget } from './utils/target-util';
 import { createRangeIteratorWithSkipFilteredRows } from './utils/selection-utils';
+import { getSheetCommandTarget } from './utils/target-util';
+import type { ISetRangeValuesMutationParams } from '../mutations/set-range-values.mutation';
 
 export interface IStyleTypeValue<T> {
     type: keyof IStyleData;
@@ -75,8 +75,8 @@ export const SetStyleCommand: ICommand<ISetStyleCommandParams<unknown>> = {
         const target = getSheetCommandTarget(univerInstanceService);
         if (!target) return false;
 
-        const { unitId, subUnitId, worksheet } = target;
-        const { range, style } = params;
+        const { worksheet } = target;
+        const { range, style, unitId: paramsUnitId, subUnitId: paramsSubUnitId } = params;
         const commandService = accessor.get(ICommandService);
         const undoRedoService = accessor.get(IUndoRedoService);
         const selectionManagerService = accessor.get(SheetsSelectionsService);
@@ -112,8 +112,8 @@ export const SetStyleCommand: ICommand<ISetStyleCommandParams<unknown>> = {
         }
 
         const setRangeValuesMutationParams: ISetRangeValuesMutationParams = {
-            subUnitId,
-            unitId,
+            subUnitId: paramsSubUnitId || target.subUnitId,
+            unitId: paramsUnitId || target.unitId,
             cellValue: cellValue.getMatrix(),
         };
 
@@ -136,7 +136,7 @@ export const SetStyleCommand: ICommand<ISetStyleCommandParams<unknown>> = {
 
         if (setRangeValuesResult && result.result) {
             undoRedoService.pushUndoRedo({
-                unitID: unitId,
+                unitID: setRangeValuesMutationParams.unitId,
                 undoMutations: [{ id: SetRangeValuesMutation.id, params: undoSetRangeValuesMutationParams }, ...undos],
                 redoMutations: [{ id: SetRangeValuesMutation.id, params: setRangeValuesMutationParams }, ...redos],
             });
@@ -230,7 +230,8 @@ export const SetUnderlineCommand: ICommand = {
         if (selection.primary) {
             currentlyUnderline = !!worksheet
                 .getRange(selection.primary.startRow, selection.primary.startColumn)
-                .getUnderline().s;
+                .getUnderline()
+                .s;
         }
 
         const setStyleParams: ISetStyleCommandParams<{ s: number }> = {
@@ -265,7 +266,8 @@ export const SetStrikeThroughCommand: ICommand = {
         if (selection.primary) {
             currentlyStrokeThrough = !!worksheet
                 .getRange(selection.primary.actualRow, selection.primary.actualColumn)
-                .getStrikeThrough().s;
+                .getStrikeThrough()
+                .s;
         }
 
         const setStyleParams: ISetStyleCommandParams<{ s: number }> = {
@@ -297,7 +299,8 @@ export const SetOverlineCommand: ICommand = {
         if (selection.primary) {
             currentlyOverline = !!worksheet
                 .getRange(selection.primary.startRow, selection.primary.startColumn)
-                .getOverline().s;
+                .getOverline()
+                .s;
         }
 
         const setStyleParams: ISetStyleCommandParams<{ s: number }> = {

--- a/packages/sheets/src/commands/commands/set-style.command.ts
+++ b/packages/sheets/src/commands/commands/set-style.command.ts
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-import {
-    BooleanNumber,
-    CommandType,
-    FontItalic,
-    FontWeight,
-    ICommandService,
-    IUndoRedoService,
-    IUniverInstanceService,
-    ObjectMatrix,
-    sequenceExecute,
-    Tools,
-} from '@univerjs/core';
 import type {
     HorizontalAlign,
     IAccessor,
@@ -38,14 +26,26 @@ import type {
     VerticalAlign,
     WrapStrategy,
 } from '@univerjs/core';
+import type { ISetRangeValuesMutationParams } from '../mutations/set-range-values.mutation';
 
+import type { ISheetCommandSharedParams } from '../utils/interface';
+import {
+    BooleanNumber,
+    CommandType,
+    FontItalic,
+    FontWeight,
+    ICommandService,
+    IUndoRedoService,
+    IUniverInstanceService,
+    ObjectMatrix,
+    sequenceExecute,
+    Tools,
+} from '@univerjs/core';
 import { SheetsSelectionsService } from '../../services/selections/selection-manager.service';
 import { SheetInterceptorService } from '../../services/sheet-interceptor/sheet-interceptor.service';
 import { SetRangeValuesMutation, SetRangeValuesUndoMutationFactory } from '../mutations/set-range-values.mutation';
 import { createRangeIteratorWithSkipFilteredRows } from './utils/selection-utils';
 import { getSheetCommandTarget } from './utils/target-util';
-import type { ISheetCommandSharedParams } from '../../../lib/types';
-import type { ISetRangeValuesMutationParams } from '../mutations/set-range-values.mutation';
 
 export interface IStyleTypeValue<T> {
     type: keyof IStyleData;

--- a/packages/sheets/src/commands/commands/set-style.command.ts
+++ b/packages/sheets/src/commands/commands/set-style.command.ts
@@ -44,6 +44,7 @@ import { SheetInterceptorService } from '../../services/sheet-interceptor/sheet-
 import { SetRangeValuesMutation, SetRangeValuesUndoMutationFactory } from '../mutations/set-range-values.mutation';
 import { createRangeIteratorWithSkipFilteredRows } from './utils/selection-utils';
 import { getSheetCommandTarget } from './utils/target-util';
+import type { ISheetCommandSharedParams } from '../../../lib/types';
 import type { ISetRangeValuesMutationParams } from '../mutations/set-range-values.mutation';
 
 export interface IStyleTypeValue<T> {
@@ -51,9 +52,7 @@ export interface IStyleTypeValue<T> {
     value: T | T[][];
 }
 
-interface ISetStyleCommonParams {
-    subUnitId?: string;
-    unitId?: string;
+interface ISetStyleCommonParams extends Partial<ISheetCommandSharedParams> {
     range?: IRange;
 }
 
@@ -72,11 +71,11 @@ export const SetStyleCommand: ICommand<ISetStyleCommandParams<unknown>> = {
     handler: async <T> (accessor: IAccessor, params: ISetStyleCommandParams<T>) => {
         const univerInstanceService = accessor.get(IUniverInstanceService);
 
-        const target = getSheetCommandTarget(univerInstanceService);
+        const target = getSheetCommandTarget(univerInstanceService, params);
         if (!target) return false;
 
-        const { worksheet } = target;
-        const { range, style, unitId: paramsUnitId, subUnitId: paramsSubUnitId } = params;
+        const { unitId, subUnitId, worksheet } = target;
+        const { range, style } = params;
         const commandService = accessor.get(ICommandService);
         const undoRedoService = accessor.get(IUndoRedoService);
         const selectionManagerService = accessor.get(SheetsSelectionsService);
@@ -112,8 +111,8 @@ export const SetStyleCommand: ICommand<ISetStyleCommandParams<unknown>> = {
         }
 
         const setRangeValuesMutationParams: ISetRangeValuesMutationParams = {
-            subUnitId: paramsSubUnitId || target.subUnitId,
-            unitId: paramsUnitId || target.unitId,
+            subUnitId,
+            unitId,
             cellValue: cellValue.getMatrix(),
         };
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #3502

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

```ts
const sheet1 = univerAPI.getActiveWorkbook().insertSheet();
const sheet2 = univerAPI.getActiveWorkbook().insertSheet();

const marks = [
  {
    id: sheet1.getSheetId(),
    row: 0,
    col: 0,
  },
  {
    id: sheet2.getSheetId(),
    row: 1,
    col: 1,
  },
];

marks.forEach((m) => {
  console.log(m);
  if (m.id === sheet1.getSheetId()) {
    univerAPI
      .getActiveWorkbook()
      ?.getSheetBySheetId(m.id)
      ?.getRange(m.row, m.col, 1, 1)
      .setBackgroundColor('red');
  }

  if (m.id === sheet2.getSheetId()) {
    univerAPI
      .getActiveWorkbook()
      ?.getSheetBySheetId(m.id)
      ?.getRange(m.row, m.col, 1, 1)
      .setBackgroundColor('green');
  }
});

```

![image](https://github.com/user-attachments/assets/96587df9-6043-4ebb-b4b3-f480f69e21f3)


<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
