### PR TITLE
fix(render): fix scrollbar calculation issue that caused an extra blank area on the far right

### DIFF
--- a/packages/engine-render/src/shape/scroll-bar.ts
+++ b/packages/engine-render/src/shape/scroll-bar.ts
@@ -115,7 +115,7 @@ export class ScrollBar extends Disposable {
     private _vThumbMargin = DEFAULT_THUMB_MARGIN;
     private _hThumbMargin = DEFAULT_THUMB_MARGIN;
 
-    // origin: barBorder
+    // origin: barBorder, used for strokeWidth of scroll track, is draw on the center of the track border, so the visible border thickness is barBorder / 2 at both side of the track, and the visible track thickness is `trackThickness - barBorder`.
     private _trackBorderThickness = 1;
     private _thumbLengthRatio = 1;
 
@@ -287,14 +287,24 @@ export class ScrollBar extends Disposable {
         return this.verticalThumbRect?.visible || false;
     }
 
+    /**
+     * The horizontal scroll thumb thickness.
+     */
     get scrollHorizonThumbThickness() {
         return Math.max(0, this._trackThickness - this._hThumbMargin * 2);
     }
 
+    /**
+     * The vertical scroll thumb thickness.
+     */
     get scrollVerticalThumbThickness() {
         return Math.max(0, this._trackThickness - this._vThumbMargin * 2);
     }
 
+    /**
+     * The scroll track thickness.
+     * trackThickness = scrollTrackSize(horizonScrollTrack.height/verticalScrollTrack.width) + trackBorderThickness
+     */
     set barSize(v: number) {
         this._trackThickness = v;
     }
@@ -309,6 +319,10 @@ export class ScrollBar extends Disposable {
 
     get trackThickness() {
         return this._trackThickness;
+    }
+
+    get totalSize() {
+        return this._trackThickness + this._trackBorderThickness;
     }
 
     static attachTo(view: Viewport, props?: IScrollBarProps) {

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -197,6 +197,14 @@ export class Viewport {
     private _paddingEndY: number = 0;
 
     /**
+     * The viewMain viewport's marginLeft and marginTop is used to calculate the scrollBar position.
+     * marginLeft = rowHeaderWidthAndMarginLeft;
+     * marginTop = columnHeaderHeightAndMarginTop;
+     */
+    private _marginLeft: number = 0;
+    private _marginTop: number = 0;
+
+    /**
      * viewbound of cache area, cache area is slightly bigger than viewbound.
      */
     private _cacheBound: IBoundRectNoAngle | null;
@@ -511,6 +519,11 @@ export class Viewport {
             startY: 0,
             endY: 0,
         });
+    }
+
+    setMargin(marginLeft: number, marginTop: number) {
+        this._marginLeft = marginLeft;
+        this._marginTop = marginTop;
     }
 
     /**
@@ -1102,8 +1115,9 @@ export class Viewport {
         const freezeWidth = this._paddingEndX - this._paddingStartX;
         const scaleY = this.scene.scaleY;
         const scaleX = this.scene.scaleX;
-        const maxViewportScrollX = this._sceneWidthAfterScale - freezeWidth * scaleX - width;
-        const maxViewportScrollY = this._sceneHeightAfterScale - freezeHeight * scaleY - height;
+        const scrollBarThicknessTotalSize = this.getScrollBar()?.totalSize ?? 0;
+        const maxViewportScrollX = this._sceneWidthAfterScale - this._marginLeft * scaleX - freezeWidth * scaleX - width + scrollBarThicknessTotalSize;
+        const maxViewportScrollY = this._sceneHeightAfterScale - this._marginTop * scaleY - freezeHeight * scaleY - height + scrollBarThicknessTotalSize;
         return {
             viewportScrollX: Tools.clamp(viewportScrollX, this._paddingStartX, maxViewportScrollX / scaleX),
             viewportScrollY: Tools.clamp(viewportScrollY, this._paddingStartY, maxViewportScrollY / scaleY),
@@ -1166,8 +1180,8 @@ export class Viewport {
         if (!this.width || this.width < 0) return;
         if (!this.height || this.height < 0) return;
         const { width, height } = this._calcViewPortSize();
-        const sceneWidthCurrVpAfterScale = (this._scene.width - this._paddingEndX) * this._scene.scaleX;
-        const sceneHeightCurrVpAfterScale = (this._scene.height - this._paddingEndY) * this._scene.scaleY;
+        const sceneWidthCurrVpAfterScale = (this._scene.width - this._marginLeft - this._paddingEndX) * this._scene.scaleX;
+        const sceneHeightCurrVpAfterScale = (this._scene.height - this._marginTop - this._paddingEndY) * this._scene.scaleY;
         this._sceneWCurrVpAfterScale = sceneWidthCurrVpAfterScale;
         this._sceneHCurrVpAfterScale = sceneHeightCurrVpAfterScale;
         this._sceneWidthAfterScale = this._scene.width * this._scene.scaleX;

--- a/packages/sheets-ui/src/controllers/render-controllers/freeze.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/freeze.render-controller.ts
@@ -192,7 +192,7 @@ export class HeaderFreezeRenderController extends Disposable implements IRenderM
         this._zoomRefresh();
     }
 
-    // eslint-disable-next-line max-lines-per-function, complexity
+    // eslint-disable-next-line max-lines-per-function
     private _createFreeze(
         freezeDirectionType: FREEZE_DIRECTION_TYPE = FREEZE_DIRECTION_TYPE.ROW,
         freezeConfig?: IFreeze
@@ -207,20 +207,9 @@ export class HeaderFreezeRenderController extends Disposable implements IRenderM
         if (position == null || skeleton == null) return null;
 
         const sheetObject = this._getSheetObject()!;
-        const engine = sheetObject.engine;
-        const canvasMaxWidth = engine?.width || 0;
-        const canvasMaxHeight = engine?.height || 0;
         const scene = sheetObject.scene;
         const { startX, startY } = position;
         const { rowTotalHeight, columnTotalWidth, rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop } = skeleton;
-
-        const contentWidth = canvasMaxWidth > columnTotalWidth + rowHeaderWidthAndMarginLeft
-            ? canvasMaxWidth
-            : columnTotalWidth + columnHeaderHeightAndMarginTop;
-
-        const contentHeight = canvasMaxHeight > rowTotalHeight + columnHeaderHeightAndMarginTop
-            ? canvasMaxHeight
-            : rowTotalHeight + columnHeaderHeightAndMarginTop;
 
         this._changeToRow = freezeRow;
         this._changeToColumn = freezeColumn;
@@ -254,7 +243,7 @@ export class HeaderFreezeRenderController extends Disposable implements IRenderM
 
             this._rowFreezeMainRect = new Rect(FREEZE_ROW_MAIN_NAME, {
                 fill,
-                width: contentWidth * 2 / scale,
+                width: columnTotalWidth,
                 height: freezeSize,
                 left: rowHeaderWidthAndMarginLeft,
                 top: startY - freezeOffset,
@@ -286,7 +275,7 @@ export class HeaderFreezeRenderController extends Disposable implements IRenderM
             this._columnFreezeMainRect = new Rect(FREEZE_COLUMN_MAIN_NAME, {
                 fill,
                 width: freezeSize,
-                height: contentHeight * 2 / scale,
+                height: rowTotalHeight,
                 left: startX - FREEZE_OFFSET,
                 top: columnHeaderHeightAndMarginTop,
                 zIndex: 3,

--- a/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ICommandInfo, IExecutionOptions, IRange, Nullable, Workbook, Worksheet } from '@univerjs/core';
+import type { BooleanNumber, ICommandInfo, IExecutionOptions, IRange, Nullable, Workbook, Worksheet } from '@univerjs/core';
 import type { ISetFormulaCalculationNotificationMutation } from '@univerjs/engine-formula';
 import type { IAfterRender$Info, IBasicFrameInfo, IExtendFrameInfo, IRenderContext, IRenderModule, IScrollBarProps, ISummaryFrameInfo, ISummaryMetric, ITimeMetric, IViewportInfos, Scene } from '@univerjs/engine-render';
 import type { IUniverSheetsUIConfig } from '../../config/config';
@@ -260,12 +260,15 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         scene.enableLayerCache(SHEET_COMPONENT_MAIN_LAYER_INDEX, SHEET_COMPONENT_HEADER_LAYER_INDEX);
     }
 
-    private _initViewports(scene: Scene, rowHeader: { width: number }, columnHeader: { height: number }) {
+    private _initViewports(scene: Scene, rowHeader: { width: number; hidden?: BooleanNumber }, columnHeader: { height: number; hidden?: BooleanNumber }) {
+        const rowHeaderWidth = rowHeader.hidden ? 0 : rowHeader.width;
+        const columnHeaderHeight = columnHeader.hidden ? 0 : columnHeader.height;
         const bufferEdgeX = 100;
         const bufferEdgeY = 100;
+
         const viewMain = new Viewport(SHEET_VIEWPORT_KEY.VIEW_MAIN, scene, {
-            left: rowHeader.width,
-            top: columnHeader.height,
+            left: rowHeaderWidth,
+            top: columnHeaderHeight,
             bottom: 0,
             right: 0,
             isWheelPreventDefaultX: true,
@@ -300,9 +303,9 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
         });
         const viewRowBottom = new Viewport(SHEET_VIEWPORT_KEY.VIEW_ROW_BOTTOM, scene, {
             left: 0,
-            top: columnHeader.height,
+            top: columnHeaderHeight,
             bottom: 0,
-            width: rowHeader.width + 1,
+            width: rowHeaderWidth + 1,
             isWheelPreventDefaultX: true,
         });
         const viewColumnLeft = new Viewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_LEFT, scene, {
@@ -310,17 +313,17 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             isWheelPreventDefaultX: true,
         });
         const viewColumnRight = new Viewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_RIGHT, scene, {
-            left: rowHeader.width,
+            left: rowHeaderWidth,
             top: 0,
-            height: columnHeader.height + 1,
+            height: columnHeaderHeight + 1,
             right: 0,
             isWheelPreventDefaultX: true,
         });
         const viewLeftTop = new Viewport(SHEET_VIEWPORT_KEY.VIEW_LEFT_TOP, scene, {
             left: 0,
             top: 0,
-            width: rowHeader.width,
-            height: columnHeader.height,
+            width: rowHeaderWidth,
+            height: columnHeaderHeight,
             isWheelPreventDefaultX: true,
         });
 

--- a/packages/sheets-ui/src/controllers/render-controllers/skeleton.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/skeleton.render-controller.ts
@@ -61,5 +61,6 @@ export class SheetSkeletonRenderController extends Disposable implements IRender
             width: rowHeaderWidthAndMarginLeft + columnTotalWidth,
             height: columnHeaderHeightAndMarginTop + rowTotalHeight,
         });
+        scene.getMainViewport().setMargin(rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop);
     }
 }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #4947
close #5492

Before:
<img width="2180" height="1911" alt="image" src="https://github.com/user-attachments/assets/acba2484-2bbb-4183-a00d-74adec4725e4" />



After: -->
<img width="2186" height="1911" alt="image" src="https://github.com/user-attachments/assets/7325505f-cbfb-4419-98b8-1f091610f3d7" />


1. Fix an issue where an extra blank area would be rendered on the right side when the canvas area was smaller than the content area.
<img width="2187" height="1911" alt="image" src="https://github.com/user-attachments/assets/0f27bafb-7c63-4b4a-9385-63452fc9fd26" />


2. Fix an issue where the freeze line would extend beyond the content area.
<img width="2185" height="1911" alt="image" src="https://github.com/user-attachments/assets/1df5b7f7-430a-44c3-b6d6-ce9ec90074c5" />



<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
