### PR TITLE
fix(sheet): parseValue handle number

### DIFF
--- a/packages/sheets-ui/src/controllers/editor/__tests__/end-edit.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/editor/__tests__/end-edit.controller.spec.ts
@@ -600,6 +600,10 @@ describe('Test EndEditController', () => {
             it('should handle escaped quotes in strings', () => {
                 expect(normalizeStringByLexer('="He said, ""Hello, .5!"""')).toBe('="He said, ""Hello, .5!"""');
             });
+            it('Illegal strings should not be modified', () => {
+                expect(normalizeStringByLexer('=SUM(11, 2 2, 33)')).toBe('=SUM(11, 2 2, 33)');
+                expect(normalizeStringByLexer('=SUM(11, 123 123, 33)')).toBe('=SUM(11, 123 123, 33)');
+            });
         });
     });
 });

--- a/packages/sheets-ui/src/controllers/utils/char-tools.ts
+++ b/packages/sheets-ui/src/controllers/utils/char-tools.ts
@@ -145,7 +145,7 @@ function normalizeFormulaString(str: string, normalStr: string, lexerTreeBuilder
                 }
                 // Entering =.07/0.1 in a cell will automatically convert to =0.07/0.1
                 // Entering =1.0+2.00 in a cell will automatically convert to =1+2
-                else if (typeof parsedValue.v === 'number') {
+                else if (typeof parsedValue.v === 'number' && (parsedValue.z === undefined || !numfmt.isDate(parsedValue.z))) {
                     const v = `${parsedValue.v}`;
                     const startIndex = node.startIndex + totalOffset + 1;
                     const endIndex = node.endIndex + totalOffset + 2;


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->

## What's updated?

Fix parse cell input

How to test?
1. Enter `=SUM(11, 2 2, 33)` in the Cell
2. Keep `=SUM(11, 2 2, 33)` (Previously it was correctly coverted to `=SUM(11, 45324, 33)`)


<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
