### PR TITLE
refactor(core)!: move facade exports to facade directory and update imports

### DIFF
--- a/common/shared/eslint/index.js
+++ b/common/shared/eslint/index.js
@@ -1,6 +1,7 @@
 const jsdoc = require('eslint-plugin-jsdoc');
 const eslintPluginReadableTailwind = require('eslint-plugin-readable-tailwind');
 const noExternalImportsInFacade = require('./plugins/no-external-imports-in-facade');
+const noFacadeImportsOutsideFacade = require('./plugins/no-facade-imports-outside-facade');
 const noSelfPackageImports = require('./plugins/no-self-package-imports');
 
 exports.baseRules = {
@@ -146,6 +147,7 @@ exports.typescriptPreset = () => {
                 rules: {
                     'no-external-imports-in-facade': noExternalImportsInFacade,
                     'no-self-package-imports': noSelfPackageImports,
+                    'no-facade-imports-outside-facade': noFacadeImportsOutsideFacade,
                 },
             },
         },
@@ -186,6 +188,7 @@ exports.univerSourcePreset = () => {
         ],
         rules: {
             'univer/no-self-package-imports': 'error',
+            'univer/no-facade-imports-outside-facade': 'error',
         },
         languageOptions: {
             parser: require('@typescript-eslint/parser'),

--- a/common/shared/eslint/index.js
+++ b/common/shared/eslint/index.js
@@ -197,7 +197,6 @@ exports.facadePreset = () => {
     return {
         files: ['**/src/facade/**/*.ts'],
         ignores: [
-            '**/core/src/**/*.ts',
             '**/__tests__/**/*',
             '**/*.spec.ts',
             '**/*.test.ts',

--- a/common/shared/eslint/plugins/no-facade-imports-outside-facade.js
+++ b/common/shared/eslint/plugins/no-facade-imports-outside-facade.js
@@ -1,0 +1,82 @@
+// no-facade-imports-outside-facade.js
+const path = require('node:path');
+
+const rule = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Disallow imports containing facade in non-facade files',
+        },
+        messages: {
+            noFacadeImports: 'Imports containing "facade" are not allowed in non-facade files: "{{importPath}}"',
+        },
+    },
+
+    create(context) {
+        const filename = context.getFilename();
+        const normalizedPath = filename.split(path.sep).join('/');
+
+        const isInPackages = normalizedPath.includes('/packages/');
+        const isInFacade = normalizedPath.includes('/facade/');
+
+        if (!isInPackages || isInFacade) {
+            return {};
+        }
+
+        // get parent dir
+        const parentDirMatch = normalizedPath.match(/\/([^/]+)\/packages\//);
+        if (!parentDirMatch) {
+            return {};
+        }
+
+        const parentDir = parentDirMatch[1];
+        const packagePrefix = parentDir === 'univer'
+            ? '@univerjs/' :
+            parentDir === 'univer-pro'
+                ? '@univerjs-pro/' :
+                null;
+
+        if (!packagePrefix) {
+            return {};
+        }
+
+        return {
+            ImportDeclaration(node) {
+                const importPath = node.source.value;
+
+                // Check if the import path contains 'facade'
+                if (importPath.includes('facade')) {
+                    context.report({
+                        node,
+                        messageId: 'noFacadeImports',
+                        data: { importPath },
+                    });
+                }
+            },
+            ExportNamedDeclaration(node) {
+                if (node.source) {
+                    const exportPath = node.source.value;
+                    if (exportPath.includes('facade')) {
+                        context.report({
+                            node,
+                            messageId: 'noFacadeImports',
+                            data: { importPath: exportPath },
+                        });
+                    }
+                }
+            },
+            ExportAllDeclaration(node) {
+                const exportPath = node.source.value;
+                if (exportPath.includes('facade')) {
+                    context.report({
+                        node,
+                        messageId: 'noFacadeImports',
+                        data: { importPath: exportPath },
+                    });
+                }
+            },
+        };
+    },
+};
+
+module.exports = rule;

--- a/examples-node/src/cases/basic.ts
+++ b/examples-node/src/cases/basic.ts
@@ -15,7 +15,8 @@
  */
 
 import process from 'node:process';
-import { awaitTime, FUniver } from '@univerjs/core';
+import { awaitTime } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { createUniverOnNode } from '../sdk';
 
 // From now on, Univer is a full-stack SDK.

--- a/examples/src/docs/main.ts
+++ b/examples/src/docs/main.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Univer, LocaleType, LogLevel, UniverInstanceType, UserManagerService } from '@univerjs/core';
+import { LocaleType, LogLevel, Univer, UniverInstanceType, UserManagerService } from '@univerjs/core';
 import { FUniver } from '@univerjs/core/facade';
 import { UniverDebuggerPlugin } from '@univerjs/debugger';
 import { defaultTheme } from '@univerjs/design';

--- a/examples/src/docs/main.ts
+++ b/examples/src/docs/main.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { FUniver, LocaleType, LogLevel, Univer, UniverInstanceType, UserManagerService } from '@univerjs/core';
+import { Univer, LocaleType, LogLevel, UniverInstanceType, UserManagerService } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { UniverDebuggerPlugin } from '@univerjs/debugger';
 import { defaultTheme } from '@univerjs/design';
 import { UniverDocsPlugin } from '@univerjs/docs';

--- a/examples/src/mobile-s/main.ts
+++ b/examples/src/mobile-s/main.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { FUniver } from '@univerjs/core';
+import type { FUniver } from '@univerjs/core/facade';
 import { LocaleType, LogLevel, Univer, UniverInstanceType, UserManagerService } from '@univerjs/core';
 import { defaultTheme } from '@univerjs/design';
 import { UniverDocsPlugin } from '@univerjs/docs';

--- a/examples/src/sheets/main.ts
+++ b/examples/src/sheets/main.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { FUniver, ILogService, LocaleType, LogLevel, Univer, UniverInstanceType, UserManagerService } from '@univerjs/core';
+import { ILogService, LocaleType, LogLevel, Univer, UniverInstanceType, UserManagerService } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { UniverDebuggerPlugin } from '@univerjs/debugger';
 import { defaultTheme } from '@univerjs/design';
 import { UniverDocsPlugin } from '@univerjs/docs';

--- a/examples/src/uni/main.ts
+++ b/examples/src/uni/main.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { FUniver, Injector, LocaleType, LogLevel, Univer, UniverInstanceType } from '@univerjs/core';
+import { Injector, LocaleType, LogLevel, Univer, UniverInstanceType } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { UniverDebuggerPlugin } from '@univerjs/debugger';
 import { defaultTheme } from '@univerjs/design';
 import { UniverDocsPlugin } from '@univerjs/docs';

--- a/packages-experimental/debugger/src/commands/commands/unit.command.ts
+++ b/packages-experimental/debugger/src/commands/commands/unit.command.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import type { FUniver, ICommand, IWorkbookData, Univer, Workbook } from '@univerjs/core';
+import type { ICommand, IWorkbookData, Univer, Workbook } from '@univerjs/core';
+import type { FUniver } from '@univerjs/core/facade';
 import { CommandType, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
 import { ILocalFileService } from '@univerjs/ui';
 

--- a/packages-experimental/sheets-source-binding/src/facade/f-enum.ts
+++ b/packages-experimental/sheets-source-binding/src/facade/f-enum.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FEnum } from '@univerjs/core';
+import { FEnum } from '@univerjs/core/facade';
 import { BindModeEnum, DataBindingNodeTypeEnum } from '@univerjs/sheets-source-binding';
 
 /**
@@ -42,7 +42,7 @@ class FSourceBindingEnum extends FEnum implements ISourceBindingEnumMixin {
 
 FEnum.extend(FSourceBindingEnum);
 
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEnum extends ISourceBindingEnumMixin { }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,8 @@
     ],
     "exports": {
         ".": "./src/index.ts",
-        "./*": "./src/*"
+        "./*": "./src/*",
+        "./facade": "./src/facade/index.ts"
     },
     "main": "./src/index.ts",
     "types": "./lib/types/index.d.ts",
@@ -40,6 +41,11 @@
                 "import": "./lib/es/*",
                 "require": "./lib/cjs/*",
                 "types": "./lib/types/index.d.ts"
+            },
+            "./facade": {
+                "import": "./lib/es/facade.js",
+                "require": "./lib/cjs/facade.js",
+                "types": "./lib/types/facade/index.d.ts"
             },
             "./lib/*": "./lib/*"
         }

--- a/packages/core/src/facade/f-base.ts
+++ b/packages/core/src/facade/f-base.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Injector } from '@wendellhu/redi';
+import type { Injector } from '@univerjs/core';
 import { Disposable } from '@univerjs/core';
 
 /**

--- a/packages/core/src/facade/f-base.ts
+++ b/packages/core/src/facade/f-base.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Injector } from '@wendellhu/redi';
-import { Disposable } from '../shared';
+import { Disposable } from '@univerjs/core';
 
 /**
  * `FBase` is a base class for all facade classes.
@@ -80,7 +80,7 @@ export class FBaseInitialable extends Disposable {
     /**
      * @ignore
      */
-    _initialize(injector: Injector) { }
+    _initialize(injector: Injector): void { }
 
     /**
      * @ignore

--- a/packages/core/src/facade/f-blob.ts
+++ b/packages/core/src/facade/f-blob.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Nullable } from '../shared';
+import type { Nullable } from '@univerjs/core';
 import { Inject, Injector } from '@wendellhu/redi';
 import { FBase } from './f-base';
 
@@ -52,7 +52,7 @@ export class FBlob extends FBase {
      * console.log(newBlob);
      * ```
      */
-    copyBlob() {
+    copyBlob(): FBlob {
         return this._injector.createInstance(FBlob, this._blob);
     }
 
@@ -66,7 +66,7 @@ export class FBlob extends FBase {
      * const newBlob = blob.getBlob();
      * ```
      */
-    getAs(contentType: string) {
+    getAs(contentType: string): FBlob {
         const newBlob = this.copyBlob();
         newBlob.setContentType(contentType);
         return newBlob;
@@ -186,7 +186,7 @@ export class FBlob extends FBase {
      * console.log(newBlob);
      * ```
      */
-    getContentType() {
+    getContentType(): string | undefined {
         return this._blob?.type;
     }
 

--- a/packages/core/src/facade/f-blob.ts
+++ b/packages/core/src/facade/f-blob.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Nullable } from '@univerjs/core';
-import { Inject, Injector } from '@wendellhu/redi';
+import { Inject, Injector } from '@univerjs/core';
 import { FBase } from './f-base';
 
 export interface IFBlobSource {

--- a/packages/core/src/facade/f-doc.ts
+++ b/packages/core/src/facade/f-doc.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel } from '../docs';
-import { Inject, Injector } from '../common/di';
+import type { DocumentDataModel } from '@univerjs/core';
+import { Inject, Injector } from '@univerjs/core';
 import { FBaseInitialable } from './f-base';
 
 /**

--- a/packages/core/src/facade/f-enum.ts
+++ b/packages/core/src/facade/f-enum.ts
@@ -14,30 +14,9 @@
  * limitations under the License.
  */
 
-import { UniverInstanceType } from '../common/unit';
-import { CommandType } from '../services/command/command.service';
-import { LifecycleStages } from '../services/lifecycle/lifecycle';
-import { BaselineOffset, BooleanNumber, BorderStyleTypes, BorderType, HorizontalAlign, TextDecoration, TextDirection, VerticalAlign } from '../types/enum';
-import { AutoFillSeries } from '../types/enum/auto-fill-series';
-import { ColorType } from '../types/enum/color-type';
-import { CommonHideTypes } from '../types/enum/common-hide-types';
-import { CopyPasteType } from '../types/enum/copy-paste-type';
-import { DataValidationErrorStyle } from '../types/enum/data-validation-error-style';
-import { DataValidationOperator } from '../types/enum/data-validation-operator';
-import { DataValidationRenderMode } from '../types/enum/data-validation-render-mode';
-import { DataValidationStatus } from '../types/enum/data-validation-status';
-import { DataValidationType } from '../types/enum/data-validation-type';
-import { DeleteDirection } from '../types/enum/delete-direction';
-import { DeveloperMetadataVisibility } from '../types/enum/developer-metadata-visibility';
-import { Dimension } from '../types/enum/dimension';
-import { Direction } from '../types/enum/direction';
-import { InterpolationPointType } from '../types/enum/interpolation-point-type';
-import { LocaleType } from '../types/enum/locale-type';
-import { MentionType } from '../types/enum/mention-type';
-import { ProtectionType } from '../types/enum/protection-type';
-import { RelativeDate } from '../types/enum/relative-date';
-import { SheetTypes } from '../types/enum/sheet-types';
-import { ThemeColorType } from '../types/enum/theme-color-type';
+/* eslint-disable ts/explicit-function-return-type */
+
+import { AutoFillSeries, BaselineOffset, BooleanNumber, BorderStyleTypes, BorderType, ColorType, CommandType, CommonHideTypes, CopyPasteType, DataValidationErrorStyle, DataValidationOperator, DataValidationRenderMode, DataValidationStatus, DataValidationType, DeleteDirection, DeveloperMetadataVisibility, Dimension, Direction, HorizontalAlign, InterpolationPointType, LifecycleStages, LocaleType, MentionType, ProtectionType, RelativeDate, SheetTypes, TextDecoration, TextDirection, ThemeColorType, UniverInstanceType, VerticalAlign } from '@univerjs/core';
 
 /**
  * @hideconstructor

--- a/packages/core/src/facade/f-event-registry.ts
+++ b/packages/core/src/facade/f-event-registry.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
+import type { IDisposable } from '@univerjs/core';
 import type { Subscription } from 'rxjs';
-import type { IDisposable } from '../common/di';
 import type { IEventParamConfig } from './f-event';
-import { Registry } from '../common/registry';
-import { toDisposable } from '../shared';
+import { Registry, toDisposable } from '@univerjs/core';
 
 export class FEventRegistry {
     protected _eventRegistry: Map<string, Registry<(param: any) => void>> = new Map();
     protected _eventHandlerMap = new Map<string, Set<() => IDisposable | Subscription>>();
     protected _eventHandlerRegisted = new Map<string, Map<() => IDisposable | Subscription, IDisposable>>();
 
-    protected _ensureEventRegistry(event: string) {
+    protected _ensureEventRegistry(event: string): Registry<(param: any) => void> {
         if (!this._eventRegistry.has(event)) {
             this._eventRegistry.set(event, new Registry());
         }
@@ -33,7 +32,7 @@ export class FEventRegistry {
         return this._eventRegistry.get(event)!;
     }
 
-    registerEventHandler(event: string, handler: () => IDisposable | Subscription) {
+    registerEventHandler(event: string, handler: () => IDisposable | Subscription): IDisposable {
         const current = this._eventHandlerMap.get(event);
         if (current) {
             current.add(handler);
@@ -48,7 +47,7 @@ export class FEventRegistry {
         });
     }
 
-    removeEvent<T extends keyof IEventParamConfig>(event: T, callback: (params: IEventParamConfig[T]) => void) {
+    removeEvent<T extends keyof IEventParamConfig>(event: T, callback: (params: IEventParamConfig[T]) => void): void {
         const map = this._ensureEventRegistry(event);
         map.delete(callback);
 
@@ -71,7 +70,7 @@ export class FEventRegistry {
      * });
      * ```
      */
-    addEvent<T extends keyof IEventParamConfig>(event: T, callback: (params: IEventParamConfig[T]) => void) {
+    addEvent<T extends keyof IEventParamConfig>(event: T, callback: (params: IEventParamConfig[T]) => void): IDisposable {
         this._ensureEventRegistry(event).add(callback);
         let current = this._eventHandlerRegisted.get(event);
         const handlers = this._eventHandlerMap.get(event);
@@ -96,7 +95,7 @@ export class FEventRegistry {
      * this.fireEvent(univerAPI.event.UnitCreated, params);
      * ```
      */
-    fireEvent<T extends keyof IEventParamConfig>(event: T, params: IEventParamConfig[T]) {
+    fireEvent<T extends keyof IEventParamConfig>(event: T, params: IEventParamConfig[T]): boolean | undefined {
         this._eventRegistry.get(event)?.getData().forEach((callback) => {
             callback(params);
         });

--- a/packages/core/src/facade/f-event.ts
+++ b/packages/core/src/facade/f-event.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import type { UniverInstanceType } from '../common/unit';
-import type { CommandType } from '../services/command/command.service';
-import type { LifecycleStages } from '../services/lifecycle/lifecycle';
-import type { IDocumentData } from '../types/interfaces';
+/* eslint-disable ts/explicit-function-return-type */
+
+import type { CommandType, IDocumentData, LifecycleStages, UniverInstanceType } from '@univerjs/core';
 import type { FDoc } from './f-doc';
 
 /**

--- a/packages/core/src/facade/f-hooks.ts
+++ b/packages/core/src/facade/f-hooks.ts
@@ -14,15 +14,9 @@
  * limitations under the License.
  */
 
-import type { IDisposable } from '../common/di';
-import type { IUndoRedoItem } from '../services/undoredo/undoredo.service';
+import type { IDisposable, IUndoRedoItem } from '@univerjs/core';
+import { ICommandService, Inject, Injector, IUndoRedoService, LifecycleService, LifecycleStages, RedoCommand, toDisposable, UndoCommand } from '@univerjs/core';
 import { filter } from 'rxjs';
-import { Inject, Injector } from '../common/di';
-import { ICommandService } from '../services/command/command.service';
-import { LifecycleStages } from '../services/lifecycle/lifecycle';
-import { LifecycleService } from '../services/lifecycle/lifecycle.service';
-import { IUndoRedoService, RedoCommand, UndoCommand } from '../services/undoredo/undoredo.service';
-import { toDisposable } from '../shared/lifecycle';
 import { FBase } from './f-base';
 
 /**
@@ -37,6 +31,7 @@ export class FHooks extends FBase {
     }
 
     /**
+     * @param callback
      * @deprecated use `univerAPI.addEvent(univerAPI.Event.LifecycleChanged)` as instead
      */
     onStarting(callback: () => void): IDisposable {
@@ -44,6 +39,7 @@ export class FHooks extends FBase {
     }
 
     /**
+     * @param callback
      * @deprecated use `univerAPI.addEvent(univerAPI.Event.LifecycleChanged)` as instead
      */
     onReady(callback: () => void): IDisposable {
@@ -51,6 +47,7 @@ export class FHooks extends FBase {
     }
 
     /**
+     * @param callback
      * @deprecated use `univerAPI.addEvent(univerAPI.Event.LifecycleChanged, () => {})` as instead
      */
     onRendered(callback: () => void): IDisposable {
@@ -58,6 +55,7 @@ export class FHooks extends FBase {
     }
 
     /**
+     * @param callback
      * @deprecated use `univerAPI.addEvent(univerAPI.Event.LifecycleChanged, () => {})` as instead
      */
     onSteady(callback: () => void): IDisposable {
@@ -65,6 +63,7 @@ export class FHooks extends FBase {
     }
 
     /**
+     * @param callback
      * @deprecated use `univerAPI.addEvent(univerAPI.Event.BeforeUndo, () => {})` as instead
      */
     onBeforeUndo(callback: (action: IUndoRedoItem) => void): IDisposable {
@@ -82,6 +81,7 @@ export class FHooks extends FBase {
     }
 
     /**
+     * @param callback
      * @deprecated use `univerAPI.addEvent(univerAPI.Event.Undo, () => {})` as instead
      */
     onUndo(callback: (action: IUndoRedoItem) => void): IDisposable {
@@ -99,6 +99,7 @@ export class FHooks extends FBase {
     }
 
     /**
+     * @param callback
      * @deprecated use `univerAPI.addEvent(univerAPI.Event.BeforeRedo, () => {})` as instead
      */
     onBeforeRedo(callback: (action: IUndoRedoItem) => void): IDisposable {
@@ -116,6 +117,7 @@ export class FHooks extends FBase {
     }
 
     /**
+     * @param callback
      * @deprecated use `univerAPI.addEvent(univerAPI.Event.Redo, () => {})` as instead
      */
     onRedo(callback: (action: IUndoRedoItem) => void): IDisposable {

--- a/packages/core/src/facade/f-univer.ts
+++ b/packages/core/src/facade/f-univer.ts
@@ -14,23 +14,10 @@
  * limitations under the License.
  */
 
+import type { CommandListener, DocumentDataModel, IDisposable, IDocumentData, IExecutionOptions, IParagraphStyle, ITextDecoration, ITextStyle, LifecycleStages } from '@univerjs/core';
 import type { Subscription } from 'rxjs';
-import type { IDisposable } from '../common/di';
-import type { DocumentDataModel } from '../docs';
-import type { CommandListener, IExecutionOptions } from '../services/command/command.service';
-import type { LifecycleStages } from '../services/lifecycle/lifecycle';
-import type { IDocumentData, IParagraphStyle, ITextDecoration, ITextStyle } from '../types/interfaces';
 import type { ICommandEvent, IEventParamConfig } from './f-event';
-import { Inject, Injector } from '../common/di';
-import { CanceledError } from '../common/error';
-import { UniverInstanceType } from '../common/unit';
-import { ParagraphStyleBuilder, ParagraphStyleValue, RichTextBuilder, RichTextValue, TextDecorationBuilder, TextStyleBuilder, TextStyleValue } from '../docs/data-model/rich-text-builder';
-import { ICommandService } from '../services/command/command.service';
-import { IUniverInstanceService } from '../services/instance/instance.service';
-import { LifecycleService } from '../services/lifecycle/lifecycle.service';
-import { RedoCommand, UndoCommand } from '../services/undoredo/undoredo.service';
-import { ColorBuilder, Disposable, toDisposable } from '../shared';
-import { Univer } from '../univer';
+import { CanceledError, ColorBuilder, Disposable, ICommandService, Inject, Injector, IUniverInstanceService, LifecycleService, ParagraphStyleBuilder, ParagraphStyleValue, RedoCommand, RichTextBuilder, RichTextValue, TextDecorationBuilder, TextStyleBuilder, TextStyleValue, toDisposable, UndoCommand, Univer, UniverInstanceType } from '@univerjs/core';
 import { FBlob } from './f-blob';
 import { FDoc } from './f-doc';
 import { FEnum } from './f-enum';
@@ -73,7 +60,7 @@ export class FUniver extends Disposable {
     /**
      * @ignore
      */
-    _initialize(injector: Injector) { }
+    _initialize(injector: Injector): void { }
 
     /**
      * @ignore
@@ -104,7 +91,7 @@ export class FUniver extends Disposable {
 
     protected _eventRegistry = new FEventRegistry();
 
-    protected registerEventHandler = (event: string, handler: () => IDisposable | Subscription) => {
+    protected registerEventHandler = (event: string, handler: () => IDisposable | Subscription): IDisposable => {
         return this._eventRegistry.registerEventHandler(event, handler);
     };
 
@@ -367,15 +354,15 @@ export class FUniver extends Disposable {
         return this._injector.createInstance(FHooks);
     }
 
-    get Enum() {
+    get Enum(): FEnum {
         return FEnum.get();
     }
 
-    get Event() {
+    get Event(): FEventName {
         return FEventName.get();
     }
 
-    get Util() {
+    get Util(): FUtil {
         return FUtil.get();
     }
 
@@ -391,7 +378,7 @@ export class FUniver extends Disposable {
      * });
      * ```
      */
-    addEvent<T extends keyof IEventParamConfig>(event: T, callback: (params: IEventParamConfig[T]) => void) {
+    addEvent<T extends keyof IEventParamConfig>(event: T, callback: (params: IEventParamConfig[T]) => void): IDisposable {
         return this._eventRegistry.addEvent(event, callback);
     }
 
@@ -405,7 +392,7 @@ export class FUniver extends Disposable {
      * this.fireEvent(univerAPI.event.UnitCreated, params);
      * ```
      */
-    protected fireEvent<T extends keyof IEventParamConfig>(event: T, params: IEventParamConfig[T]) {
+    protected fireEvent<T extends keyof IEventParamConfig>(event: T, params: IEventParamConfig[T]): boolean | undefined {
         return this._eventRegistry.fireEvent(event, params);
     }
 

--- a/packages/core/src/facade/f-usermanager.ts
+++ b/packages/core/src/facade/f-usermanager.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import type { IUser } from '../services/user-manager/user-manager.service';
-import { Inject, Injector } from '../common/di';
-import { UserManagerService } from '../services/user-manager/user-manager.service';
+import type { IUser } from '@univerjs/core';
+import { Inject, Injector, UserManagerService } from '@univerjs/core';
 import { FBase } from './f-base';
 
 /**

--- a/packages/core/src/facade/f-util.ts
+++ b/packages/core/src/facade/f-util.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { numfmt, Rectangle, Tools } from '../shared';
+import type { INumfmt } from '@univerjs/core';
+import { numfmt, Rectangle, Tools } from '@univerjs/core';
 
 /**
  * @ignore
@@ -25,7 +26,7 @@ export class FUtil {
      */
     static _instance: FUtil | null;
 
-    static get() {
+    static get(): FUtil {
         if (this._instance) {
             return this._instance;
         }
@@ -57,21 +58,21 @@ export class FUtil {
     /**
      * Rectangle utils, including range operations likes merge, subtract, split
      */
-    get rectangle() {
+    get rectangle(): typeof Rectangle {
         return Rectangle;
     }
 
     /**
      * Number format utils, including parse and strigify about date, price, etc
      */
-    get numfmt() {
+    get numfmt(): INumfmt {
         return numfmt;
     }
 
     /**
      * common tools
      */
-    get tools() {
+    get tools(): typeof Tools {
         return Tools;
     }
 }

--- a/packages/core/src/facade/index.ts
+++ b/packages/core/src/facade/index.ts
@@ -14,24 +14,10 @@
  * limitations under the License.
  */
 
-import { FUniver } from '@univerjs/core/facade';
-import { FFormula } from './f-formula';
-
-/**
- * @ignore
- */
-export interface IFUniverEngineFormulaMixin {
-    getFormula(): FFormula;
-}
-
-export class FUniverEngineFormulaMixin extends FUniver implements IFUniverEngineFormulaMixin {
-    override getFormula(): FFormula {
-        return this._injector.createInstance(FFormula);
-    }
-}
-
-FUniver.extend(FUniverEngineFormulaMixin);
-declare module '@univerjs/core/facade' {
-    // eslint-disable-next-line ts/naming-convention
-    interface FUniver extends IFUniverEngineFormulaMixin {}
-}
+export { FBase, FBaseInitialable } from './f-base';
+export { FBlob, type IFBlobSource } from './f-blob';
+export { FEnum } from './f-enum';
+export { FEventName, type IEventBase, type IEventParamConfig } from './f-event';
+export { FHooks } from './f-hooks';
+export { FUniver } from './f-univer';
+export { FUtil } from './f-util';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ import { installShims } from './common/shims';
 
 installShims();
 
+export type { INumfmt } from './shared/types/numfmt.type';
 export { debounce, get, merge, mergeWith, set } from 'lodash-es';
 export { textDiff } from './shared/text-diff';
 export { dedupe, groupBy, makeArray, remove, rotate } from './common/array';
@@ -33,13 +34,6 @@ export { AsyncInterceptorManager, composeInterceptors, createAsyncInterceptorKey
 export type { Serializable } from './common/json';
 export { MemoryCursor } from './common/memory-cursor';
 export { mixinClass } from './common/mixin';
-export { FBase, FBaseInitialable } from './facade/f-base';
-export { FUniver } from './facade/f-univer';
-export { FHooks } from './facade/f-hooks';
-export { FBlob, type IFBlobSource } from './facade/f-blob';
-export { FEventName, type IEventBase, type IEventParamConfig } from './facade/f-event';
-export { FEnum } from './facade/f-enum';
-export { FUtil } from './facade/f-util';
 export { isNumeric, isSafeNumeric } from './common/number';
 export { Registry, RegistryAsMap } from './common/registry';
 export { requestImmediateMacroTask } from './common/request-immediate-macro-task';

--- a/packages/docs-ui/src/facade/f-univer.ts
+++ b/packages/docs-ui/src/facade/f-univer.ts
@@ -15,7 +15,8 @@
  */
 
 import type { DocumentDataModel, IDocumentData } from '@univerjs/core';
-import { FUniver, UniverInstanceType } from '@univerjs/core';
+import { UniverInstanceType } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { FDocument } from './f-document';
 
 /**
@@ -70,7 +71,7 @@ export class FUniverDocsMixin extends FUniver implements IFUniverDocsUIMixin {
 }
 
 FUniver.extend(FUniverDocsMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverDocsUIMixin {}
 }

--- a/packages/engine-formula/src/facade/f-formula.ts
+++ b/packages/engine-formula/src/facade/f-formula.ts
@@ -16,7 +16,8 @@
 
 import type { ICommandInfo, IDisposable } from '@univerjs/core';
 import type { FormulaExecutedStateType, IExecutionInProgressParams, ISequenceNode, ISetFormulaCalculationNotificationMutation, ISetFormulaCalculationStartMutation } from '@univerjs/engine-formula';
-import { FBase, ICommandService, IConfigService, Inject, Injector } from '@univerjs/core';
+import { ICommandService, IConfigService, Inject, Injector } from '@univerjs/core';
+import { FBase } from '@univerjs/core/facade';
 import { ENGINE_FORMULA_CYCLE_REFERENCE_COUNT, GlobalComputingStatusService, LexerTreeBuilder, SetFormulaCalculationNotificationMutation, SetFormulaCalculationStartMutation, SetFormulaCalculationStopMutation } from '@univerjs/engine-formula';
 import { filter, firstValueFrom, map, race, timer } from 'rxjs';
 

--- a/packages/facade/src/apis/__tests__/facade.spec.ts
+++ b/packages/facade/src/apis/__tests__/facade.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import type { ICellData, Injector, Nullable } from '@univerjs/core';
+import type { FUniver } from '@univerjs/core/facade';
 import type { LambdaValueObjectObject, PrimitiveValueType } from '@univerjs/engine-formula';
 import type {
     ColumnHeaderLayout,
@@ -24,7 +25,6 @@ import type {
     SpreadsheetColumnHeader,
     SpreadsheetRowHeader,
 } from '@univerjs/engine-render';
-import type { FUniver } from '../everything';
 
 import { ICommandService, IUniverInstanceService } from '@univerjs/core';
 import { RegisterFunctionMutation, SetFormulaCalculationStartMutation } from '@univerjs/engine-formula';

--- a/packages/facade/src/apis/everything.ts
+++ b/packages/facade/src/apis/everything.ts
@@ -29,7 +29,7 @@ import '@univerjs/sheets-hyper-link-ui/facade';
 import '@univerjs/sheets-thread-comment/facade';
 import '@univerjs/sheets-conditional-formatting/facade';
 
-export { FHooks, FUniver } from '@univerjs/core';
+export { FHooks, FUniver } from '@univerjs/core/facade';
 
 export { FFormula } from '@univerjs/engine-formula/facade';
 export { FConditionalFormattingBuilder } from '@univerjs/sheets-conditional-formatting/facade';

--- a/packages/facade/src/apis/facade.ts
+++ b/packages/facade/src/apis/facade.ts
@@ -20,10 +20,10 @@ import type {
 } from '@univerjs/core';
 import type { ISocket } from '@univerjs/network';
 import {
-    FUniver,
     Quantity,
     Univer,
 } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { ISocketService, WebSocketService } from '@univerjs/network';
 
 interface IFUniverLegacy {
@@ -85,7 +85,7 @@ class FUniverLegacy extends FUniver implements IFUniverLegacy {
 }
 
 FUniver.extend(FUniverLegacy);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverLegacy {}
 }

--- a/packages/facade/src/apis/sheets/__tests__/f-conditional-formatting.spec.ts
+++ b/packages/facade/src/apis/sheets/__tests__/f-conditional-formatting.spec.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import type { FUniver, Injector, Univer } from '@univerjs/core';
+import type { Injector, Univer } from '@univerjs/core';
+import type { FUniver } from '@univerjs/core/facade';
 import { ICommandService } from '@univerjs/core/services/command/command.service.js';
 import { RemoveOtherFormulaMutation } from '@univerjs/engine-formula';
 import { SetSelectionsOperation } from '@univerjs/sheets';

--- a/packages/facade/src/apis/sheets/__tests__/f-formula.spec.ts
+++ b/packages/facade/src/apis/sheets/__tests__/f-formula.spec.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import type { FUniver, ICellData, Injector, IStyleData, Nullable } from '@univerjs/core';
+import type { ICellData, Injector, IStyleData, Nullable } from '@univerjs/core';
+import type { FUniver } from '@univerjs/core/facade';
 import type { IUniverSheetsFormulaBaseConfig } from '@univerjs/sheets-formula';
 import { ICommandService, IConfigService, IUniverInstanceService } from '@univerjs/core';
 

--- a/packages/facade/src/apis/sheets/__tests__/f-worksheet.spec.ts
+++ b/packages/facade/src/apis/sheets/__tests__/f-worksheet.spec.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import type { FUniver, Injector, Workbook } from '@univerjs/core';
+import type { Injector, Workbook } from '@univerjs/core';
+import type { FUniver } from '@univerjs/core/facade';
 import { ICommandService, IUniverInstanceService, RANGE_TYPE, UniverInstanceType } from '@univerjs/core';
 import { AddWorksheetMergeCommand, AddWorksheetMergeMutation, CancelFrozenCommand, InsertColByRangeCommand, InsertColCommand, InsertColMutation, InsertRowByRangeCommand, InsertRowCommand, InsertRowMutation, MoveColsCommand, MoveColsMutation, MoveRowsCommand, MoveRowsMutation, RemoveColByRangeCommand, RemoveColCommand, RemoveColMutation, RemoveRowByRangeCommand, RemoveRowCommand, RemoveRowMutation, RemoveWorksheetMergeCommand, RemoveWorksheetMergeMutation, SetColDataCommand, SetColDataMutation, SetColHiddenCommand, SetColHiddenMutation, SetColVisibleMutation, SetColWidthCommand, SetFrozenCommand, SetFrozenMutation, SetHorizontalTextAlignCommand, SetRangeValuesCommand, SetRangeValuesMutation, SetRowDataCommand, SetRowDataMutation, SetRowHeightCommand, SetRowHiddenCommand, SetRowHiddenMutation, SetRowVisibleMutation, SetSelectionsOperation, SetSpecificColsVisibleCommand, SetSpecificRowsVisibleCommand, SetStyleCommand, SetTextWrapCommand, SetVerticalTextAlignCommand, SetWorksheetColWidthMutation, SetWorksheetRowHeightMutation, SetWorksheetRowIsAutoHeightCommand, SetWorksheetRowIsAutoHeightMutation, SheetsSelectionsService } from '@univerjs/sheets';
 

--- a/packages/network/src/facade/f-network.ts
+++ b/packages/network/src/facade/f-network.ts
@@ -16,7 +16,8 @@
 
 import type { HTTPEvent, HTTPRequestMethod, HTTPResponse, IPostRequestParams, IRequestParams } from '@univerjs/network';
 import type { Observable } from 'rxjs';
-import { FBase, Inject, Injector } from '@univerjs/core';
+import { Inject, Injector } from '@univerjs/core';
+import { FBase } from '@univerjs/core/facade';
 import { HTTPService } from '@univerjs/network';
 
 /**

--- a/packages/network/src/facade/f-univer.ts
+++ b/packages/network/src/facade/f-univer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FUniver } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { FNetwork } from './f-network';
 
 /**
@@ -34,7 +34,7 @@ export class FUniverNetworkMixin extends FUniver implements IFUniverNetworkMixin
 }
 
 FUniver.extend(FUniverNetworkMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverNetworkMixin { }
 }

--- a/packages/sheets-crosshair-highlight/src/facade/f-univer.ts
+++ b/packages/sheets-crosshair-highlight/src/facade/f-univer.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import type { IEventBase, Injector } from '@univerjs/core';
+import type { Injector } from '@univerjs/core';
+import type { IEventBase } from '@univerjs/core/facade';
 import type { ISetCrosshairHighlightColorOperationParams } from '@univerjs/sheets-crosshair-highlight';
 import type { FWorkbook, FWorksheet } from '@univerjs/sheets/facade';
-import { FUniver, ICommandService } from '@univerjs/core';
+import { ICommandService } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { CROSSHAIR_HIGHLIGHT_COLORS, DisableCrosshairHighlightOperation, EnableCrosshairHighlightOperation, SetCrosshairHighlightColorOperation, SheetsCrosshairHighlightService } from '@univerjs/sheets-crosshair-highlight';
 
 /**
@@ -225,7 +227,7 @@ export class FUniverCrosshairHighlightMixin extends FUniver implements IFUniverC
 }
 
 FUniver.extend(FUniverCrosshairHighlightMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverCrosshairHighlightMixin {}
 

--- a/packages/sheets-data-validation/src/facade/f-event.ts
+++ b/packages/sheets-data-validation/src/facade/f-event.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import type { DataValidationStatus, IDataValidationRule, IDataValidationRuleBase, IDataValidationRuleOptions, IEventBase, IRange, ISheetDataValidationRule } from '@univerjs/core';
+import type { DataValidationStatus, IDataValidationRule, IDataValidationRuleBase, IDataValidationRuleOptions, IRange, ISheetDataValidationRule } from '@univerjs/core';
+import type { IEventBase } from '@univerjs/core/facade';
 import type { DataValidationChangeType, IRuleChange } from '@univerjs/data-validation';
 import type { FWorkbook, FWorksheet } from '@univerjs/sheets/facade';
 import type { FDataValidation } from './f-data-validation';
-import { FEventName } from '@univerjs/core';
+import { FEventName } from '@univerjs/core/facade';
 
 /**
  * Event interface triggered when a data validation rule is changed
@@ -326,7 +327,7 @@ export interface IDataValidationEventConfig {
 }
 
 FEventName.extend(FDataValidationEvent);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEventName extends IDataValidationEvent {
     }

--- a/packages/sheets-data-validation/src/facade/f-univer.ts
+++ b/packages/sheets-data-validation/src/facade/f-univer.ts
@@ -31,7 +31,8 @@ import type { IBeforeSheetDataValidationAddEvent,
     IBeforeSheetDataValidationRangeUpdateEvent,
 
 } from './f-event';
-import { CanceledError, FUniver, ICommandService } from '@univerjs/core';
+import { CanceledError, ICommandService } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import {
     AddSheetDataValidationCommand,
     RemoveSheetAllDataValidationCommand,
@@ -294,7 +295,7 @@ export class FUnvierDataValidationMixin extends FUniver implements IFUnvierDataV
 }
 
 FUniver.extend(FUnvierDataValidationMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     /**
      * @ignore
      */

--- a/packages/sheets-drawing-ui/src/facade/f-enum.ts
+++ b/packages/sheets-drawing-ui/src/facade/f-enum.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { DrawingTypeEnum, FEnum, ImageSourceType } from '@univerjs/core';
+import { DrawingTypeEnum, ImageSourceType } from '@univerjs/core';
+import { FEnum } from '@univerjs/core/facade';
 import { SheetDrawingAnchorType } from '@univerjs/sheets-drawing';
 
 /**
@@ -40,7 +41,7 @@ export class FDrawingEnumMixin extends FEnum implements IFDrawingEnumMixin {
 }
 
 FEnum.extend(FDrawingEnumMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEnum extends IFDrawingEnumMixin { }
 }

--- a/packages/sheets-drawing-ui/src/facade/f-event.ts
+++ b/packages/sheets-drawing-ui/src/facade/f-event.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import type { IDrawingSearch, IEventBase } from '@univerjs/core';
+import type { IDrawingSearch } from '@univerjs/core';
+import type { IEventBase } from '@univerjs/core/facade';
 import type { ISheetImage } from '@univerjs/sheets-drawing';
 import type { FWorkbook } from '@univerjs/sheets/facade';
 import type { FOverGridImage } from './f-over-grid-image';
-import { FEventName } from '@univerjs/core';
+import { FEventName } from '@univerjs/core/facade';
 
 /**
  * @ignore
@@ -305,7 +306,7 @@ interface IFSheetsUIEventParamConfig {
 }
 
 FEventName.extend(FDrawingEventNameMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEventName extends IFDrawingEventNameMixin { }
     interface IEventParamConfig extends IFSheetsUIEventParamConfig { }

--- a/packages/sheets-drawing-ui/src/facade/f-over-grid-image.ts
+++ b/packages/sheets-drawing-ui/src/facade/f-over-grid-image.ts
@@ -17,7 +17,8 @@
 import type { IRotationSkewFlipTransform, ISize } from '@univerjs/core';
 import type { ICellOverGridPosition } from '@univerjs/sheets';
 import type { ISheetImage, SheetDrawingAnchorType } from '@univerjs/sheets-drawing';
-import { ArrangeTypeEnum, DrawingTypeEnum, FBase, generateRandomId, ICommandService, ImageSourceType, Inject, Injector } from '@univerjs/core';
+import { ArrangeTypeEnum, DrawingTypeEnum, generateRandomId, ICommandService, ImageSourceType, Inject, Injector } from '@univerjs/core';
+import { FBase } from '@univerjs/core/facade';
 import { getImageSize } from '@univerjs/drawing';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { SetDrawingArrangeCommand, SetSheetDrawingCommand } from '@univerjs/sheets-drawing-ui';

--- a/packages/sheets-drawing-ui/src/facade/f-univer.ts
+++ b/packages/sheets-drawing-ui/src/facade/f-univer.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import type { IDrawingSearch, IEventBase, Injector } from '@univerjs/core';
+import type { IDrawingSearch, Injector } from '@univerjs/core';
+import type { IEventBase } from '@univerjs/core/facade';
 import type { ISheetImage } from '@univerjs/sheets-drawing';
 import type { IDeleteDrawingCommandParams, IInsertDrawingCommandParams, ISetDrawingCommandParams } from '@univerjs/sheets-drawing-ui';
 import type { FWorkbook } from '@univerjs/sheets/facade';
 import type { IBeforeOverGridImageChangeParamObject } from './f-event';
-import { FUniver, ICommandService } from '@univerjs/core';
+import { ICommandService } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { IDrawingManagerService, SetDrawingSelectedOperation } from '@univerjs/drawing';
 import { InsertSheetDrawingCommand, RemoveSheetDrawingCommand, SetSheetDrawingCommand } from '@univerjs/sheets-drawing-ui';
 import { FOverGridImage } from './f-over-grid-image';

--- a/packages/sheets-drawing-ui/src/facade/f-worksheet.ts
+++ b/packages/sheets-drawing-ui/src/facade/f-worksheet.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import type { IDisposable, IFBlobSource, Nullable } from '@univerjs/core';
+import type { IDisposable, Nullable } from '@univerjs/core';
+import type { IFBlobSource } from '@univerjs/core/facade';
 import type { ISheetImage } from '@univerjs/sheets-drawing';
 import type { ICanvasFloatDom, IDOMAnchor } from '@univerjs/sheets-drawing-ui';
 import type { IFComponentKey } from '@univerjs/sheets-ui/facade';

--- a/packages/sheets-filter/src/facade/f-enum.ts
+++ b/packages/sheets-filter/src/facade/f-enum.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FEnum } from '@univerjs/core';
+import { FEnum } from '@univerjs/core/facade';
 import { CustomFilterOperator } from '@univerjs/sheets-filter';
 
 /**
@@ -32,7 +32,7 @@ export class FSheetsFilterEnumMixin implements IFSheetsFilterEnumMixin {
 }
 
 FEnum.extend(FSheetsFilterEnumMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEnum extends IFSheetsFilterEnumMixin {
     }

--- a/packages/sheets-filter/src/facade/f-event.ts
+++ b/packages/sheets-filter/src/facade/f-event.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import type { ICommandInfo, IEventBase, Injector } from '@univerjs/core';
+import type { ICommandInfo, Injector } from '@univerjs/core';
+import type { IEventBase } from '@univerjs/core/facade';
 import type { ISetSheetsFilterCriteriaCommandParams } from '@univerjs/sheets-filter';
 import type { FWorkbook, FWorksheet } from '@univerjs/sheets/facade';
-import { FEventName, FUniver, ICommandService } from '@univerjs/core';
+import { ICommandService } from '@univerjs/core';
+import { FEventName, FUniver } from '@univerjs/core/facade';
 import { ClearSheetsFilterCriteriaCommand, SetSheetsFilterCriteriaCommand } from '@univerjs/sheets-filter';
 import { FSheetEventName } from '@univerjs/sheets/facade';
 
@@ -87,7 +89,7 @@ export class FSheetFilterEventName extends FEventName implements IFSheetFilterEv
 }
 
 FEventName.extend(FSheetFilterEventName);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEventName extends IFSheetFilterEventMixin { }
 }
@@ -125,7 +127,7 @@ interface ISheetRangeFilterEventParamConfig {
 }
 
 FEventName.extend(FSheetEventName);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEventName extends IFSheetFilterEventMixin { }
     interface IEventParamConfig extends ISheetRangeFilterEventParamConfig { }

--- a/packages/sheets-find-replace/src/facade/f-univer.ts
+++ b/packages/sheets-find-replace/src/facade/f-univer.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IFindReplaceState } from '@univerjs/find-replace';
-import { FUniver } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { FTextFinder } from './f-text-finder';
 
 /**
@@ -45,7 +45,7 @@ export class FUniverFindReplaceMixin extends FUniver implements IFUniverFindRepl
 }
 
 FUniver.extend(FUniverFindReplaceMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverFindReplaceMixin {}
 }

--- a/packages/sheets-formula/src/facade/f-univer.ts
+++ b/packages/sheets-formula/src/facade/f-univer.ts
@@ -15,9 +15,11 @@
  */
 
 import type { IDisposable } from '@univerjs/core';
-import { debounce, FUniver } from '@univerjs/core';
+import type { IRegisterFunctionParams } from '@univerjs/sheets-formula';
+import { debounce } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { SetFormulaCalculationStartMutation } from '@univerjs/engine-formula';
-import { type IRegisterFunctionParams, IRegisterFunctionService, RegisterFunctionService } from '@univerjs/sheets-formula';
+import { IRegisterFunctionService, RegisterFunctionService } from '@univerjs/sheets-formula';
 
 /**
  * @ignore
@@ -78,7 +80,7 @@ export class FUniverSheetsFormulaMixin extends FUniver implements IFUniverSheets
 }
 
 FUniver.extend(FUniverSheetsFormulaMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverSheetsFormulaMixin {}
 }

--- a/packages/sheets-hyper-link/src/facade/f-event.ts
+++ b/packages/sheets-hyper-link/src/facade/f-event.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import type { IEventBase } from '@univerjs/core/facade';
 import type { ICellLinkContent, ISheetHyperLink } from '@univerjs/sheets-hyper-link';
 import type { FWorkbook, FWorksheet } from '@univerjs/sheets/facade';
-import { FEventName, type IEventBase } from '@univerjs/core';
+import { FEventName } from '@univerjs/core/facade';
 
 /**
  * @ignore
@@ -126,7 +127,7 @@ export interface ISheetLinkEventConfig {
 
 FEventName.extend(FSheetLinkEvent);
 
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEventName extends IFSheetLinkEvent {
     }

--- a/packages/sheets-hyper-link/src/facade/f-univer.ts
+++ b/packages/sheets-hyper-link/src/facade/f-univer.ts
@@ -17,7 +17,8 @@
 import type { Injector } from '@univerjs/core';
 import type { IAddHyperLinkCommandParams, ICancelHyperLinkCommandParams, IUpdateHyperLinkCommandParams } from '@univerjs/sheets-hyper-link';
 import type { IBeforeSheetLinkAddEvent, IBeforeSheetLinkCancelEvent, IBeforeSheetLinkUpdateEvent } from './f-event';
-import { CanceledError, FUniver, ICommandService } from '@univerjs/core';
+import { CanceledError, ICommandService } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { AddHyperLinkCommand, CancelHyperLinkCommand, UpdateHyperLinkCommand } from '@univerjs/sheets-hyper-link';
 
 export class FSheetLinkUniver extends FUniver {

--- a/packages/sheets-sort/src/facade/f-event.ts
+++ b/packages/sheets-sort/src/facade/f-event.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import type { ICommandInfo, IEventBase, Injector } from '@univerjs/core';
+import type { ICommandInfo, Injector } from '@univerjs/core';
+import type { IEventBase } from '@univerjs/core/facade';
 import type { ISortRangeCommandParams } from '@univerjs/sheets-sort';
 import type { FRange, FWorkbook, FWorksheet } from '@univerjs/sheets/facade';
-import { FEventName, FUniver, ICommandService } from '@univerjs/core';
+import { ICommandService } from '@univerjs/core';
+import { FEventName, FUniver } from '@univerjs/core/facade';
 import { SortRangeCommand, SortType } from '@univerjs/sheets-sort';
 import { FSheetEventName } from '@univerjs/sheets/facade';
 
@@ -82,7 +84,7 @@ export interface ISheetRangeSortEventParamConfig {
 
 FEventName.extend(FSheetEventName);
 
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEventName extends IFSheetSortEventMixin { }
     interface IEventParamConfig extends ISheetRangeSortEventParamConfig { }

--- a/packages/sheets-thread-comment/src/facade/f-event.ts
+++ b/packages/sheets-thread-comment/src/facade/f-event.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import type { IEventBase, RichTextValue } from '@univerjs/core';
+import type { RichTextValue } from '@univerjs/core';
+import type { IEventBase } from '@univerjs/core/facade';
 import type { FWorkbook, FWorksheet } from '@univerjs/sheets/facade';
 import type { FTheadCommentItem, FThreadComment } from './f-thread-comment';
-import { FEventName } from '@univerjs/core';
+import { FEventName } from '@univerjs/core/facade';
 
 /**
  * @ignore
@@ -324,7 +325,7 @@ export interface ISheetCommentEventConfig {
     CommentResolved: ISheetCommentResolveEvent;
 }
 
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEventName extends ICommentEventMixin {
     }

--- a/packages/sheets-thread-comment/src/facade/f-univer.ts
+++ b/packages/sheets-thread-comment/src/facade/f-univer.ts
@@ -17,7 +17,8 @@
 import type { IDisposable, Injector } from '@univerjs/core';
 import type { IAddCommentCommandParams, IDeleteCommentCommandParams, IResolveCommentCommandParams, IThreadComment, IUpdateCommentCommandParams } from '@univerjs/thread-comment';
 import type { IBeforeSheetCommentAddEvent, IBeforeSheetCommentDeleteEvent, IBeforeSheetCommentUpdateEvent, ISheetCommentAddEvent, ISheetCommentDeleteEvent, ISheetCommentResolveEvent, ISheetCommentUpdateEvent } from './f-event';
-import { CanceledError, FUniver, ICommandService, RichTextValue } from '@univerjs/core';
+import { CanceledError, ICommandService, RichTextValue } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { AddCommentCommand, DeleteCommentCommand, ResolveCommentCommand, UpdateCommentCommand } from '@univerjs/thread-comment';
 import { FTheadCommentBuilder, FTheadCommentItem } from './f-thread-comment';
 
@@ -299,7 +300,7 @@ export class FUniverCommentMixin extends FUniver implements IFUniverCommentMixin
 
 FUniver.extend(FUniverCommentMixin);
 
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverCommentMixin {}
 }

--- a/packages/sheets-ui/src/facade/__tests__/create-test-bed.ts
+++ b/packages/sheets-ui/src/facade/__tests__/create-test-bed.ts
@@ -17,7 +17,6 @@
 import type { Dependency, IWorkbookData, UnitModel } from '@univerjs/core';
 import type { IRender } from '@univerjs/engine-render';
 import {
-    FUniver,
     ILogService,
     Inject,
     Injector,
@@ -28,8 +27,10 @@ import {
     ThemeService,
     Univer,
     UniverInstanceType } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { LexerTreeBuilder } from '@univerjs/engine-formula';
 import { Engine, IRenderingEngine, IRenderManagerService, RenderManagerService } from '@univerjs/engine-render';
+
 import {
     SheetInterceptorService,
 } from '@univerjs/sheets';

--- a/packages/sheets-ui/src/facade/f-event.ts
+++ b/packages/sheets-ui/src/facade/f-event.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import type { IEventBase, IRange, RichTextValue } from '@univerjs/core';
+import type { IRange, RichTextValue } from '@univerjs/core';
+import type { IEventBase } from '@univerjs/core/facade';
 import type { DeviceInputEventType, SpreadsheetSkeleton } from '@univerjs/engine-render';
 import type { CommandListenerSkeletonChange } from '@univerjs/sheets';
 import type { FRange, FWorkbook, FWorksheet } from '@univerjs/sheets/facade';
 import type { KeyCode } from '@univerjs/ui';
-import { FEventName } from '@univerjs/core';
+import { FEventName } from '@univerjs/core/facade';
 
 /**
  * Event interface triggered when cell editing starts
@@ -811,7 +812,7 @@ export interface IFSheetsUIEventParamConfig {
 }
 
 FEventName.extend(FSheetsUIEventName);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEventName extends IFSheetsUIEventNameMixin { }
     interface IEventParamConfig extends IFSheetsUIEventParamConfig { }

--- a/packages/sheets-ui/src/facade/f-univer.ts
+++ b/packages/sheets-ui/src/facade/f-univer.ts
@@ -30,7 +30,8 @@ import type { CommandListenerSkeletonChange } from '@univerjs/sheets';
 import type { IEditorBridgeServiceVisibleParam, ISetZoomRatioCommandParams, ISheetPasteByShortKeyParams, IViewportScrollState } from '@univerjs/sheets-ui';
 import type { FRange } from '@univerjs/sheets/facade';
 import type { IBeforeClipboardChangeParam, IBeforeClipboardPasteParam, IBeforeSheetEditEndEventParams, IBeforeSheetEditStartEventParams, ISheetEditChangingEventParams, ISheetEditEndedEventParams, ISheetEditStartedEventParams } from './f-event';
-import { CanceledError, DisposableCollection, DOCS_NORMAL_EDITOR_UNIT_ID_KEY, FUniver, ICommandService, ILogService, IUniverInstanceService, LifecycleService, LifecycleStages, RichTextValue, toDisposable, UniverInstanceType } from '@univerjs/core';
+import { CanceledError, DisposableCollection, DOCS_NORMAL_EDITOR_UNIT_ID_KEY, ICommandService, ILogService, IUniverInstanceService, LifecycleService, LifecycleStages, RichTextValue, toDisposable, UniverInstanceType } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { RichTextEditingMutation } from '@univerjs/docs';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { COMMAND_LISTENER_SKELETON_CHANGE, getSkeletonChangedEffectedRange, SheetsSelectionsService } from '@univerjs/sheets';
@@ -990,7 +991,7 @@ export class FUniverSheetsUIMixin extends FUniver implements IFUniverSheetsUIMix
 
 FUniver.extend(FUniverSheetsUIMixin);
 
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverSheetsUIMixin { }
 }

--- a/packages/sheets-zen-editor/src/facade/f-univer.ts
+++ b/packages/sheets-zen-editor/src/facade/f-univer.ts
@@ -18,7 +18,8 @@ import type { DocumentDataModel, Injector } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
 import type { IEditorBridgeServiceVisibleParam } from '@univerjs/sheets-ui';
 import type { IBeforeSheetEditEndEventParams, IBeforeSheetEditStartEventParams, ISheetEditChangingEventParams, ISheetEditEndedEventParams, ISheetEditStartedEventParams } from '@univerjs/sheets-ui/facade';
-import { CanceledError, DOCS_ZEN_EDITOR_UNIT_ID_KEY, FUniver, ICommandService, IUniverInstanceService, RichTextValue } from '@univerjs/core';
+import { CanceledError, DOCS_ZEN_EDITOR_UNIT_ID_KEY, ICommandService, IUniverInstanceService, RichTextValue } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { RichTextEditingMutation } from '@univerjs/docs';
 
 import { IEditorBridgeService } from '@univerjs/sheets-ui';
@@ -207,7 +208,7 @@ export class FUniverSheetsZenEditorMixin extends FUniver implements IFUniverShee
 
 FUniver.extend(FUniverSheetsZenEditorMixin);
 
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverSheetsZenEditorMixin { }
 }

--- a/packages/sheets/src/facade/f-defined-name.ts
+++ b/packages/sheets/src/facade/f-defined-name.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import type { ISetDefinedNameMutationParam } from '@univerjs/engine-formula';
 import type { FWorksheet } from './f-worksheet';
-import { FBase, generateRandomId, IAuthzIoService, ICommandService, Inject, Injector, IPermissionService, LocaleService } from '@univerjs/core';
-import { IDefinedNamesService, type ISetDefinedNameMutationParam, serializeRange } from '@univerjs/engine-formula';
+import { generateRandomId, IAuthzIoService, ICommandService, Inject, Injector, IPermissionService, LocaleService } from '@univerjs/core';
+import { FBase } from '@univerjs/core/facade';
+import { IDefinedNamesService, serializeRange } from '@univerjs/engine-formula';
 import { RangeProtectionRuleModel, RemoveDefinedNameCommand, SCOPE_WORKBOOK_VALUE_DEFINED_NAME, SetDefinedNameCommand, WorksheetProtectionPointModel, WorksheetProtectionRuleModel } from '@univerjs/sheets';
 
 /**

--- a/packages/sheets/src/facade/f-enum.ts
+++ b/packages/sheets/src/facade/f-enum.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FEnum } from '@univerjs/core';
+import { FEnum } from '@univerjs/core/facade';
 import { SheetSkeletonChangeType, SheetValueChangeType } from '@univerjs/sheets';
 
 /**
@@ -45,7 +45,7 @@ export class FSheetsEnum implements IFSheetsEnum {
 }
 
 FEnum.extend(FSheetsEnum);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     export interface FEnum extends IFSheetsEnum {
     }

--- a/packages/sheets/src/facade/f-event.ts
+++ b/packages/sheets/src/facade/f-event.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import type { IEventBase, IWorkbookData, IWorksheetData, UniverInstanceType } from '@univerjs/core';
+import type { IWorkbookData, IWorksheetData, UniverInstanceType } from '@univerjs/core';
+import type { IEventBase } from '@univerjs/core/facade';
 import type { CommandListenerValueChange } from '@univerjs/sheets';
 import type { FRange } from './f-range';
 import type { FWorkbook } from './f-workbook';
 import type { FWorksheet } from './f-worksheet';
-import { FEventName } from '@univerjs/core';
+import { FEventName } from '@univerjs/core/facade';
 
 /**
  * Interface for sheet-related events
@@ -663,7 +664,7 @@ export class FSheetEventName extends FEventName implements IFSheetEventMixin {
 }
 
 FEventName.extend(FSheetEventName);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEventName extends IFSheetEventMixin { }
     interface IEventParamConfig extends ISheetEventParamConfig { }

--- a/packages/sheets/src/facade/f-permission.ts
+++ b/packages/sheets/src/facade/f-permission.ts
@@ -18,7 +18,8 @@ import type { RangePermissionPointConstructor, WorkbookPermissionPointConstructo
 import type { ISetWorksheetPermissionPointsMutationParams } from '@univerjs/sheets';
 import type { Observable } from 'rxjs';
 import type { FRange } from './f-range';
-import { FBase, generateRandomId, IAuthzIoService, ICommandService, Inject, Injector, IPermissionService, Rectangle } from '@univerjs/core';
+import { generateRandomId, IAuthzIoService, ICommandService, Inject, Injector, IPermissionService, Rectangle } from '@univerjs/core';
+import { FBase } from '@univerjs/core/facade';
 import { AddRangeProtectionMutation, AddWorksheetProtectionMutation, DeleteRangeProtectionMutation, DeleteWorksheetProtectionMutation, getAllWorksheetPermissionPoint, getAllWorksheetPermissionPointByPointPanel, PermissionPointsDefinitions, RangeProtectionRuleModel, SetRangeProtectionMutation, SetWorksheetPermissionPointsMutation, UnitObject, WorkbookEditablePermission, WorksheetEditPermission, WorksheetProtectionPointModel, WorksheetProtectionRuleModel, WorksheetViewPermission } from '@univerjs/sheets';
 
 /**

--- a/packages/sheets/src/facade/f-range.ts
+++ b/packages/sheets/src/facade/f-range.ts
@@ -17,7 +17,8 @@
 import type { BorderStyleTypes, BorderType, CellValue, CustomData, ICellData, IColorStyle, IDocumentData, IObjectMatrixPrimitiveType, IRange, IStyleData, ITextDecoration, Nullable, Workbook, Worksheet } from '@univerjs/core';
 import type { ISetBorderBasicCommandParams, ISetHorizontalTextAlignCommandParams, ISetRangeValuesCommandParams, ISetStyleCommandParams, ISetTextWrapCommandParams, ISetVerticalTextAlignCommandParams, IStyleTypeValue, SplitDelimiterEnum } from '@univerjs/sheets';
 import type { FHorizontalAlignment, FVerticalAlignment } from './utils';
-import { BooleanNumber, Dimension, FBaseInitialable, ICommandService, Inject, Injector, Rectangle, RichTextValue, TextStyleValue, WrapStrategy } from '@univerjs/core';
+import { BooleanNumber, Dimension, ICommandService, Inject, Injector, Rectangle, RichTextValue, TextStyleValue, WrapStrategy } from '@univerjs/core';
+import { FBaseInitialable } from '@univerjs/core/facade';
 import { FormulaDataModel, serializeRange, serializeRangeWithSheet } from '@univerjs/engine-formula';
 import { addMergeCellsUtil, DeleteWorksheetRangeThemeStyleCommand, getAddMergeMutationRangeByType, RemoveWorksheetMergeCommand, SetBorderBasicCommand, SetHorizontalTextAlignCommand, SetRangeValuesCommand, SetStyleCommand, SetTextWrapCommand, SetVerticalTextAlignCommand, SetWorksheetRangeThemeStyleCommand, SheetRangeThemeService, SplitTextToColumnsCommand } from '@univerjs/sheets';
 import { FWorkbook } from './f-workbook';
@@ -1256,7 +1257,7 @@ export class FRange extends FBaseInitialable {
      * const merge = range.merge();
      * const anchor = worksheet.getRange(0,0);
      * const isPartOfMerge = anchor.isPartOfMerge();
-     * console.log('debugger, isPartOfMerge) // true
+     * console.log('debugger', isPartOfMerge); // true
      * ```
      */
     isPartOfMerge(): boolean {

--- a/packages/sheets/src/facade/f-sheet-hooks.ts
+++ b/packages/sheets/src/facade/f-sheet-hooks.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { FBase, Inject, Injector } from '@univerjs/core';
+import { Inject, Injector } from '@univerjs/core';
+import { FBase } from '@univerjs/core/facade';
 
 /**
  * @hideconstructor

--- a/packages/sheets/src/facade/f-univer.ts
+++ b/packages/sheets/src/facade/f-univer.ts
@@ -19,7 +19,8 @@ import type { CommandListenerValueChange, IInsertSheetCommandParams, IRemoveShee
 import type { IBeforeSheetCreateEventParams, ISheetCreatedEventParams } from './f-event';
 import type { FRange } from './f-range';
 import type { FWorksheet } from './f-worksheet';
-import { CanceledError, FUniver, ICommandService, IUniverInstanceService, toDisposable, UniverInstanceType } from '@univerjs/core';
+import { CanceledError, ICommandService, IUniverInstanceService, toDisposable, UniverInstanceType } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { COMMAND_LISTENER_VALUE_CHANGE, getValueChangedEffectedRange, InsertSheetCommand, RemoveSheetCommand, SetGridlinesColorCommand, SetTabColorCommand, SetWorksheetActiveOperation, SetWorksheetHideCommand, SetWorksheetNameCommand, SetWorksheetOrderCommand, ToggleGridlinesCommand } from '@univerjs/sheets';
 import { FDefinedNameBuilder } from './f-defined-name';
 import { FPermission } from './f-permission';
@@ -643,7 +644,7 @@ export class FUniverSheetsMixin extends FUniver implements IFUniverSheetsMixin {
 }
 
 FUniver.extend(FUniverSheetsMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverSheetsMixin { }
 }

--- a/packages/sheets/src/facade/f-workbook.ts
+++ b/packages/sheets/src/facade/f-workbook.ts
@@ -18,7 +18,8 @@ import type { CommandListener, CustomData, ICommandInfo, IDisposable, IRange, IW
 import type { ISetDefinedNameMutationParam } from '@univerjs/engine-formula';
 import type { IRangeThemeStyleJSON, ISetSelectionsOperationParams, ISheetCommandSharedParams } from '@univerjs/sheets';
 import type { FontLine as _FontLine } from './f-range';
-import { FBaseInitialable, ICommandService, ILogService, Inject, Injector, IPermissionService, IResourceLoaderService, IUniverInstanceService, LocaleService, mergeWorksheetSnapshotWithDefault, RedoCommand, toDisposable, UndoCommand, UniverInstanceType } from '@univerjs/core';
+import { ICommandService, ILogService, Inject, Injector, IPermissionService, IResourceLoaderService, IUniverInstanceService, LocaleService, mergeWorksheetSnapshotWithDefault, RedoCommand, toDisposable, UndoCommand, UniverInstanceType } from '@univerjs/core';
+import { FBaseInitialable } from '@univerjs/core/facade';
 import { IDefinedNamesService } from '@univerjs/engine-formula';
 import { CopySheetCommand, getPrimaryForRange, InsertSheetCommand, RangeThemeStyle, RegisterWorksheetRangeThemeStyleCommand, RemoveSheetCommand, SCOPE_WORKBOOK_VALUE_DEFINED_NAME, SetDefinedNameCommand, SetSelectionsOperation, SetWorksheetActiveOperation, SetWorksheetOrderCommand, SheetRangeThemeService, SheetsSelectionsService, UnregisterWorksheetRangeThemeStyleCommand, WorkbookEditablePermission } from '@univerjs/sheets';
 import { FDefinedName, FDefinedNameBuilder } from './f-defined-name';

--- a/packages/sheets/src/facade/f-worksheet.ts
+++ b/packages/sheets/src/facade/f-worksheet.ts
@@ -18,7 +18,8 @@ import type { CustomData, ICellData, IColumnData, IColumnRange, IDisposable, IFr
 import type { ISetColDataCommandParams, ISetGridlinesColorCommandParams, ISetRangeValuesMutationParams, ISetRowDataCommandParams, ISetTextWrapCommandParams, IToggleGridlinesCommandParams } from '@univerjs/sheets';
 import type { FDefinedName } from './f-defined-name';
 import type { FWorkbook } from './f-workbook';
-import { BooleanNumber, Direction, FBaseInitialable, ICommandService, ILogService, Inject, Injector, ObjectMatrix, RANGE_TYPE, WrapStrategy } from '@univerjs/core';
+import { BooleanNumber, Direction, ICommandService, ILogService, Inject, Injector, ObjectMatrix, RANGE_TYPE, WrapStrategy } from '@univerjs/core';
+import { FBaseInitialable } from '@univerjs/core/facade';
 import { deserializeRangeWithSheet } from '@univerjs/engine-formula';
 import { CancelFrozenCommand, ClearSelectionAllCommand, ClearSelectionContentCommand, ClearSelectionFormatCommand, copyRangeStyles, InsertColByRangeCommand, InsertRowByRangeCommand, MoveColsCommand, MoveRowsCommand, RemoveColByRangeCommand, RemoveRowByRangeCommand, SetColDataCommand, SetColHiddenCommand, SetColWidthCommand, SetFrozenCommand, SetGridlinesColorCommand, SetRangeValuesMutation, SetRowDataCommand, SetRowHeightCommand, SetRowHiddenCommand, SetSpecificColsVisibleCommand, SetSpecificRowsVisibleCommand, SetTabColorCommand, SetTextWrapCommand, SetWorksheetDefaultStyleMutation, SetWorksheetHideCommand, SetWorksheetNameCommand, SetWorksheetRowIsAutoHeightCommand, SetWorksheetRowIsAutoHeightMutation, SetWorksheetShowCommand, SheetsSelectionsService, ToggleGridlinesCommand } from '@univerjs/sheets';
 import { FDefinedNameBuilder } from './f-defined-name';

--- a/packages/ui/src/facade/f-enum.ts
+++ b/packages/ui/src/facade/f-enum.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FEnum } from '@univerjs/core';
+import { FEnum } from '@univerjs/core/facade';
 import { BuiltInUIPart } from '@univerjs/ui';
 
 /**
@@ -35,7 +35,7 @@ export class FUIEnum extends FEnum implements IFUIEnumMixin {
 
 FEnum.extend(FUIEnum);
 
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FEnum extends IFUIEnumMixin {}
 }

--- a/packages/ui/src/facade/f-hooks.ts
+++ b/packages/ui/src/facade/f-hooks.ts
@@ -15,7 +15,8 @@
  */
 
 import type { IDisposable } from '@univerjs/core';
-import { FHooks, ICommandService } from '@univerjs/core';
+import { ICommandService } from '@univerjs/core';
+import { FHooks } from '@univerjs/core/facade';
 import { CopyCommand, PasteCommand, SheetPasteShortKeyCommandName } from '@univerjs/ui';
 
 /**
@@ -104,7 +105,7 @@ export class FHooksSheetsMixin extends FHooks implements IFHooksSheetsUIMixin {
 }
 
 FHooks.extend(FHooksSheetsMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FHooks extends IFHooksSheetsUIMixin {}
 }

--- a/packages/ui/src/facade/f-menu-builder.ts
+++ b/packages/ui/src/facade/f-menu-builder.ts
@@ -16,7 +16,8 @@
 
 import type { IAccessor } from '@univerjs/core';
 import type { IMenuButtonItem, IMenuItem, MenuSchemaType } from '@univerjs/ui';
-import { CommandType, FBase, ICommandService, Inject, Injector, Tools } from '@univerjs/core';
+import { CommandType, ICommandService, Inject, Injector, Tools } from '@univerjs/core';
+import { FBase } from '@univerjs/core/facade';
 import { IMenuManagerService, MenuItemType, MenuManagerPosition, RibbonPosition, RibbonStartGroup } from '@univerjs/ui';
 
 /**

--- a/packages/ui/src/facade/f-shortcut.ts
+++ b/packages/ui/src/facade/f-shortcut.ts
@@ -16,7 +16,8 @@
 
 import type { IDisposable } from '@univerjs/core';
 import type { IShortcutItem } from '@univerjs/ui';
-import { FBase, Inject, Injector } from '@univerjs/core';
+import { Inject, Injector } from '@univerjs/core';
+import { FBase } from '@univerjs/core/facade';
 import { IShortcutService } from '@univerjs/ui';
 
 /**

--- a/packages/ui/src/facade/f-univer.ts
+++ b/packages/ui/src/facade/f-univer.ts
@@ -18,7 +18,7 @@ import type { IDisposable } from '@univerjs/core';
 import type { IMessageProps } from '@univerjs/design';
 import type { BuiltInUIPart, ComponentType, IComponentOptions, IDialogPartMethodOptions, ISidebarMethodOptions } from '@univerjs/ui';
 import type { IFacadeMenuItem, IFacadeSubmenuItem } from './f-menu-builder';
-import { FUniver } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { ComponentManager, connectInjector, CopyCommand, IDialogService, IMessageService, ISidebarService, IUIPartsService, PasteCommand } from '@univerjs/ui';
 import { FMenu, FSubmenu } from './f-menu-builder';
@@ -264,7 +264,7 @@ export class FUniverUIMixin extends FUniver implements IFUniverUIMixin {
 }
 
 FUniver.extend(FUniverUIMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverUIMixin { }
 }

--- a/packages/uniscript/src/services/script-execution.service.ts
+++ b/packages/uniscript/src/services/script-execution.service.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { createIdentifier, Disposable, FUniver, ILogService, Inject, Injector } from '@univerjs/core';
+import { createIdentifier, Disposable, ILogService, Inject, Injector } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 
 export const IUniscriptExecutionService = createIdentifier<IUniscriptExecutionService>('univer.uniscript.execution-service');
 

--- a/packages/uniscript/src/services/script-execution.service.ts
+++ b/packages/uniscript/src/services/script-execution.service.ts
@@ -15,6 +15,7 @@
  */
 
 import { createIdentifier, Disposable, ILogService, Inject, Injector } from '@univerjs/core';
+// eslint-disable-next-line univer/no-facade-imports-outside-facade
 import { FUniver } from '@univerjs/core/facade';
 
 export const IUniscriptExecutionService = createIdentifier<IUniscriptExecutionService>('univer.uniscript.execution-service');

--- a/packages/watermark/src/facade/f-univer.ts
+++ b/packages/watermark/src/facade/f-univer.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IImageWatermarkConfig, ITextWatermarkConfig } from '@univerjs/watermark';
-import { FUniver } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { IWatermarkTypeEnum, WatermarkImageBaseConfig, WatermarkService, WatermarkTextBaseConfig } from '@univerjs/watermark';
 
 /**
@@ -90,7 +90,7 @@ export class FUniverWatermarkMixin extends FUniver {
 }
 
 FUniver.extend(FUniverWatermarkMixin);
-declare module '@univerjs/core' {
+declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
     interface FUniver extends IFUniverWatermarkMixin {}
 }

--- a/tests/formula-integration/src/__testing__/univer.ts
+++ b/tests/formula-integration/src/__testing__/univer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FUniver } from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
 import { createUniverOnNode } from 'examples-node';
 
 export function createFormulaTestBed() {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
 BREAKING CHANGE:

The following imports previously from `@univerjs/core` should now be imported from `@univerjs/core/facade`:  
`FBase`, `FBaseInitialable`, `FUniver`, `FHooks`, `FBlob`, `IFBlobSource`, `FEventName`, `IEventBase`, `IEventParamConfig`, `FEnum`, `FUtil`.
﻿
Before:

```js
import { FUniver } from '@univerjs/core';
```

After: 

```js
import { FUniver } from '@univerjs/core/facade';
```

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
