### PR TITLE
fix: setSelections by top-left input if refString col more 16384

### DIFF
--- a/packages/sheets-ui/src/views/defined-name/DefinedName.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedName.tsx
@@ -20,7 +20,7 @@ import type { ChangeEvent, KeyboardEvent } from 'react';
 import type { IScrollToCellCommandParams } from '../../commands/commands/set-scroll.command';
 import { AbsoluteRefType, debounce, ICommandService, IUniverInstanceService, ThemeService, UniverInstanceType } from '@univerjs/core';
 import { borderRightClassName, clsx, Dropdown } from '@univerjs/design';
-import { deserializeRangeWithSheet, IDefinedNamesService, isReferenceString, LexerTreeBuilder, serializeRangeWithSheet } from '@univerjs/engine-formula';
+import { deserializeRangeWithSheet, IDefinedNamesService, isReferenceStringWithEffectiveColumn, LexerTreeBuilder, serializeRangeWithSheet } from '@univerjs/engine-formula';
 import { MoreDownIcon } from '@univerjs/icons';
 import { getPrimaryForRange, SetSelectionsOperation, SetWorksheetShowCommand, SheetsSelectionsService } from '@univerjs/sheets';
 import { useDependency } from '@univerjs/ui';
@@ -158,7 +158,7 @@ export function DefinedName({ disable }: { disable: boolean }) {
         if (definedName) {
             setRangeString(inputValue);
             focusDefinedName(definedName);
-        } else if (isReferenceString(inputValue)) {
+        } else if (isReferenceStringWithEffectiveColumn(inputValue)) {
             setRangeString(inputValue);
             focusSelection(inputValue);
         } else {


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

While thinking about creating defined names through the upper left input, I came across a case where the current method was skipping test1 values ​​and other similar ones. It seems that this method will solve this problem.

Sorry, I didn't immediately think about the need for such a restriction.

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
