### PR TITLE
feat: side menu stylization

### DIFF
--- a/packages/docs-ui/src/components/side-menu/index.tsx
+++ b/packages/docs-ui/src/components/side-menu/index.tsx
@@ -46,7 +46,7 @@ export interface ISideMenuInstance {
     scrollTo: (id: string) => void;
 }
 
-const commonClass = 'univer-overflow-hidden univer-font-[500] univer-truncate univer-h-[24px] univer-mb-2 univer-leading-[24px] univer-ellipsis univer-cursor-pointer';
+const commonClass = 'univer-overflow-hidden univer-font-[500] univer-truncate univer-h-[24px] univer-mb-2 univer-leading-[24px] univer-ellipsis univer-cursor-pointer univer-pr-1 ';
 const titleClass = 'univer-text-base univer-font-semibold';
 const h1Class = 'univer-text-sm univer-font-semibold';
 const textClass = 'univer-text-sm';

--- a/packages/docs-ui/src/views/side-menu/index.tsx
+++ b/packages/docs-ui/src/views/side-menu/index.tsx
@@ -229,7 +229,7 @@ function DocSideMenuContent() {
                 open={open}
                 onOpenChange={setOpen}
                 mode={mode}
-                maxWidth={mode === 'float' ? undefined : Math.floor(left)}
+                maxWidth={mode === 'float' ? undefined : Math.floor(left) - 10}
                 wrapperClass="univer-mt-12"
                 activeId={activeId}
                 onClick={handleClick}


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

I was examining the sidebar menu where paragraphs are displayed and noticed that the heading text actually overlaps the border, and if the text exceeds the maximum size, the menu border overlaps the document border. I'd suggest some small indents, and I think it looks nicer. I'd probably increase the right padding even more.

By the way, team, I want to let you know that I'll be on vacation for the next few weeks, so if anything happens, I'm not missing, I'm just on vacation =)

Before:

<img width="1709" height="636" alt="image" src="https://github.com/user-attachments/assets/25968ecb-ae3a-4ccd-8071-81df256a3f77" />

<img width="219" height="211" alt="image" src="https://github.com/user-attachments/assets/004758e8-06cf-451b-9528-688ddcd26fed" />

<img width="1715" height="399" alt="image" src="https://github.com/user-attachments/assets/01b291ca-2ef1-448a-9bcc-594b26de83c8" />

<img width="170" height="195" alt="image" src="https://github.com/user-attachments/assets/ee4182c1-8268-4e4b-af68-68149642c6a0" />

After: 

<img width="1709" height="636" alt="image" src="https://github.com/user-attachments/assets/6e53b33d-57ae-45f1-8468-76ee59203a6e" />

<img width="1709" height="636" alt="image" src="https://github.com/user-attachments/assets/f713e678-72e9-4d94-8e42-e148256e2274" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
