### PR TITLE
feat: sidebar use default cursor

### DIFF
--- a/packages/ui/src/views/components/sidebar/Sidebar.tsx
+++ b/packages/ui/src/views/components/sidebar/Sidebar.tsx
@@ -133,9 +133,9 @@ export function Sidebar() {
             >
                 <header
                     className={`
-                      univer-sticky univer-top-0 univer-z-10 univer-box-border univer-flex univer-items-center
-                      univer-justify-between univer-bg-white univer-p-4 univer-pb-2 univer-text-base univer-font-medium
-                      univer-text-gray-800
+                      univer-sticky univer-top-0 univer-z-10 univer-box-border univer-flex univer-cursor-default
+                      univer-items-center univer-justify-between univer-bg-white univer-p-4 univer-pb-2 univer-text-base
+                      univer-font-medium univer-text-gray-800
                       dark:!univer-bg-gray-900 dark:!univer-text-white
                     `}
                 >
@@ -152,7 +152,7 @@ export function Sidebar() {
                     </a>
                 </header>
 
-                <section className="univer-box-border univer-px-4" style={options?.bodyStyle}>
+                <section className="univer-box-border univer-cursor-default univer-px-4" style={options?.bodyStyle}>
                     {options?.children}
                 </section>
 


### PR DESCRIPTION
close #xxx

I continued studying the cursor's behavior and paid attention to the sidebar.

on headings and sections, including those with subheadings, the cursor becomes for text. I think this is not entirely expected, especially since in some cases the text cannot even be selected for copying. 
For example, I can't select text on the shortcut bar.

<img width="461" height="396" alt="image" src="https://github.com/user-attachments/assets/de7b21b8-68ff-40ae-b202-4ccd153b1835" />

<img width="461" height="396" alt="image" src="https://github.com/user-attachments/assets/dea0168c-aa05-4d3d-b1ab-c35e399b7730" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
