### PR TITLE
fix(sheet): support bind delete & date type source

### DIFF
--- a/packages-experimental/sheets-source-binding/src/controllers/binding-manager.ts
+++ b/packages-experimental/sheets-source-binding/src/controllers/binding-manager.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+import type { IMutationInfo } from '@univerjs/core';
 import type { ICellBindingNode, ICellBindingNodeParam } from '../types';
-import { Disposable, generateRandomId } from '@univerjs/core';
+import { Disposable, generateRandomId, Inject, IUniverInstanceService, Range } from '@univerjs/core';
+
+import { ClearSelectionAllCommand, ClearSelectionContentCommand, getSheetCommandTarget, SheetInterceptorService, SheetsSelectionsService } from '@univerjs/sheets';
 import { Subject } from 'rxjs';
 import { SheetBindingModel } from '../model/binding-model';
 import { BindingSourceChangeTypeEnum } from '../types';
@@ -32,12 +35,47 @@ interface IBindingNodeInfo {
 export class SheetsBindingManager extends Disposable {
     modelMap: Map<string, Map<string, SheetBindingModel>> = new Map();
 
-    private _cellBindInfoUpdate$ = new Subject<IBindingNodeInfo & { changeType: BindingSourceChangeTypeEnum;oldSourceId?: string }>();
+    private _cellBindInfoUpdate$ = new Subject<IBindingNodeInfo & { changeType: BindingSourceChangeTypeEnum; oldSourceId?: string }>();
     cellBindInfoUpdate$ = this._cellBindInfoUpdate$.asObservable();
 
     constructor(
+        @IUniverInstanceService private readonly _univerInstanceService: IUniverInstanceService,
+        @Inject(SheetInterceptorService) private readonly _sheetInterceptorService: SheetInterceptorService,
+        @Inject(SheetsSelectionsService) private readonly _sheetsSelectionsService: SheetsSelectionsService
     ) {
         super();
+        this._initRemoveCommand();
+    }
+
+    private _initRemoveCommand() {
+        this.disposeWithMe(
+            this._sheetInterceptorService.interceptCommand({
+                getMutations: (command) => {
+                    const redos: IMutationInfo[] = [];
+                    const undos: IMutationInfo[] = [];
+                    const selections = this._sheetsSelectionsService.getCurrentSelections();
+                    const target = getSheetCommandTarget(this._univerInstanceService);
+                    if (!target || !selections || selections.length === 0) {
+                        return {
+                            redos: [],
+                            undos: [],
+                        };
+                    }
+                    const { unitId, subUnitId } = target;
+                    if (command.id === ClearSelectionContentCommand.id || command.id === ClearSelectionAllCommand.id) {
+                        selections.forEach(({ range }) => {
+                            Range.foreach(range, (row, column) => {
+                                const node = this.getBindingNode(unitId, subUnitId, row, column);
+                                if (node) {
+                                    this.removeBindingNode(unitId, subUnitId, row, column);
+                                }
+                            });
+                        });
+                    }
+                    return { redos, undos };
+                },
+            })
+        );
     }
 
     getBindingModelBySourceId(sourceId: string) {

--- a/packages-experimental/sheets-source-binding/src/controllers/binding-manager.ts
+++ b/packages-experimental/sheets-source-binding/src/controllers/binding-manager.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IMutationInfo } from '@univerjs/core';
-import type { ICellBindingNode, ICellBindingNodeParam } from '../types';
+import type { ICellBindingJSON, ICellBindingNode, ICellBindingNodeParam } from '../types';
 import { Disposable, generateRandomId, Inject, IUniverInstanceService, Range } from '@univerjs/core';
 
 import { ClearSelectionAllCommand, ClearSelectionContentCommand, getSheetCommandTarget, SheetInterceptorService, SheetsSelectionsService } from '@univerjs/sheets';
@@ -165,10 +165,27 @@ export class SheetsBindingManager extends Disposable {
         return undefined;
     }
 
-    createModel(unitId: string, subunitId: string, json?: any): SheetBindingModel {
+    createModel(unitId: string, subunitId: string, json?: ICellBindingNode[]): SheetBindingModel {
         const model = new SheetBindingModel(json);
         this.addModel(unitId, subunitId, model);
         return model;
+    }
+
+    toJSON(unitId: string) {
+        const rs: ICellBindingJSON = {};
+        const subMap = this.modelMap.get(unitId);
+        if (subMap) {
+            subMap.forEach((model, subunitId) => {
+                rs[subunitId] = model.toJSON();
+            });
+        }
+        return rs;
+    }
+
+    fromJSON(unitId: string, json: ICellBindingJSON) {
+        Object.entries(json).forEach(([subunitId, nodes]) => {
+            this.createModel(unitId, subunitId, nodes);
+        });
     }
 
     override dispose(): void {

--- a/packages-experimental/sheets-source-binding/src/controllers/binding-manager.ts
+++ b/packages-experimental/sheets-source-binding/src/controllers/binding-manager.ts
@@ -190,5 +190,6 @@ export class SheetsBindingManager extends Disposable {
 
     override dispose(): void {
         this.modelMap.clear();
+        this._cellBindInfoUpdate$.complete();
     }
 }

--- a/packages-experimental/sheets-source-binding/src/controllers/source-manager.ts
+++ b/packages-experimental/sheets-source-binding/src/controllers/source-manager.ts
@@ -115,4 +115,9 @@ export class SheetsSourceManager extends Disposable {
             unitMap.set(source.id, model);
         }
     }
+
+    override dispose(): void {
+        this._sourceDataUpdate$.complete();
+        this.sourceMap.clear();
+    }
 }

--- a/packages-experimental/sheets-source-binding/src/facade/f-workbook.ts
+++ b/packages-experimental/sheets-source-binding/src/facade/f-workbook.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DataBindingNodeTypeEnum, SourceModelBase } from '@univerjs/sheets-source-binding';
-import { SheetsSourceBindService } from '@univerjs/sheets-source-binding';
+import { SheetsSourceBindService, SheetsSourceManager } from '@univerjs/sheets-source-binding';
 import { FWorkbook } from '@univerjs/sheets/facade';
 
 export interface IFWorkbookSourceBindingMixin {
@@ -76,11 +76,8 @@ export class FWorkbookSourceBinding extends FWorkbook implements IFWorkbookSourc
 
     override setSourceData(sourceId: string, data: any): void {
         const injector = this._injector;
-        const sheetsSourceBindService = injector.get(SheetsSourceBindService);
-        const source = sheetsSourceBindService.getSource(this.getId(), sourceId);
-        if (source) {
-            source.setSourceData(data);
-        }
+        const sheetsSourceManager = injector.get(SheetsSourceManager);
+        sheetsSourceManager.updateSourceData(this.getId(), sourceId, data);
     }
 
     override usePathMode(): void {

--- a/packages-experimental/sheets-source-binding/src/facade/f-workbook.ts
+++ b/packages-experimental/sheets-source-binding/src/facade/f-workbook.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DataBindingNodeTypeEnum, SourceModelBase } from '@univerjs/sheets-source-binding';
+import type { DataBindingNodeTypeEnum, ISourceBindingInfo, SourceModelBase } from '@univerjs/sheets-source-binding';
 import { SheetsSourceBindService, SheetsSourceManager } from '@univerjs/sheets-source-binding';
 import { FWorkbook } from '@univerjs/sheets/facade';
 
@@ -23,6 +23,7 @@ export interface IFWorkbookSourceBindingMixin {
      * Create a source model with the specified type.
      * @param {DataBindingNodeTypeEnum} type The source type.
      * @param {boolean} [isListObject] Whether the source is a list object.
+     * @param {string} [id] The source id.
      * @returns {SourceModelBase} The source data of sheet.
      */
     createSource(type: DataBindingNodeTypeEnum, isListObject?: boolean, id?: string | undefined): SourceModelBase;
@@ -59,6 +60,10 @@ export interface IFWorkbookSourceBindingMixin {
      * ```
      */
     setSourceData(sourceId: string, data: any): void;
+
+    loadSourceBindingPathInfo(obj: ISourceBindingInfo): void;
+
+    saveSourceBindingPathInfo(): ISourceBindingInfo;
 }
 
 export class FWorkbookSourceBinding extends FWorkbook implements IFWorkbookSourceBindingMixin {
@@ -90,6 +95,18 @@ export class FWorkbookSourceBinding extends FWorkbook implements IFWorkbookSourc
         const injector = this._injector;
         const sheetsSourceBindService = injector.get(SheetsSourceBindService);
         sheetsSourceBindService.useValueMode();
+    }
+
+    override loadSourceBindingPathInfo(obj: ISourceBindingInfo): void {
+        const injector = this._injector;
+        const sheetsSourceBindService = injector.get(SheetsSourceBindService);
+        sheetsSourceBindService.loadSourceBindingPathInfo(this.getId(), obj);
+    }
+
+    override saveSourceBindingPathInfo(): ISourceBindingInfo {
+        const injector = this._injector;
+        const sheetsSourceBindService = injector.get(SheetsSourceBindService);
+        return sheetsSourceBindService.getSourceBindingPathInfo(this.getId());
     }
 }
 

--- a/packages-experimental/sheets-source-binding/src/facade/f-workbook.ts
+++ b/packages-experimental/sheets-source-binding/src/facade/f-workbook.ts
@@ -39,6 +39,26 @@ export interface IFWorkbookSourceBindingMixin {
      * @param {string} sourceId The source id.
      */
     getSource(sourceId: string): SourceModelBase | undefined;
+    /**
+     * Set the source data by the specified source id.
+     * @param {string} sourceId - The source id which you want to set data.
+     * @param data - The source data. If the source is a list object, the data should be an array of objects.
+     * If the isListObject is false, the data should look like below:
+     * ```typescript
+     * {
+     *   fields: ['name', 'age'],
+     *   records: [['Tom', 18], ['Jerry', 20]]
+     * }
+     * ```
+     * If the isListObject is true, the data should look like below:
+     * ```typescript
+     * {
+     *   fields: ['name', 'age'],
+     *   records: [{name: 'Tom', age: 18}, {name: 'Jerry', age: 20}]
+     * }
+     * ```
+     */
+    setSourceData(sourceId: string, data: any): void;
 }
 
 export class FWorkbookSourceBinding extends FWorkbook implements IFWorkbookSourceBindingMixin {
@@ -52,6 +72,15 @@ export class FWorkbookSourceBinding extends FWorkbook implements IFWorkbookSourc
         const injector = this._injector;
         const sheetsSourceBindService = injector.get(SheetsSourceBindService);
         return sheetsSourceBindService.getSource(this.getId(), sourceId);
+    }
+
+    override setSourceData(sourceId: string, data: any): void {
+        const injector = this._injector;
+        const sheetsSourceBindService = injector.get(SheetsSourceBindService);
+        const source = sheetsSourceBindService.getSource(this.getId(), sourceId);
+        if (source) {
+            source.setSourceData(data);
+        }
     }
 
     override usePathMode(): void {

--- a/packages-experimental/sheets-source-binding/src/facade/f-workbook.ts
+++ b/packages-experimental/sheets-source-binding/src/facade/f-workbook.ts
@@ -25,7 +25,7 @@ export interface IFWorkbookSourceBindingMixin {
      * @param {boolean} [isListObject] Whether the source is a list object.
      * @returns {SourceModelBase} The source data of sheet.
      */
-    createSource(type: DataBindingNodeTypeEnum, isListObject?: boolean): SourceModelBase;
+    createSource(type: DataBindingNodeTypeEnum, isListObject?: boolean, id?: string | undefined): SourceModelBase;
     /**
      * Switch to path mode.In this mode, the path will show in cell.
      */
@@ -62,10 +62,10 @@ export interface IFWorkbookSourceBindingMixin {
 }
 
 export class FWorkbookSourceBinding extends FWorkbook implements IFWorkbookSourceBindingMixin {
-    override createSource(type: DataBindingNodeTypeEnum, isListObject?: boolean): SourceModelBase {
+    override createSource(type: DataBindingNodeTypeEnum, isListObject?: boolean, id?: string | undefined): SourceModelBase {
         const injector = this._injector;
         const sheetsSourceBindService = injector.get(SheetsSourceBindService);
-        return sheetsSourceBindService.createSource(this.getId(), type, isListObject);
+        return sheetsSourceBindService.createSource(this.getId(), type, isListObject, id);
     }
 
     override getSource(sourceId: string): SourceModelBase | undefined {

--- a/packages-experimental/sheets-source-binding/src/index.ts
+++ b/packages-experimental/sheets-source-binding/src/index.ts
@@ -20,4 +20,4 @@ export { UniverSheetsBindingSourcePlugin } from './plugin';
 export { BindModeEnum, DataBindingNodeTypeEnum } from './types';
 export { SheetsSourceBindService } from './services/source-binding-service';
 export { SheetsSourceManager } from './controllers/source-manager';
-export type { ICellBindingNode, ICellBindingNodeParam } from './types';
+export type { ICellBindingNode, ICellBindingNodeParam, ISourceBindingInfo } from './types';

--- a/packages-experimental/sheets-source-binding/src/index.ts
+++ b/packages-experimental/sheets-source-binding/src/index.ts
@@ -19,4 +19,5 @@ export { SourceModelBase } from './model/source-model';
 export { UniverSheetsBindingSourcePlugin } from './plugin';
 export { BindModeEnum, DataBindingNodeTypeEnum } from './types';
 export { SheetsSourceBindService } from './services/source-binding-service';
+export { SheetsSourceManager } from './controllers/source-manager';
 export type { ICellBindingNode, ICellBindingNodeParam } from './types';

--- a/packages-experimental/sheets-source-binding/src/model/binding-model.ts
+++ b/packages-experimental/sheets-source-binding/src/model/binding-model.ts
@@ -23,14 +23,14 @@ export class SheetBindingModel {
 
     private _sourceIdMap: Map<string, string[]> = new Map();
 
-    constructor(json?: any) {
+    constructor(json?: ICellBindingNode[]) {
         if (json) {
             this._init(json);
         }
     }
 
-    _init(json: any): void {
-        this.fromJSON();
+    _init(json: ICellBindingNode[]): void {
+        this.fromJSON(json);
     }
 
     getBindingNodesBySourceId(sourceId: string): ICellBindingNode[] | undefined {
@@ -86,12 +86,14 @@ export class SheetBindingModel {
         return this._nodeMap.get(nodeId);
     }
 
-    fromJSON(): void {
-
+    fromJSON(nodes: ICellBindingNode[]): void {
+        nodes.forEach((node) => {
+            this.setBindingNode(node.row, node.column, node);
+        });
     }
 
-    toJSON() {
-
+    toJSON(): ICellBindingNode[] {
+        return Array.from(this._nodeMap.values());
     }
 }
 

--- a/packages-experimental/sheets-source-binding/src/model/source-model.ts
+++ b/packages-experimental/sheets-source-binding/src/model/source-model.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ICellBindingNode, IListDataBindingNode, IListSourceData, IListSourceInfo, IObjectSourceInfo } from '../types';
+import type { ICellBindingNode, IListDataBindingNode, IListSourceData, IListSourceInfo, IObjectSourceInfo, ISourceJSON } from '../types';
 import { CellValueType, type ICellData } from '@univerjs/core';
 import { DataBindingNodeTypeEnum } from '../types';
 
@@ -66,6 +66,20 @@ export abstract class SourceModelBase {
     setSourceData(data: any): void {
         this._data = data;
         this._hasData = true;
+    }
+
+    toJSON(): ISourceJSON {
+        return {
+            id: this.id,
+            type: this.type,
+        };
+    }
+
+    fromJSON(info: ISourceJSON): void {
+        // @ts-ignore
+        this.id = info.id;
+        // @ts-ignore
+        this.type = info.type;
     }
 
     abstract getSourceInfo(): any;

--- a/packages-experimental/sheets-source-binding/src/services/source-binding-service.ts
+++ b/packages-experimental/sheets-source-binding/src/services/source-binding-service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ICellBindingNodeParam, IListSourceInfo } from '../types';
+import type { ICellBindingNodeParam, IListSourceInfo, ISourceBindingInfo } from '../types';
 import { Disposable, Inject, InterceptorEffectEnum, RTree } from '@univerjs/core';
 import { INTERCEPTOR_POINT, SheetInterceptorService } from '@univerjs/sheets';
 
@@ -79,6 +79,18 @@ export class SheetsSourceBindService extends Disposable {
 
     createSource(unitId: string, type: DataBindingNodeTypeEnum, isListObject?: boolean, id?: string) {
         return this._sheetsSourceManager.createSource(unitId, type, isListObject, id);
+    }
+
+    getSourceBindingPathInfo(unitId: string) {
+        return {
+            source: this._sheetsSourceManager.toJSON(unitId),
+            cellBinding: this._sheetsBindingManager.toJSON(unitId),
+        };
+    }
+
+    loadSourceBindingPathInfo(unitId: string, obj: ISourceBindingInfo) {
+        this._sheetsSourceManager.fromJSON(unitId, obj.source);
+        this._sheetsBindingManager.fromJSON(unitId, obj.cellBinding);
     }
 
     private _ensureRTreeCollection(unitId: string) {

--- a/packages-experimental/sheets-source-binding/src/services/source-binding-service.ts
+++ b/packages-experimental/sheets-source-binding/src/services/source-binding-service.ts
@@ -256,4 +256,8 @@ export class SheetsSourceBindService extends Disposable {
             },
         }));
     }
+
+    override dispose(): void {
+        this._bindModelRTreeCollection.clear();
+    }
 }

--- a/packages-experimental/sheets-source-binding/src/services/source-binding-service.ts
+++ b/packages-experimental/sheets-source-binding/src/services/source-binding-service.ts
@@ -203,9 +203,7 @@ export class SheetsSourceBindService extends Disposable {
                 const { sourceId } = node;
                 const source = this._sheetsSourceManager.getSource(unitId, sourceId);
                 if (source && source.hasData()) {
-                    return {
-                        v: source?.getData(node, row, col) || '',
-                    };
+                    return source?.getData(node, row, col) || { v: '' };
                 }
             }
         }
@@ -219,9 +217,7 @@ export class SheetsSourceBindService extends Disposable {
                     const { sourceId } = node;
                     const source = this._sheetsSourceManager.getSource(unitId, sourceId);
                     if (source && source.hasData()) {
-                        return {
-                            v: source?.getData(node, row, col) || '',
-                        };
+                        return source?.getData(node, row, col) || { v: '' };
                     }
                 }
             }
@@ -230,7 +226,8 @@ export class SheetsSourceBindService extends Disposable {
 
     private _registerInterceptor() {
         this.disposeWithMe(this._sheetInterceptorService.intercept(INTERCEPTOR_POINT.CELL_CONTENT, {
-            effect: InterceptorEffectEnum.Value,
+            effect: InterceptorEffectEnum.Value | InterceptorEffectEnum.Style,
+            priority: 102,
             handler: (cell, context, next) => {
                 const { row, col, unitId, subUnitId } = context;
                 let value = null;

--- a/packages-experimental/sheets-source-binding/src/types.ts
+++ b/packages-experimental/sheets-source-binding/src/types.ts
@@ -100,6 +100,10 @@ export interface ICellBindingNodeParam {
      * The target column of the binding node.
      */
     column: number;
+     /**
+      * Whether treat the data as date.
+      */
+    isDate?: boolean;
     nodeId?: string; // optional in ICellBindingNodeParam
 }
 

--- a/packages-experimental/sheets-source-binding/src/types.ts
+++ b/packages-experimental/sheets-source-binding/src/types.ts
@@ -166,3 +166,16 @@ export enum BindingSourceChangeTypeEnum {
     Update = 'update',
 }
 
+export interface ISourceJSON {
+    id: string;
+    type: DataBindingNodeTypeEnum;
+}
+
+export interface ICellBindingJSON {
+    [subUnitId: string]: ICellBindingNode[];
+}
+
+export interface ISourceBindingInfo {
+    source: ISourceJSON[];
+    cellBinding: ICellBindingJSON;
+}

--- a/packages/sheets/src/facade/f-workbook.ts
+++ b/packages/sheets/src/facade/f-workbook.ts
@@ -403,6 +403,7 @@ export class FWorkbook extends FBaseInitialable {
      * activeSpreadsheet.onCommandExecuted((command) => {
      *   console.log('Command executed:', command);
      * });
+     * ```
      */
     onCommandExecuted(callback: CommandListener): IDisposable {
         return this._commandService.onCommandExecuted((command) => {


### PR DESCRIPTION
- support delete bind path when delete cell

![image](https://github.com/user-attachments/assets/d2d7cfb5-a82a-49e3-b11f-14a30f437e8b)

```
const fWorkbook = univerAPI.getActiveWorkbook();
const fSheet = fWorkbook.getActiveSheet();

const source = fWorkbook.createSource(univerAPI.Enum.DataBindingNodeTypeEnum.Object);
source.setSourceData({
    user: {
        name: '猿婶'
    }
})

fSheet.setBindingNode({
    row: 1,
    column: 2,
    path: 'user.name',
    type: univerAPI.Enum.DataBindingNodeTypeEnum.Object,
    sourceId: source.getId()
})

const listSource = fWorkbook.createSource(univerAPI.Enum.DataBindingNodeTypeEnum.List, false);
listSource.setSourceData({
    fields: ['商品', '种类','日期'],
    records: [['苹果', '水果', 1736942545041], ['香蕉', '水果',1736942545041], ['圆珠笔', '文具',1736942545041]]
})
fSheet.setBindingNode({
    row: 1,
    column: 4,
    path: '商品',
    type: univerAPI.Enum.DataBindingNodeTypeEnum.List,
    sourceId: listSource.getId()
})

fSheet.setBindingNode({
    row: 1,
    column: 5,
    path: '种类',
    type: univerAPI.Enum.DataBindingNodeTypeEnum.List,
    sourceId: listSource.getId()
})
fSheet.setBindingNode({
    row: 1,
    column: 6,
    path: '日期',
    type: univerAPI.Enum.DataBindingNodeTypeEnum.List,
    sourceId: listSource.getId(),
    isDate:true,
})

```
