### PR TITLE
fix: clear array formula

### DIFF
--- a/packages/sheets-formula/src/controllers/utils/__tests__/ref-range-formula.spec.ts
+++ b/packages/sheets-formula/src/controllers/utils/__tests__/ref-range-formula.spec.ts
@@ -112,6 +112,7 @@ describe('Ref range formula test', () => {
                         x: 0,
                         y: 1,
                     },
+                    3: null,
                 },
             };
 
@@ -129,6 +130,7 @@ describe('Ref range formula test', () => {
                         f: null,
                         si: 'id2',
                     },
+                    3: null,
                 },
             };
             expect(formulaDataToCellData(formulaData)).toStrictEqual(cellData);

--- a/packages/sheets-formula/src/controllers/utils/ref-range-formula.ts
+++ b/packages/sheets-formula/src/controllers/utils/ref-range-formula.ts
@@ -590,7 +590,8 @@ function getUndoFormulaData(rangeList: IRangeChange[], oldFormulaMatrix: ObjectM
  */
 export function formulaDataItemToCellData(formulaDataItem: Nullable<IFormulaDataItem>): Nullable<ICellData> {
     if (formulaDataItem == null) {
-        return;
+        // null presents clearing cell content
+        return null;
     }
     const { f, si, x = 0, y = 0 } = formulaDataItem;
     const checkFormulaString = isFormulaString(f);
@@ -637,7 +638,8 @@ export function formulaDataToCellData(formulaData: IObjectMatrixPrimitiveType<IF
         const cellDataItem = formulaDataItemToCellData(formulaDataItem);
 
         // Originally matrix clone would filter out undefined, but after changing to getMatrix, you need to filter manually here
-        if (!cellDataItem) {
+        //  Filter out meaningless undefined, but consider null meaningful because null represents clearing cell content
+        if (cellDataItem === undefined) {
             return;
         }
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
## Problem

1. Open a blank collaborative spreadsheet.

2. Enter "W" in cell B2.

3. Enter =ROW(INDIRECT("1:"&LEN(B2))) in cell B11.

4. Right-click on cell B11 - Clear - Clear contents.

5. Refresh the page and modify the content of cell B2. An anomaly is found: the content of cell B11 reappears

## Update
null presents clearing cell content
Filter out meaningless undefined, but consider null meaningful because null represents clearing cell content

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
