### PR TITLE
feat: filter defined name list if  input event

### DIFF
--- a/packages/sheets-ui/src/views/defined-name/DefinedNameOverlay.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameOverlay.tsx
@@ -22,11 +22,11 @@ import { borderBottomClassName, clsx, scrollbarClassName } from '@univerjs/desig
 import { IDefinedNamesService } from '@univerjs/engine-formula';
 import { SetWorksheetShowCommand } from '@univerjs/sheets';
 import { ISidebarService, useDependency } from '@univerjs/ui';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { SidebarDefinedNameOperation } from '../../commands/operations/sidebar-defined-name.operation';
 import { DEFINED_NAME_CONTAINER } from './component-name';
 
-export function DefinedNameOverlay() {
+export function DefinedNameOverlay({ search, isInputEvent }: { search: string; isInputEvent: boolean }) {
     const commandService = useDependency(ICommandService);
     const localeService = useDependency(LocaleService);
     const definedNamesService = useDependency(IDefinedNamesService);
@@ -72,6 +72,12 @@ export function DefinedNameOverlay() {
         };
     }, []);
 
+    const filteredDefinedNames = useMemo(() => {
+        return search && isInputEvent
+            ? definedNames.filter((i) => i.name.toLowerCase().includes(search.toLowerCase()))
+            : definedNames;
+    }, [search, isInputEvent, definedNames]);
+
     const openSlider = () => {
         commandService.executeCommand(SidebarDefinedNameOperation.id, { value: 'open' });
     };
@@ -97,7 +103,7 @@ export function DefinedNameOverlay() {
             <ul
                 className={clsx('univer-m-0 univer-max-h-[360px] univer-list-none univer-overflow-y-auto univer-p-0', scrollbarClassName)}
             >
-                {definedNames.map((definedName, index) => {
+                {filteredDefinedNames.map((definedName, index) => {
                     return (
                         <li
                             key={index}


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

I will continue to close defined name input resolution issue. 

Considering that there could be quite a few of them and considering the example of Google Sheets, I assumed that it would be a good idea to open a drop-down list when there are matches

Initially, I didn't want to open it if it looked like refString, however, the logic breaks when executing the same test1, so in the end I made this implementation, an example in the video

If you agree with this proposal, perhaps in the next pull request, I would suggest highlighting the matches in the filtered list.

<!-- How to test them. -->
create several defined names and use defined name input

After: 

https://github.com/user-attachments/assets/467cb828-4baf-42c2-a323-fe1647009043

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
