### PR TITLE
fix(engine-formula): fix COUNTIF results mismatch when criteria is number

### DIFF
--- a/packages/engine-formula/src/basics/inverted-index-cache.ts
+++ b/packages/engine-formula/src/basics/inverted-index-cache.ts
@@ -81,7 +81,24 @@ export class InvertedIndexCache {
     }
 
     getCellPositions(unitId: string, sheetId: string, column: number, value: string | number | boolean, rowsInCache: NumericTuple[]) {
-        const rows = this._cache.get(unitId)?.get(sheetId)?.get(column)?.get(value);
+        const columnMap = this._cache.get(unitId)?.get(sheetId)?.get(column);
+        if (!columnMap) {
+            return undefined;
+        }
+
+        // Try to get rows with the original value
+        let rows = columnMap.get(value);
+
+        // If not found and value is a number, try to get rows with the string representation
+        // If not found and value is a string that represents a number, try to get rows with the number
+        if (!rows) {
+            if (typeof value === 'number') {
+                rows = columnMap.get(String(value));
+            } else if (typeof value === 'string' && !Number.isNaN(Number(value))) {
+                rows = columnMap.get(Number(value));
+            }
+        }
+
         // return rows?.values().filter((row) => rowsInCache.some(([start, end]) => row >= start && row <= end));
         return rows && [...rows].filter((row) => rowsInCache.some(([start, end]) => row >= start && row <= end));
     }

--- a/packages/engine-formula/src/functions/statistical/countif/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/statistical/countif/__tests__/index.spec.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it } from 'vitest';
 import { ErrorType } from '../../../../basics/error-type';
 import { ArrayValueObject, transformToValue, transformToValueObject } from '../../../../engine/value-object/array-value-object';
-import { StringValueObject } from '../../../../engine/value-object/primitive-object';
+import { NumberValueObject, StringValueObject } from '../../../../engine/value-object/primitive-object';
 import { FUNCTION_NAMES_STATISTICAL } from '../../function-names';
 import { Countif } from '../index';
 
@@ -148,6 +148,70 @@ describe('Test countif function', () => {
                 [1, 1, 1, 1, 1, 1],
                 [1, 1, 1, 1, 1, 1],
             ]);
+        });
+
+        it('Range with number criteria', async () => {
+            const range = ArrayValueObject.create(/*ts*/ `{
+                1;
+                2;
+                3;
+                2
+            }`);
+
+            const criteria = NumberValueObject.create(2);
+
+            const resultObject = testFunction.calculate(range, criteria);
+            expect(resultObject.getValue()).toBe(2);
+        });
+
+        it('Range with string criteria matching number', async () => {
+            const range = ArrayValueObject.create(/*ts*/ `{
+                1;
+                2;
+                3;
+                2
+            }`);
+
+            const criteria = StringValueObject.create('2');
+
+            const resultObject = testFunction.calculate(range, criteria);
+            expect(resultObject.getValue()).toBe(2);
+        });
+
+        it('Range with number criteria matching same value', async () => {
+            const range = ArrayValueObject.create(/*ts*/ `{
+                1;
+                2;
+                3
+            }`);
+
+            const criteria = NumberValueObject.create(2);
+
+            const resultObject = testFunction.calculate(range, criteria);
+            expect(resultObject.getValue()).toBe(1);
+        });
+
+        it('Range with string criteria matching number in range (issue #6065)', async () => {
+            // Simulates COUNTIF(A:A, A3) where A3 contains "1" (string) and A:A contains 1 (number)
+            const range = ArrayValueObject.create({
+                calculateValueList: transformToValueObject([
+                    [1],
+                    [2],
+                    [3],
+                ]),
+                rowCount: 3,
+                columnCount: 1,
+                unitId: '',
+                sheetId: '',
+                row: 0,
+                column: 0,
+            });
+
+            // A3 contains "1" as string
+            const criteria = StringValueObject.create('1');
+
+            const resultObject = testFunction.calculate(range, criteria);
+            expect(resultObject.getValue()).toBe(1);
         });
     });
 });


### PR DESCRIPTION
…meric string

Fix issue #6065 where COUNTIF(A:A, A3) returns 0 instead of 1 when A3 contains a numeric string (e.g., "1") and range contains numbers.

The bug was caused by CELL_INVERTED_INDEX_CACHE using strict type matching for cache keys. When criteria "1" (string) was converted to NumberValueObject(1) during comparison, the cache lookup failed because the cache stored the original string key "1" but lookup used number key 1.

- Updated getCellPositions to fallback to alternative type lookup when original key is not found (number <-> string conversion)
- Added test cases for numeric criteria matching

Closes #6065

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->


<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
