### PR TITLE
fix(sheets-conditional-formatting): apply conditional formatting for triggered sheet

### DIFF
--- a/packages/sheets-conditional-formatting/src/commands/commands/add-cf.command.ts
+++ b/packages/sheets-conditional-formatting/src/commands/commands/add-cf.command.ts
@@ -46,7 +46,7 @@ export const AddCfCommand: ICommand<IAddCfCommandParams> = {
         const commandService = accessor.get(ICommandService);
         const conditionalFormattingRuleModel = accessor.get(ConditionalFormattingRuleModel);
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        const target = getSheetCommandTarget(univerInstanceService);
+        const target = getSheetCommandTarget(univerInstanceService, params);
         if (!target) return false;
 
         const { unitId, subUnitId } = target;


### PR DESCRIPTION
Right now if you try to apply conditional formatting on some sheet formatting will be applied to active sheet (not that you're trying to apply).

Other commands (e.g. [clear range](https://github.com/dream-num/univer/blob/dev/packages/sheets-conditional-formatting/src/commands/commands/clear-range-cf.command.ts#L53) and other in this folder) pass `params` parameter.

How to test:
- Open sheet
- Execute code in console

```
const workbook = univerAPI.getActiveWorkbook();

// create a new sheet (and switch to this sheet)
const sheet = workbook.insertSheet('Conditional sheet');

// switch back to initial sheet to make created sheet inactive
workbook.setActiveSheet(workbook.getSheets()[1])

// fill out data
for (let i = 1; i <= 10; i++) {
  sheet.getRange(`A${i}`).setValue(i);
}

// setup conditional formatting rule
sheet.addConditionalFormattingRule({
    "cfId": "QXIZ__zc",
    "ranges": [
        {
            "startRow": 0,
            "startColumn": 0,
            "endRow": 9,
            "endColumn": 0,
            "startAbsoluteRefType": 0,
            "endAbsoluteRefType": 0,
            "rangeType": 0
        }
    ],
    "rule": {
        "type": "highlightCell",
        "subType": "number",
        "operator": "greaterThan",
        "style": {
            "cl": {
                "rgb": "#2f56ef"
            },
            "bg": {
                "rgb": "#e8ecfc"
            }
        },
        "value": 5
    },
    "stopIfTrue": false
})

// switch to created sheet
workbook.setActiveSheet(sheet)
```


Expected result:
Conditional formatting is applied to created sheet.

Actual result (before the fix):
Conditional formatting is applied to first sheet.

I didn't find any tests so no tests from my side.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
