### PR TITLE
fix: insert cols&rows from rigth mouse btn menu

### DIFF
--- a/packages/sheets/src/commands/commands/insert-row-col.command.ts
+++ b/packages/sheets/src/commands/commands/insert-row-col.command.ts
@@ -175,7 +175,7 @@ export const InsertRowByRangeCommand: ICommand = {
 export const InsertRowBeforeCommand: ICommand = {
     type: CommandType.COMMAND,
     id: 'sheet.command.insert-row-before',
-    handler: async (accessor: IAccessor) => {
+    handler: async (accessor: IAccessor, params: IInsertMultiRowsCommandParams) => {
         const selectionManagerService = accessor.get(SheetsSelectionsService);
         const selections = selectionManagerService.getCurrentSelections()?.map((s) => s.range);
         let range: IRange;
@@ -193,7 +193,10 @@ export const InsertRowBeforeCommand: ICommand = {
         if (!target) return false;
 
         const { worksheet, subUnitId, unitId } = target;
-        const { startRow, endRow } = range;
+        const count = params.value || 0;
+
+        const startRow = range.startRow;
+        const endRow = range.startRow + count - 1;
         const startColumn = 0;
         const endColumn = worksheet.getColumnCount() - 1;
         const insertRowParams: IInsertRowCommandParams = {
@@ -474,7 +477,7 @@ export const InsertColByRangeCommand: ICommand<IInsertColCommandParams> = {
 export const InsertColBeforeCommand: ICommand = {
     type: CommandType.COMMAND,
     id: 'sheet.command.insert-col-before',
-    handler: async (accessor: IAccessor) => {
+    handler: async (accessor: IAccessor, params: IInsertMultiRowsCommandParams) => {
         const selectionManagerService = accessor.get(SheetsSelectionsService);
         const selections = selectionManagerService.getCurrentSelections();
         let range: IRange;
@@ -490,8 +493,9 @@ export const InsertColBeforeCommand: ICommand = {
         if (!target) return false;
 
         const { worksheet, unitId, subUnitId } = target;
-
-        const { startColumn, endColumn } = range;
+        const count = params.value || 0;
+        const startColumn = range.startColumn;
+        const endColumn = range.startColumn + count - 1;
         const startRow = 0;
         const endRow = worksheet.getRowCount() - 1;
 


### PR DESCRIPTION
<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #5762 


<!-- A description of the proposed changes. -->

Considering that ui provides the ability to select the number of inserted columns and rows, I fixed this option

<!-- How to test them. -->

right-click on a cell, select the desired number of rows or columns, click on this button

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

despite the selected quantity, only one column or cell was inserted, the behavior is noted in the video in issue

After: -->
I attached the result of the changes to the video, it works as expected
[Screencast from 2025-08-28 21-34-00.webm](https://github.com/user-attachments/assets/92d8fe9d-34d5-4b52-935a-683064a7c5ce)
