### PR TITLE
feat(docs): active color on icon color or bg toolbar

### DIFF
--- a/packages/ui/src/services/menu/menu.ts
+++ b/packages/ui/src/services/menu/menu.ts
@@ -122,6 +122,10 @@ export function isMenuSelectorItem<T extends MenuItemDefaultValueType>(v: IMenuI
     return v.type === MenuItemType.SELECTOR || v.type === MenuItemType.SUBITEMS;
 }
 
+export function isMenuButtonSelectorItem<T extends MenuItemDefaultValueType>(v: IMenuItem): v is IMenuSelectorItem<T> {
+    return v.type === MenuItemType.BUTTON_SELECTOR;
+}
+
 export type MenuItemDefaultValueType = string | number | undefined;
 
 export type IMenuItem = IMenuButtonItem<MenuItemDefaultValueType> | IMenuSelectorItem<MenuItemDefaultValueType, any>;

--- a/packages/ui/src/views/components/ribbon/ToolbarItem.tsx
+++ b/packages/ui/src/views/components/ribbon/ToolbarItem.tsx
@@ -36,7 +36,7 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IDisplayMenuItem<IMenu
     const layoutService = useDependency(ILayoutService);
     const componentManager = useDependency(ComponentManager);
 
-    const { value, hidden, disabled, activated } = useToolbarItemStatus(props);
+    const { value, hidden, disabled, activated, selectionsValue } = useToolbarItemStatus(props);
 
     const executeCommand = (commandId: string, params?: Record<string, unknown>) => {
         layoutService.focus();
@@ -57,6 +57,7 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IDisplayMenuItem<IMenu
             });
         }
     }, [selections]);
+
     const options = useObservable(selections$) as IValueOption[];
 
     const icon$ = useMemo(() => {
@@ -132,7 +133,7 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IDisplayMenuItem<IMenu
                         <CustomLabel
                             icon={iconToDisplay}
                             title={title!}
-                            value={value}
+                            value={selectionsValue ?? value}
                             label={label}
                             onChange={handleSelectionsValueChange}
                         />

--- a/packages/ui/src/views/components/ribbon/hook.ts
+++ b/packages/ui/src/views/components/ribbon/hook.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import type { Subscription } from 'rxjs';
+import type { Observable, Subscription } from 'rxjs';
 import type { IDisplayMenuItem, IMenuItem } from '../../../services/menu/menu';
 import { useEffect, useState } from 'react';
+import { isMenuButtonSelectorItem } from '../../../services/menu/menu';
 
 export interface IToolbarItemStatus {
     disabled: boolean;
@@ -24,6 +25,8 @@ export interface IToolbarItemStatus {
     value: any;
     activated: boolean;
     hidden: boolean;
+    // eslint-disable-next-line ts/no-explicit-any
+    selectionsValue: any;
 }
 
 // TODO@wzhudev: maybe we should use `useObservable` here.
@@ -37,21 +40,34 @@ export function useToolbarItemStatus(menuItem: IDisplayMenuItem<IMenuItem>): ITo
     const { disabled$, hidden$, activated$, value$ } = menuItem;
 
     // eslint-disable-next-line ts/no-explicit-any
+    let selectionsValue$: Observable<any> | undefined;
+
+    if (isMenuButtonSelectorItem(menuItem)) {
+        const { selections } = menuItem;
+
+        if (Array.isArray(selections)) {
+            selectionsValue$ = selections?.[0]?.value$;
+        }
+    }
+
+    // eslint-disable-next-line ts/no-explicit-any
     const [value, setValue] = useState<any>();
     const [disabled, setDisabled] = useState(false);
     const [activated, setActivated] = useState(false);
     const [hidden, setHidden] = useState(false);
+    // eslint-disable-next-line ts/no-explicit-any
+    const [selectionsValue, setSelectionsValue] = useState<any>();
 
     useEffect(() => {
         const subscriptions: Subscription[] = [];
-
         disabled$ && subscriptions.push(disabled$.subscribe((disabled) => setDisabled(disabled)));
         hidden$ && subscriptions.push(hidden$.subscribe((hidden) => setHidden(hidden)));
         activated$ && subscriptions.push(activated$.subscribe((activated) => setActivated(activated)));
         value$ && subscriptions.push(value$.subscribe((value) => setValue(value)));
+        selectionsValue$ && subscriptions.push(selectionsValue$.subscribe((value) => setSelectionsValue(value)));
 
         return () => subscriptions.forEach((subscription) => subscription.unsubscribe());
-    }, [activated$, disabled$, hidden$, value$]);
+    }, [activated$, disabled$, hidden$, value$, selectionsValue$]);
 
-    return { disabled, value, activated, hidden };
+    return { disabled, value, activated, hidden, selectionsValue };
 }


### PR DESCRIPTION
close #xxx

We noticed the non-obvious behavior of the component icons that appear when text is selected.

So, for example, if we select text and choose a color, we can see a change in the icon color, but if we focus there again, the default color will appear.

This solves the problem, and overall, it seems to me to be an adequate solution, but I see that on line 50 there was selections being retrieved from props, and in theory, it's probably possible to get them from there, but it seems like that would require more changes, and it was originally there for something a little different

Before:

https://github.com/user-attachments/assets/975adfe1-ea18-4965-90d0-53bfb8d9b49d


After: 

https://github.com/user-attachments/assets/2f3c9c10-8674-4ff6-ba58-5abd86e120f3


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
