### PR TITLE
feat: increase UX in formulaBar

### DIFF
--- a/packages/sheets-ui/src/views/formula-bar/FormulaBar.tsx
+++ b/packages/sheets-ui/src/views/formula-bar/FormulaBar.tsx
@@ -303,7 +303,7 @@ export function FormulaBar(props: IProps) {
                               univer-text-base
                               dark:!univer-text-white
                             `, {
-                                'univer-cursor-pointer univer-text-green-600 hover:univer-bg-gray-100 dark:!univer-text-green-400 dark:hover:!univer-bg-gray-700': iconActivated,
+                                'univer-cursor-pointer univer-text-red-600 hover:univer-bg-gray-100 dark:!univer-text-green-400 dark:hover:!univer-bg-gray-700': iconActivated,
                             })}
                             onClick={handleCloseBtnClick}
                         >
@@ -315,7 +315,7 @@ export function FormulaBar(props: IProps) {
                               univer-text-base
                               dark:!univer-text-white
                             `, {
-                                'univer-cursor-pointer univer-text-red-600 hover:univer-bg-gray-100 dark:!univer-text-red-400 dark:hover:!univer-bg-gray-700': iconActivated,
+                                'univer-cursor-pointer univer-text-green-600 hover:univer-bg-gray-100 dark:!univer-text-red-400 dark:hover:!univer-bg-gray-700': iconActivated,
                             })}
                             onClick={handleConfirmBtnClick}
                         >


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->
I'd like to suggest some minor changes to the bar formula. The thing is, the actions of canceling or applying an input have colors that hint to the user about the opposite result. For example, red, the color of destructive behavior, seems a little odd to me that it's on a successful action.

Conversely, when I see a cross that seems to delete my input, I find it odd that it's green.

I think the current proposal could improve the user experience and better meet their expectations, including by drawing on experience with other editors, including Excel, Libre, and others.

Libre:
<img width="431" height="304" alt="image" src="https://github.com/user-attachments/assets/2d8e411a-5aa5-4e11-900b-83ad70ce464a" />

Excel:
<img width="721" height="313" alt="image" src="https://github.com/user-attachments/assets/aa965730-5f37-421e-804b-5a92efe4a425" />


Before:

<img width="335" height="230" alt="image" src="https://github.com/user-attachments/assets/be0e5f49-e26e-430c-9c43-7b19479b976a" />

After:

<img width="211" height="135" alt="image" src="https://github.com/user-attachments/assets/5af7b2a0-503f-4165-90db-6de30bd2dadf" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
