### PR TITLE
feat(design): allow customizing the `Dialog` component's width beyond predefined limits

### DIFF
--- a/packages/design/src/components/dialog/Dialog.tsx
+++ b/packages/design/src/components/dialog/Dialog.tsx
@@ -322,6 +322,7 @@ export function Dialog(props: IDialogProps) {
                 style={{
                     ...style,
                     width: width ? (typeof width === 'number' ? `${width}px` : width) : undefined,
+                    maxWidth: width ? 'initial' : undefined,
                     ...(draggable
                         ? {
                             position: 'absolute',


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #5610

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
