### PR TITLE
fix: pop up wrong position after click on toolbar-more icon

### DIFF
--- a/packages/ui/src/views/components/ribbon/Ribbon.tsx
+++ b/packages/ui/src/views/components/ribbon/Ribbon.tsx
@@ -354,6 +354,7 @@ export function Ribbon(props: IRibbonProps) {
                         >
                             <Dropdown
                                 collisionPadding={{ right: 12, left: 12 }}
+                                onOpenAutoFocus={(e) => e.preventDefault()}
                                 overlay={(
                                     <div
                                         className={`


### PR DESCRIPTION
close #6341

<!-- A description of the proposed changes. -->

I came to the conclusion that this pop-up shouldn't happen on the first click; it's due to autofocus.

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
