### PR TITLE
feat: add remove fonts to facade

### DIFF
--- a/examples/src/sheets/main.ts
+++ b/examples/src/sheets/main.ts
@@ -200,6 +200,8 @@ function createNewInstance() {
     //     { value: 'Helvetica Neue', label: 'Helvetica Neue', category: 'sans-serif' },
     // ]);
 
+    // window.univerAPI.removeFonts(['SimSun']);
+
     customRegisterEvent(univer, window.univerAPI!);
     // customRangePopups(univer, window.univerAPI!);
 }

--- a/packages/ui/src/facade/f-univer.ts
+++ b/packages/ui/src/facade/f-univer.ts
@@ -439,6 +439,16 @@ export interface IFUniverUIMixin {
      * ```
      */
     addFonts(fonts: IFontConfig[]): void;
+
+    /**
+     * Remove fonts to the font list.
+     * @param fonts The array of font to remove.
+     * @example
+     * ```ts
+     * univerAPI.removeFonts(["Arial"]);
+     * ```
+     */
+    removeFonts(fonts: string[]): void;
 }
 
 /**
@@ -537,6 +547,13 @@ export class FUniverUIMixin extends FUniver implements IFUniverUIMixin {
                 ...font,
                 isCustom: true,
             });
+        });
+    }
+
+    override removeFonts(fonts: string[]): void {
+        const fontService = this._injector.get(IFontService);
+        fonts.forEach((font) => {
+            fontService.removeFont(font);
         });
     }
 }

--- a/packages/ui/src/services/font.service.ts
+++ b/packages/ui/src/services/font.service.ts
@@ -238,12 +238,6 @@ export class FontService implements IFontService, IDisposable {
             return false;
         }
 
-        const fontToRemove = fonts[fontIndex];
-        if (!fontToRemove.isCustom) {
-            // Prevent removal of built-in fonts
-            return false;
-        }
-
         const updatedFonts = fonts.filter((font) => font.value !== value);
         this.fonts$.next(updatedFonts);
         return true;


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

It's clear that your project is popular and used worldwide. Each country has its own linguistic peculiarities, so I would suggest having the most flexible font settings.
For example, out of 15 fonts currently available, only 4 is used most often in my country, and most of the existing ones cannot be used.

Considering the project offers a wide range of customization options for most features, it seems like this wouldn't be a bad idea. I understand that your goal was to prevent the deletion of default fonts, but they could likely be customized by some of your users.

up to you

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
