### PR TITLE
fix: 2 errors with the same text

### DIFF
--- a/packages/sheets-numfmt-ui/src/controllers/numfmt-alert-render.controller.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/numfmt-alert-render.controller.ts
@@ -82,16 +82,20 @@ export class NumfmtAlertRenderController extends Disposable implements IRenderMo
                         return;
                     }
 
-                    const currentAlert = this._cellAlertManagerService.currentAlert.get(ALERT_KEY);
-                    const currentLoc = currentAlert?.alert?.location;
-                    if (
-                        currentLoc &&
-                        currentLoc.row === location.row &&
-                        currentLoc.col === location.col &&
-                        currentLoc.subUnitId === location.subUnitId &&
-                        currentLoc.unitId === location.unitId
-                    ) {
-                        return;
+                    const currentAlerts = this._cellAlertManagerService.currentAlert;
+
+                    for (const [_, value] of currentAlerts.entries()) {
+                        const currentLoc = value?.alert?.location;
+
+                        if (
+                            currentLoc &&
+                            currentLoc.row === location.row &&
+                            currentLoc.col === location.col &&
+                            currentLoc.subUnitId === location.subUnitId &&
+                            currentLoc.unitId === location.unitId
+                        ) {
+                            return;
+                        }
                     }
 
                     this._cellAlertManagerService.showAlert({


### PR DESCRIPTION
close #5972

<!-- A description of the proposed changes. -->

When trying to fix the bug, given that we had previously used a check for the presence of an error message in this cell by key, I wondered if this was necessary. So, two different errors would generally be shown in one cell, and given that we had already encountered two errors with the same text, it seemed appropriate to me.

In fact, I think that this problem, or rather the clearing of other error messages, still requires attention, perhaps they should be cleared when a new one appears... but this is a subject for another discussion


Before:

described in issue

After: 
<img width="857" height="304" alt="image" src="https://github.com/user-attachments/assets/6e923efe-e49f-484e-b322-8f6f7bf59842" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
