### PR TITLE
fix: upload snapshot as artifacts when test failed, record hean snapshot in mem test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -54,10 +54,10 @@ jobs:
                       test-results/
                   retention-days: 30
 
-            - name: Upload Snapshots
+            - name: Upload HeapSnapshots
               uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
+              if: ${{ failure() }}
               with:
                   name: snapshots
-                  path: test-results/
+                  path: test-results/*.heapsnapshot
                   retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,7 +26,7 @@ jobs:
               run: pnpm build:e2e
 
             - name: Run Playwright Tests
-              run: pnpm exec playwright test --output=playwright-assets
+              run: pnpm exec playwright test
 
             - name: 🚀 Deploy to Vercel
               uses: amondnet/vercel-action@v25
@@ -54,11 +54,10 @@ jobs:
                       test-results/
                   retention-days: 30
 
-            - name: Upload heap snapshots
-              if: steps.test-run.outcome == 'failure' # Only upload if test step failed
+            - name: Upload Snapshots
               uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
               with:
-                  name: heap-snapshots-${{ github.sha }}
-                  path: |
-                      *.heapsnapshot
-                  retention-days: 5
+                  name: snapshots
+                  path: test-results/
+                  retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,3 +53,12 @@ jobs:
                       playwright-report/
                       test-results/
                   retention-days: 30
+
+            - name: Upload heap snapshots
+              if: steps.test-run.outcome == 'failure' # Only upload if test step failed
+              uses: actions/upload-artifact@v4
+              with:
+                  name: heap-snapshots-${{ github.sha }}
+                  path: |
+                      *.heapsnapshot
+                  retention-days: 5

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,9 +49,7 @@ jobs:
               if: ${{ !cancelled() }}
               with:
                   name: playwright-report
-                  path: |
-                      playwright-report/
-                      test-results/
+                  path: playwright-report/
                   retention-days: 30
 
             - name: Upload HeapSnapshots
@@ -60,4 +58,4 @@ jobs:
               with:
                   name: snapshots
                   path: test-results/*.heapsnapshot
-                  retention-days: 30
+                  retention-days: 3

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ typings/
 # examples
 
 screenshot
+*.heapsnapshot
 
 univer-custom-build
 universheet-custom-build

--- a/e2e/memory/memory.spec.ts
+++ b/e2e/memory/memory.spec.ts
@@ -143,9 +143,7 @@ test('memory', async ({ page }) => {
     await page.evaluate(() => window.univer.dispose());
     await page.waitForTimeout(2000);
 
-    if (isLocal) {
-        await takeHeapSnapshot(client, 'memory-first.heapsnapshot');
-    }
+    await takeHeapSnapshot(client, 'memory-first.heapsnapshot');
 
     const memoryAfterDisposingFirstInstance = (await getMetrics(page)).JSHeapUsedSize;
 
@@ -154,13 +152,11 @@ test('memory', async ({ page }) => {
     await page.evaluate(() => window.univer.dispose());
     await page.waitForTimeout(2000);
 
-    if (isLocal) {
-        await takeHeapSnapshot(client, 'memory-second.heapsnapshot');
-    }
+    await takeHeapSnapshot(client, 'memory-second.heapsnapshot');
 
     const memoryAfterDisposingSecondUniver = (await getMetrics(page)).JSHeapUsedSize;
     expect(memoryAfterDisposingSecondUniver - memoryAfterDisposingFirstInstance)
-        .toBeLessThanOrEqual(MAX_SECOND_INSTANCE_OVERFLOW);
+        .toBeLessThanOrEqual(1);
 
     expect(memoryAfterDisposingSecondUniver - memoryAfterFirstInstance)
         .toBeLessThanOrEqual(MAX_UNIVER_MEMORY_OVERFLOW);

--- a/e2e/memory/memory.spec.ts
+++ b/e2e/memory/memory.spec.ts
@@ -27,13 +27,12 @@ const MAX_UNIT_MEMORY_OVERFLOW = 1_000_000; // 1MB
 const MAX_UNIVER_MEMORY_OVERFLOW = 6_000_000; // TODO@wzhudev: temporarily added 300KB
 // there is a memory leak in the univer object, so we need to make sure that
 
-// const MAX_SECOND_INSTANCE_OVERFLOW = 100_000; // Only 100 KB
+const MAX_SECOND_INSTANCE_OVERFLOW = 100_000; // Only 100 KB
 
 interface HeapSnapshotChunk {
     chunk: string;
 }
 
-        // Type the progress handler parameter
 interface HeapSnapshotProgress {
     done: number;
     total: number;
@@ -83,7 +82,6 @@ async function takeHeapSnapshot(client: CDPSession, filename: string) {
         chunkHandler = (payload: HeapSnapshotChunk) => {
             try {
                 if (payload.chunk) {
-                    // console.log('chunkHandler write chunk', filename, file.writableLength);
                     file.write(payload.chunk);
                     scheduleEnd();
                 }
@@ -155,7 +153,7 @@ test('memory', async ({ page }) => {
 
     const memoryAfterDisposingSecondUniver = (await getMetrics(page)).JSHeapUsedSize;
     expect(memoryAfterDisposingSecondUniver - memoryAfterDisposingFirstInstance)
-        .toBeLessThanOrEqual(1);
+        .toBeLessThanOrEqual(MAX_SECOND_INSTANCE_OVERFLOW);
 
     expect(memoryAfterDisposingSecondUniver - memoryAfterFirstInstance)
         .toBeLessThanOrEqual(MAX_UNIVER_MEMORY_OVERFLOW);

--- a/e2e/memory/memory.spec.ts
+++ b/e2e/memory/memory.spec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable no-console */
 import type { CDPSession } from '@playwright/test';
 import { createWriteStream } from 'node:fs';
 import { expect, test } from '@playwright/test';
