### PR TITLE
feat: add display underline depending on type

### DIFF
--- a/mockdata/src/docs/default-document.data-simple.ts
+++ b/mockdata/src/docs/default-document.data-simple.ts
@@ -54,10 +54,26 @@ const exampleTables = [
 
 const title = 'Examples of Accessible Data Tables\r';
 const description = 'Basic Data Table with Column Headings\r';
+
+const dotted = 'dotted\r';
+const dotted_heavy = 'dotted_heavy\r';
+const dash = 'dash\r';
+const dashed_heavy = 'dashed_heavy\r';
+const dash_long = 'dash_long\r';
+const dash_long_heavy = 'dash_long_heavy\r';
+const dot_dash = 'dot_dash\r';
+const dash_dot_heavy = 'dash_dot_heavy\r';
+const dot_dot_dash = 'dot_dot_dash\r';
+const dash_dot_dot_heavy = 'dash_dot_dot_heavy\r';
+const thick = 'thick\r';
+const wave = 'wave\r';
+
+const underline = `${dotted}${dotted_heavy}${dash}${dashed_heavy}${dash_long}${dash_long_heavy}${dot_dash}${dash_dot_heavy}${dot_dot_dash}${dash_dot_dot_heavy}${thick}${wave}`;
+
 const summary = 'These example tables contain captions and summaries. When you copy any of these tables into your page you must edit the caption and summary. The caption can be edited in the Design view but the summary text must be edited in Code view. Click inside the table, then select the table tag on the tag selector, then switch to Code view and edit the text in the summary attribute.\r';
 const tableStream = createTableDataStream(exampleTables);
 
-const dataStream = `${title}${description}${tableStream}${summary}\n`;
+const dataStream = `${title}${description}${underline}${tableStream}${summary}\n`;
 
 const startIndex = dataStream.indexOf(TABLE_START);
 const endIndex = tableStream.length + startIndex;
@@ -125,6 +141,234 @@ function createTextRuns() {
     });
 
     offset += description.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dotted.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 8,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dotted.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dotted_heavy.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 9,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dotted_heavy.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dash.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 0,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dash.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dashed_heavy.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 3,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dashed_heavy.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dash_long.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 4,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dash_long.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dash_long_heavy.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 5,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dash_long_heavy.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dot_dash.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 6,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dot_dash.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dash_dot_heavy.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 2,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dash_dot_heavy.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dot_dot_dash.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 7,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dot_dot_dash.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + dash_dot_dot_heavy.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 1,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += dash_dot_dot_heavy.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + thick.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 13,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += thick.length;
+
+    textRuns.push({
+        st: offset,
+        ed: offset + wave.length,
+        ts: {
+            fs: 12,
+            ff: 'Helvetica Neue',
+            cl: {
+                rgb: '#54585a',
+            },
+            ul: {
+                s: 1,
+                t: 14,
+            },
+            bl: BooleanNumber.FALSE,
+        },
+    });
+
+    offset += wave.length;
 
     textRuns.push({
         st: offset,

--- a/mockdata/src/sheets/demo/default-workbook-data-demo.ts
+++ b/mockdata/src/sheets/demo/default-workbook-data-demo.ts
@@ -14508,6 +14508,149 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                         s: 'pwABhz',
                     },
                 },
