### PR TITLE
fix(ui): registered vue components can't access the appContext

### DIFF
--- a/packages/ui/src/common/index.ts
+++ b/packages/ui/src/common/index.ts
@@ -16,3 +16,4 @@
 
 export * from './component-manager';
 export * from './z-index-manager';
+export * from "./teleport";

--- a/packages/ui/src/common/teleport.ts
+++ b/packages/ui/src/common/teleport.ts
@@ -1,0 +1,43 @@
+import { Fragment, reactive, Teleport, markRaw, defineComponent, h } from "vue";
+
+let active = false;
+const items = reactive<{ [key: string]: any }>({});
+
+export function connect(
+    id: string | number,
+    component: any,
+    container: HTMLDivElement,
+    props: Record<string, any>
+) {
+    if (active) {
+        items[id] = markRaw(
+            defineComponent({
+                render: () =>
+                    h(Teleport, { to: container } as any, [
+                        h(component, props),
+                    ]),
+            })
+        );
+    }
+}
+
+export function disconnect(id: string | number) {
+    if (active) {
+        delete items[id];
+    }
+}
+
+export function getTeleport(): any {
+    active = true;
+
+    return defineComponent({
+        setup() {
+            return () =>
+                h(
+                    Fragment,
+                    {},
+                    Object.keys(items).map((id) => h(items[id]))
+                );
+        },
+    });
+}


### PR DESCRIPTION
motivation：When I register a vue component in Univer, I want to be able to access the globally registered components and directives of the external vue application in the component, which is a problem. 

So I fixed it.

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
