### PR TITLE
feat: more numfmt type cursor to default

### DIFF
--- a/packages/sheets-numfmt-ui/src/views/components/MoreNumfmtType.tsx
+++ b/packages/sheets-numfmt-ui/src/views/components/MoreNumfmtType.tsx
@@ -99,8 +99,8 @@ export function Options() {
                     <div
                         key={index}
                         className={`
-                          univer-flex univer-h-7 univer-items-center univer-justify-between univer-gap-6 univer-rounded
-                          univer-px-2 univer-text-sm
+                          univer-flex univer-h-7 univer-cursor-default univer-items-center univer-justify-between
+                          univer-gap-6 univer-rounded univer-px-2 univer-text-sm
                           hover:univer-bg-gray-100
                           dark:hover:!univer-bg-gray-700
                         `}


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

All drop-down lists use the default cursor, but for some reason, the format drop-down menu uses the text cursor. I fixed it like everywhere else.

Also, in general, I'd like to point out that it seems to me that all such menus require a pointer cursor. This is more expected by users, but this probably requires a separate pull request for all such places.

Before:
<img width="381" height="566" alt="image" src="https://github.com/user-attachments/assets/8f8351a9-08e0-4c0e-a842-2e50dc3de099" />

After: 
<img width="381" height="566" alt="image" src="https://github.com/user-attachments/assets/2a95fe43-1dca-4a96-a2a0-637d05c23940" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
