### PR TITLE
fix(selection): clean up empty cell styles in copyRangeStyles function

### DIFF
--- a/packages/sheets/src/commands/commands/utils/selection-utils.ts
+++ b/packages/sheets/src/commands/commands/utils/selection-utils.ts
@@ -18,7 +18,7 @@ import type { ICellData, IInterceptor, IObjectMatrixPrimitiveType, IRange, ISele
 import type { ISelectionWithStyle } from '../../../basics/selection';
 
 import type { ISetSelectionsOperationParams } from '../../operations/selection.operation';
-import { RANGE_TYPE, Rectangle, selectionToArray } from '@univerjs/core';
+import { RANGE_TYPE, Rectangle, selectionToArray, Tools } from '@univerjs/core';
 import { IgnoreRangeThemeInterceptorKey, RangeThemeInterceptorId } from '../../../services/sheet-interceptor/interceptor-const';
 import { SetSelectionsOperation } from '../../operations/selection.operation';
 
@@ -272,6 +272,24 @@ export function copyRangeStyles(
             cellValue[row][column] = { s: cell.s };
         }
     }
+
+    for (const row in cellValue) {
+        for (const col in cellValue[row]) {
+            const cell = cellValue[row][col];
+            if (cell.s && typeof cell.s === 'object' && Tools.isEmptyObject(cell.s)) {
+                delete cell.s;
+            }
+
+            if (Tools.isEmptyObject(cell)) {
+                delete cellValue[row][col];
+            }
+        }
+
+        if (Tools.isEmptyObject(cellValue[row])) {
+            delete cellValue[row];
+        }
+    }
+
     return cellValue;
 }
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
