### PR TITLE
fix(engine-formula): fix incorrect type conversion when comparing string literal dates (fixes #6392)

### DIFF
--- a/packages/engine-formula/src/engine/value-object/__tests__/array-value-object.spec.ts
+++ b/packages/engine-formula/src/engine/value-object/__tests__/array-value-object.spec.ts
@@ -428,6 +428,36 @@ describe('arrayValueObject test', () => {
             expect(stringValueObject.isString()).toBeTruthy();
         });
 
+        it('ValueObjectFactory should not convert quoted date string to number (issue #6392)', () => {
+            // When a date string is wrapped in quotes (string literal), it should remain a string
+            // not be converted to a date number
+            const dateStringLiteral = ValueObjectFactory.create('"2026-01-01"');
+
+            expect(dateStringLiteral.isString()).toBeTruthy();
+            expect(dateStringLiteral.getValue()).toBe('2026-01-01');
+
+            // Unquoted date string may be converted to number (date serial number)
+            const dateString = ValueObjectFactory.create('2026-01-01');
+
+            // This could be either string or number depending on implementation,
+            // but quoted strings should always be strings
+            expect(dateStringLiteral.isString()).toBeTruthy();
+        });
+
+        it('ValueObjectFactory should not convert quoted time string to number', () => {
+            const timeStringLiteral = ValueObjectFactory.create('"12:30:00"');
+
+            expect(timeStringLiteral.isString()).toBeTruthy();
+            expect(timeStringLiteral.getValue()).toBe('12:30:00');
+        });
+
+        it('ValueObjectFactory should not convert quoted percentage to number', () => {
+            const percentStringLiteral = ValueObjectFactory.create('"50%"');
+
+            expect(percentStringLiteral.isString()).toBeTruthy();
+            expect(percentStringLiteral.getValue()).toBe('50%');
+        });
+
         it('ValueObjectFactory create ErrorValueObject ', () => {
             let errorValueObject = ValueObjectFactory.create(Number.NaN);
 

--- a/packages/engine-formula/src/engine/value-object/array-value-object.ts
+++ b/packages/engine-formula/src/engine/value-object/array-value-object.ts
@@ -1974,7 +1974,8 @@ export class ValueObjectFactory {
             }
 
             // value ignore whether it is a number pattern
-            if (!isIgnoreNumberPattern) {
+            // If the rawValue is wrapped in double quotes (string literal), it should not be converted to a number/date pattern
+            if (!isIgnoreNumberPattern && !isStringWrappedByDoubleQuotes(rawValue)) {
                 const { isNumberPattern, value, pattern } = stringIsNumberPattern(rawValue);
                 if (isNumberPattern) {
                     return NumberValueObject.create(value as number, pattern as string);

--- a/packages/engine-formula/src/functions/meta/compare/__tests__/index.spec.ts
+++ b/packages/engine-formula/src/functions/meta/compare/__tests__/index.spec.ts
@@ -201,6 +201,43 @@ describe('Test compare function', () => {
             const result = testFunction.calculate(value1, value2);
             expect(getObjectValue(result)).toStrictEqual([[ErrorType.REF, ErrorType.REF, ErrorType.REF, ErrorType.REF, ErrorType.REF, ErrorType.REF], [ErrorType.REF, ErrorType.REF, ErrorType.REF, ErrorType.REF, ErrorType.REF, ErrorType.NAME]]);
         });
+
+        it('Comparing string cell reference with string literal date (issue #6392)', () => {
+            // When comparing a cell reference containing a date string with a string literal date,
+            // the comparison should be lexical (string comparison), not date/numeric comparison
+            const cellValue = StringValueObject.create('2025-01-01');
+            const stringLiteral = StringValueObject.create('2026-01-01');
+
+            testFunction.setCompareType(compareToken.GREATER_THAN_OR_EQUAL);
+            const result = testFunction.calculate(cellValue, stringLiteral);
+            // "2025-01-01" >= "2026-01-01" should be FALSE (lexical comparison)
+            expect(result.getValue()).toBe(false);
+
+            testFunction.setCompareType(compareToken.LESS_THAN);
+            const result2 = testFunction.calculate(cellValue, stringLiteral);
+            // "2025-01-01" < "2026-01-01" should be TRUE (lexical comparison)
+            expect(result2.getValue()).toBe(true);
+
+            testFunction.setCompareType(compareToken.EQUALS);
+            const result3 = testFunction.calculate(cellValue, stringLiteral);
+            // "2025-01-01" = "2026-01-01" should be FALSE
+            expect(result3.getValue()).toBe(false);
+        });
+
+        it('Comparing string cell reference with same string literal date', () => {
+            const cellValue = StringValueObject.create('2025-01-01');
+            const stringLiteral = StringValueObject.create('2025-01-01');
+
+            testFunction.setCompareType(compareToken.EQUALS);
+            const result = testFunction.calculate(cellValue, stringLiteral);
+            // "2025-01-01" = "2025-01-01" should be TRUE
+            expect(result.getValue()).toBe(true);
+
+            testFunction.setCompareType(compareToken.GREATER_THAN_OR_EQUAL);
+            const result2 = testFunction.calculate(cellValue, stringLiteral);
+            // "2025-01-01" >= "2025-01-01" should be TRUE
+            expect(result2.getValue()).toBe(true);
+        });
     });
 });
 // describe('Test compare function2', () => {


### PR DESCRIPTION
## Bug Description

When comparing a cell reference containing a date string with a string literal date, the comparison should be lexical (string comparison), not date/numeric comparison.

For example, if cell A1 contains the string "2025-01-01" (as a string literal, not a formatted number), the formula `=A1>="2026-01-01"` should return FALSE (lexical comparison). However, Univer was incorrectly returning TRUE because it was converting the string literal "2026-01-01" to a date number.

Fixes #6392

## Root Cause

The issue was in `ValueObjectFactory.create()` method. When processing string literals like `"2026-01-01"`, it called `stringIsNumberPattern()` which strips the quotes and attempts to parse the content as a date/time/number pattern using `numfmt.parseDate()`. This caused string literals to be incorrectly converted to `NumberValueObject`.

## Fix

Added a check to skip number/date pattern conversion for values wrapped in double quotes (string literals). String literals should always remain as `StringValueObject` to ensure proper lexical comparison.

## Changes

- Modified `ValueObjectFactory.create()` to skip number pattern conversion for quoted strings
- Added test cases for quoted date/time/percentage strings
- Added test cases for string comparison with date literals

## Testing

- All existing tests pass
- New test cases verify the fix works correctly for the reported issue