### PR TITLE
fix: active cell border color

### DIFF
--- a/packages/core/src/sheets/util.ts
+++ b/packages/core/src/sheets/util.ts
@@ -168,7 +168,7 @@ export function getFontFormat(format?: Nullable<IStyleData>): IStyleBase {
     if (!format) {
         return {};
     }
-    const { ff, fs, it, bl, ul, st, ol, cl, bg } = format;
+    const { ff, fs, it, bl, ul, st, ol, cl, bg, bd } = format;
     const style: IStyleBase = {};
     ff && (style.ff = ff);
     fs && (style.fs = fs);
@@ -179,6 +179,8 @@ export function getFontFormat(format?: Nullable<IStyleData>): IStyleBase {
     ol && (style.ol = ol);
     cl && (style.cl = cl);
     bg && (style.bg = bg);
+    bd && (style.bd = bd);
+
     return style;
 }
 

--- a/packages/sheets-ui/src/components/border-panel/BorderPanel.tsx
+++ b/packages/sheets-ui/src/components/border-panel/BorderPanel.tsx
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
+import type { DocumentDataModel, IBorderData, Nullable,
+} from '@univerjs/core';
 import type { IBorderInfo } from '@univerjs/sheets';
 import type { IBorderPanelProps } from './interface';
-import { BorderStyleTypes } from '@univerjs/core';
+import {
+    BorderStyleTypes,
+    DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
+    IUniverInstanceService,
+} from '@univerjs/core';
 import { clsx, ColorPicker, Dropdown, Separator } from '@univerjs/design';
 import { MoreDownIcon, PaintBucketDoubleIcon } from '@univerjs/icons';
 import { BorderStyleManagerService } from '@univerjs/sheets';
@@ -71,9 +77,21 @@ const BORDER_SIZE_CHILDREN = [
     },
 ];
 
+function getBorderColor(borderData: Nullable<IBorderData>): string | undefined {
+    if (!borderData) return;
+    for (const key in borderData) {
+        const border = borderData[key as keyof IBorderData];
+        if (border?.cl?.rgb) return border.cl.rgb;
+    }
+}
+
 export function BorderPanel(props: IBorderPanelProps) {
     const componentManager = useDependency(ComponentManager);
     const borderStyleManagerService = useDependency(BorderStyleManagerService);
+    const univerInstanceService = useDependency(IUniverInstanceService);
+    const editorDataModel = univerInstanceService.getUnit<DocumentDataModel>(DOCS_NORMAL_EDITOR_UNIT_ID_KEY);
+    const textRuns = editorDataModel?.getBody()?.textRuns;
+    const color = getBorderColor(textRuns?.[0]?.ts?.bd);
 
     const { onChange, value } = props;
 
@@ -126,7 +144,7 @@ export function BorderPanel(props: IBorderPanelProps) {
                     <Dropdown
                         overlay={(
                             <div className="univer-rounded-lg univer-p-4">
-                                <ColorPicker onChange={(value) => handleClick(value, 'color')} />
+                                <ColorPicker value={color} onChange={(value) => handleClick(value, 'color')} />
                             </div>
                         )}
                     >


### PR DESCRIPTION
the color in the color picker for cells that have borders has always been default. Now it has the same behavior as other color pickers

Before: always default color #000000

After: 

[Screencast from 2025-09-13 21-25-20.webm](https://github.com/user-attachments/assets/614d2961-2ed0-46bd-b9ac-43af6ca0a036)


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
