### PR TITLE
fix: dark mode tab

### DIFF
--- a/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/SheetBarItem.tsx
+++ b/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/SheetBarItem.tsx
@@ -59,7 +59,7 @@ export function SheetBarItem(props: IBaseSheetBarProps) {
             className={clsx(`
               univer-mx-1 univer-box-border univer-flex univer-flex-grow univer-cursor-pointer univer-select-none
               univer-flex-row univer-items-center univer-rounded univer-text-xs univer-transition-[colors,box-shadow]
-              dark:!univer-text-white
+              dark:univer-text-white
             `, currentSelected
                 ? `
                   univer-justify-center univer-bg-white univer-font-bold univer-text-primary-700 univer-shadow
@@ -68,7 +68,7 @@ export function SheetBarItem(props: IBaseSheetBarProps) {
                 : `
                   univer-font-medium univer-text-gray-900
                   hover:univer-bg-gray-100
-                  dark:hover:!univer-bg-gray-700
+                  dark:hover:univer-bg-gray-700
                 `)}
             style={{
                 backgroundColor: !currentSelected && color ? color : '',


### PR DESCRIPTION
## Issue 1
In dark mode, the sheet tab has a light background and should use dark text
![image](https://github.com/user-attachments/assets/7d80734b-4a8a-4c51-bc26-20158285f122)

## Issue 2
Tabs with background colors have inconsistent hover effects in light mode and dark mode

https://github.com/user-attachments/assets/3332286f-0468-48d4-9be1-dae43dbfac93

