### PR TITLE
fix: parsing of number formats should be done in plugins

### DIFF
--- a/packages/sheets-numfmt-ui/src/controllers/__tests__/editor.controller.spec.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/__tests__/editor.controller.spec.ts
@@ -160,4 +160,162 @@ describe('test editor', () => {
         // The date-time drop is a numeric value, not a literal string
         expect(result?.v).toBe(0.5231712962962963);
     });
+
+    it('edit number will throw style in this editing', () => {
+        const sheetInterceptorService = testBed.get(SheetInterceptorService);
+        const cellData = {
+            p: {
+                id: '__INTERNAL_EDITOR__DOCS_NORMAL',
+                documentStyle: {
+                    pageSize: {
+                        width: 230.41758728027344,
+                    },
+                    marginTop: 6,
+                    marginBottom: 2,
+                    marginRight: 2,
+                    marginLeft: 2,
+                    renderConfig: {
+                        verticalAlign: 0,
+                        horizontalAlign: 0,
+                        wrapStrategy: 0,
+                        background: {},
+                        centerAngle: 0,
+                        vertexAngle: 0,
+                    },
+                },
+                body: {
+                    dataStream: '2022-11-11\r\n',
+                    textRuns: [
+                        {
+                            st: 0,
+                            ed: 2,
+                            ts: {
+                                ff: 'Arial',
+                                fs: 11,
+                            },
+                        },
+                        {
+                            st: 2,
+                            ed: 10,
+                            ts: {
+                                ff: 'Arial',
+                                fs: 11,
+                                bl: 1,
+                            },
+                        },
+                    ],
+                    paragraphs: [
+                        {
+                            startIndex: 10,
+                            paragraphStyle: {
+                                horizontalAlign: 0,
+                            },
+                        },
+                    ],
+                    customRanges: [],
+                    customDecorations: [],
+                },
+                drawings: {},
+                drawingsOrder: [],
+                settings: {
+                    zoomRatio: 1,
+                },
+            },
+            v: null,
+            f: null,
+            si: null,
+        };
+        const location = {
+            workbook,
+            worksheet,
+            unitId,
+            subUnitId,
+            row: 0,
+            col: 0,
+            origin: cellData,
+        };
+
+        const result = sheetInterceptorService.writeCellInterceptor.fetchThroughInterceptors(AFTER_CELL_EDIT)(cellData, location);
+        expect(result?.s).toBeFalsy();
+        expect(result?.p).toBeFalsy();
+        expect(result?.v).toBe(44876);
+    });
+
+    it('edit number with bullet should keep rich text', () => {
+        const sheetInterceptorService = testBed.get(SheetInterceptorService);
+        const richTextParams = {
+            id: '__INTERNAL_EDITOR__ZEN_EDITOR',
+            documentStyle: {
+                pageSize: {
+                    width: 595,
+                },
+                documentFlavor: 0,
+                marginTop: 0,
+                marginBottom: 0,
+                marginRight: 0,
+                marginLeft: 0,
+                renderConfig: {
+                    vertexAngle: 0,
+                    centerAngle: 0,
+                },
+            },
+            drawings: {},
+            drawingsOrder: [],
+            body: {
+                dataStream: '123123123\r\n',
+                textRuns: [
+                    {
+                        st: 0,
+                        ed: 9,
+                        ts: {
+                            ff: 'Arial',
+                            fs: 11,
+                        },
+                    },
+                ],
+                paragraphs: [
+                    {
+                        startIndex: 9,
+                        paragraphStyle: {
+                            horizontalAlign: 0,
+                        },
+                        bullet: {
+                            nestingLevel: 0,
+                            textStyle: {
+                                fs: 20,
+                            },
+                            listType: 'CHECK_LIST',
+                            listId: 'xIECkc',
+                        },
+                    },
+                ],
+                sectionBreaks: [
+                    {
+                        startIndex: 10,
+                    },
+                ],
+                customRanges: [],
+                customDecorations: [],
+            },
+        };
+        const cellData = {
+            p: richTextParams,
+            v: null,
+            f: null,
+            si: null,
+        };
+        const location = {
+            workbook,
+            worksheet,
+            unitId,
+            subUnitId,
+            row: 0,
+            col: 0,
+            origin: cellData,
+        };
+
+        const result = sheetInterceptorService.writeCellInterceptor.fetchThroughInterceptors(AFTER_CELL_EDIT)(cellData, location);
+        expect(result?.p).toEqual(richTextParams);
+        expect(result?.v).toBeFalsy();
+    });
 });

