### PR TITLE
fix: add style in copy-sheet event

### DIFF
--- a/packages/sheets/src/commands/commands/copy-worksheet.command.ts
+++ b/packages/sheets/src/commands/commands/copy-worksheet.command.ts
@@ -56,11 +56,13 @@ export const CopySheetCommand: ICommand = {
         config.name = getCopyUniqueSheetName(workbook, localeService, config.name);
         config.id = generateRandomId();
         const sheetIndex = workbook.getSheetIndex(worksheet);
+        const styles = workbook.getStyles().toJSON();
 
         const insertSheetMutationParams: IInsertSheetMutationParams = {
             index: sheetIndex + 1,
             sheet: config,
             unitId,
+            styles,
         };
 
         const removeSheetMutationParams: IRemoveSheetMutationParams = InsertSheetUndoMutationFactory(


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->
In this issue https://github.com/dream-num/univer/issues/5967,  we discussed the problem of passing a style ID that collaborators might not receive in events. After which, @wpxp123456 made some changes, and overall, it's great, but unfortunately, these styles were never finished, this fix is ​​aimed at that
Sorry for my overactivity, but it seems like it's worth finishing

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
