### PR TITLE
fix: after select font family cant write text (docs and sheets)

### DIFF
--- a/packages/ui/src/components/font-family/FontFamilyItem.tsx
+++ b/packages/ui/src/components/font-family/FontFamilyItem.tsx
@@ -20,11 +20,13 @@ import { Tooltip } from '@univerjs/design';
 import { InfoIcon } from '@univerjs/icons';
 import { useEffect, useState } from 'react';
 import { IFontService } from '../../services/font.service';
+import { ILayoutService } from '../../services/layout/layout.service';
 import { useDependency } from '../../utils/di';
 
 export const FontFamilyItem = ({ id, value }: { id: string; value: string }) => {
     const commandService = useDependency(ICommandService);
     const fontService = useDependency(IFontService);
+    const layoutService = useDependency(ILayoutService);
 
     const [fonts, setFonts] = useState<IFontConfig[]>([]);
 
@@ -41,6 +43,7 @@ export const FontFamilyItem = ({ id, value }: { id: string; value: string }) => 
     const localeService = useDependency(LocaleService);
 
     function handleSelectFont(value: string) {
+        layoutService.focus();
         commandService.executeCommand(id, { value });
     }
 


### PR DESCRIPTION
close #6754

If you start writing text (regardless of whether it's a table or a document), and then, without losing focus, select a font family and try to continue writing text, you won't see any changes

Before:

In the video in the example before, after selecting the font family, I try to enter text

https://github.com/user-attachments/assets/193cab3e-0b3d-486a-8b37-05d9235e5afe

After: 

https://github.com/user-attachments/assets/e83ac7a3-cbcb-4b0c-8b62-34787e58a5e7


## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
