### PR TITLE
fix: content in the image edit button

### DIFF
--- a/packages/drawing-ui/src/views/panel/DrawingArrange.tsx
+++ b/packages/drawing-ui/src/views/panel/DrawingArrange.tsx
@@ -68,7 +68,7 @@ export const DrawingArrange = (props: IDrawingArrangeProps) => {
                 <div>{localeService.t('image-panel.arrange.title')}</div>
             </header>
 
-            <div className="univer-grid univer-grid-cols-2 univer-gap-2 univer-px-8">
+            <div className="univer-grid univer-grid-cols-2 univer-gap-2">
                 <Button onClick={() => { onArrangeBtnClick(ArrangeTypeEnum.forward); }}>
                     <MoveUpIcon />
                     {localeService.t('image-panel.arrange.forward')}


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

In the group of buttons for editing images in the fr and ru languages, the icon moved beyond the button


Before:

<img width="391" height="533" alt="image" src="https://github.com/user-attachments/assets/8a918ea8-7c30-4680-9a8f-f9c1dc4a9584" />

<img width="391" height="533" alt="image" src="https://github.com/user-attachments/assets/99b60b97-37bb-4b96-9103-8815d16c1017" />

After: 

<img width="391" height="533" alt="image" src="https://github.com/user-attachments/assets/9c8c1f5b-1d53-469a-981f-419a0b36e43e" />

<img width="391" height="533" alt="image" src="https://github.com/user-attachments/assets/d4619190-1e44-4dfe-85df-ec7c7e832a59" />


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
