### PR TITLE
fix: placement at fitst row after entering in the top line

### DIFF
--- a/packages/sheets-ui/src/commands/commands/utils/selection-utils.ts
+++ b/packages/sheets-ui/src/commands/commands/utils/selection-utils.ts
@@ -84,6 +84,9 @@ export function findNextRange(
             if (next <= boundary.endRow) {
                 destRange.startRow = next;
                 destRange.endRow = next;
+            } else if (next === worksheet.getRowCount()) {
+                destRange.startRow = next - 1;
+                destRange.endRow = next - 1;
             } else if (isGoBack) {
                 destRange.startRow = boundary.startRow;
                 destRange.endRow = boundary.startRow;


### PR DESCRIPTION
close #6134

<!-- A description of the proposed changes. -->

I still decided to study the problem described in the issues, and I found a solution to this, but perhaps this was the intended solution, so having the same problem with the last column, I would like to offer only line by line for now

I understand that maybe when I'm on the last line and pressing the down arrow on the keyboard, I might expect to go to the first line, but when I'm editing on line 1000, which is quite far away, and pressing enter after entering my value, I don't expect that at all, I'd like to stay at the bottom

I think the user can only expect confirmation of their entered value

By the way, Google Sheets doesn't wrap when saving or when moving with the down arrow. I think it's clear with Excel that there's no limit to the number of rows, so this isn't expected.

from some point of view, one could also consider adding a new line if there is nowhere to go below, this could also be a solution


In any case, it's up to you to decide, but as I noted above, when I first encountered this, I didn't expect it at all

After: 

[Screencast from 2025-11-11 22-20-45.webm](https://github.com/user-attachments/assets/874a91d6-8be6-41c8-8ff8-71e23b403c8e)

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
