### PR TITLE
feat: active border type in dropdown value

### DIFF
--- a/packages/sheets-ui/src/components/border-panel/BorderPanel.tsx
+++ b/packages/sheets-ui/src/components/border-panel/BorderPanel.tsx
@@ -230,7 +230,7 @@ export function BorderPanel(props: IBorderPanelProps) {
                                   univer-fill-gray-900
                                   dark:!univer-fill-white
                                 `}
-                                type={BorderStyleTypes.THIN}
+                                type={type ?? BorderStyleTypes.THIN}
                             />
                             <MoreDownIcon className="dark:!univer-text-white" />
                         </button>


### PR DESCRIPTION
In the process of highlighting the CheckMark Icon of the active border, I missed the implementation directly in the dropdown value. this solves the problem

Before:

always Thin

After: 

[Screencast from 2025-09-17 20-43-42.webm](https://github.com/user-attachments/assets/66c70ce1-4861-41a2-b757-f3a21294bb4c)

## Pull Request Checklist
- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
