### PR TITLE
fix: remove style in cache map

### DIFF
--- a/packages/core/src/sheets/styles.ts
+++ b/packages/core/src/sheets/styles.ts
@@ -93,9 +93,10 @@ export class Styles {
     }
 
     remove(id: string): void {
-        if (this._styles[id]) {
+        const s = this._styles[id];
+        if (s) {
             delete this._styles[id];
-            this._cacheMap.delete(JSON.stringify(this._styles[id]));
+            this._cacheMap.delete(JSON.stringify(s));
         }
     }
 


### PR DESCRIPTION
Fix remove style in cache map, because `delete this.styles[id]` removed the style property, so the `JSON.stringify(this.styles[id])` always undefined.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
