### PR TITLE
fix: defined name input style

### DIFF
--- a/packages/sheets-ui/src/views/defined-name/DefinedName.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedName.tsx
@@ -130,7 +130,7 @@ export function DefinedName({ disable }: { disable: boolean }) {
         >
             <input
                 className={clsx(`
-                  univer-box-border univer-h-full univer-w-full univer-appearance-none univer-px-1.5
+                  univer-box-border univer-h-full univer-w-full univer-appearance-none univer-pl-1.5 univer-pr-5
                   univer-text-gray-900
                   focus:univer-outline-none
                   dark:!univer-border-r-gray-700 dark:!univer-bg-gray-900 dark:!univer-text-white


### PR DESCRIPTION
close #6305

After:
<img width="1839" height="794" alt="image" src="https://github.com/user-attachments/assets/44336769-1c1b-4831-91af-7d0f4e921464" />

<img width="127" height="64" alt="image" src="https://github.com/user-attachments/assets/54975244-988a-4bc7-b207-02eb6b8c06d4" />


it works roughly like in libre
<img width="284" height="202" alt="image" src="https://github.com/user-attachments/assets/ef07f719-d247-4a45-8317-4b8259446be9" />

but perhaps I would suggest making the input boundaries when focusing, basically like in Google
<img width="284" height="202" alt="image" src="https://github.com/user-attachments/assets/5f1098b2-ddcc-4abb-bf1f-77181cdfee84" />


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
