### PR TITLE
feat: mark active font family

### DIFF
--- a/packages/sheets-ui/src/controllers/menu/menu.ts
+++ b/packages/sheets-ui/src/controllers/menu/menu.ts
@@ -388,7 +388,7 @@ export function StrikeThroughMenuItemFactory(accessor: IAccessor): IMenuButtonIt
     };
 }
 
-export function FontFamilySelectorMenuItemFactory(accessor: IAccessor): IMenuSelectorItem<string> {
+export function FontFamilySelectorMenuItemFactory(accessor: IAccessor): IMenuSelectorItem<string, string | undefined> {
     const commandService = accessor.get(ICommandService);
     const univerInstanceService = accessor.get(IUniverInstanceService);
     const selectionManagerService = accessor.get(SheetsSelectionsService);
@@ -420,6 +420,23 @@ export function FontFamilySelectorMenuItemFactory(accessor: IAccessor): IMenuSel
                     id: SetRangeFontFamilyCommand.id,
                 },
             },
+            value$: deriveStateFromActiveSheet$(univerInstanceService, defaultValue, ({ worksheet }) => new Observable<string>((subscriber) => {
+                let ff = defaultValue;
+
+                const primary = selectionManagerService.getCurrentLastSelection()?.primary;
+                if (primary != null) {
+                    const cell = worksheet.getCellStyle(primary.startRow, primary.startColumn);
+                    const defaultStyle = worksheet.getDefaultCellStyleInternal();
+                    const rowStyle = worksheet.getRowStyle(primary.startRow);
+                    const colStyle = worksheet.getColumnStyle(primary.startColumn);
+                    const style = composeStyles(defaultStyle, rowStyle, colStyle, cell);
+                    if (style.ff) {
+                        ff = style.ff;
+                    }
+                }
+
+                subscriber.next(ff);
+            })),
         }],
         disabled$,
         value$: deriveStateFromActiveSheet$(univerInstanceService, defaultValue, ({ worksheet }) => new Observable((subscriber) => {

--- a/packages/ui/src/components/font-family/FontFamilyItem.tsx
+++ b/packages/ui/src/components/font-family/FontFamilyItem.tsx
@@ -17,8 +17,8 @@
 import type { IFontConfig } from '../../services/font.service';
 import { ICommandService, LocaleService } from '@univerjs/core';
 import { Tooltip } from '@univerjs/design';
-import { InfoIcon } from '@univerjs/icons';
-import { useEffect, useState } from 'react';
+import { CheckMarkIcon, InfoIcon } from '@univerjs/icons';
+import { useEffect, useMemo, useState } from 'react';
 import { IFontService } from '../../services/font.service';
 import { useDependency } from '../../utils/di';
 
@@ -27,6 +27,8 @@ export const FontFamilyItem = ({ id, value }: { id: string; value: string }) => 
     const fontService = useDependency(IFontService);
 
     const [fonts, setFonts] = useState<IFontConfig[]>([]);
+
+    const _value = useMemo(() => value, [value]);
 
     useEffect(() => {
         const subscription = fontService.fonts$.subscribe((fonts) => {
@@ -50,24 +52,31 @@ export const FontFamilyItem = ({ id, value }: { id: string; value: string }) => 
             style={{ fontFamily: value }}
         >
             {fonts.map((font) => (
-                <li key={font.value}>
-                    <button
-                        className={`
-                          univer-flex univer-h-7 univer-w-full univer-appearance-none univer-items-center
-                          univer-justify-between univer-gap-6 univer-rounded univer-border-none univer-bg-transparent
-                          univer-px-2
-                          hover:univer-bg-gray-100
-                          dark:!univer-text-white
-                          dark:hover:!univer-bg-gray-700
-                        `}
+                <li
+                    key={font.value}
+                    onClick={() => handleSelectFont(font.value)}
+                    className={`
+                      univer-flex univer-h-7 univer-cursor-pointer univer-items-center univer-justify-between
+                      univer-gap-2 univer-rounded univer-px-2 univer-py-1
+                      hover:univer-bg-gray-100
+                      dark:!univer-text-white
+                      dark:hover:!univer-bg-gray-700
+                    `}
+                >
+                    <span>
+                        {_value === font.value && (
+                            <CheckMarkIcon
+                                className="univer-block univer-size-4 univer-fill-current univer-text-primary-600"
+                            />
+                        )}
+                    </span>
+                    <span
+                        className="univer-flex univer-items-center univer-gap-2"
                         style={{
                             fontFamily: font.value,
                         }}
-                        type="button"
-                        onClick={() => handleSelectFont(font.value)}
                     >
                         {localeService.t(font.label)}
-
                         {!fontService.isFontSupported(font.value) && (
                             <Tooltip title={localeService.t('fontFamily.not-supported')}>
                                 <InfoIcon
@@ -78,7 +87,7 @@ export const FontFamilyItem = ({ id, value }: { id: string; value: string }) => 
                                 />
                             </Tooltip>
                         )}
-                    </button>
+                    </span>
                 </li>
             ))}
         </ul>


### PR DESCRIPTION
Happy New Year Univer team. I wish you prosperity, wealth, and good luck in everything!

close #xxx

I noticed that the active font size is highlighted, but the active font family is not

Before:

the active font is not marked

After: 

https://github.com/user-attachments/assets/686110bd-c36c-45d5-842d-68b6be3be85b


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
