### PR TITLE
refactor: rename PLUGIN_CONFIG_KEY

### DIFF
--- a/packages-experimental/action-recorder/src/controllers/config.schema.ts
+++ b/packages-experimental/action-recorder/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'action-recorder.config';
+export const ACTION_RECORDER_PLUGIN_CONFIG_KEY = 'action-recorder.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(ACTION_RECORDER_PLUGIN_CONFIG_KEY);
 
 export interface IUniverActionRecorderConfig {
     menu?: MenuConfig;

--- a/packages-experimental/action-recorder/src/plugin.ts
+++ b/packages-experimental/action-recorder/src/plugin.ts
@@ -18,7 +18,7 @@ import type { Dependency } from '@univerjs/core';
 import type { IUniverActionRecorderConfig } from './controllers/config.schema';
 import { IConfigService, Inject, Injector, Plugin } from '@univerjs/core';
 import { ActionRecorderController } from './controllers/action-recorder.controller';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { ACTION_RECORDER_PLUGIN_CONFIG_KEY, defaultPluginConfig } from './controllers/config.schema';
 import { ActionRecorderService } from './services/action-recorder.service';
 import { ActionReplayService } from './services/replay.service';
 
@@ -41,7 +41,7 @@ export class UniverActionRecorderPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(ACTION_RECORDER_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages-experimental/debugger/src/controllers/config.schema.ts
+++ b/packages-experimental/debugger/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'debugger.config';
+export const DEBUGGER_PLUGIN_CONFIG_KEY = 'debugger.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DEBUGGER_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDebuggerConfig {
     menu?: MenuConfig;

--- a/packages-experimental/debugger/src/debugger-plugin.ts
+++ b/packages-experimental/debugger/src/debugger-plugin.ts
@@ -17,7 +17,7 @@
 import type { Dependency } from '@univerjs/core';
 import type { IUniverDebuggerConfig } from './controllers/config.schema';
 import { IConfigService, Inject, Injector, Plugin } from '@univerjs/core';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { DEBUGGER_PLUGIN_CONFIG_KEY, defaultPluginConfig } from './controllers/config.schema';
 import { DebuggerController } from './controllers/debugger.controller';
 import { E2EController } from './controllers/e2e/e2e.controller';
 import { PerformanceMonitorController } from './controllers/performance-monitor.controller';
@@ -40,7 +40,7 @@ export class UniverDebuggerPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DEBUGGER_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/data-validation/src/controllers/config.schema.ts
+++ b/packages/data-validation/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'data-validation.config';
+export const DATA_VALIDATION_PLUGIN_CONFIG_KEY = 'data-validation.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DATA_VALIDATION_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDataValidationConfig {
 }

--- a/packages/data-validation/src/plugin.ts
+++ b/packages/data-validation/src/plugin.ts
@@ -19,7 +19,7 @@ import type { IUniverDataValidationConfig } from './controllers/config.schema';
 import { ICommandService, IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import { AddDataValidationCommand, RemoveAllDataValidationCommand, RemoveDataValidationCommand, UpdateDataValidationOptionsCommand, UpdateDataValidationSettingCommand } from './commands/commands/data-validation.command';
 import { AddDataValidationMutation, RemoveDataValidationMutation, UpdateDataValidationMutation } from './commands/mutations/data-validation.mutation';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { DATA_VALIDATION_PLUGIN_CONFIG_KEY, defaultPluginConfig } from './controllers/config.schema';
 import { DataValidationResourceController } from './controllers/dv-resource.controller';
 import { DataValidationModel } from './models/data-validation-model';
 import { DataValidatorRegistryService } from './services/data-validator-registry.service';
@@ -40,7 +40,7 @@ export class UniverDataValidationPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DATA_VALIDATION_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/docs-drawing-ui/src/controllers/config.schema.ts
+++ b/packages/docs-drawing-ui/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'docs-drawing-ui.config';
+export const DOCS_DRAWING_UI_PLUGIN_CONFIG_KEY = 'docs-drawing-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DOCS_DRAWING_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDocsDrawingUIConfig {
 }

--- a/packages/docs-drawing-ui/src/plugin.ts
+++ b/packages/docs-drawing-ui/src/plugin.ts
@@ -22,10 +22,10 @@ import { UniverDrawingPlugin } from '@univerjs/drawing';
 import { UniverDrawingUIPlugin } from '@univerjs/drawing-ui';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { UniverUIPlugin } from '@univerjs/ui';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
-import { DocDrawingUIController } from './controllers/doc-drawing.controller';
+import { defaultPluginConfig, DOCS_DRAWING_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DocDrawingAddRemoveController } from './controllers/doc-drawing-notification.controller';
 import { DocDrawingTransformerController } from './controllers/doc-drawing-transformer-update.controller';
+import { DocDrawingUIController } from './controllers/doc-drawing.controller';
 import { DocDrawingPopupMenuController } from './controllers/drawing-popup-menu.controller';
 import { DocDrawingTransformUpdateController } from './controllers/render-controllers/doc-drawing-transform-update.controller';
 import { DocDrawingUpdateRenderController } from './controllers/render-controllers/doc-drawing-update.render-controller';
@@ -48,7 +48,7 @@ export class UniverDocsDrawingUIPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DOCS_DRAWING_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/docs-drawing/src/controllers/config.schema.ts
+++ b/packages/docs-drawing/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'docs-drawing.config';
+export const DOCS_DRAWING_PLUGIN_CONFIG_KEY = 'docs-drawing.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DOCS_DRAWING_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDocsDrawingConfig {
 }

--- a/packages/docs-drawing/src/plugin.ts
+++ b/packages/docs-drawing/src/plugin.ts
@@ -17,7 +17,7 @@
 import type { Dependency } from '@univerjs/core';
 import type { IUniverDocsDrawingConfig } from './controllers/config.schema';
 import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, DOCS_DRAWING_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DocDrawingController, DOCS_DRAWING_PLUGIN } from './controllers/doc-drawing.controller';
 import { DocDrawingService, IDocDrawingService } from './services/doc-drawing.service';
 
@@ -34,7 +34,7 @@ export class UniverDocsDrawingPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DOCS_DRAWING_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/docs-hyper-link-ui/src/controllers/config.schema.ts
+++ b/packages/docs-hyper-link-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'docs-hyper-link-ui.config';
+export const DOCS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY = 'docs-hyper-link-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DOCS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDocsHyperLinkUIConfig {
     menu?: MenuConfig;

--- a/packages/docs-hyper-link-ui/src/plugin.ts
+++ b/packages/docs-hyper-link-ui/src/plugin.ts
@@ -19,7 +19,7 @@ import type { IUniverDocsHyperLinkUIConfig } from './controllers/config.schema';
 import { DependentOn, IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import { UniverDocsHyperLinkPlugin } from '@univerjs/docs-hyper-link';
 import { IRenderManagerService } from '@univerjs/engine-render';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, DOCS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DocHyperLinkSelectionController } from './controllers/doc-hyper-link-selection.controller';
 import { DocHyperLinkEventRenderController } from './controllers/render-controllers/hyper-link-event.render-controller';
 import { DocHyperLinkRenderController } from './controllers/render-controllers/render.controller';
@@ -45,7 +45,7 @@ export class UniverDocsHyperLinkUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DOCS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/docs-hyper-link/src/controllers/config.schema.ts
+++ b/packages/docs-hyper-link/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'docs-hyper-link.config';
+export const DOCS_HYPER_LINK_PLUGIN_CONFIG_KEY = 'docs-hyper-link.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DOCS_HYPER_LINK_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDocsHyperLinkConfig {
 }

--- a/packages/docs-hyper-link/src/plugin.ts
+++ b/packages/docs-hyper-link/src/plugin.ts
@@ -18,7 +18,7 @@ import type { Dependency } from '@univerjs/core';
 import type { IUniverDocsHyperLinkConfig } from './controllers/config.schema';
 import { ICommandService, IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import { AddHyperLinkMuatation, DeleteHyperLinkMuatation, UpdateHyperLinkMuatation } from './commands/mutations/hyper-link.mutation';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, DOCS_HYPER_LINK_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DOC_HYPER_LINK_PLUGIN, DocHyperLinkResourceController } from './controllers/resource.controller';
 
 export class UniverDocsHyperLinkPlugin extends Plugin {
@@ -35,7 +35,7 @@ export class UniverDocsHyperLinkPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DOCS_HYPER_LINK_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/docs-mention-ui/src/controllers/config.schema.ts
+++ b/packages/docs-mention-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'docs-mention-ui.config';
+export const DOCS_MENTION_UI_PLUGIN_CONFIG_KEY = 'docs-mention-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DOCS_MENTION_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDocsMentionUIConfig {
     menu?: MenuConfig;

--- a/packages/docs-mention-ui/src/plugin.ts
+++ b/packages/docs-mention-ui/src/plugin.ts
@@ -17,11 +17,11 @@
 import type { Dependency } from '@univerjs/core';
 import type { IUniverDocsMentionUIConfig } from './controllers/config.schema';
 import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, DOCS_MENTION_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DocMentionTriggerController } from './controllers/doc-mention-trigger.controller';
 import { DocMentionUIController } from './controllers/doc-mention-ui.controller';
-import { DocMentionService } from './services/doc-mention.service';
 import { DocMentionPopupService } from './services/doc-mention-popup.service';
