### PR TITLE
feat: add clear icon on defined name comment; fix: overlaying a value on clear icon

### DIFF
--- a/packages/design/src/components/input/Input.tsx
+++ b/packages/design/src/components/input/Input.tsx
@@ -118,6 +118,10 @@ export const Input = forwardRef<HTMLInputElement, IInputProps>(
             return () => observer?.disconnect();
         }, [slotRef.current]);
 
+        useEffect(() => {
+            if (allowClear && !(slot && slotRef.current)) setPaddingRight(26);
+        }, []); // only enough for init, otherwise it works again when you click it
+
         return (
             <div
                 data-u-comp="input"

--- a/packages/sheets-ui/src/views/defined-name/DefinedNameInput.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameInput.tsx
@@ -282,6 +282,7 @@ export const DefinedNameInput = (props: IDefinedNameInputProps) => {
                     placeholder={localeService.t('definedName.inputCommentPlaceholder')}
                     value={commentValue}
                     onChange={setCommentValue}
+                    allowClear
                 />
             </div>
             <div


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->
I noticed that the values ​​in the input that have an icon for clearing the value overlap the icon itself. It's clickable, but I don't think that's supposed to happen. I noticed that there's already logic regarding the right margin for slots, so I decided to use a separate useEffect and add a check that would not conflict with slots, also in [] I deliberately did not add allowClear, since this caused an extra trigger, since the first time the value was entered, an indent would still be needed. 

I also found it strange that the name itself had this icon in defined names, but the comment didn't have it.

Before:
<img width="329" height="295" alt="image" src="https://github.com/user-attachments/assets/905df512-37f0-46a5-8cbc-4d70a71004f6" />

After: -->
<img width="329" height="295" alt="image" src="https://github.com/user-attachments/assets/a7fe5f47-ca5d-4319-aaa4-aa34c8d62f3d" />

<img width="329" height="295" alt="image" src="https://github.com/user-attachments/assets/bc3f48d9-12e5-4082-94b5-57e0a2f2d6d5" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
