### PR TITLE
fix: err with updateInlineDrawingCoordsAndBorder

### DIFF
--- a/packages/engine-render/src/components/docs/layout/tools.ts
+++ b/packages/engine-render/src/components/docs/layout/tools.ts
@@ -486,7 +486,7 @@ export function updateInlineDrawingCoordsAndBorder(ctx: ILayoutContext, pages: I
             const lastDivide = line.divides[line.divides.length - 1];
             const lastGlyph = lastDivide.glyphGroup[lastDivide.glyphGroup.length - 1];
 
-            if (lastGlyph.streamType === DataStreamTreeTokenType.PARAGRAPH && paragraphStyle?.borderBottom) {
+            if (lastGlyph?.streamType === DataStreamTreeTokenType.PARAGRAPH && paragraphStyle?.borderBottom) {
                 line.borderBottom = paragraphStyle.borderBottom;
             }
         }


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->
With certain copy-paste combinations, an error appeared in the console
<img width="705" height="223" alt="image" src="https://github.com/user-attachments/assets/fa74eff0-57f4-4dd7-8a88-094987c942b2" />

Before:
<img width="705" height="223" alt="image" src="https://github.com/user-attachments/assets/fa74eff0-57f4-4dd7-8a88-094987c942b2" />
After:

no error


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
