### PR TITLE
fix: icon more will disappear when change screen in some cases

### DIFF
--- a/packages/ui/src/views/components/ribbon/Ribbon.tsx
+++ b/packages/ui/src/views/components/ribbon/Ribbon.tsx
@@ -226,7 +226,7 @@ export function Ribbon(props: IRibbonProps) {
                     setFakeToolbarVisible(false);
                 });
             }
-        }, 100));
+        }, 10));
 
         observer.observe(containerRef.current);
 


### PR DESCRIPTION
close #xxx

We noticed that in some cases, when changing the adaptivity, the more icon may disappear, despite throttling. We experimented with this issue and came to the conclusion that if we reduce the value to 10, this problem cannot be reproduced.

The reason for this is that in some cases CollapsedIds becomes 0, which is of course not the case. You can easily see this if, for example, you write console.log(newCollapsedIds.length, collapsedIds.length) on line 225.

Before:

https://github.com/user-attachments/assets/60c2ec57-3961-4009-b699-66229bc85b74

After:
work

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