+                28: {
+                    12: {
+                        v: 'DASH DASH DASH',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 0,
+                            },
+                        },
+                    },
+                },
+                30: {
+                    12: {
+                        v: 'DASH DOT DOT HEAVY',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 1,
+                            },
+                        },
+                    },
+                },
+                32: {
+                    12: {
+                        v: 'DASH DOT HEAVY',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 2,
+                            },
+                        },
+                    },
+                },
+                34: {
+                    12: {
+                        v: 'DASHED HEAVY',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 3,
+                            },
+                        },
+                    },
+                },
+                36: {
+                    12: {
+                        v: 'DASH LONG',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 4,
+                            },
+                        },
+                    },
+                },
+                38: {
+                    12: {
+                        v: 'DASH LONG HEAVY',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 5,
+                            },
+                        },
+                    },
+                },
+                40: {
+                    12: {
+                        v: 'DOT DASH',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 6,
+                            },
+                        },
+                    },
+                },
+                42: {
+                    12: {
+                        v: 'DOT DOT DASH',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 7,
+                            },
+                        },
+                    },
+                },
+                44: {
+                    12: {
+                        v: 'DOTTED',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 8,
+                            },
+                        },
+                    },
+                },
+                46: {
+                    12: {
+                        v: 'DOTTED HEAVY',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 9,
+                            },
+                        },
+                    },
+                },
+                48: {
+                    12: {
+                        v: 'WAVE',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 14,
+                            },
+                        },
+                    },
+                },
+                50: {
+                    12: {
+                        v: 'WAVE HEAVY',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 16,
+                            },
+                        },
+                    },
+                },
+                52: {
+                    12: {
+                        v: 'THICK',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 13,
+                            },
+                        },
+                    },
+                },
             },
 
             freeze: {
@@ -14588,7 +14731,11 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                     ah: 19,
                 },
             },
