### PR TITLE
fix(docs): double click trigger defaule value (fs,ff,cl,bg)

### DIFF
--- a/packages/docs-ui/src/commands/commands/inline-format.command.ts
+++ b/packages/docs-ui/src/commands/commands/inline-format.command.ts
@@ -359,7 +359,7 @@ export const SetInlineFormatCommand: ICommand<ISetInlineFormatCommandParams> = {
 
                 docMenuStyleService.setStyleCache(
                     {
-                        [key]: cacheStyle?.[key] !== undefined
+                        [key]: cacheStyle?.[key] !== undefined && isNeedReverseValue(key)
                             ? getReverseFormatValue(
                                 cacheStyle,
                                 key,
@@ -417,6 +417,10 @@ export const SetInlineFormatCommand: ICommand<ISetInlineFormatCommandParams> = {
 
 function isTextDecoration(value: unknown | ITextDecoration): value is ITextDecoration {
     return value !== null && typeof value === 'object';
+}
+
+function isNeedReverseValue(key: keyof IStyleBase): boolean {
+    return !(/fs|ff|cl|bg/.test(key));
 }
 
 function getReverseFormatValue(ts: Nullable<ITextStyle>, key: keyof IStyleBase, preCommandId: string) {


### PR DESCRIPTION
close #6755

<!-- A description of the proposed changes. -->

on documents, if you click again on the font family, size, color, or background selection, it resets to the default

Before:

https://github.com/user-attachments/assets/b95b16d8-b995-491a-9084-634c43879c1d

After:

https://github.com/user-attachments/assets/7f973049-9dc8-4679-9f3d-3fe236e0ddc8


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
