### PR TITLE
fix: increase concatenation

### DIFF
--- a/packages/sheets-ui/src/commands/commands/inline-format.command.ts
+++ b/packages/sheets-ui/src/commands/commands/inline-format.command.ts
@@ -181,8 +181,7 @@ export const SetRangeFontIncreaseCommand: ICommand = {
             const textRun = getFontStyleAtCursor(accessor);
             if (textRun != null) {
                 const value = textRun.ts?.fs ?? defaultValue;
-
-                params.value = value >= 400 ? 400 : value + 1;
+                params.value = value >= 400 ? 400 : +value + 1;
             }
 
             return commandService.executeCommand(SetInlineFormatFontSizeCommand.id, params);
@@ -191,7 +190,7 @@ export const SetRangeFontIncreaseCommand: ICommand = {
         if (primary != null) {
             const style = worksheet.getComposedCellStyle(primary.startRow, primary.startColumn);
             const value = style.fs ?? defaultValue;
-            params.value = value >= 400 ? 400 : value + 1;
+            params.value = value >= 400 ? 400 : +value + 1;
             return commandService.executeCommand(SetFontSizeCommand.id, params);
         }
 


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->
In general, when we increase the font size, everything works fine, but if we enter the font size manually, press enter, and only then increase the font, then font concatenation occurs, and with 30 entered, we can get 301

Before:

https://github.com/user-attachments/assets/3d1d6a12-445c-4928-bdbc-2662a997b831


After: 

https://github.com/user-attachments/assets/a8928bee-48d7-4b8b-a3ac-1a2f46255933


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
