### PR TITLE
feat(ui)!: rename default ribbon type to collapsed

### DIFF
--- a/examples/src/sheets/main.ts
+++ b/examples/src/sheets/main.ts
@@ -126,7 +126,6 @@ function createNewInstance() {
         [UniverRenderEnginePlugin],
         [UniverUIPlugin, {
             container: 'app',
-            ribbonType: 'classic',
             customFontFamily: {
                 list: [
                     { value: 'PingFang SC', label: '苹方（简）', category: 'sans-serif' },

--- a/packages/ui/src/controllers/ui/ui.controller.ts
+++ b/packages/ui/src/controllers/ui/ui.controller.ts
@@ -17,7 +17,7 @@
 import type { IFontConfig } from '../../services/font.service';
 import { createIdentifier } from '@univerjs/core';
 
-export type RibbonType = 'default' | 'simple' | 'classic';
+export type RibbonType = 'collapsed' | 'simple' | 'classic';
 
 export interface IWorkbenchOptions {
     container?: string | HTMLElement;

--- a/packages/ui/src/views/components/ribbon/Ribbon.tsx
+++ b/packages/ui/src/views/components/ribbon/Ribbon.tsx
@@ -232,7 +232,7 @@ export function Ribbon(props: IRibbonProps) {
                     'univer-grid-cols-none': ribbon.length === 1,
                 }, borderBottomClassName)}
             >
-                {ribbonType === 'default' && ribbon.length > 1 && (
+                {ribbonType === 'collapsed' && ribbon.length > 1 && (
                     <DefaultMenu
                         ribbon={ribbon}
                         activatedTab={activatedTab}

--- a/packages/ui/src/views/workbench/Workbench.tsx
+++ b/packages/ui/src/views/workbench/Workbench.tsx
@@ -49,7 +49,7 @@ export function DesktopWorkbenchContent(props: IUniverWorkbenchProps) {
         footer = true,
         headerMenu = true,
         contextMenu = true,
-        ribbonType = 'default',
+        ribbonType = 'classic',
         mountContainer,
         onRendered,
     } = props;


### PR DESCRIPTION
Rename the ribbon type literal from 'default' to 'collapsed'. Switch the implicit workbench fallback to 'classic'. Remove the explicit classic ribbon config from the sheets example.

BREAKING CHANGE: The ribbon type value 'default' is no longer valid. Use 'collapsed' instead. When ribbonType is omitted, the UI now defaults to 'classic'.

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
