### PR TITLE
fix(docs): fixed insertion of pictures from other sites with clipboard

### DIFF
--- a/packages/docs-ui/src/controllers/render-controllers/doc-clipboard.controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc-clipboard.controller.ts
@@ -25,7 +25,6 @@ import {
 } from '@univerjs/core';
 import {
     HTML_CLIPBOARD_MIME_TYPE,
-    imageMimeTypeSet,
     PLAIN_TEXT_CLIPBOARD_MIME_TYPE,
 } from '@univerjs/ui';
 import { takeUntil } from 'rxjs';
@@ -54,31 +53,66 @@ export class DocClipboardController extends RxDisposable implements IRenderModul
     }
 
     private _initLegacyPasteCommand(): void {
-        this._docSelectionRenderService?.onPaste$.pipe(takeUntil(this.dispose$)).subscribe((config) => {
-            if (!whenDocOrEditor(this._contextService)) {
-                return;
+        this._docSelectionRenderService?.onPaste$
+            .pipe(takeUntil(this.dispose$))
+            .subscribe(async (config) => {
+                if (!whenDocOrEditor(this._contextService)) {
+                    return;
+                }
+
+                config!.event.preventDefault();
+                const clipboardEvent = config!.event as ClipboardEvent;
+                let htmlContent = clipboardEvent.clipboardData?.getData(HTML_CLIPBOARD_MIME_TYPE);
+                const textContent = clipboardEvent.clipboardData?.getData(PLAIN_TEXT_CLIPBOARD_MIME_TYPE);
+
+                const files = [...(clipboardEvent.clipboardData?.items || [])]
+                    .filter((item) => item.kind === 'file' && item.type?.startsWith('image/'))
+                    .map((item) => {
+                        const blob = item.getAsFile();
+                        if (!blob) return null;
+                        const ext = item.type.split('/')[1]?.split('+')[0] || 'png';
+                        return new File([blob], `pasted_image_${Date.now()}.${ext}`, { type: item.type });
+                    })
+                    .filter((e): e is File => !!e);
+
+                if (!files.length && htmlContent) {
+                    const extractedFiles = await this._extractImagesFromHtml(htmlContent);
+                    if (extractedFiles.length) {
+                        files.push(...extractedFiles);
+                    }
+                }
+
+                const editor = this._editorService.getEditor(this._context.unitId);
+                if (!!editor && (htmlContent ?? '').indexOf('</table>') > -1) {
+                    htmlContent = '';
+                }
+
+                this._docClipboardService.legacyPaste({ html: htmlContent, text: textContent, files });
+            });
+    }
+
+    private async _extractImagesFromHtml(html: string): Promise<File[]> {
+        const files: File[] = [];
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const images = doc.querySelectorAll('img');
+
+        for (const img of images) {
+            const src = img.src || img.getAttribute('data-src');
+            if (!src || !src.startsWith('http')) continue;
+
+            try {
+                const response = await fetch(src, { mode: 'cors' });
+                if (!response.ok) continue;
+                const blob = await response.blob();
+                const contentType = blob.type || 'image/png';
+                const ext = contentType.split('/')[1]?.split('+')[0] || 'png';
+                const file = new File([blob], `extracted_${Date.now()}.${ext}`, { type: contentType });
+                files.push(file);
+            } catch (e) {
+                console.warn('[DocClipboardController] Failed to fetch image from HTML', src, e);
             }
-
-            config!.event.preventDefault();
-            const clipboardEvent = config!.event as ClipboardEvent;
-            let htmlContent = clipboardEvent.clipboardData?.getData(HTML_CLIPBOARD_MIME_TYPE);
-            const textContent = clipboardEvent.clipboardData?.getData(PLAIN_TEXT_CLIPBOARD_MIME_TYPE);
-
-            const files = [...(clipboardEvent.clipboardData?.items || [])]
-                .filter((item) => imageMimeTypeSet.has(item.type))
-                .map((item) => item.getAsFile()!)
-                .filter((e) => !!e);
-
-            // TODO: @JOCS, work around to fix https://github.com/dream-num/univer-pro/issues/2006. and then when you paste it,
-            // you need to distinguish between different editors,
-            // because different editors have different pasting effects. For example, when editing a state, you can't paste a table
-            const editor = this._editorService.getEditor(this._context.unitId);
-
-            if (!!editor && (htmlContent ?? '').indexOf('</table>') > -1) {
-                htmlContent = '';
-            }
-
-            this._docClipboardService.legacyPaste({ html: htmlContent, text: textContent, files });
-        });
+        }
+        return files;
     }
 }

