### PR TITLE
fix(formula): fix TEXTJOIN formula calculation when the ignoreEmpty parameter is true

### DIFF
--- a/packages/engine-formula/src/functions/text/textjoin/__test__/index.spec.ts
+++ b/packages/engine-formula/src/functions/text/textjoin/__test__/index.spec.ts
@@ -128,6 +128,14 @@ describe('Test textjoin function', () => {
             });
             const result6 = testFunction.calculate(delimiter, ignoreEmpty6, text);
             expect(getObjectValue(result6)).toStrictEqual('Hi, Univer, test');
+
+            const text2 = StringValueObject.create('');
+            const text3 = StringValueObject.create('1');
+            const text4 = StringValueObject.create('2');
+            const text5 = StringValueObject.create('3');
+            const ignoreEmpty7 = BooleanValueObject.create(true);
+            const result7 = testFunction.calculate(delimiter, ignoreEmpty7, text2, text3, text2, text2, text4, text2, text5);
+            expect(getObjectValue(result7)).toStrictEqual('1, 2, 3');
         });
 
         it('Text value test', () => {

--- a/packages/engine-formula/src/functions/text/textjoin/index.ts
+++ b/packages/engine-formula/src/functions/text/textjoin/index.ts
@@ -79,7 +79,7 @@ export class Textjoin extends BaseFunction {
         let _textValues = textValues;
 
         if (ignoreEmptyValue) {
-            _textValues = textValues.filter((value) => value !== null);
+            _textValues = textValues.filter((value) => value !== null && value !== '');
         }
 
         let result = '';


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
