### PR TITLE
fix: font family label

### DIFF
--- a/packages/ui/src/components/font-family/FontFamily.tsx
+++ b/packages/ui/src/components/font-family/FontFamily.tsx
@@ -53,7 +53,7 @@ export const FontFamily = ({ id, value, disabled$ }: IFontFamilyProps) => {
         });
 
         if (!font) {
-            return fixedValue;
+            return localeService.t(value);
         }
 
         return localeService.t(font.label);


### PR DESCRIPTION
close #xxx

When I implemented a font search in the input, I incorrectly set the return if the font was not found, which is why there was no space in fonts for several words

Before:
<img width="290" height="133" alt="image" src="https://github.com/user-attachments/assets/d8223cf7-b592-47f7-8b5e-fd28cadb2862" />

After:

https://github.com/user-attachments/assets/dc548245-6e8f-4267-ae8b-5dae433fb601


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
