### PR TITLE
fix(ui): ribbon others tab flickering resolved

### DIFF
--- a/packages/ui/src/views/components/ribbon/Ribbon.tsx
+++ b/packages/ui/src/views/components/ribbon/Ribbon.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+import type { ComponentType } from 'react';
+import type { IMenuSchema } from '../../../services/menu/menu-manager.service';
 import { LocaleService, useDependency } from '@univerjs/core';
 import { MoreFunctionSingle } from '@univerjs/icons';
 import clsx from 'clsx';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import type { ComponentType } from 'react';
 
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { IMenuManagerService } from '../../../services/menu/menu-manager.service';
 import { MenuManagerPosition, RibbonPosition } from '../../../services/menu/types';
 import { ComponentContainer } from '../ComponentContainer';
@@ -27,7 +28,6 @@ import { ToolbarButton } from '../ribbon/Button/ToolbarButton';
 import styles from './index.module.less';
 import { ToolbarItem } from './ToolbarItem';
 import { DropdownWrapper, TooltipWrapper } from './TooltipButtonWrapper';
-import type { IMenuSchema } from '../../../services/menu/menu-manager.service';
 
 interface IRibbonProps {
     headerMenuComponents?: Set<ComponentType>;
@@ -117,6 +117,27 @@ export function Ribbon(props: IRibbonProps) {
         };
     }, [ribbon, category, collapsedIds]);
 
+    const fakeToolbarContent = useMemo(() => (
+        activeGroup.allGroups.map((groupItem) => (
+            <div key={groupItem.key} className={styles.toolbarGroup}>
+                {groupItem.children?.map((child) => (
+                    child.item && (
+                        <ToolbarItem
+                            key={child.key}
+                            ref={(ref) => {
+                                toolbarItemRefs.current[child.key] = {
+                                    el: ref?.nativeElement as HTMLDivElement,
+                                    key: child.key,
+                                };
+                            }}
+                            {...child.item}
+                        />
+                    )
+                ))}
+            </div>
+        ))
+    ), [activeGroup.allGroups]);
+
     return (
         <>
             {/* header */}
@@ -201,24 +222,7 @@ export function Ribbon(props: IRibbonProps) {
                     // opacity: 1,
                 }}
             >
-                {activeGroup.allGroups.map((groupItem) => (
-                    <div key={groupItem.key} className={styles.toolbarGroup}>
-                        {groupItem.children?.map((child) => (
-                            child.item && (
-                                <ToolbarItem
-                                    key={child.key}
-                                    ref={(ref) => {
-                                        toolbarItemRefs.current[child.key] = {
-                                            el: ref?.nativeElement as HTMLDivElement,
-                                            key: child.key,
-                                        };
-                                    }}
-                                    {...child.item}
-                                />
-                            )
-                        ))}
-                    </div>
-                ))}
+                {fakeToolbarContent}
             </div>
         </>
     );


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #3744

<!-- A description of the proposed changes. -->
This PR addresses the flickering issue in the Ribbon component's 'Others' tab. The problem was caused by unnecessary re-renders triggered by the ResizeObserver. The fix implements useMemo for the fake toolbar content to prevent unnecessary re-creation and optimizes the ResizeObserver usage to reduce unnecessary updates.

<!-- How to test them. -->
To test:
- Open `http://localhost:3002/sheets/`.
- Observe the 'Others' tab in the Ribbon, especially when resizing the window.
- Verify that the tab remains stable without constant flickering.
## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
