### PR TITLE
fix(numfmt): use next in writeCellInterceptor

### DIFF
--- a/packages/sheets-numfmt-ui/src/controllers/numfmt.editor.controller.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/numfmt.editor.controller.ts
@@ -114,7 +114,7 @@ export class NumfmtEditorController extends Disposable {
                                     case 'grouped':
                                     case 'number': {
                                         const cell = context.worksheet.getCellRaw(row, col);
-                                        return cell;
+                                        return next && next(cell);
                                     }
                                     case 'percent':
                                     case 'date':


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

## What's updated?

`next()` is not used here, which makes the subsequent interception unable to execute

## How to test?

use 
[snapshot-formula-numfmt.json](https://github.com/user-attachments/files/18423584/snapshot-formula-numfmt.json)


before

![image](https://github.com/user-attachments/assets/b7e253cf-9f7d-46f1-b299-2e91b192556a)

after

![image](https://github.com/user-attachments/assets/728a0bce-f02b-45de-aae7-c6dd76d82fe2)



<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
