### PR TITLE
fix(sheets-hyper-link-ui): hyper-link tooltip display far away of the cell bound

### DIFF
--- a/packages/sheets-ui/src/services/hover-manager.service.ts
+++ b/packages/sheets-ui/src/services/hover-manager.service.ts
@@ -300,6 +300,30 @@ export class HoverManagerService extends Disposable {
         }
 
         const rect = customRange?.rects.pop() ?? bullet?.rect ?? drawing?.rect;
+        const displayRect = rect && (() => {
+            const absoluteTop = rect.top + cell.mergeInfo.startY + topOffset;
+            const absoluteBottom = rect.bottom + cell.mergeInfo.startY + topOffset;
+            const absoluteLeft = rect.left + cell.mergeInfo.startX + leftOffset;
+            const absoluteRight = rect.right + cell.mergeInfo.startX + leftOffset;
+
+            const cellTop = cell.mergeInfo.startY + topOffset;
+            const cellBottom = cell.mergeInfo.endY + topOffset;
+            const cellLeft = cell.mergeInfo.startX + leftOffset;
+            const cellRight = cell.mergeInfo.endX + leftOffset;
+
+            const clampedTop = Math.min(Math.max(absoluteTop, cellTop), cellTop);
+            const clampedBottom = Math.min(absoluteBottom, cellBottom);
+            const clampedLeft = Math.min(Math.max(absoluteLeft, cellLeft), cellLeft);
+            const clampedRight = Math.min(absoluteRight, cellRight);
+
+            return {
+                top: clampedTop,
+                bottom: clampedBottom,
+                left: clampedLeft,
+                right: clampedRight,
+            };
+        })();
+
         return {
             location,
             position,
@@ -307,12 +331,7 @@ export class HoverManagerService extends Disposable {
             customRange: customRange?.range,
             bullet: bullet?.paragraph,
             drawing,
-            rect: rect && {
-                top: rect.top + cell.mergeInfo.startY + topOffset,
-                bottom: rect.bottom + cell.mergeInfo.startY + topOffset,
-                left: rect.left + cell.mergeInfo.startX + leftOffset,
-                right: rect.right + cell.mergeInfo.startX + leftOffset,
-            },
+            rect: displayRect,
         };
     }
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
