### PR TITLE
fix(sheets-drawing-ui): fix `drawing-move-right` translation in zh-CN & zh-TW

### DIFF
--- a/packages/sheets-drawing-ui/src/locale/zh-CN.ts
+++ b/packages/sheets-drawing-ui/src/locale/zh-CN.ts
@@ -52,7 +52,7 @@ const locale = {
             'drawing-move-down': '下移绘图',
             'drawing-move-up': '上移绘图',
             'drawing-move-left': '左移绘图',
-            'drawing-move-right': '下移绘图',
+            'drawing-move-right': '右移绘图',
             'drawing-delete': '删除绘图',
         },
     },

--- a/packages/sheets-drawing-ui/src/locale/zh-TW.ts
+++ b/packages/sheets-drawing-ui/src/locale/zh-TW.ts
@@ -55,7 +55,7 @@ const locale: typeof zhCN = {
             'drawing-move-down': '下移繪圖',
             'drawing-move-up': '上移繪圖',
             'drawing-move-left': '左移繪圖',
-            'drawing-move-right': '下移繪圖',
+            'drawing-move-right': '右移繪圖',
             'drawing-delete': '刪除繪圖',
         },
     },


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #3993

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
