### PR TITLE
fix: delete sheet get location err

### DIFF
--- a/packages/core/src/sheets/sheet-skeleton.ts
+++ b/packages/core/src/sheets/sheet-skeleton.ts
@@ -1038,7 +1038,8 @@ export class SheetSkeleton extends Skeleton {
         this._cellData = null as unknown as ObjectMatrix<Nullable<ICellData>>;
         this._styles = null as unknown as Styles;
         //@ts-ignore
-        this.worksheet = null as unknown as Worksheet;
+        // this breaks the getLocation method when deleting a sheet.
+        // this.worksheet = null as unknown as Worksheet;
     }
 }
 


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->
When deleting a sheet, the workbook stops displaying. I looked at the changelog and came to the conclusion that this is related to memory leak optimization https://github.com/dream-num/univer/pull/5988 At this time I decided to suggest commenting this out and giving a comment in the code about it. 
I wanted to clarify if you're only releasing this on Saturday, as it seems to me that this is a pretty disruptive change, and perhaps a patch would be appropriate. What do you think?

Before:
[Screencast from 2025-10-21 12-16-20.webm](https://github.com/user-attachments/assets/c92aebdd-39cd-422e-ab21-627f7fd5fad6)

After: 

works as before

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
