### PR TITLE
fix: ul margin in funtions list

### DIFF
--- a/packages/sheets-formula-ui/src/views/more-functions/select-function/SelectFunction.tsx
+++ b/packages/sheets-formula-ui/src/views/more-functions/select-function/SelectFunction.tsx
@@ -165,7 +165,7 @@ export function SelectFunction(props: ISelectFunctionProps) {
             {selectList.length > 0 && (
                 <ul
                     className={clsx(`
-                      univer-m-0 univer-mt-2 univer-box-border univer-max-h-72 univer-w-full univer-select-none
+                      univer-mb-0 univer-mt-2 univer-box-border univer-max-h-72 univer-w-full univer-select-none
                       univer-list-none univer-overflow-y-auto univer-rounded univer-p-3 univer-outline-none
                     `, borderClassName, scrollbarClassName)}
                     onKeyDown={handleSelectListKeyDown}


### PR DESCRIPTION

close #xxx

<!-- A description of the proposed changes. -->

Although it works well for me on the demo, I noticed that it can have unstable behavior.

For example, look at this option
<img width="1518" height="1004" alt="image" src="https://github.com/user-attachments/assets/fcf1f1e5-4e3f-421a-a085-fe4747e6c286" />

<img width="386" height="60" alt="image" src="https://github.com/user-attachments/assets/7a114b62-3f58-4fdb-b1b4-4d067732a792" />

While studying the developer console, I noticed that the style with a top margin can be interrupted by the zero margin style.

<img width="848" height="842" alt="image" src="https://github.com/user-attachments/assets/0d6675c7-6cd6-45a9-824e-bccfe16be4a8" />

perhaps this will have more stable behavior, since on my project, the situation is exactly the same

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
