### PR TITLE
fix: colorPickerDialog normalize short hex

### DIFF
--- a/packages/design/src/components/color-picker/color-conversion.ts
+++ b/packages/design/src/components/color-picker/color-conversion.ts
@@ -105,6 +105,7 @@ export const rgbToHsv = (r: number, g: number, b: number): [number, number, numb
 };
 
 export const hexToHsv = (hex: string): [number, number, number] => {
+    if (hex.length === 4) hex = `#${hex.slice(1).split('').map((i) => i + i).join('')}`;
     const [r, g, b] = hex.match(/\w\w/g)!.map((x) => Number.parseInt(x, 16));
     return rgbToHsv(r, g, b);
 };


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

When selecting an additional color, if its abbreviated notation is received as the quality, Nan is displayed in the input

Before:

<img width="1518" height="1004" alt="image" src="https://github.com/user-attachments/assets/03b060c7-d2ae-414a-9306-879fcd659949" />

After:

<img width="336" height="296" alt="image" src="https://github.com/user-attachments/assets/4761d8b5-3768-4c21-ab61-f41303232e53" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
