### PR TITLE
feat: add space on create sheet copy

### DIFF
--- a/packages/sheets/src/commands/commands/__tests__/copy-worksheet.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/copy-worksheet.command.spec.ts
@@ -97,11 +97,11 @@ describe('Test copy worksheet commands', () => {
                 localeService.setLocale(LocaleType.EN_US);
                 const name = 'Sheet1';
 
-                expect(getCopyUniqueSheetName(workbook, localeService, name)).toBe('Sheet1(Copy)');
+                expect(getCopyUniqueSheetName(workbook, localeService, name)).toBe('Sheet1 (Copy)');
 
-                workbook.addWorksheet('sheet1-copy', 0, { name: 'Sheet1(Copy)' });
+                workbook.addWorksheet('sheet1-copy', 0, { name: 'Sheet1 (Copy)' });
 
-                expect(getCopyUniqueSheetName(workbook, localeService, name)).toBe('Sheet1(Copy2)');
+                expect(getCopyUniqueSheetName(workbook, localeService, name)).toBe('Sheet1 (Copy2)');
             });
         });
     });

--- a/packages/sheets/src/commands/commands/copy-worksheet.command.ts
+++ b/packages/sheets/src/commands/commands/copy-worksheet.command.ts
@@ -101,11 +101,11 @@ export const CopySheetCommand: ICommand = {
 
 // If Sheet1(Copy) already exists and you copy Sheet1, you should get Sheet1(Copy2)
 export function getCopyUniqueSheetName(workbook: Workbook, localeService: LocaleService, name: string): string {
-    let output = name + localeService.t('sheets.tabs.sheetCopy', '');
+    let output = `${name} ${localeService.t('sheets.tabs.sheetCopy', '')}`;
     let count = 2;
 
     while (workbook.checkSheetName(output)) {
-        output = name + localeService.t('sheets.tabs.sheetCopy', `${count}`);
+        output = `${name} ${localeService.t('sheets.tabs.sheetCopy', `${count}`)}`;
         count++;
     }
     return output;


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

I thought I'd make one more suggestion before I go on vacation =)

When copying a sheet name, there are currently no spaces between the new sheet name and the extension (copy). However, perhaps you could consider my suggestion to add this issue, as I think it would improve the user experience.

For example,
- Excel uses a space between the new name and the copy number:
![photo_2025-09-24_17-39-15](https://github.com/user-attachments/assets/576120b1-ceb5-4ed5-830d-f9c8d5e00ba3)

- LibreOffice uses an underscore:
<img width="395" height="101" alt="image" src="https://github.com/user-attachments/assets/209e06c9-40eb-4b21-b40a-6a0747dce2f0" />


- Google also uses a space:
<img width="542" height="135" alt="image" src="https://github.com/user-attachments/assets/2fb2fe11-f88d-4246-a315-d98d5f0348b4" />


Before: has no spaces, written together

After:
<img width="586" height="90" alt="image" src="https://github.com/user-attachments/assets/443a16d9-167e-41d7-9174-1dc21ae78e95" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
