### PR TITLE
fix: tooltip if content overflow show ellipsis

### DIFF
--- a/packages/design/src/components/tooltip/Tooltip.tsx
+++ b/packages/design/src/components/tooltip/Tooltip.tsx
@@ -254,7 +254,7 @@ export function Tooltip(props: ITooltipProps) {
                 onMouseEnter={() => showTooltip()}
                 onMouseLeave={() => hideTooltip()}
             >
-                <div>{title}</div>
+                <div className="univer-break-words">{title}</div>
                 <div
                     ref={arrowRef}
                     className={`


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

When examining link tooltips in documents, if the link text exceeds the tooltip length, the text extends beyond it. As it turns out, this is typical not only for documents but also for tables. I believe the fix in this PR addresses all possible overflow cases.

I'd like to point out that I initially wanted to suggest ellipsis, but I noticed that some links behave differently. There are links that only display on one line if they've been split. Therefore, given that some links can be quite long, it makes sense to impose some kind of line limit.

Before:
<img width="692" height="317" alt="image" src="https://github.com/user-attachments/assets/3d886254-00c9-4cff-a877-1f84351d1485" />

<img width="728" height="266" alt="image" src="https://github.com/user-attachments/assets/e0084722-e628-49ff-b4d2-0461f1160e6b" />

After: 

<img width="492" height="218" alt="image" src="https://github.com/user-attachments/assets/210c980a-e2e3-4edf-aa6a-3653592ab766" />

<img width="492" height="218" alt="image" src="https://github.com/user-attachments/assets/f6dc5ec6-7998-4aa8-81fb-c9c69bb8f6b2" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
