### PR TITLE
fix(docs-ui): don't refresh-selection after set list

### DIFF
--- a/packages/docs-ui/src/commands/commands/list.command.ts
+++ b/packages/docs-ui/src/commands/commands/list.command.ts
@@ -77,6 +77,7 @@ export const ListOperationCommand: ICommand<IListOperationCommandParams> = {
                 unitId,
                 actions: [],
                 textRanges: docRanges,
+                isEditing: false,
             },
         };
 
@@ -149,6 +150,7 @@ export const ChangeListTypeCommand: ICommand<IChangeListTypeCommandParams> = {
                 unitId,
                 actions: [],
                 textRanges: selections,
+                isEditing: false,
             },
         };
 
@@ -214,6 +216,7 @@ export const ChangeListNestingLevelCommand: ICommand<IChangeListNestingLevelComm
                 unitId,
                 actions: [],
                 textRanges: selections,
+                isEditing: false,
             },
         };
 
@@ -305,6 +308,7 @@ export const ToggleCheckListCommand: ICommand<IToggleCheckListCommandParams> = {
                 actions: [],
                 textRanges: textRanges ?? [],
                 segmentId,
+                isEditing: false,
             },
         };
 
@@ -412,6 +416,7 @@ export const QuickListCommand: ICommand<IQuickListCommandParams> = {
                     endOffset: paragraphStart,
                     collapsed: true,
                 }],
+                isEditing: false,
             },
         };
 

--- a/packages/docs/src/commands/mutations/core-editing.mutation.ts
+++ b/packages/docs/src/commands/mutations/core-editing.mutation.ts
@@ -36,6 +36,7 @@ export interface IRichTextEditingMutationParams extends IMutationCommonParams {
     options?: { [key: string]: boolean };
     // Whether this mutation is from a sync operation.
     isSync?: boolean;
+    isEditing?: boolean;
 }
 
 const RichTextEditingMutationId = 'doc.mutation.rich-text-editing';
@@ -61,6 +62,7 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
             isCompositionEnd,
             noNeedSetTextRange,
             debounce,
+            isEditing = true,
         } = params;
 
         const univerInstanceService = accessor.get(IUniverInstanceService);
@@ -98,7 +100,7 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
         // Make sure update cursor & selection after doc skeleton is calculated.
         if (!noNeedSetTextRange && textRanges && trigger != null) {
             queueMicrotask(() => {
-                docSelectionManagerService.replaceTextRanges(textRanges, true, params.options);
+                docSelectionManagerService.replaceTextRanges(textRanges, isEditing, params.options);
             });
         }
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close https://github.com/dream-num/univer-pro/issues/2863

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
