### PR TITLE
fix: active text color in docs

### DIFF
--- a/packages/docs-ui/src/controllers/menu/menu.ts
+++ b/packages/docs-ui/src/controllers/menu/menu.ts
@@ -617,7 +617,7 @@ export function HeadingSelectorMenuItemFactory(accessor: IAccessor): IMenuSelect
     };
 }
 
-export function TextColorSelectorMenuItemFactory(accessor: IAccessor): IMenuSelectorItem<string> {
+export function TextColorSelectorMenuItemFactory(accessor: IAccessor): IMenuSelectorItem<string, string | undefined> {
     const commandService = accessor.get(ICommandService);
     const themeService = accessor.get(ThemeService);
 
@@ -634,6 +634,29 @@ export function TextColorSelectorMenuItemFactory(accessor: IAccessor): IMenuSele
                     hoverable: false,
                     selectable: false,
                 },
+                value$: new Observable<string>((subscriber) => {
+                    const defaultValue = DEFAULT_STYLES.cl.rgb;
+                    const calc = () => {
+                        const textRun = getFontStyleAtCursor(accessor);
+
+                        if (!textRun) {
+                            subscriber.next(defaultValue);
+                            return;
+                        }
+
+                        const color = textRun.ts?.cl?.rgb;
+                        subscriber.next(color ?? defaultValue);
+                    };
+
+                    const disposable = commandService.onCommandExecuted((c) => {
+                        if (c.id === SetInlineFormatTextColorCommand.id) {
+                            calc();
+                        }
+                    });
+
+                    calc();
+                    return disposable.dispose;
+                }),
             },
         ],
         value$: new Observable<string>((subscriber) => {


### PR DESCRIPTION
Similar implementation of the previous PR for setting the active color in the color picker, only in documents

[Screencast from 2025-09-08 21-45-27.webm](https://github.com/user-attachments/assets/03329d1f-8686-41b6-9625-f23ae56f1154)
