### PR TITLE
fix: dispose and createUnit cause viewport height collapse

### DIFF
--- a/packages/engine-render/src/canvas.ts
+++ b/packages/engine-render/src/canvas.ts
@@ -40,6 +40,7 @@ interface ICanvasProps {
     height?: number;
     pixelRatio?: number;
     mode?: CanvasRenderMode;
+    name: string;
 }
 
 /**
@@ -56,17 +57,15 @@ export class Canvas {
     isCache = false;
 
     private _pixelRatio = 1;
-
     private _canvasEle: Nullable<HTMLCanvasElement>;
-
     private _context: Nullable<UniverRenderingContext>;
-
     private _width = 0;
-
     private _height = 0;
+    private _name = '';
 
     constructor(props?: ICanvasProps) {
         props = props || {};
+        this._name = props.name || '';
 
         this._canvasEle = createCanvasElement();
         // set inline styles
@@ -127,6 +126,9 @@ export class Canvas {
     }
 
     setSize(width?: number, height?: number, pixelRatioParam?: number) {
+        // if (this._name === 'engine') {
+        //     console.log('canvas set size', width, height);
+        // }
         // this.setWidth(width || 0);
         // this.setHeight(height || 0);
         this._pixelRatio = pixelRatioParam || getDevicePixelRatio();

--- a/packages/engine-render/src/canvas.ts
+++ b/packages/engine-render/src/canvas.ts
@@ -40,7 +40,6 @@ interface ICanvasProps {
     height?: number;
     pixelRatio?: number;
     mode?: CanvasRenderMode;
-    name: string;
 }
 
 /**
@@ -57,15 +56,17 @@ export class Canvas {
     isCache = false;
 
     private _pixelRatio = 1;
+
     private _canvasEle: Nullable<HTMLCanvasElement>;
+
     private _context: Nullable<UniverRenderingContext>;
+
     private _width = 0;
+
     private _height = 0;
-    private _name = '';
 
     constructor(props?: ICanvasProps) {
         props = props || {};
-        this._name = props.name || '';
 
         this._canvasEle = createCanvasElement();
         // set inline styles
@@ -126,9 +127,6 @@ export class Canvas {
     }
 
     setSize(width?: number, height?: number, pixelRatioParam?: number) {
-        // if (this._name === 'engine') {
-        //     console.log('canvas set size', width, height);
-        // }
         // this.setWidth(width || 0);
         // this.setHeight(height || 0);
         this._pixelRatio = pixelRatioParam || getDevicePixelRatio();

--- a/packages/engine-render/src/engine.ts
+++ b/packages/engine-render/src/engine.ts
@@ -136,7 +136,6 @@ export class Engine extends ThinEngine<Scene> {
     constructor(elemWidth: number = 1, elemHeight: number = 1, pixelRatio?: number, mode?: CanvasRenderMode) {
         super();
         this._canvas = new Canvas({
-            name: 'engine',
             mode,
             width: elemWidth,
             height: elemHeight,
@@ -220,7 +219,6 @@ export class Engine extends ThinEngine<Scene> {
         this._container = elem;
         this._container.appendChild(this.getCanvasElement());
 
-        // console.log('setContainer >>>>>>>>>>>>>>', elem);
         if (resize) {
             this.resize();
 
@@ -809,7 +807,6 @@ export class Engine extends ThinEngine<Scene> {
             this._pointer[PointerInput.Vertical] = evt.clientY;
             this._pointer[PointerInput.DeltaHorizontal] = evt.movementX;
             this._pointer[PointerInput.DeltaVertical] = evt.movementY;
-            // console.log('pointerMoveEvent_1', previousHorizontal, evt.clientX, previousVertical, evt.clientY, this._pointer);
             const deviceEvent = evt as IPointerEvent;
             deviceEvent.deviceType = deviceType;
 

--- a/packages/engine-render/src/engine.ts
+++ b/packages/engine-render/src/engine.ts
@@ -136,6 +136,7 @@ export class Engine extends ThinEngine<Scene> {
     constructor(elemWidth: number = 1, elemHeight: number = 1, pixelRatio?: number, mode?: CanvasRenderMode) {
         super();
         this._canvas = new Canvas({
+            name: 'engine',
             mode,
             width: elemWidth,
             height: elemHeight,
@@ -219,6 +220,7 @@ export class Engine extends ThinEngine<Scene> {
         this._container = elem;
         this._container.appendChild(this.getCanvasElement());
 
+        // console.log('setContainer >>>>>>>>>>>>>>', elem);
         if (resize) {
             this.resize();
 

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -861,7 +861,7 @@ export class Viewport {
 
         let width = this._width;
         let height = this._height;
-        const size = this._getViewPortSize();
+        const size = this._calcViewPortSize();
 
         // if (m[0] > 1) {
         width = size.width;
@@ -1073,7 +1073,7 @@ export class Viewport {
         if (this.isActive === false) {
             return;
         }
-        const { width, height } = this._getViewPortSize();
+        const { width, height } = this._calcViewPortSize();
         // const pixelRatio = this.getPixelRatio();
         // coord = Transform.create([pixelRatio, 0, 0, pixelRatio, 0, 0]).applyPoint(
         //     coord
@@ -1129,7 +1129,7 @@ export class Viewport {
 
         scrollX = scrollX ?? this.scrollX;
         scrollY = scrollY ?? this.scrollY;
-        const { height, width } = this._getViewPortSize();
+        const { height, width } = this._calcViewPortSize();
         if (this._sceneWCurrVpAfterScale <= width) {
             scrollX = 0;
         }
@@ -1168,7 +1168,7 @@ export class Viewport {
      * @returns
      */
     _limitViewportScroll(viewportScrollX: number, viewportScrollY: number) {
-        const { width, height } = this._getViewPortSize();
+        const { width, height } = this._calcViewPortSize();
         // Not enough! freeze row & col should also take into consideration.
         const freezeHeight = this._paddingEndY - this._paddingStartY;
         const freezeWidth = this._paddingEndX - this._paddingStartX;
@@ -1215,7 +1215,7 @@ export class Viewport {
      * resize canvas & use viewportScrollXY to scrollTo
      */
     private _resizeCacheCanvas() {
-        const { width, height } = this._getViewPortSize();
+        const { width, height } = this._calcViewPortSize();
         // if (this.viewportKey === 'viewColumnRight') {
         //     console.log('resizeCacheCanvas', height);
         // }
@@ -1240,7 +1240,7 @@ export class Viewport {
         // viewport width is negative when canvas container has not been set to engine.
         if (!this.width || this.width < 0) return;
         if (!this.height || this.height < 0) return;
-        const { width, height } = this._getViewPortSize();
+        const { width, height } = this._calcViewPortSize();
         const sceneWidthCurrVpAfterScale = (this._scene.width - this._paddingEndX) * this._scene.scaleX;
         const sceneHeightCurrVpAfterScale = (this._scene.height - this._paddingEndY) * this._scene.scaleY;
         this._sceneWCurrVpAfterScale = sceneWidthCurrVpAfterScale;
@@ -1260,7 +1260,7 @@ export class Viewport {
         this.markForceDirty(true);
     }
 
-    private _getViewPortSize() {
+    private _calcViewPortSize() {
         const parent = this._scene.getParent();
         const { width: parentWidth, height: parentHeight } = parent;
         const { scaleX = 1, scaleY = 1 } = this._scene;
@@ -1277,7 +1277,7 @@ export class Viewport {
         this._left = left;
         this._top = top;
 
-        if (this._explicitViewportWidthSet) {
+        if (Tools.isDefine(this._widthOrigin) || this._explicitViewportWidthSet) {
             // viewMainLeft viewMainLeftTop ---> width is specific by freezeline
             width = (this._widthOrigin || 0) * scaleX;
         } else {
@@ -1285,7 +1285,7 @@ export class Viewport {
             width = parentWidth - (this._left + this._right);
         }
 
-        if (this._explicitViewportHeightSet) {
+        if (Tools.isDefine(this._heightOrigin) || this._explicitViewportHeightSet) {
             //viewMainLeftTop viewMainTop ---> height is specific by freezeline
             height = (this._heightOrigin || 0) * scaleY;
         } else {
@@ -1603,7 +1603,7 @@ export class Viewport {
             this.right = props.right;
         }
 
-        if (Tools.isDefine(props?.width) && this._explicitViewportWidthSet) {
+        if (Tools.isDefine(props?.width)) {
             this.width = props?.width;
             this._widthOrigin = props?.width;
         } else {
@@ -1611,7 +1611,7 @@ export class Viewport {
             this._widthOrigin = null;
         }
 
-        if (Tools.isDefine(props?.height) && this._explicitViewportHeightSet) {
+        if (Tools.isDefine(props?.height)) {
             this.height = props?.height;
             this._heightOrigin = props?.height;
         } else {

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -373,15 +373,6 @@ export class Viewport {
 
     set height(height: Nullable<number>) {
         const maxHeight = this.scene.getParent().height;
-        // if (this.viewportKey === 'viewColumnRight' && height) {
-        //     if (window.lastH === 20) {
-        //         if (height === 1) {
-        //             // debugger;
-        //         }
-        //     }
-        //     window.lastH = height;
-        //     console.log(' viewColumnRight set height', height, 'max', maxHeight, 'lastH', window.lastH);
-        // }
         if (Tools.isDefine(height)) {
             this._height = Tools.clamp(height!, 0, maxHeight);
         } else {
@@ -1216,9 +1207,6 @@ export class Viewport {
      */
     private _resizeCacheCanvas() {
         const { width, height } = this._calcViewPortSize();
-        // if (this.viewportKey === 'viewColumnRight') {
-        //     console.log('resizeCacheCanvas', height);
-        // }
         this.width = width;
         this.height = height;
         const scaleX = this.scene.scaleX;
@@ -1264,9 +1252,6 @@ export class Viewport {
         const parent = this._scene.getParent();
         const { width: parentWidth, height: parentHeight } = parent;
         const { scaleX = 1, scaleY = 1 } = this._scene;
-        // if (this.viewportKey === 'viewColumnRight') {
-        //     console.log('viewColumnRight getVP size parentH', parent.height, this._explicitViewportHeightSet, 'origin:', this._heightOrigin);
-        // }
 
         let width;
         let height;

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -373,6 +373,15 @@ export class Viewport {
 
     set height(height: Nullable<number>) {
         const maxHeight = this.scene.getParent().height;
+        // if (this.viewportKey === 'viewColumnRight' && height) {
+        //     if (window.lastH === 20) {
+        //         if (height === 1) {
+        //             // debugger;
+        //         }
+        //     }
+        //     window.lastH = height;
+        //     console.log(' viewColumnRight set height', height, 'max', maxHeight, 'lastH', window.lastH);
+        // }
         if (Tools.isDefine(height)) {
             this._height = Tools.clamp(height!, 0, maxHeight);
         } else {
@@ -1207,6 +1216,9 @@ export class Viewport {
      */
     private _resizeCacheCanvas() {
         const { width, height } = this._getViewPortSize();
+        // if (this.viewportKey === 'viewColumnRight') {
+        //     console.log('resizeCacheCanvas', height);
+        // }
         this.width = width;
         this.height = height;
         const scaleX = this.scene.scaleX;
@@ -1250,10 +1262,11 @@ export class Viewport {
 
     private _getViewPortSize() {
         const parent = this._scene.getParent();
-
         const { width: parentWidth, height: parentHeight } = parent;
-
         const { scaleX = 1, scaleY = 1 } = this._scene;
+        // if (this.viewportKey === 'viewColumnRight') {
+        //     console.log('viewColumnRight getVP size parentH', parent.height, this._explicitViewportHeightSet, 'origin:', this._heightOrigin);
+        // }
 
         let width;
         let height;
@@ -1592,7 +1605,7 @@ export class Viewport {
 
         if (Tools.isDefine(props?.width) && this._explicitViewportWidthSet) {
             this.width = props?.width;
-            this._widthOrigin = this.width;
+            this._widthOrigin = props?.width;
         } else {
             this.width = null;
             this._widthOrigin = null;
@@ -1600,7 +1613,7 @@ export class Viewport {
 
         if (Tools.isDefine(props?.height) && this._explicitViewportHeightSet) {
             this.height = props?.height;
-            this._heightOrigin = this.height;
+            this._heightOrigin = props?.height;
         } else {
             this.height = null;
             this._heightOrigin = null;

--- a/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
@@ -241,7 +241,6 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
     private _initViewports(scene: Scene, rowHeader: { width: number }, columnHeader: { height: number }) {
         const bufferEdgeX = 100;
         const bufferEdgeY = 100;
-        window.sc = scene;
 
         const viewMain = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN, scene, {
             left: rowHeader.width,
@@ -249,8 +248,6 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             bottom: 0,
             right: 0,
             isWheelPreventDefaultX: true,
-            //explicitViewportWidthSet: false,
-            //explicitViewportHeightSet: false,
             allowCache: true,
             bufferEdgeX,
             bufferEdgeY,
@@ -258,8 +255,6 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewMainLeftTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN_LEFT_TOP, scene, {
             isWheelPreventDefaultX: true,
             active: false,
-            //explicitViewportWidthSet: true,
-            //explicitViewportHeightSet: true,
             allowCache: true,
             bufferEdgeX: 0,
             bufferEdgeY: 0,
@@ -268,8 +263,6 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewMainLeft = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN_LEFT, scene, {
             isWheelPreventDefaultX: true,
             active: false,
-            //explicitViewportWidthSet: true,
-            //explicitViewportHeightSet: false,
             allowCache: true,
             bufferEdgeX: 0,
             bufferEdgeY,
@@ -278,8 +271,6 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewMainTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN_TOP, scene, {
             isWheelPreventDefaultX: true,
             active: false,
-            //explicitViewportWidthSet: false,
-            //explicitViewportHeightSet: true,
             allowCache: true,
             bufferEdgeX,
             bufferEdgeY: 0,
@@ -288,8 +279,6 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewRowTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_ROW_TOP, scene, {
             active: false,
             isWheelPreventDefaultX: true,
-            //explicitViewportWidthSet: true,
-            //explicitViewportHeightSet: true,
         });
 
         const viewRowBottom = new Viewport(SHEET_VIEWPORT_KEY.VIEW_ROW_BOTTOM, scene, {
@@ -298,15 +287,11 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             bottom: 0,
             width: rowHeader.width,
             isWheelPreventDefaultX: true,
-            //explicitViewportWidthSet: true,
-            //explicitViewportHeightSet: false,
         });
 
         const viewColumnLeft = new Viewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_LEFT, scene, {
             active: false,
             isWheelPreventDefaultX: true,
-            //explicitViewportWidthSet: true,
-            //explicitViewportHeightSet: true,
         });
 
         const viewColumnRight = new Viewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_RIGHT, scene, {
@@ -315,8 +300,6 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             height: columnHeader.height,
             right: 0,
             isWheelPreventDefaultX: true,
-            //explicitViewportWidthSet: false,
-            //explicitViewportHeightSet: true,
         });
 
         const viewLeftTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_LEFT_TOP, scene, {
@@ -325,8 +308,6 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             width: rowHeader.width,
             height: columnHeader.height,
             isWheelPreventDefaultX: true,
-            //explicitViewportWidthSet: true,
-            //explicitViewportHeightSet: true,
         });
 
         return {

--- a/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
@@ -249,8 +249,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             bottom: 0,
             right: 0,
             isWheelPreventDefaultX: true,
-            explicitViewportWidthSet: false,
-            explicitViewportHeightSet: false,
+            //explicitViewportWidthSet: false,
+            //explicitViewportHeightSet: false,
             allowCache: true,
             bufferEdgeX,
             bufferEdgeY,
@@ -258,8 +258,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewMainLeftTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN_LEFT_TOP, scene, {
             isWheelPreventDefaultX: true,
             active: false,
-            explicitViewportWidthSet: true,
-            explicitViewportHeightSet: true,
+            //explicitViewportWidthSet: true,
+            //explicitViewportHeightSet: true,
             allowCache: true,
             bufferEdgeX: 0,
             bufferEdgeY: 0,
@@ -268,8 +268,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewMainLeft = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN_LEFT, scene, {
             isWheelPreventDefaultX: true,
             active: false,
-            explicitViewportWidthSet: true,
-            explicitViewportHeightSet: false,
+            //explicitViewportWidthSet: true,
+            //explicitViewportHeightSet: false,
             allowCache: true,
             bufferEdgeX: 0,
             bufferEdgeY,
@@ -278,8 +278,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewMainTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN_TOP, scene, {
             isWheelPreventDefaultX: true,
             active: false,
-            explicitViewportWidthSet: false,
-            explicitViewportHeightSet: true,
+            //explicitViewportWidthSet: false,
+            //explicitViewportHeightSet: true,
             allowCache: true,
             bufferEdgeX,
             bufferEdgeY: 0,
@@ -288,8 +288,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const viewRowTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_ROW_TOP, scene, {
             active: false,
             isWheelPreventDefaultX: true,
-            explicitViewportWidthSet: true,
-            explicitViewportHeightSet: true,
+            //explicitViewportWidthSet: true,
+            //explicitViewportHeightSet: true,
         });
 
         const viewRowBottom = new Viewport(SHEET_VIEWPORT_KEY.VIEW_ROW_BOTTOM, scene, {
@@ -298,15 +298,15 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             bottom: 0,
             width: rowHeader.width,
             isWheelPreventDefaultX: true,
-            explicitViewportWidthSet: true,
-            explicitViewportHeightSet: false,
+            //explicitViewportWidthSet: true,
+            //explicitViewportHeightSet: false,
         });
 
         const viewColumnLeft = new Viewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_LEFT, scene, {
             active: false,
             isWheelPreventDefaultX: true,
-            explicitViewportWidthSet: true,
-            explicitViewportHeightSet: true,
+            //explicitViewportWidthSet: true,
+            //explicitViewportHeightSet: true,
         });
 
         const viewColumnRight = new Viewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_RIGHT, scene, {
@@ -315,8 +315,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             height: columnHeader.height,
             right: 0,
             isWheelPreventDefaultX: true,
-            explicitViewportWidthSet: false,
-            explicitViewportHeightSet: true,
+            //explicitViewportWidthSet: false,
+            //explicitViewportHeightSet: true,
         });
 
         const viewLeftTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_LEFT_TOP, scene, {
@@ -325,8 +325,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             width: rowHeader.width,
             height: columnHeader.height,
             isWheelPreventDefaultX: true,
-            explicitViewportWidthSet: true,
-            explicitViewportHeightSet: true,
+            //explicitViewportWidthSet: true,
+            //explicitViewportHeightSet: true,
         });
 
         return {

--- a/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
@@ -241,6 +241,7 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
     private _initViewports(scene: Scene, rowHeader: { width: number }, columnHeader: { height: number }) {
         const bufferEdgeX = 100;
         const bufferEdgeY = 100;
+        window.sc = scene;
 
         const viewMain = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN, scene, {
             left: rowHeader.width,


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close https://github.com/dream-num/univer/issues/3555


Way to reproduce this issue:
first
univerAPI.disposeUnit('workbook-01')
then
univerAPI.createUniverSheet()

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
