### PR TITLE
fix(sheet): resizeObserver disconnect when unmount in sheetBarTabs

### DIFF
--- a/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/SheetBarTabs.tsx
+++ b/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/SheetBarTabs.tsx
@@ -105,7 +105,7 @@ export function SheetBarTabs() {
 
     useEffect(() => {
         updateSheetItems();
-        const slideTabBar = setupSlideTabBarInit();
+        const { slideTabBar, disconnectResizeObserver } = setupSlideTabBarInit();
         const disposable = setupStatusUpdate();
         const subscribeList = [
             setupSubscribeScroll(),
@@ -118,6 +118,7 @@ export function SheetBarTabs() {
             disposable.dispose();
             slideTabBar.destroy();
             subscribeList.forEach((subscribe) => subscribe.unsubscribe());
+            disconnectResizeObserver && disconnectResizeObserver();
         };
     }, [resetOrder, workbook]);
 
@@ -199,9 +200,9 @@ export function SheetBarTabs() {
         slideTabBarRef.current.slideTabBar = slideTabBar;
 
         // FIXME@Dushusir: First time asynchronous rendering will cause flickering problems
-        resizeInit(slideTabBar);
+        const disconnectResizeObserver = resizeInit(slideTabBar);
 
-        return slideTabBar;
+        return { slideTabBar, disconnectResizeObserver };
     };
 
     const config = configService.getConfig<IUniverUIConfig>(UI_PLUGIN_CONFIG_KEY);
@@ -385,6 +386,9 @@ export function SheetBarTabs() {
 
         // Start the observer
         observer.observe(slideTabBarContainer);
+
+        // Return the cleanup function that disconnects the observer
+        return () => observer.disconnect();
     };
 
     const onVisibleChange = (visible: boolean) => {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close [#3653](https://github.com/dream-num/univer-pro/issues/3653)

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