+import { DocMentionService } from './services/doc-mention.service';
 import { DOC_MENTION_UI_PLUGIN } from './types/const/const';
 
 export class UniverDocsMentionUIPlugin extends Plugin {
@@ -40,7 +40,7 @@ export class UniverDocsMentionUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DOCS_MENTION_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/docs-thread-comment-ui/src/controllers/config.schema.ts
+++ b/packages/docs-thread-comment-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'docs-thread-comment-ui.config';
+export const DOCS_THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY = 'docs-thread-comment-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DOCS_THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDocsThreadCommentUIConfig {
     menu?: MenuConfig;

--- a/packages/docs-thread-comment-ui/src/plugin.ts
+++ b/packages/docs-thread-comment-ui/src/plugin.ts
@@ -20,7 +20,7 @@ import { DependentOn, IConfigService, Inject, Injector, Plugin, UniverInstanceTy
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { UniverThreadCommentUIPlugin } from '@univerjs/thread-comment-ui';
 import { PLUGIN_NAME } from './common/const';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, DOCS_THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DocThreadCommentSelectionController } from './controllers/doc-thread-comment-selection.controller';
 import { DocThreadCommentUIController } from './controllers/doc-thread-comment-ui.controller';
 import { DocThreadCommentRenderController } from './controllers/render-controllers/render.controller';
@@ -44,7 +44,7 @@ export class UniverDocsThreadCommentUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DOCS_THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/docs-ui/src/controllers/config.schema.ts
+++ b/packages/docs-ui/src/controllers/config.schema.ts
@@ -19,9 +19,9 @@ import type { MenuConfig } from '@univerjs/ui';
 import type { ILayout } from '../basics';
 import { DefaultDocContainerConfig, DefaultToolbarConfig } from '../basics';
 
-export const PLUGIN_CONFIG_KEY = 'docs-ui.config';
+export const DOCS_UI_PLUGIN_CONFIG_KEY = 'docs-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DOCS_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDocsUIConfig {
     menu?: MenuConfig;

--- a/packages/docs-ui/src/controllers/doc-container-ui-controller.ts
+++ b/packages/docs-ui/src/controllers/doc-container-ui-controller.ts
@@ -15,11 +15,11 @@
  */
 
 import type { LocaleType } from '@univerjs/core';
-import { IConfigService, Inject, Injector, LocaleService } from '@univerjs/core';
-
 import type { DocContainer } from '../views/doc-container/DocContainer';
+
 import type { IUniverDocsUIConfig } from './config.schema';
-import { PLUGIN_CONFIG_KEY } from './config.schema';
+import { IConfigService, Inject, Injector, LocaleService } from '@univerjs/core';
+import { DOCS_UI_PLUGIN_CONFIG_KEY } from './config.schema';
 
 export class DocContainerUIController {
     private _docContainer?: DocContainer;
@@ -35,7 +35,7 @@ export class DocContainerUIController {
     getUIConfig() {
         const config = {
             injector: this._injector,
-            config: this._configService.getConfig<IUniverDocsUIConfig>(PLUGIN_CONFIG_KEY),
+            config: this._configService.getConfig<IUniverDocsUIConfig>(DOCS_UI_PLUGIN_CONFIG_KEY),
             changeLocale: this.changeLocale,
             getComponent: this.getComponent,
         };

--- a/packages/docs-ui/src/controllers/doc-ui.controller.ts
+++ b/packages/docs-ui/src/controllers/doc-ui.controller.ts
@@ -57,7 +57,7 @@ import {
     UnderlineShortCut,
 } from '../shortcuts/toolbar.shortcut';
 import { DocFooter } from '../views/doc-footer';
-import { PLUGIN_CONFIG_KEY } from './config.schema';
+import { DOCS_UI_PLUGIN_CONFIG_KEY } from './config.schema';
 import { menuSchema } from './menu.schema';
 
 export class DocUIController extends Disposable {
@@ -92,7 +92,7 @@ export class DocUIController extends Disposable {
     // TODO: @zhangwei, why add workbook to docs-ui?
     private _initUiParts() {
         const workbook = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_SHEET);
-        const config = this._configService.getConfig<IUniverDocsUIConfig>(PLUGIN_CONFIG_KEY);
+        const config = this._configService.getConfig<IUniverDocsUIConfig>(DOCS_UI_PLUGIN_CONFIG_KEY);
         if (config?.layout?.docContainerConfig?.footer && !workbook) {
             this.disposeWithMe(this._uiPartsService.registerComponent(BuiltInUIPart.FOOTER, () => connectInjector(DocFooter, this._injector)));
         }

--- a/packages/docs-ui/src/docs-ui-plugin.ts
+++ b/packages/docs-ui/src/docs-ui-plugin.ts
@@ -54,7 +54,7 @@ import { MoveCursorOperation, MoveSelectionOperation } from './commands/operatio
 import { DocParagraphSettingPanelOperation } from './commands/operations/doc-paragraph-setting-panel.operation';
 import { SetDocZoomRatioOperation } from './commands/operations/set-doc-zoom-ratio.operation';
 import { AppUIController } from './controllers';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, DOCS_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DocAutoFormatController } from './controllers/doc-auto-format.controller';
 import { DocHeaderFooterController } from './controllers/doc-header-footer.controller';
 import { DocMoveCursorController } from './controllers/doc-move-cursor.controller';
@@ -62,7 +62,6 @@ import { DocParagraphSettingController } from './controllers/doc-paragraph-setti
 import { DocTableController } from './controllers/doc-table.controller';
 import { DocUIController } from './controllers/doc-ui.controller';
 import { DocBackScrollRenderController } from './controllers/render-controllers/back-scroll.render-controller';
-import { DocRenderController } from './controllers/render-controllers/doc.render-controller';
 import { DocChecklistRenderController } from './controllers/render-controllers/doc-checklist.render-controller';
 import { DocClipboardController } from './controllers/render-controllers/doc-clipboard.controller';
 import { DocContextMenuRenderController } from './controllers/render-controllers/doc-contextmenu.render-controller';
@@ -71,6 +70,7 @@ import { DocIMEInputController } from './controllers/render-controllers/doc-ime-
 import { DocInputController } from './controllers/render-controllers/doc-input.controller';
 import { DocResizeRenderController } from './controllers/render-controllers/doc-resize.render-controller';
 import { DocSelectionRenderController } from './controllers/render-controllers/doc-selection-render.controller';
+import { DocRenderController } from './controllers/render-controllers/doc.render-controller';
 import { DocZoomRenderController } from './controllers/render-controllers/zoom.render-controller';
 import { DocClipboardService, IDocClipboardService } from './services/clipboard/clipboard.service';
 import { DocAutoFormatService } from './services/doc-auto-format.service';
@@ -118,7 +118,7 @@ export class UniverDocsUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DOCS_UI_PLUGIN_CONFIG_KEY, rest);
 
         this._initDependencies(_injector);
         this._initializeShortcut();

--- a/packages/docs/src/controllers/config.schema.ts
+++ b/packages/docs/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'docs.config';
+export const DOCS_PLUGIN_CONFIG_KEY = 'docs.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DOCS_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDocsConfig {
     hasScroll?: boolean;

--- a/packages/docs/src/doc-plugin.ts
+++ b/packages/docs/src/doc-plugin.ts
@@ -26,7 +26,7 @@ import {
 import { RichTextEditingMutation } from './commands/mutations/core-editing.mutation';
 import { DocsRenameMutation } from './commands/mutations/docs-rename.mutation';
 import { SetTextSelectionsOperation } from './commands/operations/text-selection.operation';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, DOCS_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DocCustomRangeController } from './controllers/custom-range.controller';
 import { DocSelectionManagerService } from './services/doc-selection-manager.service';
 import { DocStateEmitService } from './services/doc-state-emit.service';
@@ -46,7 +46,7 @@ export class UniverDocsPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DOCS_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/drawing-ui/src/controllers/config.schema.ts
+++ b/packages/drawing-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'drawing-ui.config';
+export const DRAWING_UI_PLUGIN_CONFIG_KEY = 'drawing-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DRAWING_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDrawingUIConfig {
     menu?: MenuConfig;

--- a/packages/drawing-ui/src/plugin.ts
+++ b/packages/drawing-ui/src/plugin.ts
@@ -17,7 +17,7 @@
 import type { Dependency } from '@univerjs/core';
 import type { IUniverDrawingUIConfig } from './controllers/config.schema';
 import { IConfigService, Inject, Injector, Plugin } from '@univerjs/core';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, DRAWING_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DrawingUIController } from './controllers/drawing-ui.controller';
 import { DrawingUpdateController } from './controllers/drawing-update.controller';
 import { ImageCropperController } from './controllers/image-cropper.controller';
@@ -41,7 +41,7 @@ export class UniverDrawingUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DRAWING_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/drawing/src/controllers/config.schema.ts
+++ b/packages/drawing/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { DependencyOverride } from '@univerjs/core';
 
-export const PLUGIN_CONFIG_KEY = 'drawing.config';
+export const DRAWING_PLUGIN_CONFIG_KEY = 'drawing.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(DRAWING_PLUGIN_CONFIG_KEY);
 
 export interface IUniverDrawingConfig {
     override?: DependencyOverride;

--- a/packages/drawing/src/plugin.ts
+++ b/packages/drawing/src/plugin.ts
@@ -15,14 +15,14 @@
  */
 
 import type { Dependency } from '@univerjs/core';
-import { IConfigService, Inject, Injector, mergeOverrideWithDependencies, Plugin } from '@univerjs/core';
-
-import { ImageIoService } from './services/image-io-impl.service';
-import { DrawingManagerService } from './services/drawing-manager-impl.service';
-import { IImageIoService } from './services/image-io.service';
-import { IDrawingManagerService } from './services/drawing-manager.service';
 import type { IUniverDrawingConfig } from './controllers/config.schema';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+
+import { IConfigService, Inject, Injector, mergeOverrideWithDependencies, Plugin } from '@univerjs/core';
+import { defaultPluginConfig, DRAWING_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { DrawingManagerService } from './services/drawing-manager-impl.service';
+import { IDrawingManagerService } from './services/drawing-manager.service';
+import { ImageIoService } from './services/image-io-impl.service';
+import { IImageIoService } from './services/image-io.service';
 
 const PLUGIN_NAME = 'UNIVER_DRAWING_PLUGIN';
 
@@ -38,7 +38,7 @@ export class UniverDrawingPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(DRAWING_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/engine-formula/src/controller/config.schema.ts
+++ b/packages/engine-formula/src/controller/config.schema.ts
@@ -18,9 +18,9 @@ import type { Ctor } from '@univerjs/core';
 import type { IFunctionNames } from '../basics/function';
 import type { BaseFunction } from '../functions/base-function';
 
-export const PLUGIN_CONFIG_KEY = 'engine-formula.config';
+export const ENGINE_FORMULA_PLUGIN_CONFIG_KEY = 'engine-formula.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(ENGINE_FORMULA_PLUGIN_CONFIG_KEY);
 
 export interface IUniverEngineFormulaConfig {
     notExecuteFormula?: boolean;

--- a/packages/engine-formula/src/controller/formula.controller.ts
+++ b/packages/engine-formula/src/controller/formula.controller.ts
@@ -58,7 +58,7 @@ import { functionText } from '../functions/text/function-map';
 import { functionUniver } from '../functions/univer/function-map';
 import { functionWeb } from '../functions/web/function-map';
 import { IFunctionService } from '../services/function.service';
-import { PLUGIN_CONFIG_KEY } from './config.schema';
+import { ENGINE_FORMULA_PLUGIN_CONFIG_KEY } from './config.schema';
 
 export class FormulaController extends Disposable {
     constructor(
@@ -104,7 +104,7 @@ export class FormulaController extends Disposable {
     }
 
     private _registerFunctions() {
-        const config = this._configService.getConfig<IUniverEngineFormulaConfig>(PLUGIN_CONFIG_KEY);
+        const config = this._configService.getConfig<IUniverEngineFormulaConfig>(ENGINE_FORMULA_PLUGIN_CONFIG_KEY);
 
         const functions: BaseFunction[] = (
             [

--- a/packages/engine-formula/src/index.ts
+++ b/packages/engine-formula/src/index.ts
@@ -164,7 +164,7 @@ export { FormulaDependencyTreeVirtual } from './engine/dependency/dependency-tre
 export { generateAstNode } from './engine/utils/generate-ast-node';
 export { type IFeatureCalculationManagerParam } from './services/feature-calculation-manager.service';
 export { DEFAULT_INTERVAL_COUNT } from './services/calculate-formula.service';
-export { type IUniverEngineFormulaConfig, PLUGIN_CONFIG_KEY } from './controller/config.schema';
+export { PLUGIN_CONFIG_KEY as ENGINE_FORMULA_PLUGIN_CONFIG_KEY, type IUniverEngineFormulaConfig } from './controller/config.schema';
 
 export { generateRandomDependencyTreeId } from './engine/dependency/formula-dependency';
 export { DependencyManagerBaseService } from './services/dependency-manager.service';

--- a/packages/engine-formula/src/index.ts
+++ b/packages/engine-formula/src/index.ts
@@ -164,7 +164,7 @@ export { FormulaDependencyTreeVirtual } from './engine/dependency/dependency-tre
 export { generateAstNode } from './engine/utils/generate-ast-node';
 export { type IFeatureCalculationManagerParam } from './services/feature-calculation-manager.service';
 export { DEFAULT_INTERVAL_COUNT } from './services/calculate-formula.service';
-export { PLUGIN_CONFIG_KEY as ENGINE_FORMULA_PLUGIN_CONFIG_KEY, type IUniverEngineFormulaConfig } from './controller/config.schema';
+export { ENGINE_FORMULA_PLUGIN_CONFIG_KEY, type IUniverEngineFormulaConfig } from './controller/config.schema';
 
 export { generateRandomDependencyTreeId } from './engine/dependency/formula-dependency';
 export { DependencyManagerBaseService } from './services/dependency-manager.service';

--- a/packages/engine-formula/src/plugin.ts
+++ b/packages/engine-formula/src/plugin.ts
@@ -18,7 +18,7 @@ import type { Dependency } from '@univerjs/core';
 import type { IUniverEngineFormulaConfig } from './controller/config.schema';
 import { IConfigService, Inject, Injector, Plugin, touchDependencies } from '@univerjs/core';
 import { CalculateController } from './controller/calculate.controller';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controller/config.schema';
+import { defaultPluginConfig, ENGINE_FORMULA_PLUGIN_CONFIG_KEY } from './controller/config.schema';
 import { FormulaController } from './controller/formula.controller';
 import { SetDefinedNameController } from './controller/set-defined-name.controller';
 import { SetDependencyController } from './controller/set-dependency.controller';
@@ -69,7 +69,7 @@ export class UniverFormulaEnginePlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(ENGINE_FORMULA_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/engine-formula/src/services/calculate-formula.service.ts
+++ b/packages/engine-formula/src/services/calculate-formula.service.ts
@@ -38,7 +38,7 @@ import {
 import { Subject } from 'rxjs';
 import { ErrorType } from '../basics/error-type';
 import { CELL_INVERTED_INDEX_CACHE } from '../basics/inverted-index-cache';
-import { PLUGIN_CONFIG_KEY } from '../controller/config.schema';
+import { ENGINE_FORMULA_PLUGIN_CONFIG_KEY } from '../controller/config.schema';
 import { Lexer } from '../engine/analysis/lexer';
 import { AstTreeBuilder } from '../engine/analysis/parser';
 import { ErrorNode } from '../engine/ast-node/base-ast-node';
@@ -265,7 +265,7 @@ export class CalculateFormulaService extends Disposable {
 
         let pendingTasks: (() => void)[] = [];
 
-        const config = this._configService.getConfig(PLUGIN_CONFIG_KEY) as IUniverEngineFormulaConfig;
+        const config = this._configService.getConfig(ENGINE_FORMULA_PLUGIN_CONFIG_KEY) as IUniverEngineFormulaConfig;
         const intervalCount = config?.intervalCount || DEFAULT_INTERVAL_COUNT;
 
         const treeCount = treeList.length;

--- a/packages/engine-render/src/controllers/config.schema.ts
+++ b/packages/engine-render/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'engine-render.config';
+export const ENGINE_RENDER_PLUGIN_CONFIG_KEY = 'engine-render.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(ENGINE_RENDER_PLUGIN_CONFIG_KEY);
 
 export interface IUniverEngineRenderConfig {
 }

--- a/packages/engine-render/src/plugin.ts
+++ b/packages/engine-render/src/plugin.ts
@@ -17,7 +17,7 @@
 import type { IUniverEngineRenderConfig } from './controllers/config.schema';
 
 import { createIdentifier, IConfigService, Inject, Injector, Plugin, registerDependencies } from '@univerjs/core';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, ENGINE_RENDER_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { Engine } from './engine';
 import { IRenderManagerService, RenderManagerService } from './render-manager/render-manager.service';
 
@@ -40,7 +40,7 @@ export class UniverRenderEnginePlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(ENGINE_RENDER_PLUGIN_CONFIG_KEY, rest);
 
         registerDependencies(this._injector, [
             [IRenderingEngine, { useFactory: () => new Engine() }],

--- a/packages/find-replace/src/controllers/config.schema.ts
+++ b/packages/find-replace/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'find-replace.config';
+export const FIND_REPLACE_PLUGIN_CONFIG_KEY = 'find-replace.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(FIND_REPLACE_PLUGIN_CONFIG_KEY);
 
 export interface IUniverFindReplaceConfig {
     menu?: MenuConfig;

--- a/packages/find-replace/src/plugin.ts
+++ b/packages/find-replace/src/plugin.ts
@@ -18,7 +18,7 @@ import type { IUniverFindReplaceConfig } from './controllers/config.schema';
 import { IConfigService, Plugin } from '@univerjs/core';
 
 import { type Dependency, Inject, Injector } from '@univerjs/core';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, FIND_REPLACE_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { FindReplaceController } from './controllers/find-replace.controller';
 import { FindReplaceService, IFindReplaceService } from './services/find-replace.service';
 
@@ -36,7 +36,7 @@ export class UniverFindReplacePlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(FIND_REPLACE_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-conditional-formatting-ui/src/controllers/config.schema.ts
+++ b/packages/sheets-conditional-formatting-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-conditional-formatting-ui.config';
+export const SHEETS_CONDITIONAL_FORMATTING_UI_PLUGIN_CONFIG_KEY = 'sheets-conditional-formatting-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_CONDITIONAL_FORMATTING_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsConditionalFormattingUIConfig {
     menu?: MenuConfig;

--- a/packages/sheets-conditional-formatting-ui/src/mobile-plugin.ts
+++ b/packages/sheets-conditional-formatting-ui/src/mobile-plugin.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IUniverSheetsConditionalFormattingUIConfig } from './controllers/config.schema';
 import {
     DependentOn,
     ICommandService,
@@ -25,6 +26,7 @@ import {
 } from '@univerjs/core';
 import { SHEET_CONDITIONAL_FORMATTING_PLUGIN, UniverSheetsConditionalFormattingPlugin } from '@univerjs/sheets-conditional-formatting';
 import { AddAverageCfCommand } from './commands/commands/add-average-cf.command';
+import { AddCfCommand } from './commands/commands/add-cf.command';
 import { AddColorScaleConditionalRuleCommand } from './commands/commands/add-color-scale-cf.command';
 import { AddDataBarConditionalRuleCommand } from './commands/commands/add-data-bar-cf.command';
 import { AddDuplicateValuesCfCommand } from './commands/commands/add-duplicate-values-cf.command';
@@ -35,19 +37,17 @@ import { AddTimePeriodCfCommand } from './commands/commands/add-time-period-cf.c
 import { AddUniqueValuesCfCommand } from './commands/commands/add-unique-values-cf.command';
 import { ClearRangeCfCommand } from './commands/commands/clear-range-cf.command';
 import { ClearWorksheetCfCommand } from './commands/commands/clear-worksheet-cf.command';
-import { OpenConditionalFormattingOperator } from './commands/operations/open-conditional-formatting-panel';
 import { DeleteCfCommand } from './commands/commands/delete-cf.command';
-import { SetCfCommand } from './commands/commands/set-cf.command';
 import { MoveCfCommand } from './commands/commands/move-cf.command';
-import { AddCfCommand } from './commands/commands/add-cf.command';
+import { SetCfCommand } from './commands/commands/set-cf.command';
 
-import { SheetsCfRenderController } from './controllers/cf.render.controller';
+import { OpenConditionalFormattingOperator } from './commands/operations/open-conditional-formatting-panel';
 import { ConditionalFormattingCopyPasteController } from './controllers/cf.copy-paste.controller';
 import { ConditionalFormattingI18nController } from './controllers/cf.i18n.controller';
-import { SheetsCfRefRangeController } from './controllers/cf.ref-range.controller';
 import { ConditionalFormattingPermissionController } from './controllers/cf.permission.controller';
-import type { IUniverSheetsConditionalFormattingUIConfig } from './controllers/config.schema';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { SheetsCfRefRangeController } from './controllers/cf.ref-range.controller';
+import { SheetsCfRenderController } from './controllers/cf.render.controller';
+import { defaultPluginConfig, SHEETS_CONDITIONAL_FORMATTING_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 
 @DependentOn(UniverSheetsConditionalFormattingPlugin)
 export class UniverSheetsConditionalFormattingMobileUIPlugin extends Plugin {
@@ -67,7 +67,7 @@ export class UniverSheetsConditionalFormattingMobileUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_CONDITIONAL_FORMATTING_UI_PLUGIN_CONFIG_KEY, rest);
 
         this._initCommand();
 

--- a/packages/sheets-conditional-formatting-ui/src/plugin.ts
+++ b/packages/sheets-conditional-formatting-ui/src/plugin.ts
@@ -56,7 +56,7 @@ import { ConditionalFormattingPermissionController } from './controllers/cf.perm
 import { SheetsCfRefRangeController } from './controllers/cf.ref-range.controller';
 import { SheetsCfRenderController } from './controllers/cf.render.controller';
 import { ConditionalFormattingViewportController } from './controllers/cf.viewport.controller';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig } from './controllers/config.schema';
 
 @DependentOn(UniverSheetsConditionalFormattingPlugin)
 export class UniverSheetsConditionalFormattingUIPlugin extends Plugin {
@@ -76,7 +76,7 @@ export class UniverSheetsConditionalFormattingUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_CONDITIONAL_FORMATTING_UI_PLUGIN_CONFIG_KEY, rest);
 
         this._initCommand();
     }

--- a/packages/sheets-conditional-formatting-ui/src/plugin.ts
+++ b/packages/sheets-conditional-formatting-ui/src/plugin.ts
@@ -56,7 +56,7 @@ import { ConditionalFormattingPermissionController } from './controllers/cf.perm
 import { SheetsCfRefRangeController } from './controllers/cf.ref-range.controller';
 import { SheetsCfRenderController } from './controllers/cf.render.controller';
 import { ConditionalFormattingViewportController } from './controllers/cf.viewport.controller';
-import { defaultPluginConfig } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_CONDITIONAL_FORMATTING_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 
 @DependentOn(UniverSheetsConditionalFormattingPlugin)
 export class UniverSheetsConditionalFormattingUIPlugin extends Plugin {

--- a/packages/sheets-conditional-formatting/src/controllers/config.schema.ts
+++ b/packages/sheets-conditional-formatting/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'ssheets-conditional-formatting.config';
+export const SHEETS_CONDITIONAL_FORMATTING_PLUGIN_CONFIG_KEY = 'ssheets-conditional-formatting.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_CONDITIONAL_FORMATTING_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsConditionalFormattingConfig {
 }

--- a/packages/sheets-conditional-formatting/src/plugin.ts
+++ b/packages/sheets-conditional-formatting/src/plugin.ts
@@ -25,7 +25,7 @@ import { MoveConditionalRuleMutation } from './commands/mutations/move-condition
 import { SetConditionalRuleMutation } from './commands/mutations/set-conditional-rule.mutation';
 import {
     defaultPluginConfig,
-    PLUGIN_CONFIG_KEY,
+    SHEETS_CONDITIONAL_FORMATTING_PLUGIN_CONFIG_KEY,
 } from './controllers/config.schema';
 import { ConditionalFormattingRuleModel } from './models/conditional-formatting-rule-model';
 import { ConditionalFormattingViewModel } from './models/conditional-formatting-view-model';
@@ -46,7 +46,7 @@ export class UniverSheetsConditionalFormattingPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_CONDITIONAL_FORMATTING_PLUGIN_CONFIG_KEY, rest);
 
         ([
             [ConditionalFormattingService],

--- a/packages/sheets-crosshair-highlight/src/controllers/config.schema.ts
+++ b/packages/sheets-crosshair-highlight/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-crosshair-highlight.config';
+export const SHEETS_CROSSHAIR_HIGHLIGHT_PLUGIN_CONFIG_KEY = 'sheets-crosshair-highlight.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_CROSSHAIR_HIGHLIGHT_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsCrosshairHighlightConfig {
     menu?: MenuConfig;

--- a/packages/sheets-crosshair-highlight/src/plugin.ts
+++ b/packages/sheets-crosshair-highlight/src/plugin.ts
@@ -15,13 +15,13 @@
  */
 
 import type { Dependency } from '@univerjs/core';
+import type { IUniverSheetsCrosshairHighlightConfig } from './controllers/config.schema';
 import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import { IRenderManagerService } from '@univerjs/engine-render';
+import { defaultPluginConfig, SHEETS_CROSSHAIR_HIGHLIGHT_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsCrosshairHighlightController } from './controllers/crosshair.controller';
 import { SheetsCrosshairHighlightService } from './services/crosshair.service';
 import { SheetCrosshairHighlightRenderController } from './views/widgets/crosshair-highlight.render-controller';
-import type { IUniverSheetsCrosshairHighlightConfig } from './controllers/config.schema';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 
 export class UniverSheetsCrosshairHighlightPlugin extends Plugin {
     static override pluginName: string = 'SHEET_CROSSHAIR_HIGHLIGHT_PLUGIN';
@@ -37,7 +37,7 @@ export class UniverSheetsCrosshairHighlightPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_CROSSHAIR_HIGHLIGHT_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-data-validation-ui/src/controllers/config.schema.ts
+++ b/packages/sheets-data-validation-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-data-validation-ui.config';
+export const SHEETS_DATA_VALIDATION_UI_PLUGIN_CONFIG_KEY = 'sheets-data-validation-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_DATA_VALIDATION_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsDataValidationUIConfig {
     menu?: MenuConfig;

--- a/packages/sheets-data-validation-ui/src/mobile-plugin.ts
+++ b/packages/sheets-data-validation-ui/src/mobile-plugin.ts
@@ -26,7 +26,7 @@ import {
     ShowDataValidationDropdown,
     ToggleValidationPanelOperation,
 } from './commands/operations/data-validation.operation';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_DATA_VALIDATION_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DataValidationAlertController } from './controllers/dv-alert.controller';
 import { DataValidationAutoFillController } from './controllers/dv-auto-fill.controller';
 import { DataValidationCopyPasteController } from './controllers/dv-copy-paste.controller';
@@ -56,7 +56,7 @@ export class UniverSheetsDataValidationMobileUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_DATA_VALIDATION_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-data-validation-ui/src/plugin.ts
+++ b/packages/sheets-data-validation-ui/src/plugin.ts
@@ -26,7 +26,7 @@ import {
     ShowDataValidationDropdown,
     ToggleValidationPanelOperation,
 } from './commands/operations/data-validation.operation';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_DATA_VALIDATION_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DataValidationAlertController } from './controllers/dv-alert.controller';
 import { DataValidationAutoFillController } from './controllers/dv-auto-fill.controller';
 import { DataValidationCopyPasteController } from './controllers/dv-copy-paste.controller';
@@ -57,7 +57,7 @@ export class UniverSheetsDataValidationUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_DATA_VALIDATION_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-data-validation-ui/src/views/components/list-dropdown/index.tsx
+++ b/packages/sheets-data-validation-ui/src/views/components/list-dropdown/index.tsx
@@ -35,7 +35,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { debounceTime } from 'rxjs';
 import { OpenValidationPanelOperation } from '../../../commands/operations/data-validation.operation';
 import { DROP_DOWN_DEFAULT_COLOR } from '../../../const';
-import { PLUGIN_CONFIG_KEY } from '../../../controllers/config.schema';
+import { SHEETS_DATA_VALIDATION_UI_PLUGIN_CONFIG_KEY } from '../../../controllers/config.schema';
 import styles from './index.module.less';
 
 interface ISelectListProps {
@@ -57,7 +57,7 @@ const SelectList = (props: ISelectListProps) => {
     const lowerFilter = filter?.toLowerCase();
     const { row, col, unitId, subUnitId } = location;
     const filteredOptions = options.filter((item) => lowerFilter ? item.label.toLowerCase().includes(lowerFilter) : true);
-    const showEditOnDropdown = configService.getConfig<IUniverSheetsDataValidationUIConfig>(PLUGIN_CONFIG_KEY)?.showEditOnDropdown ?? true;
+    const showEditOnDropdown = configService.getConfig<IUniverSheetsDataValidationUIConfig>(SHEETS_DATA_VALIDATION_UI_PLUGIN_CONFIG_KEY)?.showEditOnDropdown ?? true;
     const sheetPermissionInterceptorBaseController = useDependency(SheetPermissionInterceptorBaseController);
     const hasPermission = useMemo(() => sheetPermissionInterceptorBaseController.permissionCheckWithRanges(
         {

--- a/packages/sheets-data-validation/src/controllers/config.schema.ts
+++ b/packages/sheets-data-validation/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'sheets-data-validation.config';
+export const SHEETS_DATA_VALIDATION_PLUGIN_CONFIG_KEY = 'sheets-data-validation.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_DATA_VALIDATION_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsDataValidationConfig {
 }

--- a/packages/sheets-data-validation/src/plugin.ts
+++ b/packages/sheets-data-validation/src/plugin.ts
@@ -34,12 +34,12 @@ import {
     UpdateSheetDataValidationSettingCommand,
 } from './commands/commands/data-validation.command';
 import { DATA_VALIDATION_PLUGIN_NAME } from './common/const';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
-import { DataValidationController } from './controllers/dv.controller';
-import { DataValidationFormulaController } from './controllers/dv-formula.controller';
+import { defaultPluginConfig, SHEETS_DATA_VALIDATION_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DataValidationFormulaRefRangeController } from './controllers/dv-formula-ref-range.controller';
+import { DataValidationFormulaController } from './controllers/dv-formula.controller';
 import { DataValidationRefRangeController } from './controllers/dv-ref-range.controller';
 import { SheetDataValidationSheetController } from './controllers/dv-sheet.controller';
+import { DataValidationController } from './controllers/dv.controller';
 import { SheetDataValidationModel } from './models/sheet-data-validation-model';
 import { DataValidationCacheService } from './services/dv-cache.service';
 import { DataValidationCustomFormulaService } from './services/dv-custom-formula.service';
@@ -61,7 +61,7 @@ export class UniverSheetsDataValidationPlugin extends Plugin {
 
         // Manage the plugin configuration..
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_DATA_VALIDATION_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting() {

--- a/packages/sheets-drawing-ui/src/controllers/config.schema.ts
+++ b/packages/sheets-drawing-ui/src/controllers/config.schema.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import type { MenuConfig } from '@univerjs/ui';
 import type { DependencyOverride } from '@univerjs/core';
+import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-drawing-ui.config';
+export const SHEETS_DRAWING_UI_PLUGIN_CONFIG_KEY = 'sheets-drawing-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_DRAWING_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsDrawingUIConfig {
     menu?: MenuConfig;

--- a/packages/sheets-drawing-ui/src/plugin.ts
+++ b/packages/sheets-drawing-ui/src/plugin.ts
@@ -30,15 +30,15 @@ import { UniverDrawingPlugin } from '@univerjs/drawing';
 import { UniverDrawingUIPlugin } from '@univerjs/drawing-ui';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { UniverSheetsDrawingPlugin } from '@univerjs/sheets-drawing';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_DRAWING_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DrawingPopupMenuController } from './controllers/drawing-popup-menu.controller';
 import { SheetsDrawingRenderController } from './controllers/render-controllers/sheet-drawing.render-controller';
-import { SheetDrawingUIController } from './controllers/sheet-drawing.controller';
 import { SheetsDrawingCopyPasteController } from './controllers/sheet-drawing-copy-paste.controller';
 import { SheetDrawingPermissionController } from './controllers/sheet-drawing-permission.controller';
 import { SheetDrawingPrintingController } from './controllers/sheet-drawing-printing.controller';
 import { SheetDrawingTransformAffectedController } from './controllers/sheet-drawing-transform-affected.controller';
 import { SheetDrawingUpdateController } from './controllers/sheet-drawing-update.controller';
+import { SheetDrawingUIController } from './controllers/sheet-drawing.controller';
 import { SheetCanvasFloatDomManagerService } from './services/canvas-float-dom-manager.service';
 
 const PLUGIN_NAME = 'SHEET_IMAGE_UI_PLUGIN';
@@ -61,7 +61,7 @@ export class UniverSheetsDrawingUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_DRAWING_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-drawing/src/controllers/config.schema.ts
+++ b/packages/sheets-drawing/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'sheets-drawing.config';
+export const SHEETS_DRAWING_PLUGIN_CONFIG_KEY = 'sheets-drawing.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_DRAWING_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsDrawingConfig {
 }

--- a/packages/sheets-drawing/src/plugin.ts
+++ b/packages/sheets-drawing/src/plugin.ts
@@ -18,7 +18,7 @@ import type { Dependency } from '@univerjs/core';
 import type { IUniverSheetsDrawingConfig } from './controllers/config.schema';
 import { DependentOn, IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import { UniverDrawingPlugin } from '@univerjs/drawing';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_DRAWING_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SHEET_DRAWING_PLUGIN, SheetsDrawingLoadController } from './controllers/sheet-drawing.controller';
 import { ISheetDrawingService, SheetDrawingService } from './services/sheet-drawing.service';
 
@@ -36,7 +36,7 @@ export class UniverSheetsDrawingPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_DRAWING_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-filter-ui/src/controllers/config.schema.ts
+++ b/packages/sheets-filter-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-filter-ui.config';
+export const SHEETS_FILTER_UI_PLUGIN_CONFIG_KEY = 'sheets-filter-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_FILTER_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsFilterUIConfig {
     menu?: MenuConfig;

--- a/packages/sheets-filter-ui/src/filter-ui-desktop.plugin.ts
+++ b/packages/sheets-filter-ui/src/filter-ui-desktop.plugin.ts
@@ -27,7 +27,7 @@ import {
 } from '@univerjs/core';
 import { IRPCChannelService, toModule } from '@univerjs/rpc';
 import { UniverSheetsFilterPlugin } from '@univerjs/sheets-filter';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_FILTER_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsFilterPermissionController } from './controllers/sheets-filter-permission.controller';
 import { SheetsFilterUIDesktopController } from './controllers/sheets-filter-ui-desktop.controller';
 import { SheetsFilterPanelService } from './services/sheets-filter-panel.service';
@@ -56,7 +56,7 @@ export class UniverSheetsFilterUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_FILTER_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-filter-ui/src/filter-ui-mobile.plugin.ts
+++ b/packages/sheets-filter-ui/src/filter-ui-mobile.plugin.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { DependentOn, IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import type { Dependency } from '@univerjs/core';
-import { UniverSheetsFilterPlugin } from '@univerjs/sheets-filter';
+import type { IUniverSheetsFilterUIConfig } from './controllers/config.schema';
+import { DependentOn, IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 
+import { UniverSheetsFilterPlugin } from '@univerjs/sheets-filter';
+import { defaultPluginConfig, SHEETS_FILTER_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsFilterPermissionController } from './controllers/sheets-filter-permission.controller';
 import { SheetsFilterUIMobileController } from './controllers/sheets-filter-ui-mobile.controller';
-import type { IUniverSheetsFilterUIConfig } from './controllers/config.schema';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 
 const NAME = 'SHEET_FILTER_UI_PLUGIN';
 
@@ -42,7 +42,7 @@ export class UniverSheetsFilterMobileUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_FILTER_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-filter/src/commands/mutations/sheets-filter.mutation.ts
+++ b/packages/sheets-filter/src/commands/mutations/sheets-filter.mutation.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { CommandType } from '@univerjs/core';
 import type { IMutation, IRange, Nullable } from '@univerjs/core';
 import type { ISheetCommandSharedParams } from '@univerjs/sheets';
-
-import { SheetsFilterService } from '../../services/sheet-filter.service';
 import type { IFilterColumn } from '../../models/types';
+
+import { CommandType } from '@univerjs/core';
+import { ReCalcSheetsFilterMutationId, RemoveSheetsFilterMutationId, SetSheetsFilterCriteriaMutationId, SetSheetsFilterRangeMutationId } from '../../common/const';
+import { SheetsFilterService } from '../../services/sheet-filter.service';
 
 /**
  * Parameters of mutation {@link SetSheetsFilterRangeMutation}.
@@ -37,7 +38,7 @@ export interface ISetSheetsFilterRangeMutationParams extends ISheetCommandShared
  * don't necessarily need to remove the filter first, you can just execute this mutation.
  */
 export const SetSheetsFilterRangeMutation: IMutation<ISetSheetsFilterRangeMutationParams> = {
-    id: 'sheet.mutation.set-filter-range',
+    id: SetSheetsFilterRangeMutationId,
     type: CommandType.MUTATION,
     handler: (accessor, params) => {
         const { subUnitId, unitId, range } = params;
@@ -67,7 +68,7 @@ export interface ISetSheetsFilterCriteriaMutationParams extends ISheetCommandSha
  * A {@link CommandType.MUTATION} to set filter criteria of a given column of a {@link FilterModel}.
  */
 export const SetSheetsFilterCriteriaMutation: IMutation<ISetSheetsFilterCriteriaMutationParams> = {
-    id: 'sheet.mutation.set-filter-criteria',
+    id: SetSheetsFilterCriteriaMutationId,
     type: CommandType.MUTATION,
     handler: (accessor, params) => {
         const { subUnitId, unitId, criteria, col, reCalc = true } = params;
@@ -85,7 +86,7 @@ export const SetSheetsFilterCriteriaMutation: IMutation<ISetSheetsFilterCriteria
  * A {@link CommandType.MUTATION} to remove a {@link FilterModel} in a {@link Worksheet}.
  */
 export const RemoveSheetsFilterMutation: IMutation<ISheetCommandSharedParams> = {
-    id: 'sheet.mutation.remove-filter',
+    id: RemoveSheetsFilterMutationId,
     type: CommandType.MUTATION,
     handler: (accessor, params) => {
         const { unitId, subUnitId } = params;
@@ -98,7 +99,7 @@ export const RemoveSheetsFilterMutation: IMutation<ISheetCommandSharedParams> = 
  * A {@link CommandType.MUTATION} to re-calculate a {@link FilterModel}.
  */
 export const ReCalcSheetsFilterMutation: IMutation<ISheetCommandSharedParams> = {
-    id: 'sheet.mutation.re-calc-filter',
+    id: ReCalcSheetsFilterMutationId,
     type: CommandType.MUTATION,
     handler: (accessor, params) => {
         const { unitId, subUnitId } = params;

--- a/packages/sheets-filter/src/common/const.ts
+++ b/packages/sheets-filter/src/common/const.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2023-present DreamNum Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const SetSheetsFilterRangeMutationId = 'sheet.mutation.set-filter-range';
+export const SetSheetsFilterCriteriaMutationId = 'sheet.mutation.set-filter-criteria';
+export const RemoveSheetsFilterMutationId = 'sheet.mutation.remove-filter';
+export const ReCalcSheetsFilterMutationId = 'sheet.mutation.re-calc-filter';
+
+export const FILTER_MUTATIONS = new Set([
+    SetSheetsFilterRangeMutationId,
+    SetSheetsFilterCriteriaMutationId,
+    RemoveSheetsFilterMutationId,
+    ReCalcSheetsFilterMutationId,
+]);
+

--- a/packages/sheets-filter/src/controllers/config.schema.ts
+++ b/packages/sheets-filter/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'sheets-filter.config';
+export const SHEETS_FILTER_PLUGIN_CONFIG_KEY = 'sheets-filter.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_FILTER_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsFilterConfig {
 }

--- a/packages/sheets-filter/src/index.ts
+++ b/packages/sheets-filter/src/index.ts
@@ -25,9 +25,10 @@ export {
     lessThanOrEqualTo,
     notEquals,
 } from './models/custom-filters';
-export { FILTER_MUTATIONS, SHEET_FILTER_SNAPSHOT_ID, SheetsFilterService } from './services/sheet-filter.service';
+export { SHEET_FILTER_SNAPSHOT_ID, SheetsFilterService } from './services/sheet-filter.service';
 export type { IAutoFilter, ICustomFilter, ICustomFilters, IFilterColumn, IFilters } from './models/types';
 export { CustomFilterOperator } from './models/types';
+export { FILTER_MUTATIONS } from './common/const';
 
 // #region - all commands
 

--- a/packages/sheets-filter/src/plugin.ts
+++ b/packages/sheets-filter/src/plugin.ts
@@ -19,10 +19,8 @@ import type { IUniverSheetsFilterConfig } from './controllers/config.schema';
 
 import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import { defaultPluginConfig, SHEETS_FILTER_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
-import { SHEET_FILTER_SNAPSHOT_ID, SheetsFilterService } from './services/sheet-filter.service';
-// TODO: @ybzky Need to solve the Circular Dependency in sheet-filter.service, when the import order changes, it will cause the test to fail
-// eslint-disable-next-line perfectionist/sort-imports
 import { SheetsFilterController } from './controllers/sheets-filter.controller';
+import { SHEET_FILTER_SNAPSHOT_ID, SheetsFilterService } from './services/sheet-filter.service';
 
 export class UniverSheetsFilterPlugin extends Plugin {
     static override type = UniverInstanceType.UNIVER_SHEET;

--- a/packages/sheets-filter/src/plugin.ts
+++ b/packages/sheets-filter/src/plugin.ts
@@ -19,8 +19,10 @@ import type { IUniverSheetsFilterConfig } from './controllers/config.schema';
 
 import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import { defaultPluginConfig, SHEETS_FILTER_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
-import { SheetsFilterController } from './controllers/sheets-filter.controller';
 import { SHEET_FILTER_SNAPSHOT_ID, SheetsFilterService } from './services/sheet-filter.service';
+// TODO: @ybzky Need to solve the Circular Dependency in sheet-filter.service, when the import order changes, it will cause the test to fail
+// eslint-disable-next-line perfectionist/sort-imports
+import { SheetsFilterController } from './controllers/sheets-filter.controller';
 
 export class UniverSheetsFilterPlugin extends Plugin {
     static override type = UniverInstanceType.UNIVER_SHEET;

--- a/packages/sheets-filter/src/plugin.ts
+++ b/packages/sheets-filter/src/plugin.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import type { Dependency } from '@univerjs/core';
-
-import { SHEET_FILTER_SNAPSHOT_ID, SheetsFilterService } from './services/sheet-filter.service';
-import { SheetsFilterController } from './controllers/sheets-filter.controller';
 import type { IUniverSheetsFilterConfig } from './controllers/config.schema';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+
+import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
+import { defaultPluginConfig, SHEETS_FILTER_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { SheetsFilterController } from './controllers/sheets-filter.controller';
+import { SHEET_FILTER_SNAPSHOT_ID, SheetsFilterService } from './services/sheet-filter.service';
 
 export class UniverSheetsFilterPlugin extends Plugin {
     static override type = UniverInstanceType.UNIVER_SHEET;
@@ -35,7 +35,7 @@ export class UniverSheetsFilterPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_FILTER_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-filter/src/services/sheet-filter.service.ts
+++ b/packages/sheets-filter/src/services/sheet-filter.service.ts
@@ -25,20 +25,8 @@ import {
     UniverInstanceType,
 } from '@univerjs/core';
 import { BehaviorSubject, filter, merge, of, switchMap } from 'rxjs';
-import {
-    ReCalcSheetsFilterMutation,
-    RemoveSheetsFilterMutation,
-    SetSheetsFilterCriteriaMutation,
-    SetSheetsFilterRangeMutation,
-} from '../commands/mutations/sheets-filter.mutation';
+import { FILTER_MUTATIONS } from '../common/const';
 import { FilterModel } from '../models/filter-model';
-
-export const FILTER_MUTATIONS = new Set([
-    SetSheetsFilterRangeMutation.id,
-    SetSheetsFilterCriteriaMutation.id,
-    RemoveSheetsFilterMutation.id,
-    ReCalcSheetsFilterMutation.id,
-]);
 
 type WorksheetID = string;
 export interface ISheetsFilterResource {

--- a/packages/sheets-find-replace/src/controllers/config.schema.ts
+++ b/packages/sheets-find-replace/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'sheets-find-replace.config';
+export const SHEETS_FIND_REPLACE_PLUGIN_CONFIG_KEY = 'sheets-find-replace.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_FIND_REPLACE_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsFindReplaceConfig {
 }

--- a/packages/sheets-find-replace/src/plugin.ts
+++ b/packages/sheets-find-replace/src/plugin.ts
@@ -19,7 +19,7 @@ import type { IUniverSheetsFindReplaceConfig } from './controllers/config.schema
 import { DependentOn, IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
 import { UniverFindReplacePlugin } from '@univerjs/find-replace';
 import { UniverSheetsPlugin } from '@univerjs/sheets';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_FIND_REPLACE_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsFindReplaceController } from './controllers/sheet-find-replace.controller';
 
 const NAME = 'SHEET_FIND_REPLACE_PLUGIN';
@@ -38,7 +38,7 @@ export class UniverSheetsFindReplacePlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_FIND_REPLACE_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-hyper-link-ui/src/controllers/config.schema.ts
+++ b/packages/sheets-hyper-link-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-hyper-link-ui.config';
+export const SHEETS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY = 'sheets-hyper-link-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUrlHandler {
     navigateToOtherWebsite?: (url: string) => void;

--- a/packages/sheets-hyper-link-ui/src/plugin.ts
+++ b/packages/sheets-hyper-link-ui/src/plugin.ts
@@ -21,7 +21,7 @@ import { UniverDocsUIPlugin } from '@univerjs/docs-ui';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { UniverSheetsHyperLinkPlugin } from '@univerjs/sheets-hyper-link';
 import { SheetsHyperLinkAutoFillController } from './controllers/auto-fill.controller';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsHyperLinkCopyPasteController } from './controllers/copy-paste.controller';
 import { SheetsHyperLinkPermissionController } from './controllers/hyper-link-permission.controller';
 import { SheetsHyperLinkPopupController } from './controllers/popup.controller';
@@ -50,7 +50,7 @@ export class UniverSheetsHyperLinkUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-hyper-link-ui/src/services/resolver.service.ts
+++ b/packages/sheets-hyper-link-ui/src/services/resolver.service.ts
@@ -25,7 +25,7 @@ import { SetSelectionsOperation, SetWorksheetActiveOperation } from '@univerjs/s
 import { ERROR_RANGE, SheetHyperLinkType } from '@univerjs/sheets-hyper-link';
 import { ScrollToRangeOperation } from '@univerjs/sheets-ui';
 import { IMessageService } from '@univerjs/ui';
-import { PLUGIN_CONFIG_KEY } from '../controllers/config.schema';
+import { SHEETS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY } from '../controllers/config.schema';
 
 function getContainRange(range: IRange, worksheet: Worksheet) {
     const mergedCells = worksheet.getMergeData();
@@ -195,7 +195,7 @@ export class SheetsHyperLinkResolverService {
     }
 
     async navigateToOtherWebsite(url: string) {
-        const config = this._configService.getConfig<IUniverSheetsHyperLinkUIConfig>(PLUGIN_CONFIG_KEY);
+        const config = this._configService.getConfig<IUniverSheetsHyperLinkUIConfig>(SHEETS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY);
 
         if (config?.urlHandler?.navigateToOtherWebsite) {
             return config.urlHandler.navigateToOtherWebsite(url);

--- a/packages/sheets-hyper-link/src/controllers/config.schema.ts
+++ b/packages/sheets-hyper-link/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'sheets-hyper-link.config';
+export const SHEETS_HYPER_LINK_PLUGIN_CONFIG_KEY = 'sheets-hyper-link.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_HYPER_LINK_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsHyperLinkConfig {
 }

--- a/packages/sheets-hyper-link/src/plugin.ts
+++ b/packages/sheets-hyper-link/src/plugin.ts
@@ -17,13 +17,13 @@
 import type { IUniverSheetsHyperLinkConfig } from './controllers/config.schema';
 import { DependentOn, IConfigService, Inject, Injector, Plugin, registerDependencies, touchDependencies, UniverInstanceType } from '@univerjs/core';
 import { UniverSheetsPlugin } from '@univerjs/sheets';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_HYPER_LINK_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsHyperLinkRefRangeController } from './controllers/ref-range.controller';
 import { SheetsHyperLinkRemoveSheetController } from './controllers/remove-sheet.controller';
 import { SheetsHyperLinkRichTextRefRangeController } from './controllers/rich-text-ref-range.controller';
 import { SheetHyperLinkSetRangeController } from './controllers/set-range.controller';
-import { SheetsHyperLinkController } from './controllers/sheet-hyper-link.controller';
 import { SheetsHyperLinkResourceController } from './controllers/sheet-hyper-link-resource.controller';
+import { SheetsHyperLinkController } from './controllers/sheet-hyper-link.controller';
 import { HyperLinkModel } from './models/hyper-link.model';
 import { SheetsHyperLinkParserService } from './services/parser.service';
 import { SHEET_HYPER_LINK_PLUGIN } from './types/const';
@@ -42,7 +42,7 @@ export class UniverSheetsHyperLinkPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_HYPER_LINK_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-numfmt-ui/src/controllers/config.schema.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-numfmt.config';
+export const SHEETS_NUMFMT_UI_PLUGIN_CONFIG_KEY = 'sheets-numfmt.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_NUMFMT_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsNumfmtUIConfig {
     menu?: MenuConfig;

--- a/packages/sheets-numfmt-ui/src/plugin.ts
+++ b/packages/sheets-numfmt-ui/src/plugin.ts
@@ -18,7 +18,7 @@ import type { IUniverSheetsNumfmtUIConfig } from './controllers/config.schema';
 import { DependentOn, IConfigService, Inject, Injector, Plugin, registerDependencies, touchDependencies, UniverInstanceType } from '@univerjs/core';
 import { UniverSheetsNumfmtPlugin } from '@univerjs/sheets-numfmt';
 import { UniverSheetsUIPlugin } from '@univerjs/sheets-ui';
-import { PLUGIN_CONFIG_KEY } from '@univerjs/ui';
+import { UI_PLUGIN_CONFIG_KEY } from '@univerjs/ui';
 import { defaultPluginConfig } from './controllers/config.schema';
 import { SheetNumfmtUIController } from './controllers/numfmt.controller';
 import { NumfmtEditorController } from './controllers/numfmt.editor.controller';
@@ -45,7 +45,7 @@ export class UniverSheetsNumfmtUIPlugin extends Plugin {
             this._configService.setConfig('menu', menu, { merge: true });
         }
 
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-sort-ui/src/controllers/config.schema.ts
+++ b/packages/sheets-sort-ui/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-sort-ui.config';
+export const SHEETS_SORT_UI_PLUGIN_CONFIG_KEY = 'sheets-sort-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_SORT_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsSortUIConfig {
     menu?: MenuConfig;

--- a/packages/sheets-sort-ui/src/plugin.ts
+++ b/packages/sheets-sort-ui/src/plugin.ts
@@ -25,7 +25,7 @@ import {
     UniverInstanceType,
 } from '@univerjs/core';
 import { UniverSheetsSortPlugin } from '@univerjs/sheets-sort';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_SORT_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsSortUIController } from './controllers/sheets-sort-ui.controller';
 import { SheetsSortUIService } from './services/sheets-sort-ui.service';
 
@@ -45,7 +45,7 @@ export class UniverSheetsSortUIPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_SORT_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-sort/src/controllers/config.schema.ts
+++ b/packages/sheets-sort/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'sheets-sort.config';
+export const SHEETS_SORT_PLUGIN_CONFIG_KEY = 'sheets-sort.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_SORT_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsSortConfig {
 }

--- a/packages/sheets-sort/src/plugin.ts
+++ b/packages/sheets-sort/src/plugin.ts
@@ -18,7 +18,7 @@ import type { Dependency } from '@univerjs/core';
 import type { IUniverSheetsSortConfig } from './controllers/config.schema';
 
 import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_SORT_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsSortController } from './controllers/sheets-sort.controller';
 import { SheetsSortService } from './services/sheets-sort.service';
 
@@ -37,7 +37,7 @@ export class UniverSheetsSortPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_SORT_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-thread-comment-ui/src/controllers/config.schema.ts
+++ b/packages/sheets-thread-comment-ui/src/controllers/config.schema.ts
@@ -17,9 +17,9 @@
 import type { DependencyOverride } from '@univerjs/core';
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-thread-comment.config';
+export const SHEETS_THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY = 'sheets-thread-comment.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsThreadCommentUIConfig {
     menu?: MenuConfig;

--- a/packages/sheets-thread-comment-ui/src/plugin.ts
+++ b/packages/sheets-thread-comment-ui/src/plugin.ts
@@ -20,13 +20,13 @@ import { DependentOn, ICommandService, IConfigService, Inject, Injector, Plugin,
 import { UniverSheetsThreadCommentPlugin } from '@univerjs/sheets-thread-comment';
 import { UniverThreadCommentUIPlugin } from '@univerjs/thread-comment-ui';
 import { ShowAddSheetCommentModalOperation } from './commands/operations/comment.operation';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsThreadCommentRenderController } from './controllers/render-controllers/render.controller';
-import { SheetsThreadCommentController } from './controllers/sheets-thread-comment.controller';
 import { SheetsThreadCommentCopyPasteController } from './controllers/sheets-thread-comment-copy-paste.controller';
 import { SheetsThreadCommentHoverController } from './controllers/sheets-thread-comment-hover.controller';
 import { SheetsThreadCommentPopupController } from './controllers/sheets-thread-comment-popup.controller';
 import { ThreadCommentRemoveSheetsController } from './controllers/sheets-thread-comment-remove.controller';
+import { SheetsThreadCommentController } from './controllers/sheets-thread-comment.controller';
 import { SheetsThreadCommentPopupService } from './services/sheets-thread-comment-popup.service';
 import { SHEETS_THREAD_COMMENT } from './types/const';
 
@@ -48,7 +48,7 @@ export class UniverSheetsThreadCommentUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-thread-comment/src/controllers/config.schema.ts
+++ b/packages/sheets-thread-comment/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'sheets-thread-comment.config';
+export const SHEETS_THREAD_COMMENT_PLUGIN_CONFIG_KEY = 'sheets-thread-comment.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_THREAD_COMMENT_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsThreadCommentBaseConfig {
 }

--- a/packages/sheets-ui/src/controllers/config.schema.ts
+++ b/packages/sheets-ui/src/controllers/config.schema.ts
@@ -17,9 +17,9 @@
 import type { DependencyOverride } from '@univerjs/core';
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-ui.config';
+export const SHEETS_UI_PLUGIN_CONFIG_KEY = 'sheets-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsUIConfig {
     menu?: MenuConfig;

--- a/packages/sheets-ui/src/controllers/permission/sheet-permission-render.controller.ts
+++ b/packages/sheets-ui/src/controllers/permission/sheet-permission-render.controller.ts
@@ -30,7 +30,7 @@ import { UNIVER_SHEET_PERMISSION_ALERT_DIALOG } from '../../views/permission/err
 import { RANGE_PROTECTION_CAN_NOT_VIEW_RENDER_EXTENSION_KEY, RANGE_PROTECTION_CAN_VIEW_RENDER_EXTENSION_KEY, RangeProtectionCanNotViewRenderExtension, RangeProtectionCanViewRenderExtension } from '../../views/permission/extensions/range-protection.render';
 import { worksheetProtectionKey, WorksheetProtectionRenderExtension } from '../../views/permission/extensions/worksheet-permission.render';
 import { PermissionDetailUserPart } from '../../views/permission/panel-detail/PermissionDetailUserPart';
-import { type IUniverSheetsUIConfig, PLUGIN_CONFIG_KEY } from '../config.schema';
+import { type IUniverSheetsUIConfig, SHEETS_UI_PLUGIN_CONFIG_KEY } from '../config.schema';
 
 export interface IUniverSheetsPermissionMenuConfig {
     menu: MenuConfig;
@@ -72,7 +72,7 @@ export class SheetPermissionRenderManagerController extends Disposable {
 
     private _initUiPartComponents(): void {
         const configService = this._injector.get(IConfigService);
-        const config = configService.getConfig<IUniverSheetsUIConfig>(PLUGIN_CONFIG_KEY);
+        const config = configService.getConfig<IUniverSheetsUIConfig>(SHEETS_UI_PLUGIN_CONFIG_KEY);
         if (!config?.customComponents?.has(UNIVER_SHEET_PERMISSION_USER_PART)) {
             this.disposeWithMe(this._uiPartsService.registerComponent(UNIVER_SHEET_PERMISSION_USER_PART, () => connectInjector(PermissionDetailUserPart, this._injector)));
         }
@@ -92,7 +92,7 @@ export class SheetPermissionRenderController extends Disposable implements IRend
     ) {
         super();
 
-        const config = this._configService.getConfig<IUniverSheetsUIConfig>(PLUGIN_CONFIG_KEY);
+        const config = this._configService.getConfig<IUniverSheetsUIConfig>(SHEETS_UI_PLUGIN_CONFIG_KEY);
         if (config?.customComponents?.has(UNIVER_SHEET_PERMISSION_BACKGROUND)) {
             return;
         }
@@ -147,7 +147,7 @@ export class WorksheetProtectionRenderController extends Disposable implements I
     ) {
         super();
 
-        const config = this._configService.getConfig<IUniverSheetsUIConfig>(PLUGIN_CONFIG_KEY);
+        const config = this._configService.getConfig<IUniverSheetsUIConfig>(SHEETS_UI_PLUGIN_CONFIG_KEY);
         if (config?.customComponents?.has(UNIVER_SHEET_PERMISSION_BACKGROUND)) {
             return;
         }

--- a/packages/sheets-ui/src/controllers/sheet-ui.controller.ts
+++ b/packages/sheets-ui/src/controllers/sheet-ui.controller.ts
@@ -85,8 +85,8 @@ import {
     SetCellEditVisibleWithF2Operation,
 } from '../commands/operations/cell-edit.operation';
 import { RenameSheetOperation } from '../commands/operations/rename-sheet.operation';
-import { SetScrollOperation } from '../commands/operations/scroll.operation';
 import { ScrollToRangeOperation } from '../commands/operations/scroll-to-range.operation';
+import { SetScrollOperation } from '../commands/operations/scroll.operation';
 import { SetFormatPainterOperation } from '../commands/operations/set-format-painter.operation';
 import { SetZoomRatioOperation } from '../commands/operations/set-zoom-ratio.operation';
 import { SheetPermissionOpenDialogOperation } from '../commands/operations/sheet-permission-open-dialog.operation';
@@ -107,7 +107,7 @@ import { MENU_ITEM_INPUT_COMPONENT, MenuItemInput } from '../components/menu-ite
 import { DEFINED_NAME_CONTAINER } from '../views/defined-name/component-name';
 import { DefinedNameContainer } from '../views/defined-name/DefinedNameContainer';
 import { RenderSheetContent, RenderSheetFooter, RenderSheetHeader } from '../views/sheet-container/SheetContainer';
-import { PLUGIN_CONFIG_KEY } from './config.schema';
+import { SHEETS_UI_PLUGIN_CONFIG_KEY } from './config.schema';
 import { menuSchema } from './menu.schema';
 import {
     EditorBreakLineShortcut,
@@ -347,7 +347,7 @@ export class SheetUIController extends Disposable {
         const uiController = this._uiPartsService;
         const injector = this._injector;
 
-        const config = this._configService.getConfig<IUniverSheetsUIConfig>(PLUGIN_CONFIG_KEY);
+        const config = this._configService.getConfig<IUniverSheetsUIConfig>(SHEETS_UI_PLUGIN_CONFIG_KEY);
         if (config?.formulaBar !== false) {
             this.disposeWithMe(uiController.registerComponent(BuiltInUIPart.HEADER, () => connectInjector(RenderSheetHeader, injector)));
         }

--- a/packages/sheets-ui/src/plugin.ts
+++ b/packages/sheets-ui/src/plugin.ts
@@ -20,7 +20,7 @@ import type { IUniverSheetsUIConfig } from './controllers/config.schema';
 import { DependentOn, IConfigService, Inject, Injector, IUniverInstanceService, mergeOverrideWithDependencies, Plugin, registerDependencies, touchDependencies, UniverInstanceType } from '@univerjs/core';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { IRefSelectionsService, RefSelectionsService, UniverSheetsPlugin } from '@univerjs/sheets';
-import { PLUGIN_CONFIG_KEY as UI_PLUGIN_CONFIG_KEY } from '@univerjs/ui';
+import { UI_PLUGIN_CONFIG_KEY } from '@univerjs/ui';
 import { filter } from 'rxjs/operators';
 import { ActiveWorksheetController } from './controllers/active-worksheet/active-worksheet.controller';
 import { AutoFillController } from './controllers/auto-fill.controller';
@@ -67,13 +67,13 @@ import { SheetCanvasPopManagerService } from './services/canvas-pop-manager.serv
 import { CellAlertManagerService } from './services/cell-alert-manager.service';
 import { ISheetClipboardService, SheetClipboardService } from './services/clipboard/clipboard.service';
 import { DragManagerService } from './services/drag-manager.service';
+import { EditorBridgeService, IEditorBridgeService } from './services/editor-bridge.service';
 import { CellEditorManagerService, ICellEditorManagerService } from './services/editor/cell-editor-manager.service';
 import { SheetCellEditorResizeService } from './services/editor/cell-editor-resize.service';
 import {
     FormulaEditorManagerService,
     IFormulaEditorManagerService,
 } from './services/editor/formula-editor-manager.service';
-import { EditorBridgeService, IEditorBridgeService } from './services/editor-bridge.service';
 import { FormatPainterService, IFormatPainterService } from './services/format-painter/format-painter.service';
 import { HoverManagerService } from './services/hover-manager.service';
 import { IMarkSelectionService, MarkSelectionService } from './services/mark-selection/mark-selection.service';

--- a/packages/sheets-ui/src/plugin.ts
+++ b/packages/sheets-ui/src/plugin.ts
@@ -30,7 +30,7 @@ import { CellAlertRenderController } from './controllers/cell-alert.controller';
 import { CellCustomRenderController } from './controllers/cell-custom-render.controller';
 import { SheetCheckboxController } from './controllers/checkbox.controller';
 import { SheetClipboardController } from './controllers/clipboard/clipboard.controller';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SheetsDefinedNameController } from './controllers/defined-name/defined-name.controller';
 import { DragRenderController } from './controllers/drag-render.controller';
 import { EditorDataSyncController } from './controllers/editor/data-sync.controller';
@@ -111,7 +111,7 @@ export class UniverSheetsUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/SheetBarTabs.tsx
+++ b/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/SheetBarTabs.tsx
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
+import type { ICommandInfo } from '@univerjs/core';
+import type { IUniverUIConfig } from '@univerjs/ui';
+import type { IBaseSheetBarProps } from './SheetBarItem';
+import type { IScrollState } from './utils/slide-tab-bar';
 import { ICommandService, IConfigService, IPermissionService, LocaleService, nameCharacterCheck, Quantity, useDependency } from '@univerjs/core';
 import { Dropdown } from '@univerjs/design';
+
 import { LockSingle } from '@univerjs/icons';
 import {
     InsertSheetMutation,
@@ -32,20 +37,15 @@ import {
     WorkbookRenameSheetPermission,
     WorksheetProtectionRuleModel,
 } from '@univerjs/sheets';
-import { ContextMenuPosition, IConfirmService, Menu, PLUGIN_CONFIG_KEY as UI_PLUGIN_CONFIG_KEY, useObservable } from '@univerjs/ui';
+import { ContextMenuPosition, IConfirmService, Menu, UI_PLUGIN_CONFIG_KEY, useObservable } from '@univerjs/ui';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-
 import { merge } from 'rxjs';
-import type { ICommandInfo } from '@univerjs/core';
-import type { IUniverUIConfig } from '@univerjs/ui';
 import { useActiveWorkbook } from '../../../components/hook';
 import { IEditorBridgeService } from '../../../services/editor-bridge.service';
 import { ISheetBarService } from '../../../services/sheet-bar/sheet-bar.service';
 import styles from './index.module.less';
 import { SheetBarItem } from './SheetBarItem';
 import { SlideTabBar } from './utils/slide-tab-bar';
-import type { IBaseSheetBarProps } from './SheetBarItem';
-import type { IScrollState } from './utils/slide-tab-bar';
 
 export function SheetBarTabs() {
     const [sheetList, setSheetList] = useState<IBaseSheetBarProps[]>([]);

--- a/packages/sheets-zen-editor/src/controllers/config.schema.ts
+++ b/packages/sheets-zen-editor/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'sheets-zen-editor.config';
+export const SHEETS_ZEN_EDITOR_PLUGIN_CONFIG_KEY = 'sheets-zen-editor.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_ZEN_EDITOR_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsZenEditorConfig {
     menu?: MenuConfig;

--- a/packages/sheets-zen-editor/src/plugin.ts
+++ b/packages/sheets-zen-editor/src/plugin.ts
@@ -18,9 +18,9 @@ import type { Dependency } from '@univerjs/core';
 import type { IUniverSheetsZenEditorConfig } from './controllers/config.schema';
 
 import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
-import { ZenEditorController } from './controllers/zen-editor.controller';
+import { defaultPluginConfig, SHEETS_ZEN_EDITOR_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { ZenEditorUIController } from './controllers/zen-editor-ui.controller';
+import { ZenEditorController } from './controllers/zen-editor.controller';
 import { IZenEditorManagerService, ZenEditorManagerService } from './services/zen-editor.service';
 
 export class UniverSheetsZenEditorPlugin extends Plugin {
@@ -39,7 +39,7 @@ export class UniverSheetsZenEditorPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_ZEN_EDITOR_PLUGIN_CONFIG_KEY, rest);
 
         this._initializeDependencies(this._injector);
     }

--- a/packages/sheets/src/controllers/config.schema.ts
+++ b/packages/sheets/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { DependencyOverride } from '@univerjs/core';
 
-export const PLUGIN_CONFIG_KEY = 'sheets.config';
+export const SHEETS_PLUGIN_CONFIG_KEY = 'sheets.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SHEETS_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSheetsConfig {
     notExecuteFormula?: boolean;

--- a/packages/sheets/src/sheets-plugin.ts
+++ b/packages/sheets/src/sheets-plugin.ts
@@ -21,13 +21,13 @@ import { UniverFormulaEnginePlugin } from '@univerjs/engine-formula';
 import { BasicWorksheetController } from './controllers/basic-worksheet.controller';
 import { CalculateResultApplyController } from './controllers/calculate-result-apply.controller';
 import { ONLY_REGISTER_FORMULA_RELATED_MUTATIONS_KEY } from './controllers/config';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SHEETS_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { DefinedNameDataController } from './controllers/defined-name-data.controller';
 import { MergeCellController } from './controllers/merge-cell.controller';
 import { NumberCellDisplayController } from './controllers/number-cell.controller';
-import { RangeProtectionCache } from './model/range-protection.cache';
 import { RangeProtectionRenderModel } from './model/range-protection-render.model';
 import { RangeProtectionRuleModel } from './model/range-protection-rule.model';
+import { RangeProtectionCache } from './model/range-protection.cache';
 import { BorderStyleManagerService } from './services/border-style-manager.service';
 
 import { ExclusiveRangeService, IExclusiveRangeService } from './services/exclusive-range/exclusive-range-service';
@@ -57,7 +57,7 @@ export class UniverSheetsPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SHEETS_PLUGIN_CONFIG_KEY, rest);
 
         this._initConfig();
         this._initDependencies();

--- a/packages/slides-ui/src/controllers/config.schema.ts
+++ b/packages/slides-ui/src/controllers/config.schema.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import type { MenuConfig } from '@univerjs/ui';
 import type { DependencyOverride } from '@univerjs/core';
+import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'slides-ui.config';
+export const SLIDES_UI_PLUGIN_CONFIG_KEY = 'slides-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SLIDES_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSlidesUIConfig {
     override?: DependencyOverride;

--- a/packages/slides-ui/src/slides-ui-plugin.ts
+++ b/packages/slides-ui/src/slides-ui-plugin.ts
@@ -19,12 +19,12 @@ import type { IUniverSlidesUIConfig } from './controllers/config.schema';
 import { IConfigService, Inject, Injector, IUniverInstanceService, mergeOverrideWithDependencies, Plugin, UniverInstanceType } from '@univerjs/core';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { CanvasView } from './controllers/canvas-view';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, SLIDES_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { SlidePopupMenuController } from './controllers/popup-menu.controller';
-import { SlideRenderController } from './controllers/slide.render-controller';
 import { SlideEditingRenderController } from './controllers/slide-editing.render-controller';
 import { SlideEditorBridgeRenderController } from './controllers/slide-editor-bridge.render-controller';
 import { SlidesUIController } from './controllers/slide-ui.controller';
+import { SlideRenderController } from './controllers/slide.render-controller';
 import { ISlideEditorBridgeService, SlideEditorBridgeService } from './services/slide-editor-bridge.service';
 import { ISlideEditorManagerService, SlideEditorManagerService } from './services/slide-editor-manager.service';
 import { SlideCanvasPopMangerService } from './services/slide-popup-manager.service';
@@ -50,7 +50,7 @@ export class UniverSlidesUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SLIDES_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/slides/src/controllers/config.schema.ts
+++ b/packages/slides/src/controllers/config.schema.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export const PLUGIN_CONFIG_KEY = 'slides.config';
+export const SLIDES_PLUGIN_CONFIG_KEY = 'slides.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(SLIDES_PLUGIN_CONFIG_KEY);
 
 export interface IUniverSlidesConfig {
 }

--- a/packages/slides/src/slides-plugin.ts
+++ b/packages/slides/src/slides-plugin.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
-import { IRenderingEngine, IRenderManagerService } from '@univerjs/engine-render';
 import type { Dependency } from '@univerjs/core';
 import type { Engine } from '@univerjs/engine-render';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { IConfigService, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
+import { IRenderingEngine, IRenderManagerService } from '@univerjs/engine-render';
+import { defaultPluginConfig, SLIDES_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 // import { DocSelectionManagerService } from '@univerjs/docs';
 // import { CanvasView } from './views/render';
 
@@ -46,7 +46,7 @@ export class UniverSlidesPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(SLIDES_PLUGIN_CONFIG_KEY, rest);
 
         this._initializeDependencies(this._injector);
     }

--- a/packages/thread-comment-ui/src/controllers/config.schema.ts
+++ b/packages/thread-comment-ui/src/controllers/config.schema.ts
@@ -17,9 +17,9 @@
 import type { DependencyOverride } from '@univerjs/core';
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'thread-comment-ui.config';
+export const THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY = 'thread-comment-ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverThreadCommentUIConfig {
     overrides?: DependencyOverride;

--- a/packages/thread-comment-ui/src/plugin.ts
+++ b/packages/thread-comment-ui/src/plugin.ts
@@ -19,7 +19,7 @@ import type { IUniverThreadCommentUIConfig } from './controllers/config.schema';
 import { DependentOn, ICommandService, IConfigService, Inject, Injector, mergeOverrideWithDependencies, Plugin, UniverInstanceType } from '@univerjs/core';
 import { UniverThreadCommentPlugin } from '@univerjs/thread-comment';
 import { SetActiveCommentOperation, ToggleSheetCommentPanelOperation } from './commands/operations/comment.operations';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { ThreadCommentPanelService } from './services/thread-comment-panel.service';
 import { PLUGIN_NAME } from './types/const';
 
@@ -41,7 +41,7 @@ export class UniverThreadCommentUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(THREAD_COMMENT_UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/thread-comment/src/controllers/config.schema.ts
+++ b/packages/thread-comment/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { DependencyOverride } from '@univerjs/core';
 
-export const PLUGIN_CONFIG_KEY = 'thread-comment.config';
+export const THREAD_COMMENT_PLUGIN_CONFIG_KEY = 'thread-comment.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(THREAD_COMMENT_PLUGIN_CONFIG_KEY);
 
 export interface IUniverThreadCommentConfig {
     overrides?: DependencyOverride;

--- a/packages/thread-comment/src/plugin.ts
+++ b/packages/thread-comment/src/plugin.ts
@@ -19,7 +19,7 @@ import type { IUniverThreadCommentConfig } from './controllers/config.schema';
 import { ICommandService, IConfigService, Inject, Injector, mergeOverrideWithDependencies, Plugin, UniverInstanceType } from '@univerjs/core';
 import { AddCommentCommand, DeleteCommentCommand, DeleteCommentTreeCommand, ResolveCommentCommand, UpdateCommentCommand } from './commands/commands/comment.command';
 import { AddCommentMutation, DeleteCommentMutation, ResolveCommentMutation, UpdateCommentMutation, UpdateCommentRefMutation } from './commands/mutations/comment.mutation';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, THREAD_COMMENT_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { ThreadCommentResourceController } from './controllers/tc-resource.controller';
 import { ThreadCommentModel } from './models/thread-comment.model';
 import { IThreadCommentDataSourceService, ThreadCommentDataSourceService } from './services/tc-datasource.service';
@@ -39,7 +39,7 @@ export class UniverThreadCommentPlugin extends Plugin {
 
         // Manage the plugin configuration.
         const { ...rest } = this._config;
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(THREAD_COMMENT_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/ui/src/controllers/config.schema.ts
+++ b/packages/ui/src/controllers/config.schema.ts
@@ -18,9 +18,9 @@ import type { DependencyOverride } from '@univerjs/core';
 import type { MenuConfig } from '../services/menu/menu';
 import type { IWorkbenchOptions } from './ui/ui.controller';
 
-export const PLUGIN_CONFIG_KEY = 'ui.config';
+export const UI_PLUGIN_CONFIG_KEY = 'ui.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(UI_PLUGIN_CONFIG_KEY);
 
 export interface IUniverUIConfig extends IWorkbenchOptions {
     /** Disable auto focus when Univer bootstraps. */

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -29,7 +29,7 @@ export { Menu } from './components/menu/desktop/Menu';
 export { type INotificationOptions, type NotificationType } from './components/notification/Notification';
 export { ProgressBar } from './components/progress-bar/ProgressBar';
 export { UNI_DISABLE_CHANGING_FOCUS_KEY } from './const';
-export { type IUniverUIConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+export { type IUniverUIConfig, PLUGIN_CONFIG_KEY as UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 export { ErrorController } from './controllers/error/error.controller';
 export { menuSchema as UIMenuSchema } from './controllers/menus/menu.schema';
 export {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -29,7 +29,7 @@ export { Menu } from './components/menu/desktop/Menu';
 export { type INotificationOptions, type NotificationType } from './components/notification/Notification';
 export { ProgressBar } from './components/progress-bar/ProgressBar';
 export { UNI_DISABLE_CHANGING_FOCUS_KEY } from './const';
-export { type IUniverUIConfig, PLUGIN_CONFIG_KEY as UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+export { type IUniverUIConfig, UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 export { ErrorController } from './controllers/error/error.controller';
 export { menuSchema as UIMenuSchema } from './controllers/menus/menu.schema';
 export {

--- a/packages/ui/src/ui-plugin.ts
+++ b/packages/ui/src/ui-plugin.ts
@@ -21,12 +21,12 @@ import { DependentOn, IConfigService, IContextService, ILocalStorageService, Inj
 import { UniverRenderEnginePlugin } from '@univerjs/engine-render';
 import { ComponentManager } from './common/component-manager';
 import { ZIndexManager } from './common/z-index-manager';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, UI_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { ErrorController } from './controllers/error/error.controller';
 import { SharedController } from './controllers/shared-shortcut.controller';
 import { ShortcutPanelController } from './controllers/shortcut-display/shortcut-panel.controller';
-import { IUIController } from './controllers/ui/ui.controller';
 import { DesktopUIController } from './controllers/ui/ui-desktop.controller';
+import { IUIController } from './controllers/ui/ui.controller';
 import { DesktopBeforeCloseService, IBeforeCloseService } from './services/before-close/before-close.service';
 import { BrowserClipboardService, IClipboardInterfaceService } from './services/clipboard/clipboard-interface.service';
 import { IConfirmService } from './services/confirm/confirm.service';
@@ -49,8 +49,8 @@ import { INotificationService } from './services/notification/notification.servi
 import { IUIPartsService, UIPartsService } from './services/parts/parts.service';
 import { IPlatformService, PlatformService } from './services/platform/platform.service';
 import { CanvasPopupService, ICanvasPopupService } from './services/popup/canvas-popup.service';
-import { IShortcutService, ShortcutService } from './services/shortcut/shortcut.service';
 import { ShortcutPanelService } from './services/shortcut/shortcut-panel.service';
+import { IShortcutService, ShortcutService } from './services/shortcut/shortcut.service';
 import { DesktopSidebarService } from './services/sidebar/desktop-sidebar.service';
 import { ISidebarService } from './services/sidebar/sidebar.service';
 import { DesktopZenZoneService } from './services/zen-zone/desktop-zen-zone.service';
@@ -83,7 +83,7 @@ export class UniverUIPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(UI_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/uniscript/src/controllers/config.schema.ts
+++ b/packages/uniscript/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { MenuConfig } from '@univerjs/ui';
 
-export const PLUGIN_CONFIG_KEY = 'uniscript.config';
+export const UNISCRIPT_PLUGIN_CONFIG_KEY = 'uniscript.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(UNISCRIPT_PLUGIN_CONFIG_KEY);
 
 export interface IUniverUniscriptConfig {
     menu?: MenuConfig;

--- a/packages/uniscript/src/plugin.ts
+++ b/packages/uniscript/src/plugin.ts
@@ -17,7 +17,7 @@
 import type { Dependency } from '@univerjs/core';
 import type { IUniverUniscriptConfig } from './controllers/config.schema';
 import { IConfigService, Inject, Injector, Plugin } from '@univerjs/core';
-import { defaultPluginConfig, PLUGIN_CONFIG_KEY } from './controllers/config.schema';
+import { defaultPluginConfig, UNISCRIPT_PLUGIN_CONFIG_KEY } from './controllers/config.schema';
 import { UniscriptController } from './controllers/uniscript.controller';
 import { ScriptEditorService } from './services/script-editor.service';
 import { IUniscriptExecutionService, UniscriptExecutionService } from './services/script-execution.service';
@@ -40,7 +40,7 @@ export class UniverUniscriptPlugin extends Plugin {
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });
         }
-        this._configService.setConfig(PLUGIN_CONFIG_KEY, rest);
+        this._configService.setConfig(UNISCRIPT_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {

--- a/packages/uniscript/src/services/script-editor.service.ts
+++ b/packages/uniscript/src/services/script-editor.service.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { Disposable, IConfigService, toDisposable } from '@univerjs/core';
 import type { IDisposable } from '@univerjs/core';
 import type { editor } from 'monaco-editor';
 import type { IUniverUniscriptConfig } from '../controllers/config.schema';
-import { PLUGIN_CONFIG_KEY } from '../controllers/config.schema';
+import { Disposable, IConfigService, toDisposable } from '@univerjs/core';
+import { UNISCRIPT_PLUGIN_CONFIG_KEY } from '../controllers/config.schema';
 
 /**
  * This service is for loading monaco editor and its resources. It also holds the
@@ -42,7 +42,7 @@ export class ScriptEditorService extends Disposable {
 
     requireVscodeEditor(): void {
         if (!window.MonacoEnvironment) {
-            const config = this._configService.getConfig<IUniverUniscriptConfig>(PLUGIN_CONFIG_KEY);
+            const config = this._configService.getConfig<IUniverUniscriptConfig>(UNISCRIPT_PLUGIN_CONFIG_KEY);
 
             window.MonacoEnvironment = {
                 getWorkerUrl: config?.getWorkerUrl,

--- a/packages/watermark/src/controllers/config.schema.ts
+++ b/packages/watermark/src/controllers/config.schema.ts
@@ -16,9 +16,9 @@
 
 import type { IImageWatermarkConfig, ITextWatermarkConfig, IUserInfoWatermarkConfig } from '../common/type';
 
-export const PLUGIN_CONFIG_KEY = 'watermark.config';
+export const WATERMARK_PLUGIN_CONFIG_KEY = 'watermark.config';
 
-export const configSymbol = Symbol(PLUGIN_CONFIG_KEY);
+export const configSymbol = Symbol(WATERMARK_PLUGIN_CONFIG_KEY);
 
 export interface IUniverWatermarkConfig {
     userWatermarkSettings?: Partial<IUserInfoWatermarkConfig>;


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->


I think there may be a better way

```

export abstract class Plugin extends Disposable {
    + static configKey: string;
}


// use XXXPlugin.configKey

```

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
