### PR TITLE
fix(facade): add ranges to setBorder

### DIFF
--- a/packages/sheets/src/commands/commands/set-border-command.ts
+++ b/packages/sheets/src/commands/commands/set-border-command.ts
@@ -25,6 +25,7 @@ import type {
     IStyleData,
 } from '@univerjs/core';
 
+import type { IBorderInfo } from '../../services/border-style-manager.service';
 import type { ISetRangeValuesMutationParams } from '../mutations/set-range-values.mutation';
 import type { IResult } from './utils/target-util';
 import {
@@ -36,7 +37,7 @@ import {
     ObjectMatrix,
     Tools,
 } from '@univerjs/core';
-import { BorderStyleManagerService, type IBorderInfo } from '../../services/border-style-manager.service';
+import { BorderStyleManagerService } from '../../services/border-style-manager.service';
 import { SheetsSelectionsService } from '../../services/selections/selection.service';
 import { SetRangeValuesMutation, SetRangeValuesUndoMutationFactory } from '../mutations/set-range-values.mutation';
 import { getSheetCommandTarget } from './utils/target-util';
@@ -53,8 +54,9 @@ function forEach(range: IRange, action: (row: number, column: number) => void): 
 export interface ISetBorderBasicCommandParams {
     unitId?: string;
     subUnitId?: string;
-
+    ranges: IRange[];
     value: IBorderInfo;
+
 }
 
 export interface ISetBorderPositionCommandParams {
@@ -68,6 +70,7 @@ export interface ISetBorderStyleCommandParams {
 export interface ISetBorderCommandParams {
     unitId?: string;
     subUnitId?: string;
+    ranges?: IRange[];
 }
 
 export interface ISetBorderColorCommandParams {
@@ -546,15 +549,15 @@ export const SetBorderCommand: ICommand = {
         const target = getSheetCommandTarget(univerInstanceService, params);
         if (!target) return false;
 
-        const selections = selectionManagerService.getCurrentSelections()?.map((s) => s.range);
-        if (!selections?.length) {
+        const ranges = params?.ranges || selectionManagerService.getCurrentSelections()?.map((s) => s.range);
+        if (!ranges?.length) {
             return false;
         }
 
         const { activeBorderType } = borderStyleManagerService.getBorderInfo();
         if (!activeBorderType) return false;
 
-        const borderContext = getBorderContext(borderStyleManagerService, target, selections);
+        const borderContext = getBorderContext(borderStyleManagerService, target, ranges);
         innerBorder(borderContext);
         outlineBorder(borderContext);
         otherBorders(borderContext);
@@ -626,7 +629,7 @@ export const SetBorderBasicCommand: ICommand<ISetBorderBasicCommandParams> = {
     id: 'sheet.command.set-border-basic',
     type: CommandType.COMMAND,
     handler: (accessor: IAccessor, params: ISetBorderBasicCommandParams) => {
-        const { unitId, subUnitId, value } = params;
+        const { unitId, subUnitId, value, ranges } = params;
         const { type, color, style } = value;
 
         const commandService = accessor.get(ICommandService);
@@ -639,6 +642,7 @@ export const SetBorderBasicCommand: ICommand<ISetBorderBasicCommandParams> = {
         return commandService.syncExecuteCommand(SetBorderCommand.id, {
             unitId,
             subUnitId,
+            ranges,
         });
     },
 };

--- a/packages/sheets/src/facade/f-range.ts
+++ b/packages/sheets/src/facade/f-range.ts
@@ -623,6 +623,7 @@ export class FRange extends FBaseInitialable {
         this._commandService.syncExecuteCommand(SetBorderBasicCommand.id, {
             unitId: this._workbook.getUnitId(),
             subUnitId: this._worksheet.getSheetId(),
+            ranges: [this._range],
             value: {
                 type,
                 style,


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
## Facade API
```js
univerAPI.getActiveWorkbook().getActiveSheet().getRange('A1:B5').setBorder('outside', 8,'#ff0000');
```
<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
