### PR TITLE
Fix Formula, when the cache is setted by STRING, but is get by NUMBER.

### DIFF
--- a/packages/engine-formula/src/basics/inverted-index-cache.ts
+++ b/packages/engine-formula/src/basics/inverted-index-cache.ts
@@ -70,11 +70,7 @@ export class InvertedIndexCache {
             }
         }
 
-        // Because the inverted index cache is used for compare operation, it should be case-insensitive.
-        let _value = typeof value === 'string' ? value.toLowerCase() : value;
-        if (_value === '' || _value === null) {
-            _value = DEFAULT_EMPTY_CELL_KEY;
-        }
+        const _value = this.getValueKey(value);
 
         let cellList = columnMap.get(_value);
         if (cellList == null) {
@@ -85,16 +81,26 @@ export class InvertedIndexCache {
         cellList.add(row);
     }
 
-    getCellValuePositions(unitId: string, sheetId: string, column: number) {
-        return this._cache.get(unitId)?.get(sheetId)?.get(column);
-    }
-
-    getCellPositions(unitId: string, sheetId: string, column: number, value: string | number | boolean | null | symbol, rowsInCache: NumericTuple[]) {
+    private getValueKey(value: string | number | boolean | null | symbol) {
         // Because the inverted index cache is used for compare operation, it should be case-insensitive.
         let _value = typeof value === 'string' ? value.toLowerCase() : value;
         if (_value === '' || _value === null) {
             _value = DEFAULT_EMPTY_CELL_KEY;
         }
+
+        // Ignore the NUMBER and STRING，such as 2025 and "2025"
+        if (typeof _value === 'number') {
+            _value = String(_value);
+        }
+        return _value;
+    }
+
+    getCellValuePositions(unitId: string, sheetId: string, column: number) {
+        return this._cache.get(unitId)?.get(sheetId)?.get(column);
+    }
+
+    getCellPositions(unitId: string, sheetId: string, column: number, value: string | number | boolean | null | symbol, rowsInCache: NumericTuple[]) {
+        const _value = this.getValueKey(value);
         const rows = this._cache.get(unitId)?.get(sheetId)?.get(column)?.get(_value);
         return rows && [...rows].filter((row) => rowsInCache.some(([start, end]) => row >= start && row <= end));
     }


### PR DESCRIPTION
Such as `=SUMIFS(A:A, B:B, "2025")`, when the type of B is STRING (Set cache), the "2025" is transformed by findCompareToken to NUMBER (Get cache)

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
