### PR TITLE
fix(formula): support recursive resolution for nested defined names

### DIFF
--- a/packages/engine-formula/src/engine/analysis/lexer.ts
+++ b/packages/engine-formula/src/engine/analysis/lexer.ts
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-import type { ISequenceArray } from '../utils/sequence';
-
 import { Disposable, Inject } from '@univerjs/core';
-import { ErrorType } from '../../basics/error-type';
-import { operatorToken } from '../../basics/token';
 import { IFormulaCurrentConfigService } from '../../services/current-data.service';
 import { IDefinedNamesService } from '../../services/defined-names.service';
-import { sequenceNodeType } from '../utils/sequence';
 import { LexerTreeBuilder } from './lexer-tree-builder';
 
 export class Lexer extends Disposable {
@@ -34,92 +29,10 @@ export class Lexer extends Disposable {
     }
 
     treeBuilder(formulaString: string, transformSuffix = true) {
-        return this._lexerTreeBuilder.treeBuilder(formulaString, transformSuffix, this._injectDefinedName.bind(this), this._simpleCheckDefinedName.bind(this));
-    }
-
-    private _simpleCheckDefinedName(formulaString: string) {
-        const definedNameMap = this._formulaCurrentConfigService.getDirtyDefinedNameMap();
-        const executeUnitId = this._formulaCurrentConfigService.getExecuteUnitId();
-        if (executeUnitId != null && definedNameMap[executeUnitId] != null) {
-            const names = Object.keys(definedNameMap[executeUnitId]!);
-            for (let i = 0, len = names.length; i < len; i++) {
-                const name = names[i];
-                if (formulaString.indexOf(name) > -1) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private _checkDefinedNameDirty(token: string) {
-        const definedNameMap = this._formulaCurrentConfigService.getDirtyDefinedNameMap();
-        const executeUnitId = this._formulaCurrentConfigService.getExecuteUnitId();
-        if (executeUnitId != null && definedNameMap[executeUnitId] != null) {
-            const names = Object.keys(definedNameMap[executeUnitId]!);
-            for (let i = 0, len = names.length; i < len; i++) {
-                const name = names[i];
-                if (name === token) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private _injectDefinedName(sequenceArray: ISequenceArray[]) {
-        const unitId = this._formulaCurrentConfigService.getExecuteUnitId();
-
-        if (unitId == null) {
-            return {
-                sequenceString: '',
-                hasDefinedName: false,
-                definedNames: [],
-            };
-        }
-
-        const sequenceNodes = this._lexerTreeBuilder.getSequenceNode(sequenceArray);
-        let sequenceString = '';
-        let hasDefinedName = false;
-        const definedNames: string[] = [];
-
-        for (let i = 0, len = sequenceNodes.length; i < len; i++) {
-            const node = sequenceNodes[i];
-            if (typeof node === 'string') {
-                sequenceString += node;
-                continue;
-            }
-
-            const { nodeType, token } = node;
-
-            if (nodeType === sequenceNodeType.REFERENCE || nodeType === sequenceNodeType.FUNCTION) {
-                const definedContent = this._definedNamesService.getValueByName(unitId, token);
-                if (definedContent) {
-                    let refString = definedContent.formulaOrRefString;
-                    if (refString.substring(0, 1) === operatorToken.EQUALS) {
-                        refString = refString.substring(1);
-                    }
-                    sequenceString += refString;
-                    definedNames.push(definedContent.name);
-                    hasDefinedName = true;
-                } else if (this._checkDefinedNameDirty(token)) {
-                    sequenceString += ErrorType.NAME;
-                    hasDefinedName = true;
-                    definedNames.push(token);
-                } else {
-                    sequenceString += token;
-                }
-            } else {
-                sequenceString += token;
-            }
-        }
-
-        return {
-            sequenceString,
-            hasDefinedName,
-            definedNames,
-        };
+        return this._lexerTreeBuilder.treeBuilder(formulaString, transformSuffix, {
+            unitId: this._formulaCurrentConfigService.getExecuteUnitId(),
+            getValueByName: this._definedNamesService.getValueByName.bind(this._definedNamesService),
+            getDirtyDefinedNameMap: this._formulaCurrentConfigService.getDirtyDefinedNameMap.bind(this._formulaCurrentConfigService),
+        });
     }
 }

--- a/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
@@ -209,14 +209,16 @@ export const DefinedNameContainer = () => {
                         <div
                             key={index}
                             className={`
-                              univer-divide-x-0 univer-divide-y univer-divide-solid univer-divide-gray-200
+                              univer-relative univer-w-full univer-divide-x-0 univer-divide-y univer-divide-solid
+                              univer-divide-gray-200
                               dark:!univer-divide-gray-600
                             `}
                         >
                             <div
                                 className={clsx(`
-                                  univer-group univer-relative univer-flex univer-cursor-default univer-select-none
-                                  univer-items-center univer-justify-between univer-rounded-md univer-p-2
+                                  univer-group univer-relative univer-flex univer-w-full univer-cursor-default
+                                  univer-select-none univer-items-center univer-justify-between univer-rounded-md
+                                  univer-p-2
                                   hover:univer-bg-gray-50
                                   dark:hover:!univer-bg-gray-700
                                 `, {
@@ -239,9 +241,11 @@ export const DefinedNameContainer = () => {
                                     </div>
                                     <div
                                         className={`
-                                          univer-my-1 univer-max-h-[100px] univer-overflow-hidden univer-text-ellipsis
-                                          univer-text-xs univer-text-gray-500
+                                          univer-my-1 univer-max-h-[100px] univer-w-full univer-max-w-[190px]
+                                          univer-overflow-hidden univer-text-ellipsis univer-text-xs
+                                          univer-text-gray-500
                                         `}
+                                        title={definedName.formulaOrRefString}
                                     >
                                         {definedName.formulaOrRefString}
                                     </div>


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
### Summary
This PR fixes an issue where nested defined names were not properly resolved in formulas.  
For example, when a formula contains `=definedname1`, and `definedname1` references another defined name (`definedname2`), the engine previously failed to expand recursively.  

### Changes
- Added recursive resolution logic in defined name handling  
- Ensured circular reference prevention  
- Improved test coverage for nested defined names  

### Impact
Formulas with chained or nested defined names now evaluate correctly.

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
