### PR TITLE
fix: color picker is partially blocked

### DIFF
--- a/packages/design/src/components/dialog/DialogPrimitive.tsx
+++ b/packages/design/src/components/dialog/DialogPrimitive.tsx
@@ -37,7 +37,7 @@ const DialogOverlay = forwardRef<
         ref={ref}
         className={clsx(
             `
-              univer-bg-black/80 univer-fixed univer-inset-0 univer-z-[1050]
+              univer-bg-black/80 univer-fixed univer-inset-0 univer-z-[1080]
               data-[state=open]:univer-animate-in data-[state=open]:univer-fade-in-0
               data-[state=closed]:univer-animate-out data-[state=closed]:univer-fade-out-0
             `,
@@ -68,7 +68,7 @@ const DialogContent = forwardRef<
                   data-[state=closed]:univer-animate-out data-[state=closed]:univer-fade-out-0
                   data-[state=closed]:univer-zoom-out-95 data-[state=closed]:univer-slide-out-to-left-1/2
                   data-[state=closed]:univer-slide-out-to-top-[48%]
-                  univer-fixed univer-left-1/2 univer-top-1/2 univer-z-[1050] univer-box-border univer-grid
+                  univer-fixed univer-left-1/2 univer-top-1/2 univer-z-[1080] univer-box-border univer-grid
                   univer-w-full univer-max-w-lg -univer-translate-x-1/2 -univer-translate-y-1/2 univer-gap-4
                   univer-bg-white univer-p-4 univer-text-gray-500 univer-shadow-md univer-duration-200
                   sm:!univer-rounded-lg


### PR DESCRIPTION
<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #5647

<!-- A description of the proposed changes. -->
increase colorpicker z-index. on the screen at a low height, it was partially blocked.

<!-- How to test them. -->
Decrease the height of the window, open the choice of text or background color, click choose another color

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:-->
<img width="1300" height="554" alt="image" src="https://github.com/user-attachments/assets/3f6b3f9c-292a-4b5e-980d-07f731f31ef1" />

After:-->
<img width="1226" height="554" alt="image" src="https://github.com/user-attachments/assets/a8ed261e-30a8-487f-8a6e-1f19d9aed2b3" />

