### PR TITLE
fix: add ellipsis if defined name long

### DIFF
--- a/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
@@ -228,7 +228,7 @@ export const DefinedNameContainer = () => {
                                     <div
                                         className={`
                                           univer-my-1 univer-max-h-[100px] univer-max-w-[190px] univer-overflow-hidden
-                                          univer-text-sm univer-font-medium univer-text-gray-900
+                                          univer-text-ellipsis univer-text-sm univer-font-medium univer-text-gray-900
                                           dark:!univer-text-white
                                         `}
                                     >


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

in the defined names panel, if it exceeds the width it is cut off, I added a class so that it would be with dots

Before:
<img width="356" height="216" alt="image" src="https://github.com/user-attachments/assets/7ebf43d2-402d-4b3b-b475-aed1ccabc007" />

After:
<img width="356" height="216" alt="image" src="https://github.com/user-attachments/assets/17f21ce6-185c-4970-89be-3d3a6f2d4ea5" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
