### PR TITLE
feat: double line

### DIFF
--- a/mockdata/src/docs/default-document.data-simple.ts
+++ b/mockdata/src/docs/default-document.data-simple.ts
@@ -54,26 +54,11 @@ const exampleTables = [
 
 const title = 'Examples of Accessible Data Tables\r';
 const description = 'Basic Data Table with Column Headings\r';
-
-const dotted = 'dotted\r';
-const dotted_heavy = 'dotted_heavy\r';
-const dash = 'dash\r';
-const dashed_heavy = 'dashed_heavy\r';
-const dash_long = 'dash_long\r';
-const dash_long_heavy = 'dash_long_heavy\r';
-const dot_dash = 'dot_dash\r';
-const dash_dot_heavy = 'dash_dot_heavy\r';
-const dot_dot_dash = 'dot_dot_dash\r';
-const dash_dot_dot_heavy = 'dash_dot_dot_heavy\r';
-const thick = 'thick\r';
-const wave = 'wave\r';
-
-const underline = `${dotted}${dotted_heavy}${dash}${dashed_heavy}${dash_long}${dash_long_heavy}${dot_dash}${dash_dot_heavy}${dot_dot_dash}${dash_dot_dot_heavy}${thick}${wave}`;
-
+const underline = ['dash', 'dash dot dot heavy', 'dashed dot heavy', 'dashed heavy', 'dash long', 'dash long heavy', 'dot dash', 'dot dot dash', 'dotted', 'dotted heavy', 'double', 'none', 'single', 'thick', 'wave', 'wavy double', 'wavy heavy\r'];
 const summary = 'These example tables contain captions and summaries. When you copy any of these tables into your page you must edit the caption and summary. The caption can be edited in the Design view but the summary text must be edited in Code view. Click inside the table, then select the table tag on the tag selector, then switch to Code view and edit the text in the summary attribute.\r';
 const tableStream = createTableDataStream(exampleTables);
 
-const dataStream = `${title}${description}${underline}${tableStream}${summary}\n`;
+const dataStream = `${title}${description}${underline.join(', ')}${tableStream}${summary}\n`;
 
 const startIndex = dataStream.indexOf(TABLE_START);
 const endIndex = tableStream.length + startIndex;
@@ -142,233 +127,25 @@ function createTextRuns() {
 
     offset += description.length;
 
-    textRuns.push({
-        st: offset,
-        ed: offset + dotted.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
+    for (let i = 0; i < underline.length; i++) {
+        textRuns.push({
+            st: offset,
+            ed: offset + underline[i].length,
+            ts: {
+                fs: 12,
+                ff: 'Helvetica Neue',
+                cl: {
+                    rgb: '#54585a',
+                },
+                ul: {
+                    s: 1,
+                    t: i,
+                },
             },
-            ul: {
-                s: 1,
-                t: 8,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
+        });
 
-    offset += dotted.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + dotted_heavy.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 9,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += dotted_heavy.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + dash.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 0,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += dash.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + dashed_heavy.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 3,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += dashed_heavy.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + dash_long.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 4,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += dash_long.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + dash_long_heavy.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 5,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += dash_long_heavy.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + dot_dash.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 6,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += dot_dash.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + dash_dot_heavy.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 2,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += dash_dot_heavy.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + dot_dot_dash.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 7,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += dot_dot_dash.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + dash_dot_dot_heavy.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 1,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += dash_dot_dot_heavy.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + thick.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 13,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += thick.length;
-
-    textRuns.push({
-        st: offset,
-        ed: offset + wave.length,
-        ts: {
-            fs: 12,
-            ff: 'Helvetica Neue',
-            cl: {
-                rgb: '#54585a',
-            },
-            ul: {
-                s: 1,
-                t: 14,
-            },
-            bl: BooleanNumber.FALSE,
-        },
-    });
-
-    offset += wave.length;
+        offset += underline[i].length + 2;
+    }
 
     textRuns.push({
         st: offset,

--- a/mockdata/src/sheets/demo/default-workbook-data-demo.ts
+++ b/mockdata/src/sheets/demo/default-workbook-data-demo.ts
@@ -14651,6 +14651,28 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                         },
                     },
                 },
+                54: {
+                    12: {
+                        v: 'DOUBLE',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 10,
+                            },
+                        },
+                    },
+                },
+                56: {
+                    12: {
+                        v: 'WAVY DOUBLE',
+                        s: {
+                            ul: {
+                                s: 1,
+                                t: 15,
+                            },
+                        },
+                    },
+                },
             },
 
             freeze: {

--- a/packages/engine-render/src/components/docs/extensions/line.ts
+++ b/packages/engine-render/src/components/docs/extensions/line.ts
@@ -131,6 +131,8 @@ export class Line extends docExtension {
 
         this._setLineType(ctx, lineType ?? TextDecoration.SINGLE, lineWidth);
 
+        startY += this._isDouble(lineType) ? -0.8 : 0;
+
         const centerAngle = degToRad(centerAngleDeg);
         const vertexAngle = degToRad(vertexAngleDeg);
         const start = calculateRectRotate(
@@ -150,24 +152,34 @@ export class Line extends docExtension {
 
         ctx.beginPath();
         ctx.moveTo(start.x, start.y);
-        if (this._isWave(lineType)) {
-            for (let x = start.x; x < end.x; x++) {
-                ctx.lineTo(x, end.y + 1 * Math.sin(x * 1)); // y + amplitude * frequency
-            }
-        } else {
-            ctx.lineTo(end.x, end.y);
+
+        this._drawLineTo(ctx, start.x, end.x, end.y, lineType);
+        if (this._isDouble(lineType)) {
+            ctx.moveTo(start.x, start.y + 2);
+            this._drawLineTo(ctx, start.x, end.x, end.y + 2, lineType);
         }
 
         ctx.stroke();
         ctx.restore();
     }
 
-    private _isWave(lineType: TextDecoration | undefined): boolean {
-        return lineType === TextDecoration.WAVE || lineType === TextDecoration.WAVY_HEAVY;
+    private _drawLineTo(ctx: UniverRenderingContext, startX: number, endX: number, endY: number, lineType?: TextDecoration) {
+        if (this._isWave(lineType)) {
+            for (let x = startX; x < endX; x++) {
+                ctx.lineTo(x, endY + 0.8 * Math.sin(x * 1)); // y + amplitude * frequency
+            }
+        } else {
+            ctx.lineTo(endX, endY);
+        }
     }
 
     private _setLineType(ctx: UniverRenderingContext, style: TextDecoration, lineWidth: number) {
         switch (style) {
+            case TextDecoration.SINGLE:
+            case TextDecoration.DOUBLE:
+                ctx.lineWidth = 1;
+                ctx.setLineDash([0]);
+                return;
             case TextDecoration.DOTTED:
                 ctx.lineWidth = 1;
                 ctx.setLineDash([2]);
@@ -213,6 +225,7 @@ export class Line extends docExtension {
                 ctx.setLineDash([0]);
                 return;
             case TextDecoration.WAVE:
+            case TextDecoration.WAVY_DOUBLE:
                 ctx.lineWidth = 1;
                 return;
             case TextDecoration.WAVY_HEAVY:
@@ -222,6 +235,14 @@ export class Line extends docExtension {
                 ctx.setLineDash([0]);
                 ctx.lineWidth = lineWidth;
         }
+    }
+
+    private _isWave(lineType?: TextDecoration): boolean {
+        return lineType === TextDecoration.WAVE || lineType === TextDecoration.WAVY_HEAVY || lineType === TextDecoration.WAVY_DOUBLE;
+    }
+
+    private _isDouble(lineType?: TextDecoration): boolean {
+        return lineType === TextDecoration.DOUBLE || lineType === TextDecoration.WAVY_DOUBLE;
     }
 }
 

--- a/packages/engine-render/src/shape/text.ts
+++ b/packages/engine-render/src/shape/text.ts
@@ -149,25 +149,41 @@ export class Text extends Shape<ITextProps> {
         lineType: TextDecoration;
     }) {
         const { x, y, width, color, lineWidth, lineType } = options;
+        const offsetY = this._isDouble(lineType) ? y - 0.8 : y;
 
         ctx.save();
         ctx.strokeStyle = color;
         this._setLineType(ctx, lineType, lineWidth);
         ctx.beginPath();
-        ctx.moveTo(x, y);
-        if (this._isWave(lineType)) {
-            for (let x = 1; x < width + 1; x++) {
-                ctx.lineTo(x, y + 1 * Math.sin(x * 1)); // y + amplitude * frequency
-            }
-        } else {
-            ctx.lineTo(x + width, y);
+        ctx.moveTo(x, offsetY);
+        this._drawLine(ctx, x, offsetY, width, lineType);
+
+        if (this._isDouble(lineType)) {
+            ctx.moveTo(x, offsetY + 2);
+            this._drawLine(ctx, x, offsetY + 2, width, lineType);
         }
+
         ctx.stroke();
         ctx.restore();
     }
 
+    private static _drawLine(ctx: UniverRenderingContext, x: number, y: number, width: number, lineType: TextDecoration) {
+        if (this._isWave(lineType)) {
+            for (let i = 1; i < width + 1; i++) {
+                ctx.lineTo(i, y + 0.8 * Math.sin(i * 1)); // y + amplitude * frequency
+            }
+        } else {
+            ctx.lineTo(x + width, y);
+        }
+    }
+
     private static _setLineType(ctx: UniverRenderingContext, style: TextDecoration, lineWidth: number) {
         switch (style) {
+            case TextDecoration.SINGLE:
+            case TextDecoration.DOUBLE:
+                ctx.lineWidth = 1;
+                ctx.setLineDash([0]);
+                return;
             case TextDecoration.DOTTED:
                 ctx.lineWidth = 1;
                 ctx.setLineDash([2]);
@@ -213,6 +229,7 @@ export class Text extends Shape<ITextProps> {
                 ctx.setLineDash([0]);
                 return;
             case TextDecoration.WAVE:
+            case TextDecoration.WAVY_DOUBLE:
                 ctx.lineWidth = 1;
                 return;
             case TextDecoration.WAVY_HEAVY:
@@ -225,7 +242,11 @@ export class Text extends Shape<ITextProps> {
     }
 
     private static _isWave(lineType: TextDecoration): boolean {
-        return lineType === TextDecoration.WAVE || lineType === TextDecoration.WAVY_HEAVY;
+        return lineType === TextDecoration.WAVE || lineType === TextDecoration.WAVY_HEAVY || lineType === TextDecoration.WAVY_DOUBLE;
+    }
+
+    private static _isDouble(lineType: TextDecoration): boolean {
+        return lineType === TextDecoration.DOUBLE || lineType === TextDecoration.WAVY_DOUBLE;
     }
 
     protected override _draw(ctx: UniverRenderingContext) {


### PR DESCRIPTION
<!-- A description of the proposed changes. -->

in continuation of the underlining, i decided to finish the question with a double line. Also, i made the part i added yesterday in the demo documents a bit cleaner, i think it was too bulky even for a temporary demonstration.

in fact, I have a question about TextDecoration.NONE. Can you clarify what was meant by this concept, if it is simply its absence, then perhaps it may look strange, show: true, type: none? or was it a trigger in the command that would set show false? Also I didn't quite understand how TextDecoration.WORDS can be displayed.  As far as I could see in this repository, these values ​​are not used.

<!-- How to test them. -->

start demo => 
1. open sheet
2. open doc

After: -->
<img width="934" height="542" alt="image" src="https://github.com/user-attachments/assets/4587f198-4628-4d05-9e59-9d38773be748" />
<img width="934" height="542" alt="image" src="https://github.com/user-attachments/assets/fa2b29c7-c13d-401f-8325-6494acfc49cd" />

