### PR TITLE
fix(sheets-ui): should disable sheet menus on cell editing

### DIFF
--- a/packages/core/src/docs/data-model/text-x/build-utils/custom-range.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/custom-range.ts
@@ -23,6 +23,14 @@ export function isCustomRangeSplitSymbol(text: string) {
     return text === DataStreamTreeTokenType.CUSTOM_RANGE_END || text === DataStreamTreeTokenType.CUSTOM_RANGE_START;
 }
 
+/**
+ * Check if two ranges intersect
+ * @param line1Start - The start of the first range
+ * @param line1End - The end of the first range
+ * @param line2Start - The start of the second range
+ * @param line2End - The end of the second range
+ * @returns True if the ranges intersect, false otherwise
+ */
 export function isIntersecting(line1Start: number, line1End: number, line2Start: number, line2End: number) {
     if ((line1Start <= line2Start && line1End >= line2Start) ||
         (line1Start >= line2Start && line1Start <= line2End)) {

--- a/packages/core/src/docs/data-model/text-x/build-utils/selection.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/selection.ts
@@ -239,7 +239,7 @@ export function getRetainAndDeleteFromReplace(
     const textStart = startOffset - memoryCursor;
     const textEnd = endOffset - memoryCursor;
     const dataStream = body.dataStream;
-    const relativeCustomRanges = body.customRanges?.filter((customRange) => isIntersecting(customRange.startIndex, customRange.endIndex, startOffset, endOffset));
+    const relativeCustomRanges = body.customRanges?.filter((customRange) => isIntersecting(customRange.startIndex, customRange.endIndex, startOffset, endOffset - 1));
     const toDeleteRanges = new Set(relativeCustomRanges?.filter((customRange) => shouldDeleteCustomRange(startOffset, endOffset - startOffset, customRange, dataStream)));
     const retainPoints = new Set<number>();
     relativeCustomRanges?.forEach((range) => {

--- a/packages/core/src/docs/data-model/text-x/build-utils/text-x-utils.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/text-x-utils.ts
@@ -256,7 +256,7 @@ export function getRetainAndDeleteAndExcludeLineBreak(
         (p) => p.startIndex - memoryCursor >= textStart && p.startIndex - memoryCursor < textEnd
     );
 
-    const relativeCustomRanges = body.customRanges?.filter((customRange) => isIntersecting(customRange.startIndex, customRange.endIndex, startOffset, endOffset));
+    const relativeCustomRanges = body.customRanges?.filter((customRange) => isIntersecting(customRange.startIndex, customRange.endIndex, startOffset, endOffset - 1));
     const toDeleteRanges = new Set(relativeCustomRanges?.filter((customRange) => shouldDeleteCustomRange(startOffset, endOffset - startOffset, customRange, dataStream)));
     const retainPoints = new Set<number>();
     relativeCustomRanges?.forEach((range) => {

--- a/packages/docs-hyper-link-ui/src/views/hyper-link-edit/index.tsx
+++ b/packages/docs-hyper-link-ui/src/views/hyper-link-edit/index.tsx
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
+import type { DocumentDataModel } from '@univerjs/core';
 import { BuildTextUtils, getBodySlice, ICommandService, IUniverInstanceService, LocaleService, Tools, UniverInstanceType, useDependency, useObservable } from '@univerjs/core';
 import { Button, FormLayout, Input } from '@univerjs/design';
 import { DocSelectionManagerService } from '@univerjs/docs';
-import { DocSelectionRenderService } from '@univerjs/docs-ui';
-import { IRenderManagerService } from '@univerjs/engine-render';
 import { KeyCode } from '@univerjs/ui';
 import React, { useEffect, useState } from 'react';
-import type { DocumentDataModel } from '@univerjs/core';
 import { AddDocHyperLinkCommand } from '../../commands/commands/add-link.command';
 import { UpdateDocHyperLinkCommand } from '../../commands/commands/update-link.command';
 import { DocHyperLinkPopupService } from '../../services/hyper-link-popup.service';
@@ -47,7 +45,6 @@ export const DocHyperLinkEdit = () => {
     const editing = useObservable(hyperLinkService.editingLink$);
     const commandService = useDependency(ICommandService);
     const univerInstanceService = useDependency(IUniverInstanceService);
-    const renderManagerService = useDependency(IRenderManagerService);
 
     const docSelectionManagerService = useDependency(DocSelectionManagerService);
     const [link, setLink] = useState('');
@@ -57,8 +54,6 @@ export const DocHyperLinkEdit = () => {
     const doc = editing
         ? univerInstanceService.getUnit<DocumentDataModel>(editing.unitId, UniverInstanceType.UNIVER_DOC) :
         univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
-
-    const docSelectionRenderService = renderManagerService.getRenderById(doc!.getUnitId())?.with(DocSelectionRenderService);
 
     useEffect(() => {
         const activeRange = docSelectionManagerService.getActiveTextRange();
@@ -81,19 +76,6 @@ export const DocHyperLinkEdit = () => {
             setLink(matchedRange?.properties?.url ?? '');
         }
     }, [doc, editing, docSelectionManagerService, univerInstanceService]);
-
-    // TODO: @zhangwei, do not use docSelectionRenderService in this component.
-    useEffect(() => {
-        if (docSelectionRenderService) {
-            docSelectionRenderService.blurEditor();
-        }
-
-        return () => {
-            if (docSelectionRenderService) {
-                docSelectionRenderService.focusEditor();
-            }
-        };
-    }, [docSelectionRenderService]);
 
     const handleCancel = () => {
         hyperLinkService.hideEditPopup();

--- a/packages/docs-ui/src/services/doc-state-change-manager.service.ts
+++ b/packages/docs-ui/src/services/doc-state-change-manager.service.ts
@@ -81,8 +81,8 @@ export class DocStateChangeManagerService extends RxDisposable {
                 return;
             }
 
-            const { isCompositionEnd, ...changeState } = changeStateInfo;
-            const imeInputManagerService = this._renderManagerService.getRenderById(changeStateInfo.unitId)?.with(DocIMEInputManagerService);
+            const { isCompositionEnd, isSync, syncer, ...changeState } = changeStateInfo;
+            const imeInputManagerService = this._renderManagerService.getRenderById(isSync ? syncer! : changeStateInfo.unitId)?.with(DocIMEInputManagerService);
 
             if (imeInputManagerService == null) {
                 return;

--- a/packages/docs/src/commands/mutations/core-editing.mutation.ts
+++ b/packages/docs/src/commands/mutations/core-editing.mutation.ts
@@ -37,6 +37,7 @@ export interface IRichTextEditingMutationParams extends IMutationCommonParams {
     // Whether this mutation is from a sync operation.
     isSync?: boolean;
     isEditing?: boolean;
+    syncer?: string;
 }
 
 const RichTextEditingMutationId = 'doc.mutation.rich-text-editing';
@@ -50,6 +51,7 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
 
     type: CommandType.MUTATION,
 
+    // eslint-disable-next-line max-lines-per-function
     handler: (accessor, params) => {
         const {
             unitId,
@@ -63,6 +65,8 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
             noNeedSetTextRange,
             debounce,
             isEditing = true,
+            isSync,
+            syncer,
         } = params;
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const renderManagerService = accessor.get(IRenderManagerService);
@@ -120,6 +124,8 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
                 textRanges: prevTextRanges ?? docRanges,
             },
             isCompositionEnd,
+            isSync,
+            syncer,
         };
         docStateEmitService.emitStateChangeInfo(changeState);
 

--- a/packages/docs/src/commands/mutations/core-editing.mutation.ts
+++ b/packages/docs/src/commands/mutations/core-editing.mutation.ts
@@ -64,7 +64,6 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
             debounce,
             isEditing = true,
         } = params;
-
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const renderManagerService = accessor.get(IRenderManagerService);
         const docStateEmitService = accessor.get(DocStateEmitService);
@@ -100,7 +99,7 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
         // Make sure update cursor & selection after doc skeleton is calculated.
         if (!noNeedSetTextRange && textRanges && trigger != null) {
             queueMicrotask(() => {
-                docSelectionManagerService.replaceTextRanges(textRanges, isEditing, params.options);
+                docSelectionManagerService.replaceDocRanges(textRanges, { unitId, subUnitId: unitId }, isEditing, params.options);
             });
         }
 

--- a/packages/docs/src/services/doc-state-emit.service.ts
+++ b/packages/docs/src/services/doc-state-emit.service.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { RxDisposable } from '@univerjs/core';
-import { BehaviorSubject } from 'rxjs';
 import type { JSONXActions, Nullable } from '@univerjs/core';
 import type { ITextRangeWithStyle } from '@univerjs/engine-render';
+import { RxDisposable } from '@univerjs/core';
+import { BehaviorSubject } from 'rxjs';
 
 interface IDocChangeState {
     actions: JSONXActions;
@@ -37,6 +37,8 @@ export interface IDocStateChangeParams {
 
 export interface IDocStateChangeInfo extends IDocStateChangeParams {
     isCompositionEnd?: boolean;
+    isSync?: boolean;
+    syncer?: string;
 }
 
 export class DocStateEmitService extends RxDisposable {

--- a/packages/sheets-data-validation-ui/src/views/components/date-dropdown/index.tsx
+++ b/packages/sheets-data-validation-ui/src/views/components/date-dropdown/index.tsx
@@ -16,6 +16,7 @@
 
 import type { CellValue, Nullable } from '@univerjs/core';
 import type { DateValidator } from '@univerjs/sheets-data-validation';
+import type { IEditorBridgeServiceVisibleParam } from '@univerjs/sheets-ui';
 import type { IDropdownComponentProps } from '../../../services/dropdown-manager.service';
 import { CellValueType, DataValidationErrorStyle, ICommandService, LocaleService, numfmt, useDependency } from '@univerjs/core';
 import { Button, DatePanel } from '@univerjs/design';
@@ -24,6 +25,7 @@ import { SetRangeValuesCommand } from '@univerjs/sheets';
 import { getCellValueOrigin } from '@univerjs/sheets-data-validation';
 import { getPatternType } from '@univerjs/sheets-numfmt';
 import { SetCellEditVisibleOperation } from '@univerjs/sheets-ui';
+import { KeyCode } from '@univerjs/ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import React, { useState } from 'react';
@@ -92,7 +94,13 @@ export function DateDropdown(props: IDropdownComponentProps) {
                 t: CellValueType.NUMBER,
             }, rule))
         ) {
-            commandService.executeCommand(SetRangeValuesCommand.id, {
+            await commandService.executeCommand(SetCellEditVisibleOperation.id, {
+                visible: false,
+                eventType: DeviceInputEventType.Keyboard,
+                unitId,
+                keycode: KeyCode.ESC,
+            } as IEditorBridgeServiceVisibleParam);
+            await commandService.executeCommand(SetRangeValuesCommand.id, {
                 unitId,
                 subUnitId,
                 range: {
@@ -115,11 +123,6 @@ export function DateDropdown(props: IDropdownComponentProps) {
                         },
                     },
                 },
-            });
-            commandService.executeCommand(SetCellEditVisibleOperation.id, {
-                visible: false,
-                eventType: DeviceInputEventType.Keyboard,
-                unitId,
             });
             hideFn();
         } else {

--- a/packages/sheets-data-validation-ui/src/views/components/date-dropdown/index.tsx
+++ b/packages/sheets-data-validation-ui/src/views/components/date-dropdown/index.tsx
@@ -19,9 +19,11 @@ import type { DateValidator } from '@univerjs/sheets-data-validation';
 import type { IDropdownComponentProps } from '../../../services/dropdown-manager.service';
 import { CellValueType, DataValidationErrorStyle, ICommandService, LocaleService, numfmt, useDependency } from '@univerjs/core';
 import { Button, DatePanel } from '@univerjs/design';
+import { DeviceInputEventType } from '@univerjs/engine-render';
 import { SetRangeValuesCommand } from '@univerjs/sheets';
 import { getCellValueOrigin } from '@univerjs/sheets-data-validation';
 import { getPatternType } from '@univerjs/sheets-numfmt';
+import { SetCellEditVisibleOperation } from '@univerjs/sheets-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import React, { useState } from 'react';
@@ -113,6 +115,11 @@ export function DateDropdown(props: IDropdownComponentProps) {
                         },
                     },
                 },
+            });
+            commandService.executeCommand(SetCellEditVisibleOperation.id, {
+                visible: false,
+                eventType: DeviceInputEventType.Keyboard,
+                unitId,
             });
             hideFn();
         } else {

--- a/packages/sheets-data-validation-ui/src/views/components/list-dropdown/index.tsx
+++ b/packages/sheets-data-validation-ui/src/views/components/list-dropdown/index.tsx
@@ -18,6 +18,7 @@ import type { DocumentDataModel } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
 import type { ISetRangeValuesCommandParams, ISheetLocation } from '@univerjs/sheets';
 import type { ListMultipleValidator } from '@univerjs/sheets-data-validation';
+import type { IEditorBridgeServiceVisibleParam } from '@univerjs/sheets-ui';
 import type { IUniverSheetsDataValidationUIConfig } from '../../../controllers/config.schema';
 import type { IDropdownComponentProps } from '../../../services/dropdown-manager.service';
 import { BuildTextUtils, DataValidationRenderMode, DataValidationType, ICommandService, IConfigService, IUniverInstanceService, LocaleService, UniverInstanceType, useDependency } from '@univerjs/core';
@@ -204,7 +205,7 @@ export function ListDropDown(props: IDropdownComponentProps) {
             title={multiple ? localeService.t('dataValidation.listMultiple.dropdown') : localeService.t('dataValidation.list.dropdown')}
             value={value}
             multiple={multiple}
-            onChange={(newValue) => {
+            onChange={async (newValue) => {
                 const str = serializeListOptions(newValue);
                 const params: ISetRangeValuesCommandParams = {
                     unitId,
@@ -232,12 +233,13 @@ export function ListDropDown(props: IDropdownComponentProps) {
                     });
                 }
 
-                commandService.executeCommand(SetRangeValuesCommand.id, params);
-                commandService.executeCommand(SetCellEditVisibleOperation.id, {
+                await commandService.executeCommand(SetCellEditVisibleOperation.id, {
                     visible: false,
                     eventType: DeviceInputEventType.Keyboard,
                     unitId,
-                });
+                    keycode: KeyCode.ESC,
+                } as IEditorBridgeServiceVisibleParam);
+                commandService.executeCommand(SetRangeValuesCommand.id, params);
                 setLocalValue(str);
                 if (!multiple) {
                     hideFn();

--- a/packages/sheets-data-validation-ui/src/views/components/list-dropdown/index.tsx
+++ b/packages/sheets-data-validation-ui/src/views/components/list-dropdown/index.tsx
@@ -28,7 +28,7 @@ import { DeviceInputEventType } from '@univerjs/engine-render';
 import { CheckMarkSingle } from '@univerjs/icons';
 import { RangeProtectionPermissionEditPoint, SetRangeValuesCommand, WorkbookEditablePermission, WorksheetEditPermission } from '@univerjs/sheets';
 import { deserializeListOptions, getDataValidationCellValue, serializeListOptions } from '@univerjs/sheets-data-validation';
-import { IEditorBridgeService, SheetPermissionInterceptorBaseController } from '@univerjs/sheets-ui';
+import { IEditorBridgeService, SetCellEditVisibleOperation, SheetPermissionInterceptorBaseController } from '@univerjs/sheets-ui';
 import { KeyCode, useObservable } from '@univerjs/ui';
 import React, { useEffect, useMemo, useState } from 'react';
 import { debounceTime } from 'rxjs';
@@ -233,6 +233,11 @@ export function ListDropDown(props: IDropdownComponentProps) {
                 }
 
                 commandService.executeCommand(SetRangeValuesCommand.id, params);
+                commandService.executeCommand(SetCellEditVisibleOperation.id, {
+                    visible: false,
+                    eventType: DeviceInputEventType.Keyboard,
+                    unitId,
+                });
                 setLocalValue(str);
                 if (!multiple) {
                     hideFn();

--- a/packages/sheets-hyper-link-ui/src/commands/commands/add-hyper-link.command.ts
+++ b/packages/sheets-hyper-link-ui/src/commands/commands/add-hyper-link.command.ts
@@ -17,7 +17,6 @@
 import type { ICellData, ICommand, IDocumentData, IMutationInfo, Workbook } from '@univerjs/core';
 import type { ISetRangeValuesMutationParams } from '@univerjs/sheets';
 import { BuildTextUtils, CellValueType, CommandType, CustomRangeType, DataStreamTreeTokenType, generateRandomId, ICommandService, IUndoRedoService, IUniverInstanceService, sequenceExecuteAsync, TextX, Tools, UniverInstanceType } from '@univerjs/core';
-import { DocSelectionManagerService } from '@univerjs/docs';
 import { addCustomRangeBySelectionFactory } from '@univerjs/docs-ui';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { SetRangeValuesMutation, SetRangeValuesUndoMutationFactory } from '@univerjs/sheets';
@@ -194,13 +193,9 @@ export const AddRichHyperLinkCommand: ICommand<IAddRichHyperLinkCommandParams> =
         }
         const { documentId, link } = params;
         const commandService = accessor.get(ICommandService);
-        const textSelectionService = accessor.get(DocSelectionManagerService);
         const newId = generateRandomId();
         const { payload } = link;
-        const range = textSelectionService.getActiveTextRange();
-        if (!range) {
-            return false;
-        }
+
         const replaceSelection = addCustomRangeBySelectionFactory(accessor, {
             unitId: documentId,
             rangeId: newId,

--- a/packages/sheets-hyper-link-ui/src/controllers/menu.ts
+++ b/packages/sheets-hyper-link-ui/src/controllers/menu.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
+import type { IAccessor, Workbook } from '@univerjs/core';
+import type { IMenuItem, IShortcutItem } from '@univerjs/ui';
 import { DOCS_ZEN_EDITOR_UNIT_ID_KEY, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
 import { DocSelectionManagerService } from '@univerjs/docs';
 import { getSheetCommandTarget, RangeProtectionPermissionEditPoint, SheetsSelectionsService, WorkbookEditablePermission, WorksheetEditPermission, WorksheetInsertHyperlinkPermission, WorksheetSetCellValuePermission } from '@univerjs/sheets';
 import { getCurrentRangeDisable$, IEditorBridgeService, whenSheetEditorFocused } from '@univerjs/sheets-ui';
 import { getMenuHiddenObservable, KeyCode, MenuGroup, MenuItemType, MenuPosition, MetaKeys } from '@univerjs/ui';
 import { map, mergeMap, Observable } from 'rxjs';
-import type { IAccessor, Workbook } from '@univerjs/core';
-import type { IMenuItem, IShortcutItem } from '@univerjs/ui';
 import { InsertHyperLinkOperation, InsertHyperLinkToolbarOperation } from '../commands/operations/popup.operations';
 import { getShouldDisableCellLink, shouldDisableAddLink } from '../utils';
 
 const getLinkDisable$ = (accessor: IAccessor) => {
-    const disableRange$ = getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellValuePermission, WorksheetInsertHyperlinkPermission], rangeTypes: [RangeProtectionPermissionEditPoint] });
+    const disableRange$ = getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellValuePermission, WorksheetInsertHyperlinkPermission], rangeTypes: [RangeProtectionPermissionEditPoint] }, true);
     const univerInstanceService = accessor.get(IUniverInstanceService);
     const sheetSelectionService = accessor.get(SheetsSelectionsService);
     const disableCell$ = univerInstanceService.focused$.pipe(

--- a/packages/sheets-hyper-link-ui/src/controllers/popup.controller.ts
+++ b/packages/sheets-hyper-link-ui/src/controllers/popup.controller.ts
@@ -236,6 +236,9 @@ export class SheetsHyperLinkPopupController extends Disposable {
                     this._sheetsHyperLinkPopupService.hideCurrentPopup(HyperLinkEditSourceType.EDITING);
                     this._sheetsHyperLinkPopupService.endEditing(HyperLinkEditSourceType.EDITING);
                     this._sheetsHyperLinkPopupService.hideCurrentPopup(HyperLinkEditSourceType.VIEWING);
+                } else {
+                    this._sheetsHyperLinkPopupService.hideCurrentPopup(HyperLinkEditSourceType.ZEN_EDITOR);
+                    this._sheetsHyperLinkPopupService.endEditing(HyperLinkEditSourceType.ZEN_EDITOR);
                 }
             })
         );

--- a/packages/sheets-hyper-link-ui/src/utils/index.ts
+++ b/packages/sheets-hyper-link-ui/src/utils/index.ts
@@ -67,6 +67,9 @@ export const shouldDisableAddLink = (accessor: IAccessor) => {
     }
 
     const body = doc.getSelfOrHeaderFooterModel(activeRange.segmentId).getBody();
+    if (!body) {
+        return true;
+    }
     const paragraphs = body?.paragraphs ?? [];
 
     for (let i = 0, len = paragraphs.length; i < len; i++) {

--- a/packages/sheets-hyper-link-ui/src/utils/index.ts
+++ b/packages/sheets-hyper-link-ui/src/utils/index.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import type { DocumentDataModel, IAccessor, ITextRange, Workbook, Worksheet } from '@univerjs/core';
 import { BuildTextUtils, CustomRangeType, DataValidationType, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
 import { DocSelectionManagerService } from '@univerjs/docs';
 import { SheetsSelectionsService } from '@univerjs/sheets';
-import type { DocumentDataModel, IAccessor, ITextRange, Workbook, Worksheet } from '@univerjs/core';
 
 export const getShouldDisableCellLink = (worksheet: Worksheet, row: number, col: number) => {
     const cell = worksheet.getCell(row, col);
@@ -67,10 +67,7 @@ export const shouldDisableAddLink = (accessor: IAccessor) => {
     }
 
     const body = doc.getSelfOrHeaderFooterModel(activeRange.segmentId).getBody();
-    const paragraphs = body?.paragraphs;
-    if (!paragraphs) {
-        return true;
-    }
+    const paragraphs = body?.paragraphs ?? [];
 
     for (let i = 0, len = paragraphs.length; i < len; i++) {
         const p = paragraphs[i];

--- a/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
+++ b/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
@@ -497,11 +497,8 @@ export const CellLinkEdit = () => {
                                     const range = docSelectionManagerService.getTextRanges({ unitId: DOCS_ZEN_EDITOR_UNIT_ID_KEY, subUnitId: DOCS_ZEN_EDITOR_UNIT_ID_KEY })?.[0];
 
                                     if (docBackScrollRenderController && range) {
-                                        // TODO: this was hacking
-                                        setTimeout(() => {
-                                            docBackScrollRenderController.scrollToRange(range);
-                                            docSelectionManagerService.refreshSelection({ unitId: DOCS_ZEN_EDITOR_UNIT_ID_KEY, subUnitId: DOCS_ZEN_EDITOR_UNIT_ID_KEY });
-                                        }, 100);
+                                        docBackScrollRenderController.scrollToRange(range);
+                                        docSelectionManagerService.refreshSelection({ unitId: DOCS_ZEN_EDITOR_UNIT_ID_KEY, subUnitId: DOCS_ZEN_EDITOR_UNIT_ID_KEY });
                                     }
                                 }
                                 editorBridgeService.disableForceKeepVisible();

--- a/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
+++ b/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
@@ -221,6 +221,12 @@ export const CellLinkEdit = () => {
         };
     }, [editing, markSelectionService, themeService, univerInstanceService]);
 
+    useEffect(() => {
+        if (type === SheetHyperLinkType.RANGE && !showLabel && !isFocusRangeSelector) {
+            isFocusRangeSelectorSet(true);
+        }
+    }, [type, isFocusRangeSelector, showLabel, editorBridgeService]);
+
     const payloadInitial = useMemo(() => payload, [type]);
 
     useEffect(() => {

--- a/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
+++ b/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
@@ -230,8 +230,11 @@ export const CellLinkEdit = () => {
     const payloadInitial = useMemo(() => payload, [type]);
 
     useEffect(() => {
-        const render = renderManagerService.getRenderById(editorBridgeService.getCurrentEditorId());
+        const render = editing?.type === HyperLinkEditSourceType.ZEN_EDITOR ?
+            renderManagerService.getRenderById(DOCS_ZEN_EDITOR_UNIT_ID_KEY) :
+            renderManagerService.getRenderById(editorBridgeService.getCurrentEditorId());
         const disposeCollection = new DisposableCollection();
+
         if (render) {
             const selectionRenderService = render.with(DocSelectionRenderService);
             selectionRenderService.setReserveRangesStatus(true);

--- a/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
+++ b/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
@@ -241,11 +241,11 @@ export const CellLinkEdit = () => {
     }, [editorBridgeService, renderManagerService]);
 
     useEffect(() => {
-        popupService.setIsKeepVisible(type === SheetHyperLinkType.RANGE);
+        popupService.setIsKeepVisible(isFocusRangeSelector);
         return () => {
             popupService.setIsKeepVisible(false);
         };
-    }, [type]);
+    }, [isFocusRangeSelector, popupService]);
 
     useEffect(() => {
         return () => {

--- a/packages/sheets-ui/src/commands/commands/inline-format.command.ts
+++ b/packages/sheets-ui/src/commands/commands/inline-format.command.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ICommand } from '@univerjs/core';
 import { CommandType, EDITOR_ACTIVATED, ICommandService, IContextService } from '@univerjs/core';
 import { SetInlineFormatBoldCommand, SetInlineFormatFontFamilyCommand, SetInlineFormatFontSizeCommand, SetInlineFormatItalicCommand, SetInlineFormatStrikethroughCommand, SetInlineFormatSubscriptCommand, SetInlineFormatSuperscriptCommand, SetInlineFormatTextColorCommand, SetInlineFormatUnderlineCommand } from '@univerjs/docs-ui';
 import {
@@ -25,7 +26,6 @@ import {
     SetTextColorCommand,
     SetUnderlineCommand,
 } from '@univerjs/sheets';
-import type { ICommand } from '@univerjs/core';
 
 /**
  * It is used to set the bold style of selections or one cell, need to distinguish between
@@ -174,5 +174,21 @@ export const SetRangeTextColorCommand: ICommand = {
         }
 
         return commandService.executeCommand(SetTextColorCommand.id, params);
+    },
+};
+
+export const ResetRangeTextColorCommand: ICommand = {
+    type: CommandType.COMMAND,
+    id: 'sheet.command.reset-range-text-color',
+    handler: async (accessor) => {
+        const commandService = accessor.get(ICommandService);
+        const contextService = accessor.get(IContextService);
+        const isCellEditorFocus = contextService.getContextValue(EDITOR_ACTIVATED);
+
+        if (isCellEditorFocus) {
+            return commandService.executeCommand(SetInlineFormatTextColorCommand.id, { value: null });
+        }
+
+        return commandService.executeCommand(SetTextColorCommand.id, { value: null });
     },
 };

--- a/packages/sheets-ui/src/commands/commands/set-frozen.command.ts
+++ b/packages/sheets-ui/src/commands/commands/set-frozen.command.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import type { ICommand } from '@univerjs/core';
+import type { ISetFrozenMutationParams } from '@univerjs/sheets';
 import { CommandType, ICommandService, IUndoRedoService, IUniverInstanceService, RANGE_TYPE } from '@univerjs/core';
 import { IRenderManagerService } from '@univerjs/engine-render';
-import { getSheetCommandTarget, SetFrozenMutation, SetFrozenMutationFactory, SheetsSelectionsService } from '@univerjs/sheets';
-import type { ICommand } from '@univerjs/core';
 
-import type { ISetFrozenMutationParams } from '@univerjs/sheets';
+import { getSheetCommandTarget, SetFrozenMutation, SetFrozenMutationFactory, SheetsSelectionsService } from '@univerjs/sheets';
 import { SheetScrollManagerService } from '../../services/scroll-manager.service';
 
 export enum SetSelectionFrozenType {
@@ -58,27 +58,27 @@ export const SetSelectionFrozenCommand: ICommand<ISetSelectionFrozenCommandParam
         const { sheetViewStartRow = 0, sheetViewStartColumn = 0 } = scrollManagerService.getCurrentScrollState() || {};
         let startRow;
         let startColumn;
-        let ySplit;
-        let xSplit;
+        let freezedRowCount;
+        let freezedColCount;
         const { startRow: selectRow, startColumn: selectColumn, rangeType } = range;
         // Frozen to Row
         if (rangeType === RANGE_TYPE.ROW || type === SetSelectionFrozenType.Row) {
             startRow = selectRow;
-            ySplit = selectRow - sheetViewStartRow;
+            freezedRowCount = selectRow - sheetViewStartRow;
             startColumn = -1;
-            xSplit = 0;
+            freezedColCount = 0;
             // Frozen to Column
         } else if (rangeType === RANGE_TYPE.COLUMN || type === SetSelectionFrozenType.Column) {
             startRow = -1;
-            ySplit = 0;
+            freezedRowCount = 0;
             startColumn = selectColumn;
-            xSplit = selectColumn - sheetViewStartColumn;
+            freezedColCount = selectColumn - sheetViewStartColumn;
             // Frozen to Range
         } else if (rangeType === RANGE_TYPE.NORMAL) {
             startRow = selectRow;
-            ySplit = selectRow - sheetViewStartRow;
+            freezedRowCount = selectRow - sheetViewStartRow;
             startColumn = selectColumn;
-            xSplit = selectColumn - sheetViewStartColumn;
+            freezedColCount = selectColumn - sheetViewStartColumn;
             // Unexpected value
         } else {
             return false;
@@ -88,8 +88,8 @@ export const SetSelectionFrozenCommand: ICommand<ISetSelectionFrozenCommandParam
             subUnitId,
             startRow,
             startColumn,
-            xSplit: startColumn > 0 ? Math.max(1, xSplit) : xSplit,
-            ySplit: startRow > 0 ? Math.max(1, ySplit) : ySplit,
+            xSplit: startColumn > 0 ? Math.max(1, freezedColCount) : freezedColCount,
+            ySplit: startRow > 0 ? Math.max(1, freezedRowCount) : freezedRowCount,
         };
         const undoMutationParams: ISetFrozenMutationParams = SetFrozenMutationFactory(accessor, redoMutationParams);
 

--- a/packages/sheets-ui/src/controllers/editor/data-sync.controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/data-sync.controller.ts
@@ -185,6 +185,7 @@ export class EditorDataSyncController extends Disposable {
             ...parmas,
             isSync: true,
             unitId,
+            syncer: parmas.unitId,
         });
 
         docViewModel.reset(docDataModel);

--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -107,7 +107,8 @@ export class EditingRenderController extends Disposable implements IRenderModule
         @ICommandService private readonly _commandService: ICommandService,
         @Inject(LocaleService) protected readonly _localService: LocaleService,
         @IEditorService private readonly _editorService: IEditorService,
-        @Inject(SheetCellEditorResizeService) private readonly _sheetCellEditorResizeService: SheetCellEditorResizeService
+        @Inject(SheetCellEditorResizeService) private readonly _sheetCellEditorResizeService: SheetCellEditorResizeService,
+        @IUniverInstanceService private readonly _univerInstanceService: IUniverInstanceService
     ) {
         super();
 
@@ -694,23 +695,29 @@ export class EditingRenderController extends Disposable implements IRenderModule
             return;
         }
 
-        const { documentLayoutObject, editorUnitId } = editCellState;
+        const { documentLayoutObject } = editCellState;
         const documentDataModel = documentLayoutObject.documentModel;
         if (documentDataModel == null) {
             return;
         }
 
-        const snapshot = Tools.deepClone(documentDataModel.getSnapshot());
-        const documentViewModel = this._getEditorViewModel(editorUnitId);
+        const empty = (documentDataModel: DocumentDataModel) => {
+            const snapshot = Tools.deepClone(documentDataModel.getSnapshot());
+            const documentViewModel = this._getEditorViewModel(documentDataModel.getUnitId());
 
-        if (documentViewModel == null) {
-            return;
-        }
+            if (documentViewModel == null) {
+                return;
+            }
 
-        resetBodyStyle(snapshot.body!, removeStyle);
+            resetBodyStyle(snapshot.body!, removeStyle);
 
-        documentDataModel.reset(snapshot);
-        documentViewModel.reset(documentDataModel);
+            documentDataModel.reset(snapshot);
+            documentViewModel.reset(documentDataModel);
+        };
+
+        empty(documentDataModel);
+        const formulaDocument = this._univerInstanceService.getUnit<DocumentDataModel>(DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY, UniverInstanceType.UNIVER_DOC);
+        formulaDocument && empty(formulaDocument);
     }
 }
 

--- a/packages/sheets-ui/src/controllers/menu/menu-util.ts
+++ b/packages/sheets-ui/src/controllers/menu/menu-util.ts
@@ -100,11 +100,11 @@ export function getCurrentRangeDisable$(accessor: IAccessor, permissionTypes: IP
     const univerInstanceService = accessor.get(IUniverInstanceService);
     const workbook$ = univerInstanceService.getCurrentTypeOfUnit$<Workbook>(UniverInstanceType.UNIVER_SHEET);
     const userManagerService = accessor.get(UserManagerService);
-    const editorBridgeService = accessor.get(IEditorBridgeService);
+    const editorBridgeService = accessor.has(IEditorBridgeService) ? accessor.get(IEditorBridgeService) : null;
 
-    return combineLatest([userManagerService.currentUser$, workbook$, editorBridgeService.visible$]).pipe(
+    return combineLatest([userManagerService.currentUser$, workbook$, editorBridgeService?.visible$ ?? of(null)]).pipe(
         switchMap(([_, workbook, visible]) => {
-            if (!workbook || (visible.visible && visible.unitId === workbook.getUnitId() && !supportCellEdit)) {
+            if (!workbook || (visible?.visible && visible.unitId === workbook.getUnitId() && !supportCellEdit)) {
                 return of(true);
             }
 

--- a/packages/sheets-ui/src/controllers/menu/menu.ts
+++ b/packages/sheets-ui/src/controllers/menu/menu.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { IAccessor } from '@univerjs/core';
+import type { IMenuButtonItem, IMenuSelectorItem } from '@univerjs/ui';
 import {
     BooleanNumber,
     DEFAULT_STYLES,
@@ -32,14 +34,13 @@ import {
     VerticalAlign,
     WrapStrategy,
 } from '@univerjs/core';
+
 import { DocSelectionManagerService, SetTextSelectionsOperation } from '@univerjs/docs';
 import { SetInlineFormatCommand } from '@univerjs/docs-ui';
-
 import {
     RangeProtectionPermissionEditPoint,
     RangeProtectionPermissionViewPoint,
     ResetBackgroundColorCommand,
-    ResetTextColorCommand,
     SetBackgroundColorCommand,
     SetColHiddenMutation,
     SetColVisibleMutation,
@@ -77,10 +78,8 @@ import {
     IClipboardInterfaceService,
     MenuItemType,
 } from '@univerjs/ui';
-import { combineLatestWith, map, Observable } from 'rxjs';
-import type { IAccessor } from '@univerjs/core';
 
-import type { IMenuButtonItem, IMenuSelectorItem } from '@univerjs/ui';
+import { combineLatestWith, map, Observable } from 'rxjs';
 import {
     SheetCopyCommand,
     SheetCutCommand,
@@ -92,6 +91,7 @@ import {
 } from '../../commands/commands/clipboard.command';
 import { HideColConfirmCommand, HideRowConfirmCommand } from '../../commands/commands/hide-row-col-confirm.command';
 import {
+    ResetRangeTextColorCommand,
     SetRangeBoldCommand,
     SetRangeFontFamilyCommand,
     SetRangeFontSizeCommand,
@@ -149,7 +149,7 @@ export function FormatPainterMenuItemFactory(accessor: IAccessor): IMenuButtonIt
             };
         }),
         hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_SHEET),
-        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetCopyPermission, WorksheetEditPermission], rangeTypes: [RangeProtectionPermissionEditPoint] }),
+        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetCopyPermission, WorksheetEditPermission], rangeTypes: [RangeProtectionPermissionEditPoint] }, true),
     };
 }
 
@@ -165,7 +165,7 @@ export function BoldMenuItemFactory(accessor: IAccessor): IMenuButtonItem {
         icon: 'BoldSingle',
         title: 'Set bold',
         tooltip: 'toolbar.bold',
-        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }),
+        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }, true),
         activated$: deriveStateFromActiveSheet$(univerInstanceService, false, ({ worksheet }) => new Observable<boolean>((subscriber) => {
             const disposable = commandService.onCommandExecuted((c) => {
                 const id = c.id;
@@ -227,7 +227,15 @@ export function ItalicMenuItemFactory(accessor: IAccessor): IMenuButtonItem {
         icon: 'ItalicSingle',
         title: 'Set italic',
         tooltip: 'toolbar.italic',
-        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }),
+        disabled$: getCurrentRangeDisable$(
+            accessor,
+            {
+                workbookTypes: [WorkbookEditablePermission],
+                worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission],
+                rangeTypes: [RangeProtectionPermissionEditPoint],
+            },
+            true
+        ),
         activated$: deriveStateFromActiveSheet$(univerInstanceService, false, ({ worksheet }) => new Observable<boolean>((subscriber) => {
             const disposable = commandService.onCommandExecuted((c) => {
                 const id = c.id;
@@ -318,7 +326,7 @@ export function UnderlineMenuItemFactory(accessor: IAccessor): IMenuButtonItem {
             subscriber.next(!!(isUnderline && isUnderline.s));
             return disposable.dispose;
         })),
-        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }),
+        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }, true),
         hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_SHEET),
     };
 }
@@ -335,7 +343,7 @@ export function StrikeThroughMenuItemFactory(accessor: IAccessor): IMenuButtonIt
         icon: 'StrikethroughSingle',
         title: 'Set strike through',
         tooltip: 'toolbar.strikethrough',
-        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }),
+        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }, true),
         activated$: deriveStateFromActiveSheet$(univerInstanceService, false, ({ worksheet }) => new Observable<boolean>((subscriber) => {
             const disposable = commandService.onCommandExecuted((c) => {
                 const id = c.id;
@@ -401,7 +409,7 @@ export function FontFamilySelectorMenuItemFactory(accessor: IAccessor): IMenuSel
             value: item.value,
         })),
 
-        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }),
+        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }, true),
         value$: deriveStateFromActiveSheet$(univerInstanceService, defaultValue, ({ worksheet }) => new Observable((subscriber) => {
             const disposable = commandService.onCommandExecuted((c) => {
                 const id = c.id;
@@ -440,7 +448,7 @@ export function FontSizeSelectorMenuItemFactory(accessor: IAccessor): IMenuSelec
     const contextService = accessor.get(IContextService);
 
     const defaultValue = DEFAULT_STYLES.fs;
-    const disabled$ = getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] });
+    const disabled$ = getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }, true);
 
     return {
         id: SetRangeFontSizeCommand.id,
@@ -501,11 +509,11 @@ export function FontSizeSelectorMenuItemFactory(accessor: IAccessor): IMenuSelec
 
 export function ResetTextColorMenuItemFactory(accessor: IAccessor): IMenuButtonItem {
     return {
-        id: ResetTextColorCommand.id,
+        id: ResetRangeTextColorCommand.id,
         type: MenuItemType.BUTTON,
         title: 'toolbar.resetColor',
         icon: 'NoColor',
-        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }),
+        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }, true),
         hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_SHEET),
     };
 }
@@ -541,7 +549,7 @@ export function TextColorSelectorMenuItemFactory(accessor: IAccessor): IMenuSele
             return disposable.dispose;
         }),
         hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_SHEET),
-        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }),
+        disabled$: getCurrentRangeDisable$(accessor, { workbookTypes: [WorkbookEditablePermission], worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission], rangeTypes: [RangeProtectionPermissionEditPoint] }, true),
     };
 }
 

--- a/packages/sheets-ui/src/controllers/sheet-ui.controller.ts
+++ b/packages/sheets-ui/src/controllers/sheet-ui.controller.ts
@@ -39,6 +39,7 @@ import { DeleteRangeMoveLeftConfirmCommand } from '../commands/commands/delete-r
 import { DeleteRangeMoveUpConfirmCommand } from '../commands/commands/delete-range-move-up-confirm.command';
 import { HideColConfirmCommand, HideRowConfirmCommand } from '../commands/commands/hide-row-col-confirm.command';
 import {
+    ResetRangeTextColorCommand,
     SetRangeBoldCommand,
     SetRangeFontFamilyCommand,
     SetRangeFontSizeCommand,
@@ -228,6 +229,7 @@ export class SheetUIController extends Disposable {
             SetRangeFontSizeCommand,
             SetRangeFontFamilyCommand,
             SetRangeTextColorCommand,
+            ResetRangeTextColorCommand,
             SetItalicCommand,
             SetStrikeThroughCommand,
             SetFontFamilyCommand,

--- a/packages/sheets-ui/src/index.ts
+++ b/packages/sheets-ui/src/index.ts
@@ -128,6 +128,7 @@ export { DeleteRangeMoveLeftConfirmCommand } from './commands/commands/delete-ra
 export { DeleteRangeMoveUpConfirmCommand } from './commands/commands/delete-range-move-up-confirm.command';
 export { HideColConfirmCommand, HideRowConfirmCommand } from './commands/commands/hide-row-col-confirm.command';
 export {
+    ResetRangeTextColorCommand,
     SetRangeBoldCommand,
     SetRangeFontFamilyCommand,
     SetRangeFontSizeCommand,

--- a/packages/sheets/src/commands/commands/set-style.command.ts
+++ b/packages/sheets/src/commands/commands/set-style.command.ts
@@ -364,7 +364,7 @@ export const SetFontSizeCommand: ICommand<ISetFontSizeCommandParams> = {
 };
 
 export interface ISetColorCommandParams {
-    value: string;
+    value: string | null;
 }
 
 export const SetTextColorCommand: ICommand<ISetColorCommandParams> = {

--- a/packages/sheets/src/commands/mutations/set-frozen.mutation.ts
+++ b/packages/sheets/src/commands/mutations/set-frozen.mutation.ts
@@ -22,7 +22,15 @@ export interface ISetFrozenMutationParams {
     subUnitId: string;
     startRow: number;
     startColumn: number;
+    /**
+     * Number of frozen rows.
+     * if row freeze start at 7, end at 10, then ySplit is 3
+     */
     ySplit: number;
+    /**
+     * Number of frozen columns.
+     * if column freeze start at 7, end at 10, then xSplit is 3
+     */
     xSplit: number;
     resetScroll?: boolean;
 }

--- a/packages/ui/src/views/components/zen-zone/ZenZone.tsx
+++ b/packages/ui/src/views/components/zen-zone/ZenZone.tsx
@@ -56,5 +56,5 @@ export function ZenZone() {
         }
     }, [componentKey]);
 
-    return <section style={hidden ? { display: 'none' } : undefined} className={_className}>{Component && <Component />}</section>;
+    return <section style={hidden ? { opacity: 0, zIndex: -1 } : undefined} className={_className}>{Component && <Component />}</section>;
 }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->

实现方案
1. toolbar + context-menu在editing的状态时将sheet的菜单。
2. 编辑时context处于doc中，无法匹配到sheet的shortcut - 无需改动。
3. facade api 的调用不应该导致editing的退出，除非手动调用退出命令 - 无需改动。

close https://github.com/dream-num/univer-pro/issues/2918
close https://github.com/dream-num/univer-pro/issues/2500
close https://github.com/dream-num/univer-pro/issues/2870
close https://github.com/dream-num/univer-pro/issues/2919
close https://github.com/dream-num/univer-pro/issues/2899
close https://github.com/dream-num/univer-pro/issues/2904
close https://github.com/dream-num/univer-pro/issues/2639

close https://github.com/dream-num/univer-pro/issues/2917
close https://github.com/dream-num/univer-pro/issues/2926
close https://github.com/dream-num/univer-pro/issues/2924


These issues are not reproducible.
close https://github.com/dream-num/univer-pro/issues/2923
close https://github.com/dream-num/univer-pro/issues/2887
close https://github.com/dream-num/univer-pro/issues/2890
close https://github.com/dream-num/univer-pro/issues/2886
close https://github.com/dream-num/univer-pro/issues/2864
close https://github.com/dream-num/univer-pro/issues/2821

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
