### PR TITLE
feat: disable confirm btn if function info after use search is null

### DIFF
--- a/packages/sheets-formula-ui/src/views/more-functions/MoreFunctions.tsx
+++ b/packages/sheets-formula-ui/src/views/more-functions/MoreFunctions.tsx
@@ -87,6 +87,7 @@ export function MoreFunctions() {
                 )}
                 {selectFunction && !!workbook && (
                     <Button
+                        disabled={!functionInfo}
                         variant="primary"
                         onClick={handleConfirm}
                         className="univer-mb-5 univer-ml-4 univer-mr-0 univer-mt-0"

--- a/packages/sheets-formula-ui/src/views/more-functions/select-function/SelectFunction.tsx
+++ b/packages/sheets-formula-ui/src/views/more-functions/select-function/SelectFunction.tsx
@@ -30,7 +30,7 @@ import { FunctionHelp } from '../function-help/FunctionHelp';
 import { FunctionParams } from '../function-params/FunctionParams';
 
 export interface ISelectFunctionProps {
-    onChange: (functionInfo: IFunctionInfo) => void;
+    onChange: (functionInfo: IFunctionInfo | null) => void;
 }
 
 export function SelectFunction(props: ISelectFunctionProps) {
@@ -99,6 +99,7 @@ export function SelectFunction(props: ISelectFunctionProps) {
     const setCurrentFunctionInfo = (selectedIndex: number) => {
         if (selectList.length === 0) {
             setFunctionInfo(null);
+            onChange(null);
             return;
         }
 
@@ -106,6 +107,7 @@ export function SelectFunction(props: ISelectFunctionProps) {
         const functionInfo = descriptionService.getFunctionInfo(selectList[selectedIndex].name);
         if (!functionInfo) {
             setFunctionInfo(null);
+            onChange(null);
             return;
         }
 


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

We encountered an unexpected user experience in the functions sidebar. For example, when a user enters a search term that results in an empty list, clicking confirm inserts the previously selected function. For example, the first one in the list, before applying the search.

It seems that disabling the confirm button preserves the user experience when using search and does not lead to unexpected results.

We found similar behavior in one of the spreadsheet programs used in Russia, so we would like to propose this solution.

And considering that the type in the MoreFunctions component initially already contained null, and it is also used by default (line 34), it seems that the button disable was expected

Before:
<img width="408" height="922" alt="image" src="https://github.com/user-attachments/assets/98f27f29-2906-4ddc-9818-855b5fcccab3" />

After: 
<img width="408" height="922" alt="image" src="https://github.com/user-attachments/assets/ee5cf36a-8087-44c7-96d1-0b918a3b0c06" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
