### PR TITLE
fix: text position with horizontal alight

### DIFF
--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -832,9 +832,10 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
 
         if (horizontalAlign === HorizontalAlign.CENTER) {
             startColumn = this._getOverflowBound(row, column, 0, contentWidth / 2, horizontalAlign);
-            endColumn = this._getOverflowBound(row, column, columnCount - 1, contentWidth / 2, horizontalAlign);
+            endColumn = this._getOverflowBound(row, column, 0, contentWidth / 2, horizontalAlign);
         } else if (horizontalAlign === HorizontalAlign.RIGHT) {
             startColumn = this._getOverflowBound(row, column, 0, contentWidth);
+            endColumn = this._getOverflowBound(row, column, 0, contentWidth);
         } else {
             endColumn = this._getOverflowBound(row, column, columnCount - 1, contentWidth);
         }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #5714 

<!-- A description of the proposed changes. -->

as part of fixing this bug, I noticed that this is also a problem for right alignment. I recorded the behavior before and after on video

I understand that with center or right alignment, if the text goes beyond the content, it probably needs to be displayed, but unfortunately I haven't found a solution to this yet, and I thought that it would be better to have some text than none at all=)

<!-- How to test them. -->

start demo -> run sheets -> try horizontal align if content > col width

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:-->

[Screencast from 2025-09-08 23-27-16.webm](https://github.com/user-attachments/assets/928bf457-3779-41f0-8fc7-623009c705e9)

After: -->

[Screencast from 2025-09-08 23-12-09.webm](https://github.com/user-attachments/assets/0b6337bc-f32a-4848-8ae2-acdd17ae90c4)

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
