### PR TITLE
fix: rename tab auto close dialog err

### DIFF
--- a/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/utils/slide-tab-bar.ts
+++ b/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/utils/slide-tab-bar.ts
@@ -169,6 +169,7 @@ export class SlideTabItem {
 
                 if (e.key === 'Enter') {
                     input.blur();
+                    e.preventDefault();
                 }
             };
 


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

When attempting to rename a sheet by giving it an incorrect name, if you confirm the action via Enter, the error window closes immediately

Before:

https://github.com/user-attachments/assets/ae6a2988-84d7-47aa-b421-c4b7a6b598d1


After: 

https://github.com/user-attachments/assets/c5095def-40a1-4d50-9c32-f2ec38fbaf03


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
