### PR TITLE
fix: statistic not fully displayed

### DIFF
--- a/packages/sheets-ui/src/views/status-bar/CopyableStatisticItem.tsx
+++ b/packages/sheets-ui/src/views/status-bar/CopyableStatisticItem.tsx
@@ -69,7 +69,7 @@ export const CopyableStatisticItem: FC<IStatisticItem> = (item: IStatisticItem) 
             <div
                 key={item.name}
                 className={`
-                  univer-flex univer-max-w-24 univer-cursor-default univer-truncate univer-text-center univer-text-xs
+                  univer-flex univer-cursor-pointer univer-truncate univer-text-center univer-text-xs
                   univer-text-gray-400
                 `}
                 onClick={copyToClipboard}


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

in the statistics component when selecting a number range the content was cut off, now it is always displayed. In addition, I allowed myself to suggest you change the cursor from the default to the pointer, because this is probably a more expected behavior... but if it is necessary to remove it to the default, please let me know, I will remove it.

languages ​​that had a problem: en, fr, ru, es,  ca



Before:

<img width="1324" height="356" alt="image" src="https://github.com/user-attachments/assets/d5e5df5f-4cf8-469a-bd88-706d4a930f78" />

<img width="895" height="333" alt="image" src="https://github.com/user-attachments/assets/50710b3e-390b-40bb-9ad9-dc016b649f69" />

<img width="895" height="333" alt="image" src="https://github.com/user-attachments/assets/cf46d290-68e3-49d7-a6d8-e23aad0cda94" />

<img width="895" height="333" alt="image" src="https://github.com/user-attachments/assets/2a646304-3633-445b-8346-e5f566e0ccb3" />

<img width="895" height="333" alt="image" src="https://github.com/user-attachments/assets/69920e40-e0af-43fd-849c-9b9f1714aace" />


After: 

<img width="735" height="270" alt="image" src="https://github.com/user-attachments/assets/ade05832-e183-4f65-a66e-4eb17469e703" />

<img width="735" height="270" alt="image" src="https://github.com/user-attachments/assets/82dc4894-e98c-44b9-914c-7b7006b0638e" />

<img width="735" height="270" alt="image" src="https://github.com/user-attachments/assets/77ae6ae2-5ac3-487b-b903-8d8871520f7a" />

<img width="735" height="270" alt="image" src="https://github.com/user-attachments/assets/81c5011e-8fd1-4689-8397-e9440c8b6ea7" />

<img width="735" height="270" alt="image" src="https://github.com/user-attachments/assets/0fb5982b-66c9-4895-9423-dcc60fee2e5f" />


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