--- a/packages/sheets-ui/src/controllers/editor/__tests__/end-edit.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/editor/__tests__/end-edit.controller.spec.ts
@@ -161,7 +161,7 @@ describe('Test EndEditController', () => {
             };
 
             const cellData = getCellDataByInputCell(cell, inputCell);
-            const target = { v: '2', t: CellValueType.NUMBER, f: null, si: null, p: null };
+            const target = { v: '2', f: null, si: null, p: null };
 
             expect(cellData).toEqual({
                 ...target,
@@ -459,139 +459,6 @@ describe('Test EndEditController', () => {
 
             const isRichTextWithCellBody2 = isRichText(cellBody2);
             expect(isRichTextWithCellBody2).toBe(false);
-        });
-
-        it('test number can not set style', () => {
-            const dataStreamOnlyHaveNumber = {
-                id: '__INTERNAL_EDITOR__DOCS_NORMAL',
-                documentStyle: {
-                    pageSize: {
-                        width: 320.4903259277344,
-                    },
-                    marginTop: 0,
-                    marginBottom: 2,
-                    marginRight: 2,
-                    marginLeft: 2,
-                    renderConfig: {
-                        verticalAlign: 0,
-                        horizontalAlign: 0,
-                        wrapStrategy: 0,
-                        background: {},
-                        centerAngle: 0,
-                        vertexAngle: 0,
-                    },
-                },
-                body: {
-                    dataStream: '111111111111111\r\n',
-                    textRuns: [
-                        {
-                            st: 0,
-                            ed: 15,
-                            ts: {
-                                fs: 28,
-                            },
-                        },
-                    ],
-                    paragraphs: [
-                        {
-                            startIndex: 15,
-                            paragraphStyle: {
-                                horizontalAlign: 0,
-                            },
-                        },
-                    ],
-                    customRanges: [],
-                    customDecorations: [],
-                },
-                drawings: {},
-                drawingsOrder: [],
-                settings: {
-                    zoomRatio: 1,
-                },
-                resources: [
-                    {
-                        name: 'SHEET_THREAD_COMMENT_PLUGIN',
-                        data: '{}',
-                    },
-                    {
-                        name: 'DOC_HYPER_LINK_PLUGIN',
-                        data: '{"links":[]}',
-                    },
-                    {
-                        name: 'SHEET_AuthzIoMockService_PLUGIN',
-                        data: '{}',
-                    },
-                ],
-            };
-            const res = getCellDataByInputCell({}, { p: dataStreamOnlyHaveNumber });
-            // Because the previous cell had no style, and the value set now can be converted to a number, the style set this time is not retained.
-            expect(res?.s).toBeUndefined();
-
-            const dataStreamHaveString = {
-                id: '__INTERNAL_EDITOR__DOCS_NORMAL',
-                documentStyle: {
-                    pageSize: {
-                        width: 220.712890625,
-                    },
-                    marginTop: 0,
-                    marginBottom: 1,
-                    marginRight: 2,
-                    marginLeft: 2,
-                    renderConfig: {
-                        verticalAlign: 0,
-                        horizontalAlign: 0,
-                        wrapStrategy: 0,
-                        background: {},
-                        centerAngle: 0,
-                        vertexAngle: 0,
-                    },
-                },
-                body: {
-                    dataStream: 'qqqqqwwww\r\n',
-                    textRuns: [
-                        {
-                            st: 0,
-                            ed: 9,
-                            ts: {
-                                fs: 28,
-                            },
-                        },
-                    ],
-                    paragraphs: [
-                        {
-                            startIndex: 9,
-                            paragraphStyle: {
-                                horizontalAlign: 0,
-                            },
-                        },
-                    ],
-                    customRanges: [],
-                    customDecorations: [],
-                },
-                drawings: {},
-                drawingsOrder: [],
-                settings: {
-                    zoomRatio: 1,
-                },
-                resources: [
-                    {
-                        name: 'SHEET_THREAD_COMMENT_PLUGIN',
-                        data: '{}',
-                    },
-                    {
-                        name: 'DOC_HYPER_LINK_PLUGIN',
-                        data: '{"links":[]}',
-                    },
-                    {
-                        name: 'SHEET_AuthzIoMockService_PLUGIN',
-                        data: '{}',
-                    },
-                ],
-            };
-            const res2 = getCellDataByInputCell({}, { p: dataStreamHaveString });
-            expect(res2?.s).toStrictEqual({
-                fs: 28,
-            });
         });
     });
 });

--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -36,7 +36,6 @@ import {
     IUndoRedoService,
     IUniverInstanceService,
     LocaleService,
-    numfmt,
     toDisposable,
     Tools,
     UniverInstanceType,
@@ -729,7 +728,6 @@ export class EditingRenderController extends Disposable implements IRenderModule
     }
 }
 
-// eslint-disable-next-line
 export function getCellDataByInput(
     cellData: ICellData,
     documentDataModel: Nullable<DocumentDataModel>,
@@ -802,13 +800,6 @@ export function getCellDataByInput(
             cellData.f = null;
             cellData.si = null;
         }
-    } else if (numfmt.parseDate(newDataStream) || numfmt.parseNumber(newDataStream) || numfmt.parseTime(newDataStream)) {
-        // If it can be converted to a number and is not forced to be a string, then the style should keep prev style.
-        cellData.v = newDataStream;
-        cellData.f = null;
-        cellData.si = null;
-        cellData.p = null;
-        cellData.t = CellValueType.NUMBER;
     } else {
         // If the data is empty, the data is set to null.
         if (newDataStream === '' && cellData.v == null && cellData.p == null) {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #3741 

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
