### PR TITLE
fix: cutting to the target range does not require filtering merge cells of the same size

### DIFF
--- a/packages/sheets-ui/src/controllers/clipboard/utils.ts
+++ b/packages/sheets-ui/src/controllers/clipboard/utils.ts
@@ -184,9 +184,7 @@ export function getMoveRangeMutations(
                 .map((mergeRange) => Rectangle.getRelativeRange(mergeRange, fromRange))
                 .map((relativeRange) => Rectangle.getPositionRange(relativeRange, toRange));
 
-            const addMergeCellRanges = getAddMergeMutationRangeByType(willMoveToMergeRanges).filter(
-                (range) => !toMergeData.some((mergeRange) => Rectangle.equals(range, mergeRange))
-            );
+            const addMergeCellRanges = getAddMergeMutationRangeByType(willMoveToMergeRanges);
 
             const mergeRedos: Array<{
                 id: string;


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close https://github.com/dream-num/univer-pro/issues/2736

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
