### PR TITLE
fix(sheet): fix row、col style not effect when the cell is null

### DIFF
--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -1460,7 +1460,6 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
         const style = this.worksheet.getComposedCellStyleByCellData(row, col, cell);
         if (!cell && !style) return;
 
-
         this._setBgStylesCache(row, col, style, options);
         this._setBorderStylesCache(row, col, style, options);
         this._setFontStylesCache(row, col, { ...cell, ...{ s: style } }, style);


### PR DESCRIPTION
- when a row have row style , the style should rendered what ever the cell is null or not
- wrong
<img width="1182" height="177" alt="image" src="https://github.com/user-attachments/assets/0bef9b32-c986-48ec-b506-09991430a8b8" />
-right
<img width="1776" height="525" alt="image" src="https://github.com/user-attachments/assets/ea041f76-d103-489b-a792-cb2e4092b902" />
