### PR TITLE
fix: defined name Ru support

### DIFF
--- a/packages/core/src/shared/tools.ts
+++ b/packages/core/src/shared/tools.ts
@@ -573,7 +573,7 @@ export class Tools {
     }
 
     static isStartValidPosition(name: string): boolean {
-        const startsWithLetterOrUnderscore = /^[A-Za-z_]/.test(name);
+        const startsWithLetterOrUnderscore = /^[A-Za-zА-Яа-яЁё_]/.test(name);
 
         return startsWithLetterOrUnderscore;
     }


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

In the current implementation, although the default name in Russian is included in the input by default, it cannot be saved. This solves the problem.

<!-- How to test them. -->
start demo => change to Ru Lang => create new defined name


Before:

<img width="333" height="305" alt="image" src="https://github.com/user-attachments/assets/2f5abe2e-b5ff-4d6f-bf84-b4b17bfc1eb7" />

After:

<img width="329" height="163" alt="image" src="https://github.com/user-attachments/assets/3efd02a1-cdc3-4003-870f-7ec63729579d" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
