### PR TITLE
fix(sheets): active current font color

### DIFF
--- a/packages/core/src/types/const/const.ts
+++ b/packages/core/src/types/const/const.ts
@@ -127,7 +127,7 @@ export const DEFAULT_STYLES = {
      * color
      */
     cl: {
-        rgb: '#000',
+        rgb: '#000000',
     },
     /**
      * background

--- a/packages/sheets-ui/src/controllers/menu/menu.ts
+++ b/packages/sheets-ui/src/controllers/menu/menu.ts
@@ -533,7 +533,7 @@ export function ResetTextColorMenuItemFactory(accessor: IAccessor): IMenuButtonI
     };
 }
 
-export function TextColorSelectorMenuItemFactory(accessor: IAccessor): IMenuSelectorItem<string> {
+export function TextColorSelectorMenuItemFactory(accessor: IAccessor): IMenuSelectorItem<string, string | undefined> {
     const commandService = accessor.get(ICommandService);
     const themeService = accessor.get(ThemeService);
 
@@ -549,6 +549,29 @@ export function TextColorSelectorMenuItemFactory(accessor: IAccessor): IMenuSele
                     hoverable: false,
                     selectable: false,
                 },
+                value$: new Observable<string>((subscriber) => {
+                    const defaultValue = DEFAULT_STYLES.cl.rgb;
+                    const calc = () => {
+                        const textRun = getFontStyleAtCursor(accessor);
+
+                        if (!textRun) {
+                            subscriber.next(defaultValue);
+                            return;
+                        }
+
+                        const color = textRun.ts?.cl?.rgb;
+                        subscriber.next(color ?? defaultValue);
+                    };
+
+                    const disposable = commandService.onCommandExecuted((c) => {
+                        if (c.id === SetRangeTextColorCommand.id) {
+                            calc();
+                        }
+                    });
+
+                    calc();
+                    return disposable.dispose;
+                }),
             },
         ],
         value$: new Observable<string>((subscriber) => {

--- a/packages/sheets/src/commands/commands/__tests__/set-style.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-style.command.spec.ts
@@ -97,7 +97,7 @@ describe("Test commands used for updating cells' styles", () => {
                 .getFontColor();
         }
 
-        const defaultColor = '#000';
+        const defaultColor = '#000000';
         const color1 = '#aaa';
         const color2 = '#bbb';
         const color3 = '#ccc';
@@ -485,7 +485,7 @@ describe("Test commands used for updating cells' styles", () => {
 
                 // undo
                 expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
-                expect(getFontColor()).toBe('#000');
+                expect(getFontColor()).toBe('#000000');
                 expect(getFontThroughLine()).toStrictEqual({
                     s: BooleanNumber.TRUE,
                 }); // no color


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #5646

<!-- A description of the proposed changes. -->

Partially solved this problem, tried to fix the problem on the background, but for some reason getFontStyleAtCursor does not return the current background, probably there is some problem in this too. Thus, the problem with the active background color, unfortunately, still persists.

I also had to change the default text color to 6 hex characters, because otherwise it wouldn't match when fetching the initial active color. This is only used once in the code (except here) so it shouldn't have any effect =)

I also want to note that if this solution is confirmed, I will add similar code to the docs

<!-- How to test them. -->

start demo - open sheets - choose font color

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

behavior recorded in issue

After: -->

<img width="536" height="649" alt="image" src="https://github.com/user-attachments/assets/d0f8581f-0b9f-40f3-b926-7bbabeea09f9" />

[Screencast from 2025-09-06 21-48-15.webm](https://github.com/user-attachments/assets/e5ba6214-92fe-4825-a0c5-e88084cc45ea)

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
