### PR TITLE
feat: remove custom user func list if this empty

### DIFF
--- a/packages/sheets-formula-ui/src/services/utils.ts
+++ b/packages/sheets-formula-ui/src/services/utils.ts
@@ -19,11 +19,12 @@ import type { FunctionType, IFunctionInfo, IFunctionParam } from '@univerjs/engi
 
 export function getFunctionTypeValues(
     enumObj: typeof FunctionType,
-    localeService: LocaleService
+    localeService: LocaleService,
+    customFormula: boolean
 ): Array<{ label: string; value: string }> {
     // Exclude the DefinedName key
     return Object.keys(enumObj)
-        .filter((key) => isNaN(Number(key)) && key !== 'DefinedName' && key !== 'Table')
+        .filter((key) => isNaN(Number(key)) && key !== 'DefinedName' && key !== 'Table' && (customFormula || key !== 'User'))
         .map((key) => ({
             label: localeService.t(`formula.functionType.${key.toLocaleLowerCase()}`),
             value: `${enumObj[key as keyof typeof FunctionType]}`,

--- a/packages/sheets-formula-ui/src/views/more-functions/select-function/SelectFunction.tsx
+++ b/packages/sheets-formula-ui/src/views/more-functions/select-function/SelectFunction.tsx
@@ -15,14 +15,14 @@
  */
 
 import type { IFunctionInfo, IFunctionParam } from '@univerjs/engine-formula';
-import type { ISearchItem } from '@univerjs/sheets-formula';
+import type { ISearchItem, IUniverSheetsFormulaBaseConfig } from '@univerjs/sheets-formula';
 import type { ISidebarMethodOptions } from '@univerjs/ui';
 import type { KeyboardEvent } from 'react';
-import { LocaleService } from '@univerjs/core';
+import { IConfigService, LocaleService } from '@univerjs/core';
 import { borderClassName, clsx, Input, scrollbarClassName, Select } from '@univerjs/design';
 import { FunctionType } from '@univerjs/engine-formula';
 import { CheckMarkIcon } from '@univerjs/icons';
-import { IDescriptionService } from '@univerjs/sheets-formula';
+import { IDescriptionService, PLUGIN_CONFIG_KEY_BASE } from '@univerjs/sheets-formula';
 import { ISidebarService, useDependency, useObservable } from '@univerjs/ui';
 import { useEffect, useState } from 'react';
 import { getFunctionTypeValues } from '../../../services/utils';
@@ -34,6 +34,9 @@ export interface ISelectFunctionProps {
 }
 
 export function SelectFunction(props: ISelectFunctionProps) {
+    const configService = useDependency(IConfigService);
+    const customFunction = configService.getConfig<IUniverSheetsFormulaBaseConfig>(PLUGIN_CONFIG_KEY_BASE)?.function;
+
     const { onChange } = props;
 
     const allTypeValue = '-1';
@@ -48,7 +51,7 @@ export function SelectFunction(props: ISelectFunctionProps) {
     const sidebarService = useDependency(ISidebarService);
     const sidebarOptions = useObservable<ISidebarMethodOptions>(sidebarService.sidebarOptions$);
 
-    const options = getFunctionTypeValues(FunctionType, localeService);
+    const options = getFunctionTypeValues(FunctionType, localeService, Boolean(customFunction));
     options.unshift({
         label: localeService.t('formula.moreFunctions.allFunctions'),
         value: allTypeValue,


### PR DESCRIPTION
close #xxx

I found a way for the user to add custom functions through the UI. In fact, the list of functions currently has two empty sections: univer and user defined. This allows you to hide this section if none are defined. But am I really still concerned about the univer ones?

Before:
<img width="281" height="663" alt="image" src="https://github.com/user-attachments/assets/28bfb650-3cd0-4794-99c4-d0c8e99b44f5" />

After: 
<img width="286" height="666" alt="image" src="https://github.com/user-attachments/assets/e7561c75-cec1-44dc-95ce-f9b9b009b927" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
