### PR TITLE
fix(docs-ui): remove SetInlineFormatFontFamilyCommand from FloatToolbar

### DIFF
--- a/packages/docs-ui/src/components/float-toolbar/FloatToolbar.tsx
+++ b/packages/docs-ui/src/components/float-toolbar/FloatToolbar.tsx
@@ -19,7 +19,6 @@ import { IMenuManagerService, MenuManagerPosition, ToolbarItem, useDependency } 
 import { useEffect, useState } from 'react';
 import {
     SetInlineFormatBoldCommand,
-    SetInlineFormatFontFamilyCommand,
     SetInlineFormatFontSizeCommand,
     SetInlineFormatItalicCommand,
     SetInlineFormatStrikethroughCommand,
@@ -35,7 +34,6 @@ interface IFloatToolbarProps {
 }
 
 const DEFAULT_AVALIABLE_MENUS: string[] = [
-    SetInlineFormatFontFamilyCommand.id,
     SetInlineFormatFontSizeCommand.id,
     SetInlineFormatBoldCommand.id,
     SetInlineFormatItalicCommand.id,


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
