### PR TITLE
fix: shortcut cropped content in kbd component

### DIFF
--- a/packages/design/src/components/kbd/Kbd.tsx
+++ b/packages/design/src/components/kbd/Kbd.tsx
@@ -31,8 +31,8 @@ export function KBD(props: IKBDProps) {
     return (
         <span
             className={clsx(`
-              univer-inline-block univer-h-6 univer-select-none univer-rounded-md univer-bg-gray-50 univer-px-2
-              univer-font-mono univer-text-xs/6 univer-font-medium univer-text-gray-700
+              univer-inline-block univer-h-6 univer-select-none univer-whitespace-nowrap univer-rounded-md
+              univer-bg-gray-50 univer-px-2 univer-font-mono univer-text-xs/6 univer-font-medium univer-text-gray-700
               dark:!univer-bg-gray-700 dark:!univer-text-white
             `, borderClassName, className)}
         >

--- a/packages/design/src/components/kbd/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/design/src/components/kbd/__tests__/__snapshots__/index.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`KBD > should render with default props 1`] = `
 <div>
   <span
-    class="univer-inline-block univer-h-6 univer-select-none univer-rounded-md univer-bg-gray-50 univer-px-2 univer-font-mono univer-text-xs/6 univer-font-medium univer-text-gray-700 dark:!univer-bg-gray-700 dark:!univer-text-white univer-border-gray-200 dark:!univer-border-gray-600 univer-border-solid univer-border"
+    class="univer-inline-block univer-h-6 univer-select-none univer-whitespace-nowrap univer-rounded-md univer-bg-gray-50 univer-px-2 univer-font-mono univer-text-xs/6 univer-font-medium univer-text-gray-700 dark:!univer-bg-gray-700 dark:!univer-text-white univer-border-gray-200 dark:!univer-border-gray-600 univer-border-solid univer-border"
   >
     <kbd
       class="univer-inline-block univer-h-full"
@@ -17,7 +17,7 @@ exports[`KBD > should render with default props 1`] = `
 exports[`KBD > should render with multiple keys 1`] = `
 <div>
   <span
-    class="univer-inline-block univer-h-6 univer-select-none univer-rounded-md univer-bg-gray-50 univer-px-2 univer-font-mono univer-text-xs/6 univer-font-medium univer-text-gray-700 dark:!univer-bg-gray-700 dark:!univer-text-white univer-border-gray-200 dark:!univer-border-gray-600 univer-border-solid univer-border"
+    class="univer-inline-block univer-h-6 univer-select-none univer-whitespace-nowrap univer-rounded-md univer-bg-gray-50 univer-px-2 univer-font-mono univer-text-xs/6 univer-font-medium univer-text-gray-700 dark:!univer-bg-gray-700 dark:!univer-text-white univer-border-gray-200 dark:!univer-border-gray-600 univer-border-solid univer-border"
   >
     <kbd
       class="univer-inline-block univer-h-full"

--- a/packages/ui/src/locale/ru-RU.ts
+++ b/packages/ui/src/locale/ru-RU.ts
@@ -65,7 +65,7 @@ const locale: typeof enUS = {
         Pacifico: 'Pacifico',
     },
     'shortcut-panel': {
-        title: 'Ярлыки',
+        title: 'Сочетания клавиш',
     },
     shortcut: {
         undo: 'Отменить',
@@ -73,10 +73,10 @@ const locale: typeof enUS = {
         cut: 'Вырезать',
         copy: 'Копировать',
         paste: 'Вставить',
-        'shortcut-panel': 'Переключить панель ярлыков',
+        'shortcut-panel': 'Переключить панель сочетания клавиш',
     },
     'common-edit': 'Общие команды редактирования',
-    'toggle-shortcut-panel': 'Переключить панель ярлыков',
+    'toggle-shortcut-panel': 'Переключить панель сочетания клавиш',
     clipboard: {
         authentication: {
             title: 'Доступ запрещен',
@@ -95,7 +95,7 @@ const locale: typeof enUS = {
         confirm: 'Подтвердить',
         cancel: 'Отменить',
     },
-    'global-shortcut': 'Глобальные ярлыки',
+    'global-shortcut': 'Сочетания клавиш',
     'zoom-slider': {
         resetTo: 'Сбросить до',
     },

--- a/packages/ui/src/views/components/shortcut-panel/ShortcutPanel.tsx
+++ b/packages/ui/src/views/components/shortcut-panel/ShortcutPanel.tsx
@@ -108,11 +108,12 @@ export function ShortcutPanel() {
                             <li
                                 key={`${item.title}-${item.shortcut}`}
                                 className={`
-                                  univer-flex univer-h-10 univer-items-center univer-justify-between univer-text-sm
+                                  univer-flex univer-h-10 univer-items-center univer-justify-between univer-py-0.5
+                                  univer-text-sm
                                   last:univer-border-b-0
                                 `}
                             >
-                                <span className="univer-line-clamp-1">{item.title}</span>
+                                <span className="univer-line-clamp-2">{item.title}</span>
                                 {item.shortcut && <KBD keyboard={item.shortcut} />}
                             </li>
                         ))}


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

I noticed that the key combination for long texts has a hyphenation, which makes it impossible to read the correct key combination

I fixed this issue by initially leaving the text on a single line, but it became virtually impossible to read the description of this text; it was too hidden. Therefore, I would like to suggest, in addition to fixing the key combination itself, increasing the description text to two lines. I think this will make it more convenient for users.

The problem affected the following languages: ru, fr, es, ca


I also changed the Russian language a little, because this previous translation is not actually used in conversation and is aimed at something slightly different

Before:

<img width="170" height="221" alt="image" src="https://github.com/user-attachments/assets/ce2dec08-0f51-44ca-a19d-ff3c67c3f37a" />


<img width="387" height="238" alt="image" src="https://github.com/user-attachments/assets/8340c5df-9bc8-484a-b177-273998a69a2e" />

<img width="387" height="238" alt="image" src="https://github.com/user-attachments/assets/781bd8f8-adce-4ca1-8e9a-4c69ca3cdcde" />

<img width="387" height="238" alt="image" src="https://github.com/user-attachments/assets/50a9c4ce-9d9d-4f03-bf19-b809c6c6237a" />

<img width="387" height="238" alt="image" src="https://github.com/user-attachments/assets/e6db504c-1da7-4fcb-8bdd-d728f068225c" />

After: 

<img width="403" height="262" alt="image" src="https://github.com/user-attachments/assets/30e9a00d-14a8-40cd-b57f-4a1687fe4e54" />

<img width="177" height="221" alt="image" src="https://github.com/user-attachments/assets/e6865559-1b0e-43a4-a7d8-8aa22cd067a0" />

<img width="387" height="238" alt="image" src="https://github.com/user-attachments/assets/9d9dc3c8-a81c-4cac-abb2-1af32bf8e4ca" />

<img width="387" height="238" alt="image" src="https://github.com/user-attachments/assets/621b13aa-cad4-45bd-b0e5-9bb9b7811df7" />

<img width="387" height="238" alt="image" src="https://github.com/user-attachments/assets/f240d539-345f-4462-90da-6fd65ee9668a" />

<img width="387" height="238" alt="image" src="https://github.com/user-attachments/assets/7f09288c-8577-4e98-8808-d442d01e085b" />


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
