### PR TITLE
fix: canvas crash when draw broken image

### DIFF
--- a/packages/engine-render/src/components/sheets/extensions/font.ts
+++ b/packages/engine-render/src/components/sheets/extensions/font.ts
@@ -302,7 +302,11 @@ export class Font extends SheetExtension {
                     ctx.save();
                     ctx.translate(x + rotatedWidth / 2, y + rotatedHeight / 2);
                     ctx.rotate(angleRadians);
-                    ctx.drawImage(image, -rotatedWidth / 2, -rotatedHeight / 2, width, height);
+                    try {
+                        ctx.drawImage(image, -rotatedWidth / 2, -rotatedHeight / 2, width, height);
+                    } catch (e) {
+                        console.error(e);
+                    }
                     ctx.restore();
                 }
             }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
