### PR TITLE
fix(render): fix the issue of background rendering misalignment when hiding the first row of merged cells

### DIFF
--- a/packages/engine-render/src/components/sheets/extensions/background.ts
+++ b/packages/engine-render/src/components/sheets/extensions/background.ts
@@ -187,10 +187,38 @@ export class Background extends SheetExtension {
             return true;
         }
 
-        // getRowVisible can take a lot of time, sometimes over 20+ms, this return condition should put in the last.
-        const visibleRow = spreadsheetSkeleton.worksheet.getRowVisible(row);
-        const visibleCol = spreadsheetSkeleton.worksheet.getColVisible(col);
-        if (!visibleRow || !visibleCol) return true;
+        if (!isMerged && !isMergedMainCell) {
+            // getRowVisible can take a lot of time, sometimes over 20+ms, this return condition should put in the last.
+            const visibleRow = spreadsheetSkeleton.worksheet.getRowVisible(row);
+            if (!visibleRow) return true;
+
+            const visibleCol = spreadsheetSkeleton.worksheet.getColVisible(col);
+            if (!visibleCol) return true;
+        } else {
+            let isAllRowHidden = true;
+
+            for (let r = mergeInfo.startRow; r <= mergeInfo.endRow; r++) {
+                const visibleRow = spreadsheetSkeleton.worksheet.getRowVisible(r);
+                if (visibleRow) {
+                    isAllRowHidden = false;
+                    break;
+                }
+            }
+
+            if (isAllRowHidden) return true;
+
+            let isAllColHidden = true;
+
+            for (let c = mergeInfo.startColumn; c <= mergeInfo.endColumn; c++) {
+                const visibleCol = spreadsheetSkeleton.worksheet.getColVisible(c);
+                if (visibleCol) {
+                    isAllColHidden = false;
+                    break;
+                }
+            }
+
+            if (isAllColHidden) return true;
+        }
 
         // precise is a workaround for windows, macOS does not have this issue.
         const startXPrecise = fixLineWidthByScale(startX, scaleX);

--- a/packages/engine-render/src/components/sheets/extensions/border.ts
+++ b/packages/engine-render/src/components/sheets/extensions/border.ts
@@ -106,8 +106,10 @@ export class Border extends SheetExtension {
 
         if (!isMerged) {
             const visibleRow = spreadsheetSkeleton.worksheet.getRowVisible(row);
+            if (!visibleRow) return true;
+
             const visibleCol = spreadsheetSkeleton.worksheet.getColVisible(col);
-            if (!visibleRow || !visibleCol) return true;
+            if (!visibleCol) return true;
         }
 
         if (!this.isRenderDiffRangesByRow(mergeInfo.startRow, mergeInfo.endRow, diffRanges)) {

--- a/packages/engine-render/src/components/sheets/extensions/font.ts
+++ b/packages/engine-render/src/components/sheets/extensions/font.ts
@@ -246,8 +246,10 @@ export class Font extends SheetExtension {
 
         if (notInMergeRange) {
             const visibleRow = spreadsheetSkeleton.worksheet.getRowVisible(row);
+            if (!visibleRow) return true;
+
             const visibleCol = spreadsheetSkeleton.worksheet.getColVisible(col);
-            if (!visibleRow || !visibleCol) return true;
+            if (!visibleCol) return true;
         } else {
             let isAllRowHidden = true;
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #5857

Before:
<img width="1912" height="924" alt="image" src="https://github.com/user-attachments/assets/c0a7f0c4-1d06-4f34-8b79-30471d36c7d0" />

After: -->
<img width="1912" height="924" alt="image" src="https://github.com/user-attachments/assets/3a412d98-3e5d-4dfb-aec6-fbb6d1806f1a" />


<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
