### PR TITLE
fix(sheets): set bg active color in colorPicker; change deprecated methodgtgt

### DIFF
--- a/packages/core/src/sheets/util.ts
+++ b/packages/core/src/sheets/util.ts
@@ -168,7 +168,7 @@ export function getFontFormat(format?: Nullable<IStyleData>): IStyleBase {
     if (!format) {
         return {};
     }
-    const { ff, fs, it, bl, ul, st, ol, cl } = format;
+    const { ff, fs, it, bl, ul, st, ol, cl, bg } = format;
     const style: IStyleBase = {};
     ff && (style.ff = ff);
     fs && (style.fs = fs);
@@ -178,6 +178,7 @@ export function getFontFormat(format?: Nullable<IStyleData>): IStyleBase {
     st && (style.st = st);
     ol && (style.ol = ol);
     cl && (style.cl = cl);
+    bg && (style.bg = bg);
     return style;
 }
 


### PR DESCRIPTION


I found the problem why I was able to immediately set the active color on the background, fixed it, and at the same time, I saw that the getUniverDocInstance method  is deprecated,, I updated it too

start demo => open sheets => set BG Color => check this color in color picker


Before:

<img width="651" height="403" alt="image" src="https://github.com/user-attachments/assets/6464eada-bbfd-4abf-9198-66a66d6762ac" />

After: 

[Screencast from 2025-09-09 22-13-16.webm](https://github.com/user-attachments/assets/92c0e744-8e21-431f-95e3-ff04d652dd12)