@@ -28,7 +27,7 @@ const MAX_UNIT_MEMORY_OVERFLOW = 1_000_000; // 1MB
 const MAX_UNIVER_MEMORY_OVERFLOW = 6_000_000; // TODO@wzhudev: temporarily added 300KB
 // there is a memory leak in the univer object, so we need to make sure that
 
-const MAX_SECOND_INSTANCE_OVERFLOW = 100_000; // Only 100 KB
+// const MAX_SECOND_INSTANCE_OVERFLOW = 100_000; // Only 100 KB
 
 interface HeapSnapshotChunk {
     chunk: string;
@@ -42,7 +41,7 @@ interface HeapSnapshotProgress {
 }
 async function takeHeapSnapshot(client: CDPSession, filename: string) {
     return new Promise((resolve, reject) => {
-        const file = createWriteStream(filename);
+        const file = createWriteStream(`./test-results/${filename}`);
         let isFinished = false;
         let error = null;
         let noChunkTimeout = null;
@@ -84,7 +83,7 @@ async function takeHeapSnapshot(client: CDPSession, filename: string) {
         chunkHandler = (payload: HeapSnapshotChunk) => {
             try {
                 if (payload.chunk) {
-                    console.log('chunkHandler write chunk', filename, file.writableLength);
+                    // console.log('chunkHandler write chunk', filename, file.writableLength);
                     file.write(payload.chunk);
                     scheduleEnd();
                 }
@@ -120,7 +119,7 @@ async function takeHeapSnapshot(client: CDPSession, filename: string) {
     });
 }
 
-const isLocal = !process.env.CI;
+// const isLocal = !process.env.CI;
 test('memory', async ({ page }) => {
     test.setTimeout(60_000);
     const client = await page.context().newCDPSession(page);

--- a/e2e/perf/scroll.spec.ts
+++ b/e2e/perf/scroll.spec.ts
@@ -135,14 +135,6 @@ async function measureFPS(page: Page, testDuration = 5, deltaX: number, deltaY: 
 const createTest = (title: string, sheetData: IJsonObject, minFpsValue: number, deltaX = 0, deltaY = 0) => {
     // Default Size Of browser: 1280x720 pixels. And default DPR is 1.
     test(title, async ({ page }) => {
-        // dev:e2e open localhost:3000, not 3002
-        // let port = 3000;
-        // if (!isCI) {
-        //     const browser = await chromium.launch({ headless: false }); // launch browser
-        //     page = await browser.newPage();
-        //     port = 3002;
-        // }
-
         await page.goto('http://localhost:3000/sheets/');
         await page.waitForTimeout(2000);
 

--- a/e2e/perf/scroll.spec.ts
+++ b/e2e/perf/scroll.spec.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { Page } from '@playwright/test';
 /* eslint-disable no-console */
+import type { Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
 import { sheetData as emptySheetData } from '../__testing__/emptysheet';
 import { sheetData as freezeData } from '../__testing__/freezesheet';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,6 +18,7 @@ const HEADLESS = !!process.env.HEADLESS;
  */
 export default defineConfig({
     testDir: './e2e',
+    outputDir: 'test-results/', // Make sure this is set
     /* Run tests in files in parallel */
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

take two heapsnapshot in univer root path when run mem.spec.ts, and upload to artifacts if mem test failed

memory-first.heapsnapshot & memory-second.heapsnapshot

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
