### PR TITLE
fix(render): fix horizontal alignment error

### DIFF
--- a/packages/engine-render/src/components/sheets/extensions/font.ts
+++ b/packages/engine-render/src/components/sheets/extensions/font.ts
@@ -489,26 +489,9 @@ export class Font extends SheetExtension {
         const { vertexAngle = 0, wrapStrategy, cellData } = fontCache;
         if (cellData?.v === undefined || cellData?.v === null) return;
         const text = extractPureTextFromCell(cellData);
-        let { startX, startY, endX, endY } = renderFontCtx;
-        let cellWidth = endX - startX - paddingLeft - paddingRight;
+        const { startX, startY, endX, endY } = renderFontCtx;
+        const cellWidth = endX - startX - paddingLeft - paddingRight;
         const cellHeight = endY - startY - paddingTop - paddingBottom;
-
-        const overflowRectangle = overflowCache.getValue(row, col);
-        const isOverflow = !(wrapStrategy === WrapStrategy.WRAP && vertexAngle === 0);
-        if (isOverflow && overflowRectangle) {
-            const endColumn = overflowRectangle.endColumn;
-            const startColumn = overflowRectangle.startColumn;
-            const startRow = overflowRectangle.startRow;
-            const endRow = overflowRectangle.endRow;
-            const endCell = renderFontCtx.spreadsheetSkeleton.getCellWithCoordByIndex(endRow, endColumn);
-            endX = endCell.endX;
-            endY = endCell.endY;
-
-            const startCell = renderFontCtx.spreadsheetSkeleton.getCellWithCoordByIndex(startRow, startColumn);
-            startX = startCell.startX;
-            startY = startCell.startY;
-            cellWidth = endX - startX - paddingLeft - paddingRight;
-        }
 
         // If the horizontal alignment is not specified, we need to determine it based on the cell value type.
         let hAlign = fontCache.horizontalAlign;


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
when cell width is smaller than text width, right and center alignment rendering errors

Before:
<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/f9a34bf2-7b78-4ef0-a7c5-0e7ac7636212" />

Now:
<img width="1216" height="924" alt="image" src="https://github.com/user-attachments/assets/9d3fd6d8-2e5b-4c42-b795-20f7c2d85b35" />


<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
