### PR TITLE
feat: diagonal double border

### DIFF
--- a/packages/engine-render/src/basics/draw.ts
+++ b/packages/engine-render/src/basics/draw.ts
@@ -97,7 +97,7 @@ export function drawLineByBorderType(ctx: UniverRenderingContext, type: BORDER_L
     ctx.closePathByEnv();
 }
 
-export function drawDiagonalLineByBorderType(ctx: UniverRenderingContext, type: BORDER_LTRB, position: IPosition) {
+function drawDiagonalSingleLineByBorderType(ctx: UniverRenderingContext, type: BORDER_LTRB, position: IPosition) {
     let drawStartX = 0;
     let drawStartY = 0;
     let drawEndX = 0;
@@ -148,6 +148,61 @@ export function drawDiagonalLineByBorderType(ctx: UniverRenderingContext, type: 
     ctx.lineToByPrecision(drawEndX, drawEndY);
     ctx.closePathByEnv();
     ctx.stroke();
+}
+
+function drawDiagonalDoubleLineByBorderType(ctx: UniverRenderingContext, type: BORDER_LTRB, position: IPosition) {
+    let drawFirstStartX = 0;
+    let drawFirstStartY = 0;
+    let drawFirstEndX = 0;
+    let drawFirstEndY = 0;
+    let drawSecondStartX = 0;
+    let drawSecondStartY = 0;
+    let drawSecondEndX = 0;
+    let drawSecondEndY = 0;
+    const { startX, startY, endX, endY } = position;
+    switch (type) {
+        case BORDER_LTRB.TL_BR:
+            drawFirstStartX = startX;
+            drawFirstStartY = startY + 1.5;
+            drawFirstEndX = endX - 1.5;
+            drawFirstEndY = endY;
+            drawSecondStartX = startX + 1.5;
+            drawSecondStartY = startY;
+            drawSecondEndX = endX;
+            drawSecondEndY = endY - 1.5;
+            break;
+        case BORDER_LTRB.BL_TR:
+            drawFirstStartX = startX;
+            drawFirstStartY = endY - 1.5;
+            drawFirstEndX = endX - 1.5;
+            drawFirstEndY = startY;
+            drawSecondStartX = startX + 1.5;
+            drawSecondStartY = endY;
+            drawSecondEndX = endX;
+            drawSecondEndY = startY + 1.5;
+            break;
+    }
+
+    // ctx.clearRect(drawStartX - 1, drawStartY - 1, drawEndX - drawStartX + 2, drawEndY - drawStartY + 2);
+    ctx.beginPath();
+    ctx.moveToByPrecision(drawFirstStartX, drawFirstStartY);
+    ctx.lineToByPrecision(drawFirstEndX, drawFirstEndY);
+    ctx.closePathByEnv();
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveToByPrecision(drawSecondStartX, drawSecondStartY);
+    ctx.lineToByPrecision(drawSecondEndX, drawSecondEndY);
+    ctx.closePathByEnv();
+    ctx.stroke();
+}
+
+export function drawDiagonalineByBorderType(ctx: UniverRenderingContext, style: BorderStyleTypes, type: BORDER_LTRB, position: IPosition) {
+    if (style === BorderStyleTypes.DOUBLE && (type === BORDER_LTRB.TL_BR || type === BORDER_LTRB.BL_TR)) {
+        drawDiagonalDoubleLineByBorderType(ctx, type, position);
+    } else {
+        drawDiagonalSingleLineByBorderType(ctx, type, position);
+    }
 }
 
 export function clearLineByBorderType(ctx: UniverRenderingContext, type: BORDER_LTRB, position: IPosition) {

--- a/packages/engine-render/src/components/sheets/extensions/border.ts
+++ b/packages/engine-render/src/components/sheets/extensions/border.ts
@@ -22,7 +22,7 @@ import type { BorderCache, BorderCacheItem } from '../interfaces';
 import type { SpreadsheetSkeleton } from '../sheet.render-skeleton';
 import { BorderStyleTypes, Range } from '@univerjs/core';
 import { BORDER_TYPE as BORDER_LTRB, COLOR_BLACK_RGB, FIX_ONE_PIXEL_BLUR_OFFSET } from '../../../basics/const';
-import { drawDiagonalLineByBorderType, drawLineByBorderType, getLineWidth, setLineType } from '../../../basics/draw';
+import { drawDiagonalineByBorderType, drawLineByBorderType, getLineWidth, setLineType } from '../../../basics/draw';
 import { SpreadsheetExtensionRegistry } from '../../extension';
 import { SheetExtension } from './sheet-extension';
 
@@ -146,7 +146,7 @@ export class Border extends SheetExtension {
             ctx.setLineWidthByPrecision(lineWidth);
             ctx.strokeStyle = color || COLOR_BLACK_RGB;
 
-            drawDiagonalLineByBorderType(ctx, type, {
+            drawDiagonalineByBorderType(ctx, style, type, {
                 startX,
                 startY,
                 endX,


### PR DESCRIPTION
close #5878

<!-- A description of the proposed changes. -->

This is not a full implementation of the features that were proposed @VicKun4937, because it seems to me that this requires some decomposition into subtasks. However, I didn't know if I should include the issue number in the close. I decided to point it out just in case. When closing, it might be worth resuming the task of double underlines not related to diagonals.

But I would like to note that I have just started to try out the implementation related to this feature, and I still can’t imagine how I can remove the cross highlight between the double lines.  Perhaps you have an idea on this matter. 
I'll be glad to hear it if that's the case.

If we are closer to this PR, then it seemed necessary to me to first implement the functionality for double borders associated with diagonals

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

double borders for diagonals were not implemented

After: -->

<img width="1845" height="1041" alt="Pasted image (2)" src="https://github.com/user-attachments/assets/4979eba9-5290-49ce-91fe-52a06035ce7d" />

<img width="1845" height="1041" alt="Pasted image (3)" src="https://github.com/user-attachments/assets/c97a165f-0084-468d-ba81-a59516586567" />

<img width="1845" height="1041" alt="Pasted image" src="https://github.com/user-attachments/assets/40eb9516-4bcf-4c80-bcf5-23b7a054fb74" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
