### PR TITLE
fix: text under active input

### DIFF
--- a/packages/docs-ui/src/controllers/render-controllers/doc-editor-bridge.controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc-editor-bridge.controller.ts
@@ -17,7 +17,7 @@
 import type { DocumentDataModel, ICommandInfo, Nullable } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
 import type { IRenderContext, IRenderModule } from '@univerjs/engine-render';
-import { checkForSubstrings, Disposable, DisposableCollection, ICommandService, Inject, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
+import { checkForSubstrings, Disposable, DisposableCollection, DOCS_NORMAL_EDITOR_UNIT_ID_KEY, ICommandService, Inject, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
 import { DocSkeletonManagerService, RichTextEditingMutation } from '@univerjs/docs';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { fromEvent } from 'rxjs';
@@ -124,7 +124,14 @@ export class DocEditorBridgeController extends Disposable implements IRenderModu
 
                 const focusEditor = this._editorService.getFocusEditor();
 
-                if (editor == null || editor.isSheetEditor() || (focusEditor && focusEditor.getEditorId() === unitId)) {
+                const docSkeleton = this._getEditorSkeleton();
+                if (!docSkeleton) {
+                    return;
+                }
+
+                docSkeleton.resetInitialWidth();
+
+                if (editor == null || !docSkeleton || editor.isSheetEditor() || (focusEditor && focusEditor.getEditorId() === unitId)) {
                     return;
                 }
 
@@ -208,5 +215,9 @@ export class DocEditorBridgeController extends Disposable implements IRenderModu
                 }
             })
         );
+    }
+
+    private _getEditorSkeleton() {
+        return this._renderManagerService.getRenderById(DOCS_NORMAL_EDITOR_UNIT_ID_KEY)?.with(DocSkeletonManagerService).getSkeleton();
     }
 }

--- a/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
+++ b/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
@@ -124,6 +124,8 @@ export class DocumentSkeleton extends Skeleton {
 
     private _iteratorCount = 0;
 
+    private _initialWidth = 0;
+
     constructor(
         private _docViewModel: DocumentViewModel,
         localeService: LocaleService
@@ -140,6 +142,7 @@ export class DocumentSkeleton extends Skeleton {
         this._skeletonData = null;
         this._findLiquid = null as unknown as Liquid;
         this._docViewModel.dispose();
+        this._initialWidth = 0;
     }
 
     getViewModel() {
@@ -167,16 +170,19 @@ export class DocumentSkeleton extends Skeleton {
         return this._skeletonData;
     }
 
+    resetInitialWidth() {
+        this._initialWidth = 0;
+    }
+
     getActualSize() {
         const skeletonData = this.getSkeletonData();
-
-        let actualWidth = Number.NEGATIVE_INFINITY;
+        let actualWidth = 0;
         let actualHeight = 0;
 
         skeletonData?.pages.forEach((page) => {
             const { width, height } = page;
-            actualWidth = Math.max(actualWidth, width);
-
+            actualWidth = Math.max(this._initialWidth, width);
+            this._initialWidth = actualWidth;
             actualHeight += height;
         });
 
@@ -1165,7 +1171,6 @@ export class DocumentSkeleton extends Skeleton {
         // TODO: 10 is too small?
         if (ctx.isDirty && this._iteratorCount < 10) {
             this._iteratorCount++;
-
             resetContext(ctx);
             return this._createSkeleton(ctx, _bounds);
         } else {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #5840

<!-- A description of the proposed changes. -->

as I wrote in the issue it seemed strange to me to see the text when erasing it, at the same time, I really like your solution that appears when scrolling. It seems to me that this solution does not contradict your design, but significantly user experience and expected behavior.

Please note that the size is reset when you lose focus, it does not decrease when you delete characters, but it increases if necessary

It's up to you, but I think this decision is appropriate.


Before: recorded in issue

After: 

[Screencast from 2025-09-12 21-19-28.webm](https://github.com/user-attachments/assets/40c277f7-2c38-40f1-9bf6-febe229c96ab)

