### PR TITLE
fix: dropdown data validation dark background

### DIFF
--- a/packages/sheets-ui/src/views/dropdown/list-dropdown/index.tsx
+++ b/packages/sheets-ui/src/views/dropdown/list-dropdown/index.tsx
@@ -114,7 +114,7 @@ function SelectList(props: ISelectListProps) {
                           univer-w-full univer-rounded-md univer-border univer-border-[rgba(13,13,13,0.12)] univer-px-2
                           univer-py-1 univer-text-sm
                           focus:univer-border-primary-500 focus:univer-outline-none
-                          dark:!univer-text-white
+                          dark:!univer-bg-black dark:!univer-text-white
                         `}
                         type="text"
                         value={lowerFilter}


### PR DESCRIPTION
close #6596

Before:
<img width="297" height="325" alt="image" src="https://github.com/user-attachments/assets/e637c99a-a5bd-4bf6-923c-7660506175ee" />

After: 
<img width="353" height="179" alt="image" src="https://github.com/user-attachments/assets/8b8576ab-367f-4ac2-a0e2-bfa2628ad30a" />


I also want to add that I was a little surprised, since this is not reproducible, it is written on https://docs.univer.ai/
<img width="958" height="1176" alt="image" src="https://github.com/user-attachments/assets/344c2e57-0b97-4707-9391-99e40ffa87cd" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
