### PR TITLE
fix: uniq defined name isn´t case sensitive

### DIFF
--- a/packages/engine-formula/src/services/defined-names.service.ts
+++ b/packages/engine-formula/src/services/defined-names.service.ts
@@ -181,7 +181,13 @@ export class DefinedNamesService extends Disposable implements IDefinedNamesServ
         // Check cache first
         const cachedMap = this._nameCacheMap[unitId];
         if (cachedMap) {
-            return cachedMap[name] || null;
+            for (const key of Object.keys(cachedMap)) {
+                if (key.toLowerCase() === name.toLowerCase()) {
+                    return cachedMap[key];
+                }
+            }
+
+            return null;
         }
 
         // If not in cache, traverse the nameMap
@@ -192,7 +198,7 @@ export class DefinedNamesService extends Disposable implements IDefinedNamesServ
 
         let result = null;
         for (const item of Object.values(nameMap)) {
-            if (item.name === name) {
+            if (item.name.toLowerCase() === name.toLowerCase()) {
                 result = item;
                 break;
             }


### PR DESCRIPTION
close #6316

<!-- A description of the proposed changes. -->

uniq defined name isn´t case sensitive

After:
<img width="360" height="379" alt="image" src="https://github.com/user-attachments/assets/2adde414-87e3-424c-bc26-31a0b30770d5" />


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
