### PR TITLE
fix(sheet): set ranges for setAutoHeight

### DIFF
--- a/packages/sheets/src/facade/f-worksheet.ts
+++ b/packages/sheets/src/facade/f-worksheet.ts
@@ -919,6 +919,21 @@ export class FWorksheet extends FBaseInitialable {
     }
 
     /**
+     * Sets the height of the given ranges to auto.
+     * @param {IRange[]} ranges - The ranges to change
+     * @returns {FWorksheet} This worksheet instance for chaining
+     * @example
+     * ```typescript
+     * const fWorksheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * const ranges = [
+     * { startRow: 1, endRow: 10, startColumn: 0, endColumn: 10 },
+     * { startRow: 11, endRow: 20, startColumn: 0, endColumn: 10 },
+     * ]
+     * fWorksheet.setRowAutoHeight(ranges);
+     * ```
+     */
+    setRowAutoHeight(ranges: IRange[]): FWorksheet;
+    /**
      * Sets the height of the given rows to auto.
      * @param {number} startRow - The starting row position to change
      * @param {number} numRows - The number of rows to change
@@ -929,17 +944,25 @@ export class FWorksheet extends FBaseInitialable {
      * fWorksheet.setRowAutoHeight(1, 10);
      * ```
      */
-    setRowAutoHeight(startRow: number, numRows: number): FWorksheet {
+    setRowAutoHeight(startRow: number, numRows: number): FWorksheet;
+    setRowAutoHeight(startRow: number | IRange[], numRows?: number): FWorksheet {
+        let ranges: IRange[] = [];
+
+        if (Array.isArray(startRow)) {
+            ranges = startRow;
+        } else if (numRows !== undefined) {
+            ranges = [
+                {
+                    startRow,
+                    endRow: startRow + numRows - 1,
+                    startColumn: 0,
+                    endColumn: this._worksheet.getColumnCount() - 1,
+                },
+            ];
+        }
+
         const unitId = this._workbook.getUnitId();
         const subUnitId = this._worksheet.getSheetId();
-        const ranges = [
-            {
-                startRow,
-                endRow: startRow + numRows - 1,
-                startColumn: 0,
-                endColumn: this._worksheet.getColumnCount() - 1,
-            },
-        ];
 
         this._commandService.syncExecuteCommand(SetWorksheetRowIsAutoHeightCommand.id, {
             unitId,

--- a/packages/sheets/src/facade/f-worksheet.ts
+++ b/packages/sheets/src/facade/f-worksheet.ts
@@ -919,21 +919,6 @@ export class FWorksheet extends FBaseInitialable {
     }
 
     /**
-     * Sets the height of the given ranges to auto.
-     * @param {IRange[]} ranges - The ranges to change
-     * @returns {FWorksheet} This worksheet instance for chaining
-     * @example
-     * ```typescript
-     * const fWorksheet = univerAPI.getActiveWorkbook().getActiveSheet();
-     * const ranges = [
-     * { startRow: 1, endRow: 10, startColumn: 0, endColumn: 10 },
-     * { startRow: 11, endRow: 20, startColumn: 0, endColumn: 10 },
-     * ]
-     * fWorksheet.setRowAutoHeight(ranges);
-     * ```
-     */
-    setRowAutoHeight(ranges: IRange[]): FWorksheet;
-    /**
      * Sets the height of the given rows to auto.
      * @param {number} startRow - The starting row position to change
      * @param {number} numRows - The number of rows to change
@@ -944,26 +929,44 @@ export class FWorksheet extends FBaseInitialable {
      * fWorksheet.setRowAutoHeight(1, 10);
      * ```
      */
-    setRowAutoHeight(startRow: number, numRows: number): FWorksheet;
-    setRowAutoHeight(startRow: number | IRange[], numRows?: number): FWorksheet {
-        let ranges: IRange[] = [];
-
-        if (Array.isArray(startRow)) {
-            ranges = startRow;
-        } else if (numRows !== undefined) {
-            ranges = [
-                {
-                    startRow,
-                    endRow: startRow + numRows - 1,
-                    startColumn: 0,
-                    endColumn: this._worksheet.getColumnCount() - 1,
-                },
-            ];
-        }
-
+    setRowAutoHeight(startRow: number, numRows: number): FWorksheet {
         const unitId = this._workbook.getUnitId();
         const subUnitId = this._worksheet.getSheetId();
+        const ranges = [
+            {
+                startRow,
+                endRow: startRow + numRows - 1,
+                startColumn: 0,
+                endColumn: this._worksheet.getColumnCount() - 1,
+            },
+        ];
 
+        this._commandService.syncExecuteCommand(SetWorksheetRowIsAutoHeightCommand.id, {
+            unitId,
+            subUnitId,
+            ranges,
+        });
+
+        return this;
+    }
+
+    /**
+     * Sets the height of the given ranges to auto.
+     * @param {IRange[]} ranges - The ranges to change
+     * @returns {FWorksheet} This worksheet instance for chaining
+     * @example
+     * ```typescript
+     * const fWorksheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * const ranges = [
+     * { startRow: 1, endRow: 10, startColumn: 0, endColumn: 10 },
+     * { startRow: 11, endRow: 20, startColumn: 0, endColumn: 10 },
+     * ]
+     * fWorksheet.setRangesAutoHeight(ranges);
+     * ```
+     */
+    setRangesAutoHeight(ranges: IRange[]): FWorksheet {
+        const unitId = this._workbook.getUnitId();
+        const subUnitId = this._worksheet.getSheetId();
         this._commandService.syncExecuteCommand(SetWorksheetRowIsAutoHeightCommand.id, {
             unitId,
             subUnitId,


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
```js
// 将前 100 行设定自动行高
univerAPI.getActiveWorkbook().getActiveSheet().setRowAutoHeight(0, 100)
// 或者

// 将整个 Worksheet 的中没有行配置的行，设定自动行高
const rangesWithoutConfig = [];
const workbook = univerAPI.getActiveWorkbook()
const snapshot = workbook.save()
const worksheet = workbook.getActiveSheet()
const currentWorksheetId = worksheet.getSheetId();

const rowCount = worksheet.getLastRow();
const columnCount = worksheet.getLastColumn();
const rowData = snapshot.sheets[currentWorksheetId].rowData;
for (let i = 0; i <= rowCount; i++) {
    const row = rowData[i];
    if (!row) {
        rangesWithoutConfig.push({ startRow: i, endRow: i, startColumn:0, endColumn:columnCount });
    }
}

worksheet.setRangesAutoHeight(rangesWithoutConfig)
```

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
