### PR TITLE
fix(conditional-formatting): merge CF styles with interceptorStyle to override number format colors

### DIFF
--- a/packages/sheets-conditional-formatting-ui/src/controllers/cf.render.controller.ts
+++ b/packages/sheets-conditional-formatting-ui/src/controllers/cf.render.controller.ts
@@ -80,6 +80,14 @@ export class SheetsCfRenderController extends Disposable {
                         ...result.style,
                     };
                     Object.assign(cloneCell, { s: activeStyle });
+                    
+                    // Merge conditional formatting styles with existing interceptorStyle to ensure CF text color takes precedence
+                    if (cloneCell.interceptorStyle || result.style.cl) {
+                        cloneCell.interceptorStyle = {
+                            ...cloneCell.interceptorStyle,
+                            ...result.style,
+                        };
+                    }
                 }
 
                 if (!cloneCell.fontRenderExtension) {


### PR DESCRIPTION
When a cell has both conditional formatting and a custom number format, the number format's color was overriding the conditional formatting text color because interceptorStyle takes precedence over regular styles during rendering.

This fix ensures conditional formatting styles are merged into interceptorStyle when needed, allowing CF text colors to be applied correctly to negative values with custom number formats.

close #5338


## Pull Request Checklist

- [X] Related tickets or issues have been linked in the PR description (or missing issue).
- [X] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [X] Unit tests have been added for the changes (if applicable).
- [X] Breaking changes have been documented (or no breaking changes introduced in this PR).
