### PR TITLE
fix(docs): comment title expanded width container

### DIFF
--- a/packages/thread-comment-ui/src/views/thread-comment-panel/index.tsx
+++ b/packages/thread-comment-ui/src/views/thread-comment-panel/index.tsx
@@ -160,7 +160,6 @@ export const ThreadCommentPanel = (props: IThreadCommentPanelProps) => {
 
     const renderComment = (comment: IThreadComment) => (
         <ThreadCommentTree
-            full
             prefix={prefix}
             getSubUnitName={getSubUnitName}
             key={comment.id}

--- a/packages/thread-comment-ui/src/views/thread-comment-tree/index.tsx
+++ b/packages/thread-comment-ui/src/views/thread-comment-tree/index.tsx
@@ -405,11 +405,11 @@ export const ThreadCommentTree = (props: IThreadCommentTreeProps) => {
                         `}
                     />
                     <Tooltip showIfEllipsis title={title}>
-                        <div
+                        <span
                             className="univer-flex-1 univer-truncate"
                         >
                             {title}
-                        </div>
+                        </span>
                     </Tooltip>
                 </div>
                 {!!comments && (


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->
comment title expanded width container

I don't really understand why there's a full width there. I haven't found any cases for displaying it like that, so it seems logical to remove it.

P.S. Without replacing div with span, the tooltip doesn't work.

Before:

<img width="570" height="1197" alt="image" src="https://github.com/user-attachments/assets/d3d8bf68-d3b5-48f2-ad7f-add7664d1b20" />

After:

<img width="828" height="415" alt="image" src="https://github.com/user-attachments/assets/bcd74fa3-4991-4ed7-b3bd-9655fd1c3ac3" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
