### PR TITLE
fix: thread-comment-ui panel width

### DIFF
--- a/packages/thread-comment-ui/src/commands/operations/comment.operations.ts
+++ b/packages/thread-comment-ui/src/commands/operations/comment.operations.ts
@@ -34,7 +34,7 @@ export const ToggleSheetCommentPanelOperation: ICommand = {
             sidebarService.open({
                 header: { title: 'threadCommentUI.panel.title' },
                 children: { label: THREAD_COMMENT_PANEL },
-                width: 330,
+                width: 360,
             });
             panelService.setPanelVisible(true);
         }


### PR DESCRIPTION
close #xxx
In the comments panel, scrolling appeared along the x-axis. I fixed this by changing the width of this panel.

Additionally, I'd like to discuss another change. I noticed that a significant number of sidebars have a width of 360, while others may have variations of 312, 333, and so on. Do you think it might be worthwhile to create a default value constant for the sidebar, for example, 360, and use it for all sidebars that are smaller than this width, and for those that are larger, set the desired value

The proposal is valid due to the fact that this is essentially a single sidebar, and the user can probably expect a standard size when they appear or change.

If you agree with this statement, I will make a PR about it.

Before:
<img width="429" height="1283" alt="image" src="https://github.com/user-attachments/assets/21384067-8fbe-4b6e-b6d4-969a05515404" />
<img width="429" height="1283" alt="image" src="https://github.com/user-attachments/assets/1dd128d0-6231-4120-898a-4823de8b0e30" />

After: 
<img width="429" height="1283" alt="image" src="https://github.com/user-attachments/assets/fa704233-80ad-4716-bcae-29ffbdd36224" />
<img width="429" height="1283" alt="image" src="https://github.com/user-attachments/assets/9d828b6d-608d-441f-a3c6-0cc3fecfc56d" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
