### PR TITLE
fix: (RATE func) Validate cash flow signs and support zero PMT scenarios for Excel compatibility

### DIFF
--- a/packages/engine-formula/src/functions/financial/rate/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/financial/rate/__tests__/index.spec.ts
@@ -136,5 +136,36 @@ describe('Test rate function', () => {
                 [ErrorType.NA, ErrorType.NA, ErrorType.NA, ErrorType.NA],
             ]);
         });
+
+        // New tests for all-positive or all-negative cash flows
+        it('Returns #NUM! when all cash flows have the same positive sign', () => {
+            const result = testFunction.calculate(
+                NumberValueObject.create(12),
+                NumberValueObject.create(100),
+                NumberValueObject.create(1000),
+                NumberValueObject.create(100)
+            );
+            expect(getObjectValue(result)).toBe(ErrorType.NUM);
+        });
+
+        it('Returns #NUM! when all cash flows have the same negative sign', () => {
+            const result = testFunction.calculate(
+                NumberValueObject.create(12),
+                NumberValueObject.create(-100),
+                NumberValueObject.create(-1000),
+                NumberValueObject.create(-100)
+            );
+            expect(getObjectValue(result)).toBe(ErrorType.NUM);
+        });
+
+        it('Calculates rate correctly with mixed signs', () => {
+            const result = testFunction.calculate(
+                NumberValueObject.create(48),
+                NumberValueObject.create(0),
+                NumberValueObject.create(-8000),
+                NumberValueObject.create(9000)
+            );
+            expect(typeof getObjectValue(result)).toBe('number');
+        });
     });
 });

--- a/packages/engine-formula/src/functions/financial/rate/index.ts
+++ b/packages/engine-formula/src/functions/financial/rate/index.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { ErrorType } from '../../../basics/error-type';
+import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
 import type { BaseValueObject } from '../../../engine/value-object/base-value-object';
+import { ErrorType } from '../../../basics/error-type';
+import { expandArrayValueObject } from '../../../engine/utils/array-object';
+import { checkVariantsErrorIsStringToNumber } from '../../../engine/utils/check-variant-error';
 import { ErrorValueObject } from '../../../engine/value-object/base-value-object';
 import { NumberValueObject } from '../../../engine/value-object/primitive-object';
 import { BaseFunction } from '../../base-function';
-import type { ArrayValueObject } from '../../../engine/value-object/array-value-object';
-import { expandArrayValueObject } from '../../../engine/utils/array-object';
-import { checkVariantsErrorIsStringToNumber } from '../../../engine/utils/check-variant-error';
 
 export class Rate extends BaseFunction {
     override minParams = 3;
@@ -91,7 +91,6 @@ export class Rate extends BaseFunction {
                  (pmtValue <= 0 && pvValue <= 0 && fvValue <= 0)) {
                 return ErrorValueObject.create(ErrorType.NUM);
             }
-
 
             return this._getResult(nperValue, pmtValue, pvValue, fvValue, typeValue, guessValue, rowIndex, columnIndex);
         });

--- a/packages/engine-formula/src/functions/financial/rate/index.ts
+++ b/packages/engine-formula/src/functions/financial/rate/index.ts
@@ -82,9 +82,16 @@ export class Rate extends BaseFunction {
 
             typeValue = typeValue ? 1 : 0;
 
-            if (nperValue <= 0 || pmtValue >= 0) {
+            if (nperValue <= 0) {
                 return ErrorValueObject.create(ErrorType.NUM);
             }
+
+            // ? return error whenever the cash flows doesn’t make economic sense
+            if ((pmtValue >= 0 && pvValue >= 0 && fvValue >= 0) ||
+                 (pmtValue <= 0 && pvValue <= 0 && fvValue <= 0)) {
+                return ErrorValueObject.create(ErrorType.NUM);
+            }
+
 
             return this._getResult(nperValue, pmtValue, pvValue, fvValue, typeValue, guessValue, rowIndex, columnIndex);
         });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->
## Description
This PR fixes the `RATE` function by improving validation of cash flow inputs to prevent invalid scenarios, aligning behavior more closely with Excel.


### Previous behavior in the codebase

Previously, the function did not correctly validate the signs of cash flows and could return a `#NUM!` error even in valid cases such as lump-sum investments where `PMT` is zero. This update ensures the function only returns an error for truly invalid cash flow sign patterns, improving accuracy and user experience.

### New behavior in the codebase

- Returns an error when all cash flows (`PMT`, `PV`, and `FV`) have the same sign (all non-negative or all non-positive), reflecting invalid economic cash flow scenarios.  
  This is because in financial calculations, cash flows must include at least one outflow and one inflow to represent money moving in and out; if all cash flows are positive or all are negative, the scenario doesn’t make economic sense and no meaningful rate of return can be calculated.

- Supports cases where `PMT` is zero and valid `PV` and `FV` values exist, improving compatibility with Excel’s lump-sum RATE calculations.

- Prevents false `#NUM!` errors on valid lump-sum RATE calculations.

## How to Test

Test formulas like:

```excel
=RATE(48, 0, -8000, 9000)  // Should return a valid rate, not #NUM!
