### PR TITLE
chore: add `onlyBuiltDependencies` list

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
         "typescript": "^5.7.3",
         "vitest": "^3.0.6"
     },
+    "pnpm": {
+        "onlyBuiltDependencies": [
+            "esbuild"
+        ]
+    },
     "resolutions": {
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",


### PR DESCRIPTION
After pnpm 10 lifecycle scripts of dependencies are not executed during installation by default!  https://github.com/pnpm/pnpm/releases/tag/v10.0.0
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
