### PR TITLE
feat: set font family via text input

### DIFF
--- a/packages/sheets-ui/src/controllers/menu/menu.ts
+++ b/packages/sheets-ui/src/controllers/menu/menu.ts
@@ -393,12 +393,23 @@ export function FontFamilySelectorMenuItemFactory(accessor: IAccessor): IMenuSel
     const selectionManagerService = accessor.get(SheetsSelectionsService);
 
     const defaultValue = DEFAULT_STYLES.ff;
+    const disabled$ = getCurrentRangeDisable$(accessor, {
+        workbookTypes: [WorkbookEditablePermission],
+        worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission],
+        rangeTypes: [RangeProtectionPermissionEditPoint],
+    }, true);
 
     return {
         id: SetRangeFontFamilyCommand.id,
         tooltip: 'toolbar.font',
         type: MenuItemType.SELECTOR,
-        label: FONT_FAMILY_COMPONENT,
+        label: {
+            name: FONT_FAMILY_COMPONENT,
+            props: {
+                id: SetRangeFontFamilyCommand.id,
+                disabled$,
+            },
+        },
         selections: [{
             label: {
                 name: FONT_FAMILY_ITEM_COMPONENT,
@@ -409,11 +420,7 @@ export function FontFamilySelectorMenuItemFactory(accessor: IAccessor): IMenuSel
                 },
             },
         }],
-        disabled$: getCurrentRangeDisable$(accessor, {
-            workbookTypes: [WorkbookEditablePermission],
-            worksheetTypes: [WorksheetEditPermission, WorksheetSetCellStylePermission],
-            rangeTypes: [RangeProtectionPermissionEditPoint],
-        }, true),
+        disabled$,
         value$: deriveStateFromActiveSheet$(univerInstanceService, defaultValue, ({ worksheet }) => new Observable((subscriber) => {
             const updateSheet = () => {
                 let ff = defaultValue;

--- a/packages/ui/src/components/font-family/FontFamily.tsx
+++ b/packages/ui/src/components/font-family/FontFamily.tsx
@@ -14,16 +14,34 @@
  * limitations under the License.
  */
 
+import type { ChangeEvent, KeyboardEvent } from 'react';
+import type { IFontConfig } from '../../services/font.service';
 import type { IFontFamilyProps } from './interface';
-import { LocaleService } from '@univerjs/core';
-import { useMemo } from 'react';
+import { ICommandService, LocaleService } from '@univerjs/core';
 
-import { useDependency } from '../../utils/di';
+import { useEffect, useMemo, useState } from 'react';
+import { IFontService } from '../../services/font.service';
+import { useDependency, useObservable } from '../../utils/di';
 
-export const FontFamily = (props: IFontFamilyProps) => {
-    const { value } = props;
+export const FontFamily = ({ id, value, disabled$ }: IFontFamilyProps) => {
+    const disabled = useObservable(disabled$);
 
+    const commandService = useDependency(ICommandService);
     const localeService = useDependency(LocaleService);
+    const fontService = useDependency(IFontService);
+
+    const [inputValue, setInputValue] = useState('');
+    const [fonts, setFonts] = useState<IFontConfig[]>([]);
+
+    useEffect(() => {
+        const subscription = fontService.fonts$.subscribe((fonts) => {
+            setFonts(fonts);
+        });
+
+        return () => {
+            subscription.unsubscribe();
+        };
+    }, []);
 
     const viewValue = useMemo(() => {
         if (value == null) return '';
@@ -37,12 +55,75 @@ export const FontFamily = (props: IFontFamilyProps) => {
         return fontFamily;
     }, [value]);
 
+    useMemo(() => {
+        setInputValue(viewValue);
+    }, [value]);
+
+    function resetValue() {
+        setInputValue(value);
+    }
+
+    function handleChangeSelection(e: ChangeEvent<HTMLInputElement>) {
+        setInputValue(e.target.value);
+    }
+
+    function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+        e.stopPropagation();
+
+        if (disabled) return;
+
+        if (e.key === 'Enter') {
+            confirm();
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            resetValue();
+        }
+    }
+
+    function handleBlur() {
+        if (inputValue !== value) resetValue();
+    }
+
+    function confirm() {
+        if (inputValue.toLowerCase() === value.toLowerCase()) {
+            resetValue();
+            return;
+        }
+
+        const font = fonts.find((item) => item.value.toLowerCase() === inputValue.trim().toLowerCase());
+
+        if (!font) {
+            resetValue();
+            return;
+        };
+
+        handleSelectFont(font.value);
+    }
+
+    function handleSelectFont(value: string) {
+        commandService.executeCommand(id, { value });
+    }
+
     return (
         <div
             className="univer-w-32 univer-truncate univer-text-sm"
             style={{ fontFamily: value as string }}
         >
-            {viewValue}
+            <input
+                className={`
+                  univer-block univer-h-6 univer-border-none univer-bg-transparent univer-leading-6
+                  focus:univer-outline-none
+                  [&_input:focus]:!univer-ring-0
+                  [&_input]:univer-h-6 [&_input]:univer-w-7 [&_input]:univer-border-none
+                  [&_input]:!univer-bg-transparent [&_input]:univer-p-0 [&_input]:univer-text-sm
+                `}
+                type="text"
+                value={inputValue}
+                onChange={handleChangeSelection}
+                onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
+                disabled={disabled}
+            />
         </div>
     );
 };

--- a/packages/ui/src/components/font-family/interface.ts
+++ b/packages/ui/src/components/font-family/interface.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
+import type { Observable } from 'rxjs';
 import type { ICustomComponentProps } from '../../services/menu/menu';
 
 export interface IFontFamilyProps extends ICustomComponentProps<string> {
+    id: string;
+
     value: string;
+
+    disabled$?: Observable<boolean>;
 }
 
 export const FONT_FAMILY_COMPONENT = 'UI_FONT_FAMILY_COMPONENT';


### PR DESCRIPTION
close #6350

<!-- A description of the proposed changes. -->

It seemed counterintuitive to me that we can set the text size via input, but not the font family. This is especially relevant with the introduction of the ability to add custom fonts, and there can be quite a few of them.

This also solved issue mentioned in #6350. But if it is possible, please look at this in your locale.

After: 

https://github.com/user-attachments/assets/92a69c86-7d6b-4cc6-a779-6208ec0da882


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
