### PR TITLE
fix: defined name bar - actions tooltip position

### DIFF
--- a/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
@@ -246,44 +246,45 @@ export const DefinedNameContainer = () => {
                                         {definedName.formulaOrRefString}
                                     </div>
                                 </div>
-                                <Tooltip title={localeService.t('definedName.updateButton')} placement="top">
-                                    <a
-                                        className={`
-                                          univer-absolute univer-right-[60px] univer-top-1/2 univer-hidden
-                                          -univer-translate-y-1/2 univer-cursor-pointer univer-items-center
-                                          univer-justify-center univer-rounded univer-p-1 univer-text-xs
-                                          univer-text-primary-600
-                                          hover:univer-bg-gray-100
-                                          group-hover:univer-flex
-                                          dark:hover:!univer-bg-gray-600
-                                        `}
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            closeInsertOpenKeyEditor(definedName.id);
-                                        }}
-                                    >
-                                        <PenIcon />
-                                    </a>
-                                </Tooltip>
-                                <Tooltip title={localeService.t('definedName.deleteButton')} placement="top">
-                                    <a
-                                        className={`
-                                          univer-text-error univer-absolute univer-right-5 univer-top-1/2 univer-hidden
-                                          -univer-translate-y-1/2 univer-cursor-pointer univer-items-center
-                                          univer-justify-center univer-rounded univer-p-1 univer-text-xs
-                                          univer-text-red-600
-                                          hover:univer-bg-gray-100
-                                          group-hover:univer-flex
-                                          dark:hover:!univer-bg-gray-600
-                                        `}
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            deleteDefinedName(definedName.id);
-                                        }}
-                                    >
-                                        <DeleteIcon />
-                                    </a>
-                                </Tooltip>
+                                <div
+                                    className={`
+                                      univer-absolute univer-right-5 univer-top-1/2 univer-hidden
+                                      -univer-translate-y-1/2 univer-cursor-pointer univer-items-center
+                                      univer-justify-end univer-gap-7 univer-text-xs univer-text-primary-600
+                                      group-hover:univer-flex
+                                      dark:hover:!univer-bg-gray-600
+                                    `}
+                                >
+                                    <Tooltip title={localeService.t('definedName.updateButton')} placement="top">
+                                        <a
+                                            className={`
+                                              univer-rounded univer-p-1
+                                              hover:univer-bg-gray-100
+                                            `}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                closeInsertOpenKeyEditor(definedName.id);
+                                            }}
+                                        >
+                                            <PenIcon />
+                                        </a>
+                                    </Tooltip>
+                                    <Tooltip title={localeService.t('definedName.deleteButton')} placement="top">
+                                        <a
+                                            className={`
+                                              univer-rounded univer-p-1 univer-text-red-600
+                                              hover:univer-bg-gray-100
+                                            `}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                deleteDefinedName(definedName.id);
+                                            }}
+                                        >
+                                            <DeleteIcon />
+                                        </a>
+                                    </Tooltip>
+                                </div>
+
                             </div>
 
                             <Confirm


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

The defined name bar had a number of issues when hovering over the edit and delete buttons. At a minimum, the tooltip appeared offset from the icon, but a more serious issue was that in some locales, the tooltip overlapped the icon, making it unclickable.

p.s. i´m back 😀
Before:

<img width="357" height="219" alt="image" src="https://github.com/user-attachments/assets/4d154bd3-6e1a-4ca9-952a-50d8cea4733a" />
<img width="357" height="219" alt="image" src="https://github.com/user-attachments/assets/5767f552-f3c4-4536-8d8e-d4a03ad11a3f" />

<img width="357" height="219" alt="image" src="https://github.com/user-attachments/assets/b6901772-7363-4443-984b-29300487a12c" />

<img width="362" height="225" alt="image" src="https://github.com/user-attachments/assets/e88100d3-73cd-4797-93f2-5344cef677be" />

<img width="362" height="225" alt="image" src="https://github.com/user-attachments/assets/a37516e6-0290-4ddc-9dbf-eb570af91f91" />

<img width="362" height="225" alt="image" src="https://github.com/user-attachments/assets/5f8f65c7-a51c-4d25-9784-3632f9c6820b" />

After:

<img width="357" height="219" alt="image" src="https://github.com/user-attachments/assets/747bf93b-9e5d-4ae8-9152-9b28ce7a7843" />

<img width="357" height="219" alt="image" src="https://github.com/user-attachments/assets/8ef49b4a-d169-413f-ab79-cc747a433bb9" />

<img width="362" height="225" alt="image" src="https://github.com/user-attachments/assets/4ca18051-150c-45a9-b091-1bdb31ff9ed7" />

<img width="362" height="225" alt="image" src="https://github.com/user-attachments/assets/6b389487-d1b2-4980-976b-e5c746cd136e" />

<img width="362" height="225" alt="image" src="https://github.com/user-attachments/assets/fdde036b-a764-4ef0-b0ff-b1ef78ee2e1c" />

<img width="362" height="225" alt="image" src="https://github.com/user-attachments/assets/9cbc4122-4120-41ec-beca-08df6c9a0108" />


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
