### PR TITLE
feat: add double border

### DIFF
--- a/packages/engine-render/src/components/sheets/extensions/border.ts
+++ b/packages/engine-render/src/components/sheets/extensions/border.ts
@@ -163,6 +163,15 @@ export class Border extends SheetExtension {
                 endX,
                 endY,
             });
+
+            if (style === BorderStyleTypes.DOUBLE) {
+                drawLineByBorderType(ctx, type, (lineWidth - 1) / 2 / precisionScale, {
+                    startX: startX + 2,
+                    startY: startY + 2,
+                    endX: endX - 2,
+                    endY: endY - 2,
+                });
+            }
         }
     }
 

--- a/packages/sheets-ui/src/components/border-panel/BorderPanel.tsx
+++ b/packages/sheets-ui/src/components/border-panel/BorderPanel.tsx
@@ -69,6 +69,10 @@ const BORDER_SIZE_CHILDREN = [
         label: BorderStyleTypes.THICK,
         value: BorderStyleTypes.THICK,
     },
+    {
+        label: BorderStyleTypes.DOUBLE,
+        value: BorderStyleTypes.DOUBLE,
+    },
 ];
 
 export function BorderPanel(props: IBorderPanelProps) {

--- a/packages/sheets-ui/src/components/border-panel/border-line/BorderLine.tsx
+++ b/packages/sheets-ui/src/components/border-panel/border-line/BorderLine.tsx
@@ -19,6 +19,7 @@ import { BorderStyleTypes } from '@univerjs/core';
 import { BorderDashDot } from './icons/BorderDashDot';
 import { BorderDashDotDot } from './icons/BorderDashDotDot';
 import { BorderDashed } from './icons/BorderDashed';
+import { BorderDouble } from './icons/BorderDouble';
 import { BorderHair } from './icons/BorderHair';
 import { BorderMedium } from './icons/BorderMedium';
 import { BorderMediumDashDot } from './icons/BorderMediumDashDot';
@@ -54,6 +55,8 @@ export function BorderLine(props: IBorderLineProps) {
             return <BorderMediumDashed className={className} />;
         case BorderStyleTypes.THICK:
             return <BorderThick className={className} />;
+        case BorderStyleTypes.DOUBLE:
+            return <BorderDouble className={className} />;
         case BorderStyleTypes.THIN:
         default:
             return <BorderThin className={className} />;

--- a/packages/sheets-ui/src/components/border-panel/border-line/icons/BorderDouble.tsx
+++ b/packages/sheets-ui/src/components/border-panel/border-line/icons/BorderDouble.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const BorderDouble = ({ className }: { className: string }) => (
+    <svg className={className} width="120" height="8" viewBox="0 0 120 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M119.991 2.06215H-0.0090332V0.862152H119.991V1.86215Z"
+        />
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M119.991 6.66215H-0.0090332V5.86215H119.991V6.86215Z"
+        />
+    </svg>
+);


### PR DESCRIPTION


considering that there is a type of double borders, I decided to propose to implement it


run demo => open sheets => choose border double

Before: was not supported

After: 

<img width="698" height="457" alt="image" src="https://github.com/user-attachments/assets/5ac51a76-d3af-46a0-bac8-6ad50ffbcb1a" />

<img width="568" height="397" alt="image" src="https://github.com/user-attachments/assets/354e1d8b-8d0c-48ab-aff7-1fc7d7cba980" />

<img width="698" height="457" alt="image" src="https://github.com/user-attachments/assets/8148c7e6-efd4-4f16-967c-277a82edbf98" />


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
