### PR TITLE
fix: searchFunction long defined name

### DIFF
--- a/packages/sheets-formula-ui/src/views/formula-editor/search-function/SearchFunction.tsx
+++ b/packages/sheets-formula-ui/src/views/formula-editor/search-function/SearchFunction.tsx
@@ -224,7 +224,7 @@ function SearchFunctionFactory(props: ISearchFunctionProps, ref: any) {
                             }
                         }}
                     >
-                        <span className="univer-text-xs">
+                        <span className="univer-block univer-overflow-x-hidden univer-text-ellipsis univer-text-xs">
                             <span className="univer-text-red-500">{item.name.substring(0, searchText.length)}</span>
                             <span>{item.name.slice(searchText.length)}</span>
                         </span>


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->
In the function search pop-up window, if the name is too long, then the hover on this element does not look very good, but does the user really expect to see scrolling along the x-axis here and will use it? so my suggestion is to do it through dots on overflow

Before:
<img width="431" height="502" alt="image" src="https://github.com/user-attachments/assets/57d96be9-62c2-49ad-a785-391852fa076c" />

<img width="368" height="208" alt="image" src="https://github.com/user-attachments/assets/6ec9d7c0-222b-4ce0-916d-d2730910c494" />

I've also looked at other editors' solutions on this issue, and in my opinion, they're missing the point. How can 255 characters be readable? example:
<img width="604" height="542" alt="image" src="https://github.com/user-attachments/assets/9ba86d9a-47e7-4715-b647-c034e4769acd" />

I think this is the most optimal solution.
After: -->

<img width="325" height="478" alt="image" src="https://github.com/user-attachments/assets/8deee606-65a2-4986-b170-fdce5157104a" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
