### PR TITLE
chore: change ellipsis class to truncate; fix: defined name if ref overflow

### DIFF
--- a/packages/sheets-formula-ui/src/views/formula-editor/search-function/SearchFunction.tsx
+++ b/packages/sheets-formula-ui/src/views/formula-editor/search-function/SearchFunction.tsx
@@ -224,7 +224,7 @@ function SearchFunctionFactory(props: ISearchFunctionProps, ref: any) {
                             }
                         }}
                     >
-                        <span className="univer-block univer-overflow-x-hidden univer-text-ellipsis univer-text-xs">
+                        <span className="univer-block univer-truncate univer-text-xs">
                             <span className="univer-text-red-500">{item.name.substring(0, searchText.length)}</span>
                             <span>{item.name.slice(searchText.length)}</span>
                         </span>

--- a/packages/sheets-hyper-link-ui/src/views/CellLinkPopup/index.tsx
+++ b/packages/sheets-hyper-link-ui/src/views/CellLinkPopup/index.tsx
@@ -100,7 +100,7 @@ export const CellLinkPopupPure = (props: ICellLinkPopupPureProps) => {
                     {iconsMap[linkObj.type]}
                 </div>
                 <Tooltip showIfEllipsis title={linkObj.name} asChild>
-                    <span className="univer-flex-1 univer-overflow-hidden univer-text-ellipsis">{linkObj.name}</span>
+                    <span className="univer-flex-1 univer-truncate">{linkObj.name}</span>
                 </Tooltip>
             </div>
             <div

--- a/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
@@ -229,8 +229,8 @@ export const DefinedNameContainer = () => {
                                 <div title={definedName.comment}>
                                     <div
                                         className={`
-                                          univer-my-1 univer-max-h-[100px] univer-max-w-[190px] univer-overflow-hidden
-                                          univer-text-ellipsis univer-text-sm univer-font-medium univer-text-gray-900
+                                          univer-my-1 univer-max-h-[100px] univer-max-w-[190px] univer-truncate
+                                          univer-text-sm univer-font-medium univer-text-gray-900
                                           dark:!univer-text-white
                                         `}
                                     >
@@ -242,8 +242,7 @@ export const DefinedNameContainer = () => {
                                     <div
                                         className={`
                                           univer-my-1 univer-max-h-[100px] univer-w-full univer-max-w-[190px]
-                                          univer-overflow-hidden univer-text-ellipsis univer-text-xs
-                                          univer-text-gray-500
+                                          univer-truncate univer-text-xs univer-text-gray-500
                                         `}
                                         title={definedName.formulaOrRefString}
                                     >


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

I decided to continue exploring using ellipsis instead of truncate, and this allowed me to identify a bug. For example, in defined names, if there's too much text in a range, it adds lines up to a certain value and then truncates. Now univer-text-ellipsis is not used in the project.

I also noticed some strangeness, on certain names there is no tooltip, only the title, is this intended?

Before:
<img width="363" height="177" alt="image" src="https://github.com/user-attachments/assets/297535bc-5b13-4fce-b69e-169793aa9fc7" />

After: 
<img width="363" height="177" alt="image" src="https://github.com/user-attachments/assets/f5b1e568-d877-46f5-8150-5c61d61f5586" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
