### PR TITLE
fix: layering of elements in insert table dialog

### DIFF
--- a/packages/docs-ui/src/commands/operations/doc-create-table.operation.ts
+++ b/packages/docs-ui/src/commands/operations/doc-create-table.operation.ts
@@ -51,7 +51,7 @@ export const DocCreateTableOperation: ICommand = {
                     },
                 },
             },
-            width: 400,
+            width: 'auto',
             title: { title: localeService.t('toolbar.table.insert') },
             onConfirm: () => {
                 commandService.executeCommand(CreateDocTableCommand.id, tableCreateParams);

--- a/packages/docs-ui/src/views/table/create/TableCreate.tsx
+++ b/packages/docs-ui/src/views/table/create/TableCreate.tsx
@@ -49,7 +49,7 @@ export const DocCreateTableConfirm = ({
     }, [tableCreateParams]);
 
     return (
-        <div className="univer-flex univer-items-center univer-justify-between">
+        <div className="univer-flex univer-items-center univer-justify-between univer-gap-2">
             <div className="univer-flex univer-items-center univer-gap-2">
                 <span>{localeService.t('toolbar.table.rowCount')}</span>
                 <InputNumber


### PR DESCRIPTION
<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #5770

<!-- A description of the proposed changes. -->

in the process of solving this problem I realized why it arose, considering that the text in different languages ​​has different lengths, we get different distances between input fields. At the same time, what is good (width) for one language is bad for another. Therefore, I suggest setting the automatic size of this window, and adding gap

<!-- How to test them. -->

open doc => click insert table

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

there is an example in issue

After: -->
<img width="533" height="240" alt="ex1" src="https://github.com/user-attachments/assets/10cc8db3-258c-432a-816b-ce91e26a8896" />
<img width="677" height="248" alt="ex2" src="https://github.com/user-attachments/assets/123f1d98-abcd-40dd-aff3-bf27d6a419b4" />
<img width="533" height="240" alt="ex3" src="https://github.com/user-attachments/assets/f7877042-c766-4f7c-a2bf-c343f6e17f5c" />
<img width="677" height="248" alt="ex4" src="https://github.com/user-attachments/assets/ccc407b2-7c89-43ff-9ef3-b9ba12629ba5" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
