### PR TITLE
fix(sheets-formula-ui): handle undefined unitId in formula selection

### DIFF
--- a/packages/sheets-formula-ui/src/views/formula-editor/hooks/use-formula-selection.ts
+++ b/packages/sheets-formula-ui/src/views/formula-editor/hooks/use-formula-selection.ts
@@ -114,7 +114,8 @@ export function useFormulaSelecting(opts: { editorId: string; isFocus: boolean; 
                 }
 
                 const { sheetName, unitId } = focusingNode.range;
-                if (unitId !== univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SHEET)?.getUnitId()) {
+                const currentUnitId = univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
+                if (unitId && unitId !== currentUnitId) {
                     setIsSelecting(FormulaSelectingType.EDIT_OTHER_WORKBOOK_REFERENCE);
                 } else if (
                     (!sheetName && currentSheet.getSheetId() === sourceSheet?.getSheetId()) ||


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
Check for undefined unitId before comparison to prevent potential errors when selecting formulas across workbooks

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
