### PR TITLE
feat: help func content visible UX

### DIFF
--- a/packages/sheets-formula-ui/src/views/formula-editor/help-function/HelpFunction.tsx
+++ b/packages/sheets-formula-ui/src/views/formula-editor/help-function/HelpFunction.tsx
@@ -97,7 +97,7 @@ export function HelpFunction(props: IHelpFunctionProps) {
     const { functionInfo, paramIndex, reset } = useFormulaDescribe(isFocus, formulaText, editor);
     const editorBridgeService = useDependency(IEditorBridgeService);
     const hidden = !useObservable(editorBridgeService.helpFunctionVisible$);
-    const [contentVisible, setContentVisible] = useState(true);
+    const [contentVisible, setContentVisible] = useState(false);
     const localeService = useDependency(LocaleService);
     const required = localeService.t('formula.prompt.required');
     const optional = localeService.t('formula.prompt.optional');


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->
I'd like to suggest improving the user experience a bit with the help function component. The point is that when a user works with a function, and does so frequently, they often already know the details of its use.
Therefore, displaying expanded content every time a feature is selected in a cell doesn't seem like the best idea. And users who want to learn more about it can expand the content.

I also studied the experience of other spreadsheets and came to the conclusion that my thoughts were confirmed.
Google:
<img width="599" height="330" alt="image" src="https://github.com/user-attachments/assets/2012558a-b445-4acb-b144-7f34a6bd2767" />

Libre(It doesn't show any additional information at all, but I don't think that's the best implementation either)
<img width="746" height="172" alt="image" src="https://github.com/user-attachments/assets/417398ef-0ff5-4e66-ac2d-cf8c52aad8ab" />

Yandex(used in Russia)
<img width="526" height="171" alt="image" src="https://github.com/user-attachments/assets/14762569-aca4-43e3-acdc-61055c7318d7" />

up to you

Before:
When entering a function, additional context is shown

After: 
When entering a function, additional content is hidden

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