--- a/packages/docs-ui/src/services/clipboard/clipboard.service.ts
+++ b/packages/docs-ui/src/services/clipboard/clipboard.service.ts
@@ -18,6 +18,7 @@ import type { IDisposable, IDocumentBody, IDocumentData } from '@univerjs/core';
 import type { IDocImage } from '@univerjs/docs-drawing';
 import type { IRectRangeWithStyle, ITextRangeWithStyle } from '@univerjs/engine-render';
 import {
+    BooleanNumber,
     BuildTextUtils,
     createIdentifier,
     DataStreamTreeTokenType,
@@ -39,6 +40,7 @@ import {
     toDisposable,
     Tools,
     UniverInstanceType,
+    WrapTextType,
 } from '@univerjs/core';
 import { DocSelectionManagerService } from '@univerjs/docs';
 import { ImageSourceType } from '@univerjs/drawing';
@@ -168,13 +170,17 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
         let { html, text, files } = options;
         const currentDocInstance = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
         const docUnitId = currentDocInstance?.getUnitId() || '';
-        if (!html && !text && files.length) {
-            html = await this._createImagePasteHtml(files);
+
+        if (files.length) {
+            html = await this._createImagePasteHtml(files, docUnitId);
+            text = '';
         }
+
         if (!html && !text) {
             this._logService.warn('[DocClipboardController] html and text cannot be both empty!');
             return false;
         }
+
         const partDocData = this._genDocDataFromHtmlAndText(html, text, docUnitId);
         // Paste in sheet editing mode without paste style, so we give textRuns empty array;
         if (docUnitId === DOCS_NORMAL_EDITOR_UNIT_ID_KEY) {
@@ -520,9 +526,9 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
         return doc;
     }
 
-    private async _createImagePasteHtml(files: File[]) {
+    private async _createImagePasteHtml(files: File[], unitId?: string) {
         const doc: IDocumentData = {
-            id: '',
+            id: unitId || '',
             documentStyle: {},
             body: {
                 dataStream: '',
@@ -571,28 +577,61 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
             body.customBlocks?.push({ startIndex: index, blockId: itemId });
             drawings[itemId] = {
                 drawingId: itemId,
-                unitId: '',
-                subUnitId: '',
+                unitId: unitId || '',
+                subUnitId: unitId || '',
                 imageSourceType: image.imageSourceType,
                 title: '',
                 source: image.source,
                 description: '',
                 layoutType: PositionedObjectLayoutType.INLINE,
                 drawingType: DrawingTypeEnum.DRAWING_IMAGE,
+
                 transform: {
                     width,
                     height,
                     angle: 0,
+                    left: 0,
+                    top: 0,
+                    flipX: false,
+                    flipY: false,
+                    skewX: 0,
+                    skewY: 0,
+                    zIndex: 0,
                 },
+
                 docTransform: {
                     angle: 0,
                     size: { width, height },
                     positionH: { relativeFrom: ObjectRelativeFromH.CHARACTER, posOffset: 0 },
                     positionV: { relativeFrom: ObjectRelativeFromV.LINE, posOffset: 0 },
                 },
+
+                behindDoc: BooleanNumber.FALSE,
+                wrapText: WrapTextType.BOTH_SIDES,
+                distB: 0,
+                distL: 0,
+                distR: 0,
+                distT: 0,
+                allowTransform: true,
             } as IDocImage;
         }));
-        const html = this._umdToHtml.convert([doc]);
+        let html = this._umdToHtml.convert([doc]);
+
+        const copyId = genId();
+        html = html.replace(/(<[a-z][^>]*)/i, `$1 data-copy-id="${copyId}"`);
+
+        const cache: Partial<IDocumentData> = {
+            id: doc.id,
+            body: {
+                ...doc.body,
+                dataStream: doc.body?.dataStream || '',
+                customBlocks: [...(doc.body?.customBlocks || [])],
+            },
+            drawings: { ...doc.drawings },
+        };
+
+        copyContentCache.set(copyId, cache);
+
         return html;
     }
 }

--- a/packages/docs-ui/src/services/clipboard/clipboard.service.ts
+++ b/packages/docs-ui/src/services/clipboard/clipboard.service.ts
@@ -460,6 +460,10 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
             let html = '';
             let text = '';
             const files: File[] = [];
+
+            const currentDocInstance = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
+            const docUnitId = currentDocInstance?.getUnitId() || '';
+
             for (const clipboardItem of items) {
                 for (const type of clipboardItem.types) {
                     switch (type) {
@@ -483,11 +487,13 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
                     }
                 }
             }
-            if (!html && !text && files.length) {
-                html = await this._createImagePasteHtml(files);
+
+            if (files.length) {
+                html = await this._createImagePasteHtml(files, docUnitId);
+                text = '';
             }
 
-            return this._genDocDataFromHtmlAndText(html, text);
+            return this._genDocDataFromHtmlAndText(html, text, docUnitId);
         } catch (e) {
             return Promise.reject(e);
         }


### PR DESCRIPTION
I copy a picture from another site using the right mouse button. I go to doсs and try to paste a picture from the clipboard

Before:
There is empty space in the document

https://github.com/user-attachments/assets/78db1725-43c1-40cc-a806-d3f67044fc9c



After: 
There is a picture in the document

https://github.com/user-attachments/assets/fee5315f-4855-4ef9-a38d-74a1fe5f938e





## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
