### PR TITLE
feat: set defined name in formula bar

### DIFF
--- a/packages/engine-formula/src/services/defined-names.service.ts
+++ b/packages/engine-formula/src/services/defined-names.service.ts
@@ -223,6 +223,16 @@ export class DefinedNamesService extends Disposable implements IDefinedNamesServ
         return this._definedNameMap;
     }
 
+    getDefinedNameByRefString(unitId: string, formulaOrRefString: string) {
+        if (!this._definedNameMap[unitId]) return;
+
+        for (const [_, item] of Object.entries(this._definedNameMap[unitId])) {
+            if (item.formulaOrRefString === formulaOrRefString) {
+                return item;
+            }
+        }
+    }
+
     private _update() {
         this._update$.next(null);
     }


### PR DESCRIPTION
partial #5979

<!-- A description of the proposed changes. -->

In the linked issue I pointed out that even though the range had a defined name, it was not showing up in the input in the bar formula. now displayed

If this is supported, then as far as I understand, all that remains is to change a specific name through this input, as well as move to this cell or range, similar to how it works with the side bar

After: 

https://github.com/user-attachments/assets/63f489eb-725f-4f66-9a07-847cbfba6527


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
