### PR TITLE
revert: remove unnecessary `ctx.font =` calls, and avoid drawing out of bounds

### DIFF
--- a/e2e/perf/scroll.spec.ts
+++ b/e2e/perf/scroll.spec.ts
@@ -21,7 +21,6 @@ import { sheetData as emptySheetData } from '../__testing__/emptysheet';
 import { sheetData as freezeData } from '../__testing__/freezesheet';
 import { sheetData as mergeCellData } from '../__testing__/mergecell';
 import { sheetData as overflowData } from '../__testing__/overflow';
-import { reportToPosthog } from '../utils/report-performance';
 
 export interface IFPSData {
     fpsData: number[];
@@ -40,7 +39,7 @@ interface IFPSResult {
     maxFrameTimes: number[];
 }
 
-// const isCI = !!process.env.CI;
+const isCI = !!process.env.CI;
 /**
  * measure FPS of scrolling time.
  * @param page Page from playwright
@@ -133,7 +132,7 @@ async function measureFPS(page: Page, testDuration = 5, deltaX: number, deltaY: 
     return fpsCounterPromise as Promise<IFPSResult>;
 }
 
-const createTest = (title: string, telemetryName: string, sheetData: IJsonObject, minFpsValue: number, deltaX = 0, deltaY = 0) => {
+const createTest = (title: string, sheetData: IJsonObject, minFpsValue: number, deltaX = 0, deltaY = 0) => {
     // Default Size Of browser: 1280x720 pixels. And default DPR is 1.
     test(title, async ({ page }) => {
         await page.goto('http://localhost:3000/sheets/');
@@ -155,8 +154,6 @@ const createTest = (title: string, telemetryName: string, sheetData: IJsonObject
                 console.log('FPS', resultOfFPS.fps);
                 console.log('medianFrameTime', resultOfFPS.medianFrameTime);
                 console.log('max10FrameTimes', resultOfFPS.maxFrameTimes);
-
-                await reportToPosthog(telemetryName, resultOfFPS);
                 expect(resultOfFPS.fps).toBeGreaterThan(minFpsValue);
             });
         } catch (error) {
@@ -168,7 +165,7 @@ const createTest = (title: string, telemetryName: string, sheetData: IJsonObject
     });
 };
 
-createTest('sheet scroll empty', 'perf.sheet.scroll.empty', emptySheetData, 50, 10, 100);
-createTest('sheet scroll after freeze', 'perf.sheet.scroll.freeze', freezeData, 10, 10, 100);
-createTest('sheet scroll in a lots of merge cell', 'perf.sheet.scroll.mergeCell', mergeCellData, 10, 10, 50);
-createTest('sheet X scroll in a lots of overflow', 'perf.sheet.scroll.overflow', overflowData, 10, 50, 5);
+createTest('sheet scroll empty', emptySheetData, 50, 10, 100);
+createTest('sheet scroll after freeze', freezeData, 10, 10, 100);
+createTest('sheet scroll in a lots of merge cell', mergeCellData, 10, 10, 50);
+createTest('sheet X scroll in a lots of overflow', overflowData, 10, 50, 5);

--- a/e2e/visual-comparison/sheets/sheets-formula-related.spec.ts
+++ b/e2e/visual-comparison/sheets/sheets-formula-related.spec.ts
@@ -131,7 +131,7 @@ test('diff formula related', async () => {
 
     const filename1 = generateSnapshotName('formula-hide-row-current-worksheet');
     const screenshot1 = await page.locator(SHEET_MAIN_CANVAS_ID).screenshot();
-    await expect(screenshot1).toMatchSnapshot(filename1, { maxDiffPixels: 17 });
+    await expect(screenshot1).toMatchSnapshot(filename1, { maxDiffPixels: 30 });
 
     // restore the hidden row
     await page.evaluate(async () => {
@@ -159,7 +159,7 @@ test('diff formula related', async () => {
 
     const filename2 = generateSnapshotName('formula-filter-row-current-worksheet');
     const screenshot2 = await page.locator(SHEET_MAIN_CANVAS_ID).screenshot();
-    await expect(screenshot2).toMatchSnapshot(filename2, { maxDiffPixels: 17 });
+    await expect(screenshot2).toMatchSnapshot(filename2, { maxDiffPixels: 30 });
 
     await page.evaluate(async () => {
         const worksheet2 = window.univerAPI.getActiveWorkbook().getSheetByName('formula2');
@@ -170,7 +170,7 @@ test('diff formula related', async () => {
 
     const filename3 = generateSnapshotName('formula-filter-row-other-worksheet');
     const screenshot3 = await page.locator(SHEET_MAIN_CANVAS_ID).screenshot();
-    await expect(screenshot3).toMatchSnapshot(filename3, { maxDiffPixels: 17 });
+    await expect(screenshot3).toMatchSnapshot(filename3, { maxDiffPixels: 30 });
 
     await page.waitForTimeout(1000);
     await browser.close();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "scripts": {
         "prepare": "husky",
         "pre-commit": "lint-staged",
-        "dev": "turbo dev:demo  -- --host 0.0.0.0",
+        "dev": "turbo dev:demo",
         "dev:libs": "pnpm --filter univer-examples dev:demo-libs",
         "dev:e2e": "pnpm --filter univer-examples dev:e2e",
         "lint:types": "turbo lint:types",

--- a/packages-experimental/debugger/src/controllers/e2e/e2e.controller.ts
+++ b/packages-experimental/debugger/src/controllers/e2e/e2e.controller.ts
@@ -15,7 +15,6 @@
  */
 
 import { awaitTime, Disposable, ICommandService, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
-
 import { DEFAULT_WORKBOOK_DATA_DEMO, DEFAULT_WORKBOOK_DATA_DEMO_DEFAULT_STYLE } from '@univerjs/mockdata';
 import { DisposeUniverCommand } from '../../commands/commands/unit.command';
 import { getDefaultDocData } from './data/default-doc';

--- a/packages/core/src/sheets/sheet-skeleton.ts
+++ b/packages/core/src/sheets/sheet-skeleton.ts
@@ -97,7 +97,7 @@ export class SheetSkeleton extends Skeleton {
         this._isRowStylePrecedeColumnStyle = this._configService.getConfig(IS_ROW_STYLE_PRECEDE_COLUMN_STYLE) ?? false;
     }
 
-    resetCache() {
+    _resetCache() {
         //
     }
 
@@ -447,14 +447,10 @@ export class SheetSkeleton extends Skeleton {
      * @param bounds
      */
     calculate(): Nullable<SheetSkeleton> {
-        this.resetCache();
+        this._resetCache();
         this._updateLayout();
 
         return this;
-    }
-
-    resetRangeCache(_ranges: IRange[]): void {
-        // ...
     }
 
     private _dynamicallyUpdateRowHeaderWidth(rowHeader: {

--- a/packages/engine-render/src/components/docs/doc-component.ts
+++ b/packages/engine-render/src/components/docs/doc-component.ts
@@ -82,7 +82,7 @@ export abstract class DocComponent extends RenderComponent<
         }
     }
 
-    override render(mainCtx: UniverRenderingContext, bounds?: Partial<IViewportInfo>) {
+    override render(mainCtx: UniverRenderingContext, bounds?: IViewportInfo) {
         if (!this.visible) {
             this.makeDirty(false);
             return this;
@@ -146,5 +146,5 @@ export abstract class DocComponent extends RenderComponent<
         return false;
     }
 
-    protected abstract _draw(ctx: UniverRenderingContext, bounds?: Partial<IViewportInfo>): void;
+    protected abstract _draw(ctx: UniverRenderingContext, bounds?: IViewportInfo): void;
 }

--- a/packages/engine-render/src/components/docs/document.ts
+++ b/packages/engine-render/src/components/docs/document.ts
@@ -21,7 +21,7 @@ import type { Transform } from '../../basics/transform';
 import type { IBoundRectNoAngle, IViewportInfo } from '../../basics/vector2';
 import type { UniverRenderingContext } from '../../context';
 import type { Scene } from '../../scene';
-import type { ComponentExtension, IDrawInfo, IExtensionConfig } from '../extension';
+import type { ComponentExtension, IExtensionConfig } from '../extension';
 import type { IDocumentsConfig, IPageMarginLayout } from './doc-component';
 import type { DocumentSkeleton } from './layout/doc-skeleton';
 import { CellValueType, HorizontalAlign, VerticalAlign, WrapStrategy } from '@univerjs/core';
@@ -432,9 +432,7 @@ export class Documents extends DocComponent {
 
                                     for (const extension of glyphExtensionsExcludeBackground) {
                                         extension.extensionOffset = extensionOffset;
-                                        extension.draw(ctx, parentScale, glyph, [], {
-                                            viewBound: bounds?.viewBound,
-                                        } as IDrawInfo);
+                                        extension.draw(ctx, parentScale, glyph);
                                     }
                                 }
 

--- a/packages/engine-render/src/components/docs/layout/shaping-engine/font-cache.ts
+++ b/packages/engine-render/src/components/docs/layout/shaping-engine/font-cache.ts
@@ -218,12 +218,8 @@ export class FontCache {
         }, fontStyle);
     }
 
-    /**
-     * Measure text on another canvas.
-     * @param content
-     * @param fontString
-     * @returns IMeasureTextCache
-     */
+    // 获取有值单元格文本大小
+    // let measureTextCache = {}, measureTextCacheTimeOut = null;
     static getMeasureText(content: string, fontString: string): IMeasureTextCache {
         if (!this._context) {
             const canvas = document.createElement('canvas');
@@ -246,6 +242,7 @@ export class FontCache {
         if (mtc != null) {
             return mtc;
         }
+
         ctx.font = fontString;
 
         const textMetrics = ctx.measureText(content);

--- a/packages/engine-render/src/components/extension.ts
+++ b/packages/engine-render/src/components/extension.ts
@@ -56,7 +56,7 @@ export class ComponentExtension<T, U, V> {
         return this.Z_INDEX;
     }
 
-    draw(_ctx: UniverRenderingContext, _parentScale: IScale, _skeleton: T, _diff?: V, _more?: IDrawInfo) {
+    draw(ctx: UniverRenderingContext, parentScale: IScale, skeleton: T, diffBounds?: V, more?: IDrawInfo) {
         /* abstract */
     }
 

--- a/packages/engine-render/src/components/sheets/extensions/sheet-extension.ts
+++ b/packages/engine-render/src/components/sheets/extensions/sheet-extension.ts
@@ -54,6 +54,21 @@ export class SheetExtension extends ComponentExtension<SpreadsheetSkeleton, SHEE
         return false;
     }
 
+    // isRenderDiffRangesByColumn(column: number, diffRanges?: IRange[]) {
+    //     if (diffRanges == null || diffRanges.length === 0) {
+    //         return true;
+    //     }
+
+    //     for (const range of diffRanges) {
+    //         const { startColumn, endColumn } = range;
+    //         if (column >= startColumn && column <= endColumn) {
+    //             return true;
+    //         }
+    //     }
+
+    //     return false;
+    // }
+
     isRenderDiffRangesByColumn(curStartColumn: number, curEndColumn: number, diffRanges?: IRange[]) {
         if (diffRanges == null || diffRanges.length === 0) {
             return true;

--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -60,7 +60,6 @@ import {
     isWhiteColor,
     LocaleService,
     ObjectMatrix,
-    Range,
     searchArray,
     SheetSkeleton,
     Tools,
@@ -1128,14 +1127,15 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
         return this.worksheet.getSpanModel().getMergedCellRangeForSkeleton(range.startRow, range.startColumn, range.endRow, range.endColumn);
     }
 
-    override resetCache(): void {
+    resetCache(): void {
         this._resetCache();
     }
 
     /**
      * Any changes to sheet model would reset cache.
      */
-    _resetCache(): void {
+    override _resetCache(): void {
+        super._resetCache();
         this._stylesCache = {
             background: {},
             backgroundPositions: new ObjectMatrix<ICellWithCoord>(),
@@ -1147,16 +1147,6 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
         this._handleBgMatrix?.reset();
         this._handleBorderMatrix?.reset();
         this._overflowCache?.reset();
-    }
-
-    override resetRangeCache(ranges: IRange[]): void {
-        for (let i = 0; i < ranges.length; i++) {
-            const range = ranges[i];
-            Range.foreach(range, (row, col) => {
-                this._stylesCache.fontMatrix.realDeleteValue(row, col);
-            });
-        }
-        this.makeDirty(true);
     }
 
     _setBorderStylesCache(row: number, col: number, style: Nullable<IStyleData>, options: {

--- a/packages/engine-render/src/components/sheets/spreadsheet.ts
+++ b/packages/engine-render/src/components/sheets/spreadsheet.ts
@@ -133,7 +133,6 @@ export class Spreadsheet extends SheetComponent {
                 checkOutOfViewBound: true,
                 viewportKey: viewportInfo.viewportKey,
                 viewBound: viewportInfo.cacheBound,
-                diffBounds: viewportInfo.diffBounds,
             } as IDrawInfo);
             this.addRenderFrameTimeMetricToScene(timeKey, Tools.now() - st, scene);
         }

--- a/packages/engine-render/src/context.ts
+++ b/packages/engine-render/src/context.ts
@@ -210,22 +210,13 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
         this._context.direction = val;
     }
 
+    // font: string;
     get font() {
-        if (this._normalizedCachedFont) {
-            return this._normalizedCachedFont;
-        }
-        const fontStr = this._context.font;
-        this._normalizedCachedFont = fontStr;
-        return fontStr;
+        return this._context.font;
     }
 
-    _normalizedCachedFont: string;
     set font(val: string) {
         this._context.font = val;
-        // set font called too many times, even get font from context is time consuming.
-        // this.fontStyleStr = this._context.font;
-        // DO NOT use val to cachedStyleStr,  Actual font string may change after set to context.
-        this._normalizedCachedFont = '';
     }
 
     // fontKerning: CanvasFontKerning;
@@ -871,8 +862,6 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
      * @method
      */
     restore() {
-        this._transformCache = null;
-        this._normalizedCachedFont = '';
         this._context.restore();
     }
 
@@ -941,7 +930,6 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
 
     setTransform(...args: [any]) {
         this._transformCache = null;
-        this._normalizedCachedFont = '';
         this._context.setTransform(...args);
     }
 

--- a/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
@@ -16,7 +16,7 @@
 
 import type { ICommandInfo, IRange, Nullable, Workbook, Worksheet } from '@univerjs/core';
 import type { ISetFormulaCalculationNotificationMutation } from '@univerjs/engine-formula';
-import type { IAfterRender$Info, IBasicFrameInfo, IExtendFrameInfo, IRenderContext, IRenderModule, ISummaryFrameInfo, ISummaryMetric, ITimeMetric, IViewportInfos, Scene } from '@univerjs/engine-render';
+import type { IAfterRender$Info, IBasicFrameInfo, IExtendFrameInfo, IRenderContext, IRenderModule, ISummaryFrameInfo, ITimeMetric, IViewportInfos, Scene } from '@univerjs/engine-render';
 import { CommandType, ICommandService, Inject, Optional, Rectangle, RxDisposable } from '@univerjs/core';
 import { SetFormulaCalculationNotificationMutation } from '@univerjs/engine-formula';
 import {
@@ -46,19 +46,9 @@ interface ISetWorksheetMutationParams {
     subUnitId: string;
 }
 
-export interface ITelemetryData {
-    unitId: string;
-    sheetId: string;
-    FPS: ISummaryMetric;
-    frameTime: ISummaryMetric;
-    elapsedTimeToStart: number;
-}
-
 const FRAME_STACK_THRESHOLD = 60;
 
 export class SheetRenderController extends RxDisposable implements IRenderModule {
-    private _renderMetric$: Subject<ITelemetryData> = new Subject();
-    renderMetric$ = this._renderMetric$.asObservable();
     constructor(
         private readonly _context: IRenderContext<Workbook>,
         @Inject(SheetSkeletonManagerService) private readonly _sheetSkeletonManagerService: SheetSkeletonManagerService,
@@ -67,6 +57,7 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         @Optional(ITelemetryService) private readonly _telemetryService?: ITelemetryService
     ) {
         super();
+
         this._addNewRender();
         this._initRenderMetricSubscriber();
     }
@@ -103,6 +94,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
 
     private _afterRenderMetric$: Subject<IAfterRender$Info> = new Subject<IAfterRender$Info>();
     private _initRenderMetricSubscriber() {
+        if (!this._telemetryService) return;
+
         const { engine } = this._context;
 
         engine.beginFrame$.subscribe(() => {
@@ -146,17 +139,14 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
                 ...sceneRenderDetail.tags,
             });
             if (frameInfoList.length > FRAME_STACK_THRESHOLD) {
-                this._captureRenderMetric(frameInfoList);
+                this._renderMetricCapture(frameInfoList);
                 frameInfoList.length = 0;
             }
         });
     }
 
-    /**
-     * Send render metric to telemetry service
-     * @param frameInfoList
-     */
-    private _captureRenderMetric(frameInfoList: IExtendFrameInfo[]) {
+    private _renderMetricCapture(frameInfoList: IExtendFrameInfo[]) {
+        if (!this._telemetryService) return;
         const filteredFrameInfo = frameInfoList;//.filter((info) => info.scrolling);
         if (filteredFrameInfo.length === 0) return;
 
@@ -217,10 +207,8 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         const elapsedTimeToStart = filteredFrameInfo[filteredFrameInfo.length - 1].elapsedTime;
         const sheetId = this._context.unit.getActiveSheet().getSheetId();
         const unitId = this._context.unit.getUnitId();
-        const telemetryData: ITelemetryData = { sheetId, unitId, elapsedTimeToStart, ...summaryFrameStats };
-        this._renderMetric$.next(telemetryData);
-
-        this._telemetryService?.capture('sheet_render_cost', telemetryData);
+        const telemetryData = { sheetId, unitId, elapsedTimeToStart, ...summaryFrameStats };
+        this._telemetryService.capture('sheet_render_cost', telemetryData);
     }
 
     private _addComponent(workbook: Workbook) {

--- a/packages/sheets-ui/src/index.ts
+++ b/packages/sheets-ui/src/index.ts
@@ -29,7 +29,7 @@ export { HeaderFreezeRenderController } from './controllers/render-controllers/f
 export { HeaderMoveRenderController } from './controllers/render-controllers/header-move.render-controller';
 export { HeaderResizeRenderController } from './controllers/render-controllers/header-resize.render-controller';
 export { SheetsScrollRenderController } from './controllers/render-controllers/scroll.render-controller';
-export { type ITelemetryData, SheetRenderController } from './controllers/render-controllers/sheet.render-controller';
+export { SheetRenderController } from './controllers/render-controllers/sheet.render-controller';
 export { SheetUIController } from './controllers/sheet-ui.controller';
 export { whenFormulaEditorActivated, whenSheetEditorFocused } from './controllers/shortcuts/utils';
 export { getCoordByCell, getCoordByOffset, getSheetObject, getTransformCoord } from './controllers/utils/component-tools';


### PR DESCRIPTION
…g glyphs outside the viewBounds (#4775)"

This reverts commit cd3decd487d641738229a8c5a4213d60ff191d57.

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