-            columnData: {},
+            columnData: {
+                12: {
+                    w: 180,
+                },
+            },
             showGridlines: 1,
             rowHeader: {
                 width: 46,

--- a/packages/engine-render/src/components/docs/extensions/line.ts
+++ b/packages/engine-render/src/components/docs/extensions/line.ts
@@ -128,9 +128,8 @@ export class Line extends docExtension {
         const color =
             (c === BooleanNumber.TRUE ? getColorStyle(glyph.ts?.cl) : getColorStyle(colorStyle)) || COLOR_BLACK_RGB;
         ctx.strokeStyle = color;
-        ctx.lineWidth = lineWidth;
 
-        this._setLineType(ctx, lineType || TextDecoration.SINGLE);
+        this._setLineType(ctx, lineType ?? TextDecoration.SINGLE, lineWidth);
 
         const centerAngle = degToRad(centerAngleDeg);
         const vertexAngle = degToRad(vertexAngleDeg);
@@ -151,24 +150,77 @@ export class Line extends docExtension {
 
         ctx.beginPath();
         ctx.moveTo(start.x, start.y);
-        ctx.lineTo(end.x, end.y);
+        if (this._isWave(lineType)) {
+            for (let x = start.x; x < end.x; x++) {
+                ctx.lineTo(x, end.y + 1 * Math.sin(x * 1)); // y + amplitude * frequency
+            }
+        } else {
+            ctx.lineTo(end.x, end.y);
+        }
+
         ctx.stroke();
         ctx.restore();
     }
 
-    private _setLineType(ctx: UniverRenderingContext, style: TextDecoration) {
-        if (style === TextDecoration.DASH_DOT_DOT_HEAVY || style === TextDecoration.DOT_DOT_DASH) {
-            ctx.setLineDash([2, 2, 5, 2, 2]);
-        } else if (style === TextDecoration.DASH_DOT_HEAVY || style === TextDecoration.DOT_DASH) {
-            ctx.setLineDash([2, 5, 2]);
-        } else if (style === TextDecoration.DOTTED || style === TextDecoration.DOTTED_HEAVY) {
-            ctx.setLineDash([2]);
-        } else if (style === TextDecoration.DASH || style === TextDecoration.DASHED_HEAVY) {
-            ctx.setLineDash([3]);
-        } else if (style === TextDecoration.DASH_LONG || style === TextDecoration.DASH_LONG_HEAVY) {
-            ctx.setLineDash([6]);
-        } else {
-            ctx.setLineDash([0]);
+    private _isWave(lineType: TextDecoration | undefined): boolean {
+        return lineType === TextDecoration.WAVE || lineType === TextDecoration.WAVY_HEAVY;
+    }
+
+    private _setLineType(ctx: UniverRenderingContext, style: TextDecoration, lineWidth: number) {
+        switch (style) {
+            case TextDecoration.DOTTED:
+                ctx.lineWidth = 1;
+                ctx.setLineDash([2]);
+                return;
+            case TextDecoration.DOTTED_HEAVY:
+                ctx.lineWidth = 2;
+                ctx.setLineDash([2]);
+                return;
+            case TextDecoration.DASH:
+                ctx.lineWidth = 1;
+                ctx.setLineDash([3]);
+                return;
+            case TextDecoration.DASHED_HEAVY:
+                ctx.lineWidth = 2;
+                ctx.setLineDash([3]);
+                return;
+            case TextDecoration.DASH_LONG:
+                ctx.lineWidth = 1;
+                ctx.setLineDash([6]);
+                return;
+            case TextDecoration.DASH_LONG_HEAVY:
+                ctx.lineWidth = 2;
+                ctx.setLineDash([6]);
+                return;
+            case TextDecoration.DOT_DASH:
+                ctx.lineWidth = 1;
+                ctx.setLineDash([2, 5, 2]);
+                return;
+            case TextDecoration.DASH_DOT_HEAVY:
+                ctx.lineWidth = 2;
+                ctx.setLineDash([2, 5, 2]);
+                return;
+            case TextDecoration.DOT_DOT_DASH:
+                ctx.lineWidth = 1;
+                ctx.setLineDash([2, 2, 5, 2, 2]);
+                return;
+            case TextDecoration.DASH_DOT_DOT_HEAVY:
+                ctx.lineWidth = 2;
+                ctx.setLineDash([2, 2, 5, 2, 2]);
+                return;
+            case TextDecoration.THICK:
+                ctx.lineWidth = 2;
+                ctx.setLineDash([0]);
+                return;
+            case TextDecoration.WAVE:
+                ctx.lineWidth = 1;
+                return;
+            case TextDecoration.WAVY_HEAVY:
+                ctx.lineWidth = 2;
+                return;
+            default:
+                ctx.setLineDash([0]);
+                ctx.lineWidth = lineWidth;
         }
     }
 }

--- a/packages/engine-render/src/components/sheets/extensions/font.ts
+++ b/packages/engine-render/src/components/sheets/extensions/font.ts
@@ -535,6 +535,7 @@ export class Font extends SheetExtension {
             color: fontCache.style?.cl?.rgb,
             strokeLine: Boolean(fontCache.style?.st?.s),
             underline: Boolean(fontCache.style?.ul?.s),
+            underlineType: fontCache.style?.ul?.t,
             cellValueType: cellData.t,
         });
     }


### PR DESCRIPTION
close #5779 

<!-- A description of the proposed changes. -->

in one of the described issues, I noticed a familiar situation regarding underlining text, but I encountered it when processing import from an excel file. Now that this problem is relevant not only for me, I would like to offer a solution.
Firstly, this solved the problem of displaying underlining on documents for the most part, but I decided to go further and add similar logic to tables. I think this can serve not only as a solution for importing an Excel file depending on the enum textdecoration described in the repository, but also as a feature in the menu for adding the required underlining. in any case it shouldn't have any breaking changes

I hope you don't mind, i added an example of this implementation to the demo of documents and tables. i think it may be convenient for review, or i can remove it, after your decision

later i can add double underscore if you also support this idea

<!-- How to test them. -->
start demo 
1. open sheets
2. open docs
<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->

Before:
behavior description is in issue

After: -->

<img width="927" height="877" alt="image" src="https://github.com/user-attachments/assets/e12c03c1-d328-4ce6-ac53-f8dfe0a40b22" />

<img width="628" height="757" alt="image" src="https://github.com/user-attachments/assets/52c7bcec-c115-4502-8262-085676291383" />

<img width="401" height="750" alt="image" src="https://github.com/user-attachments/assets/9dcd5e99-f6c2-49c7-90bd-4f06b4a5f0bc" />

