### PR TITLE
fix: change font size props value to number; increase font

### DIFF
--- a/packages/ui/src/components/font-size/FontSize.tsx
+++ b/packages/ui/src/components/font-size/FontSize.tsx
@@ -37,7 +37,7 @@ export const FontSize = (props: IFontSizeProps) => {
         e.stopPropagation();
 
         if (e.code === 'Enter') {
-            onChange(realValue.toString());
+            onChange(realValue);
         }
     }
 

--- a/packages/ui/src/components/font-size/interface.ts
+++ b/packages/ui/src/components/font-size/interface.ts
@@ -18,14 +18,14 @@ import type { Observable } from 'rxjs';
 import type { ICustomComponentProps } from '../../services/menu/menu';
 import { NamedStyleType } from '@univerjs/core';
 
-export interface IFontSizeProps extends ICustomComponentProps<string> {
-    value: string;
+export interface IFontSizeProps extends ICustomComponentProps<number> {
+    value: number;
 
     min: number;
 
     max: number;
 
-    onChange: (value: string) => void;
+    onChange: (value: number) => void;
 
     disabled$?: Observable<boolean>;
 }


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

I returned to a previously identified issue with increasing the font size after entering it via input. I was even prompted to do this by the fact that the event that generates the font size change was returning a string instead of the expected number. For example:

<img width="423" height="189" alt="image" src="https://github.com/user-attachments/assets/3cadf431-823f-40af-823c-39cfec57c6a7" />

The current solution both fixes the bug reported in #6509 and provides a more expected type for the cell size - number.

<img width="307" height="336" alt="image" src="https://github.com/user-attachments/assets/cbec9560-762e-42e4-9d01-93c0a5858ef4" />

considering that the IStyleData interface itself defines this as a number

Before:
reported in #6509
After: 

https://github.com/user-attachments/assets/c917a39f-f2f8-4230-bf81-228f0c80f149


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
