### PR TITLE
chore: revisions of repeating styles associated with truncate

### DIFF
--- a/packages/docs-ui/src/components/side-menu/index.tsx
+++ b/packages/docs-ui/src/components/side-menu/index.tsx
@@ -46,7 +46,7 @@ export interface ISideMenuInstance {
     scrollTo: (id: string) => void;
 }
 
-const commonClass = 'univer-overflow-hidden univer-font-[500] univer-truncate univer-h-[24px] univer-mb-2 univer-leading-[24px] univer-ellipsis univer-cursor-pointer univer-pr-1 ';
+const commonClass = 'univer-font-[500] univer-truncate univer-h-[24px] univer-mb-2 univer-leading-[24px] univer-cursor-pointer univer-pr-1 ';
 const titleClass = 'univer-text-base univer-font-semibold';
 const h1Class = 'univer-text-sm univer-font-semibold';
 const textClass = 'univer-text-sm';

--- a/packages/sheets-filter-ui/src/views/components/SheetsFilterByValuesPanel.tsx
+++ b/packages/sheets-filter-ui/src/views/components/SheetsFilterByValuesPanel.tsx
@@ -99,8 +99,7 @@ export function FilterByValue(props: { model: ByValuesModel }) {
                         <span
                             data-u-comp="sheets-filter-panel-values-item-text"
                             className={`
-                              univer-mx-1 univer-inline-block univer-flex-shrink univer-overflow-hidden
-                              univer-text-ellipsis univer-whitespace-nowrap univer-text-gray-900
+                              univer-mx-1 univer-inline-block univer-flex-shrink univer-truncate univer-text-gray-900
                               dark:!univer-text-white
                             `}
                         >

--- a/packages/sheets-ui/src/views/defined-name/DefinedNameOverlay.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameOverlay.tsx
@@ -115,8 +115,8 @@ export function DefinedNameOverlay() {
                             >
                                 <div
                                     className={`
-                                      univer-w-[50%] univer-flex-shrink-0 univer-overflow-hidden univer-text-ellipsis
-                                      univer-whitespace-nowrap univer-text-sm univer-text-gray-600
+                                      univer-w-[50%] univer-flex-shrink-0 univer-truncate univer-text-sm
+                                      univer-text-gray-600
                                       dark:!univer-text-gray-200
                                     `}
                                     title={definedName.name}
@@ -125,8 +125,8 @@ export function DefinedNameOverlay() {
                                 </div>
                                 <div
                                     className={`
-                                      univer-w-[50%] univer-flex-shrink-0 univer-overflow-hidden univer-text-ellipsis
-                                      univer-whitespace-nowrap univer-text-xs univer-text-gray-400
+                                      univer-w-[50%] univer-flex-shrink-0 univer-truncate univer-text-xs
+                                      univer-text-gray-400
                                     `}
                                     title={definedName.formulaOrRefString}
                                 >

--- a/packages/sheets-ui/src/views/dropdown/list-dropdown/index.tsx
+++ b/packages/sheets-ui/src/views/dropdown/list-dropdown/index.tsx
@@ -133,9 +133,8 @@ function SelectList(props: ISelectListProps) {
                         >
                             <div
                                 className={clsx(`
-                                  univer-inline-flex univer-h-4 univer-w-fit univer-items-center univer-overflow-hidden
-                                  univer-truncate univer-whitespace-nowrap univer-rounded-full univer-px-1.5
-                                  univer-text-xs
+                                  univer-inline-flex univer-h-4 univer-w-fit univer-items-center univer-truncate
+                                  univer-rounded-full univer-px-1.5 univer-text-xs
                                 `, {
                                     'univer-text-gray-900': !isDark,
                                     'univer-text-white': isDark,

--- a/packages/sheets-ui/src/views/mobile/sheet-bar/MobileSheetBar.tsx
+++ b/packages/sheets-ui/src/views/mobile/sheet-bar/MobileSheetBar.tsx
@@ -121,9 +121,8 @@ function MobileSheetBarImpl(props: { workbook: Workbook }) {
                         className={clsx(
                             `
                               univer-box-border univer-h-full univer-min-w-12 univer-max-w-[120px] univer-shrink-0
-                              univer-flex-nowrap univer-items-center univer-overflow-hidden univer-truncate
-                              univer-whitespace-nowrap univer-px-1 univer-py-0.5 univer-text-center univer-text-xs
-                              univer-leading-7
+                              univer-flex-nowrap univer-items-center univer-truncate univer-px-1 univer-py-0.5
+                              univer-text-center univer-text-xs univer-leading-7
                             `,
                             borderRightClassName,
                             {

--- a/packages/ui/src/components/common-label/index.tsx
+++ b/packages/ui/src/components/common-label/index.tsx
@@ -36,7 +36,7 @@ export const CommonLabel = (props: ICommonLabelProps) => {
 
     return (
         <div
-            className="univer-overflow-hidden univer-truncate univer-text-sm"
+            className="univer-truncate univer-text-sm"
         >
             {viewValue}
         </div>

--- a/packages/ui/src/components/font-family/FontFamily.tsx
+++ b/packages/ui/src/components/font-family/FontFamily.tsx
@@ -39,7 +39,7 @@ export const FontFamily = (props: IFontFamilyProps) => {
 
     return (
         <div
-            className="univer-w-32 univer-overflow-hidden univer-truncate univer-text-sm"
+            className="univer-w-32 univer-truncate univer-text-sm"
             style={{ fontFamily: value as string }}
         >
             {viewValue}


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

In previous PRs, I noticed that there was a duplication of styles, since univer-truncate is actually 

.univer-truncate {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
}

It seems that combining it with .univer-text-ellipsis, .univer-whitespace-nowrap, or .univer-overflow-hidden doesn't make sense.

also, for example, in packages/docs-ui/src/components/side-menu/index.tsx univer-ellipsis was used, which I generally did not find, since there is only univer-text-ellipsis

As a result, after this fix, univer-text-ellipsis remains to be encountered in the code only 4 times and it can probably also be replaced with truncate

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
