### PR TITLE
fix: increase/decrease font size with cell.P

### DIFF
--- a/packages/sheets-ui/src/controllers/menu/utils.ts
+++ b/packages/sheets-ui/src/controllers/menu/utils.ts
@@ -28,9 +28,11 @@ export function getFontStyleAtCursor(accessor: IAccessor) {
     if (editorDataModel == null || activeTextRange == null) return null;
 
     const textRuns = editorDataModel.getBody()?.textRuns;
+
     if (textRuns == null) return;
 
-    const { startOffset } = activeTextRange;
-    const textRun = textRuns.find(({ st, ed }) => startOffset >= st && startOffset <= ed);
+    const { startOffset, endOffset } = activeTextRange;
+    const textRun = textRuns.find(({ st, ed }) => startOffset >= st && endOffset <= ed);
+
     return textRun;
 }


### PR DESCRIPTION
close  #6273

<!-- A description of the proposed changes. -->

the previous condition did not work correctly, it literally always corresponded to the first element of the array
example: 
have start startOffset 19 and endOffset 23 and this textRuns:
[    
{ "st": 0, "ed": 19, "ts": { "ul": { "s": 1, "t": 1 } } },
{"st": 19,"ed": 23,"ts": {"ul": {"s": 1,"t": 1},"fs": 20}}
]

and as you can see, I fully comply with the first element, while actually focusing on the second

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
