### PR TITLE
feat: add page setup precision

### DIFF
--- a/packages/docs-ui/src/views/page-settings/index.tsx
+++ b/packages/docs-ui/src/views/page-settings/index.tsx
@@ -35,6 +35,10 @@ export interface IPageSettings {
         left: number;
         right: number;
     };
+    pageSise: {
+        width: number;
+        height: number;
+    };
 }
 
 const getPaperSize = (size: ISize) => {
@@ -60,6 +64,10 @@ export function PageSettings(props: IConfirmChildrenProps) {
     const localeService = useDependency(LocaleService);
     const [settings, setSettings] = useState<IPageSettings>(() => ({
         paperSize: getPaperSize(documentStyle.pageSize!),
+        pageSise: {
+            width: documentStyle.pageSize?.width ?? 0,
+            height: documentStyle.pageSize?.height ?? 0,
+        },
         orientation: documentStyle.pageOrient ?? PageOrientType.PORTRAIT,
         margins: {
             top: documentStyle.marginTop ?? 0,
@@ -80,11 +88,15 @@ export function PageSettings(props: IConfirmChildrenProps) {
     }, [settings]);
 
     const handlePaperSizeChange = (value: string) => {
-        setSettings((prev) => ({ ...prev, paperSize: value }));
+        setSettings((prev) => ({ ...prev, paperSize: value, pageSise: PAGE_SIZE[value as PaperType] }));
     };
 
     const handleOrientationChange = (value: PageOrientType) => {
-        setSettings((prev) => ({ ...prev, orientation: value }));
+        setSettings((prev) => ({
+            ...prev,
+            orientation: value,
+            pageSise: { width: settings.pageSise.height, height: settings.pageSise.width },
+        }));
     };
 
     const handleMarginChange = (position: keyof IPageSettings['margins'], value: number | null) => {
@@ -135,6 +147,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                             </label>
                             <InputNumber
                                 precision={2}
+                                max={settings.pageSise.height / 2}
                                 value={settings.margins.top}
                                 onChange={(e) => handleMarginChange('top', e)}
                             />
@@ -145,6 +158,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                             </label>
                             <InputNumber
                                 precision={2}
+                                max={settings.pageSise.height / 2}
                                 value={settings.margins.bottom}
                                 onChange={(e) => handleMarginChange('bottom', e)}
                             />
@@ -157,6 +171,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                             </label>
                             <InputNumber
                                 precision={2}
+                                max={settings.pageSise.width / 2}
                                 value={settings.margins.left}
                                 onChange={(e) => handleMarginChange('left', e)}
                             />
@@ -167,6 +182,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                             </label>
                             <InputNumber
                                 precision={2}
+                                max={settings.pageSise.width / 2}
                                 value={settings.margins.right}
                                 onChange={(e) => handleMarginChange('right', e)}
                             />


### PR DESCRIPTION
close #6212

<!-- A description of the proposed changes. -->

add precision for indents when setting up a page

After:
<img width="915" height="585" alt="image" src="https://github.com/user-attachments/assets/5a26a08b-f801-47e8-86e5-40c9ac0d9e96" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
