### PR TITLE
fix: tiny menu quick tile text wrap in some localizations

### DIFF
--- a/packages/ui/src/components/menu/desktop/TinyMenuGroup.tsx
+++ b/packages/ui/src/components/menu/desktop/TinyMenuGroup.tsx
@@ -53,10 +53,10 @@ function QuickTileMenuItem(props: IUIQuickTileMenuItemProps) {
             type="button"
             className={clsx(
                 `
-                  univer-relative univer-box-border univer-flex univer-size-12 univer-appearance-none univer-flex-col
-                  univer-items-center univer-justify-center univer-gap-0.5 univer-rounded-lg univer-border-none
-                  univer-bg-white univer-p-0 univer-font-medium univer-text-gray-700 univer-outline-none
-                  univer-transition-all
+                  univer-relative univer-box-border univer-flex univer-size-12 univer-w-full univer-appearance-none
+                  univer-flex-col univer-items-center univer-justify-center univer-gap-0.5 univer-rounded-lg
+                  univer-border-none univer-bg-white univer-p-0 univer-font-medium univer-text-gray-700
+                  univer-outline-none univer-transition-all
                   focus-visible:univer-ring-2 focus-visible:univer-ring-primary-600 focus-visible:univer-ring-offset-0
                   dark:!univer-bg-gray-700 dark:!univer-text-gray-100
                 `,
@@ -93,7 +93,7 @@ function QuickTileMenuItem(props: IUIQuickTileMenuItemProps) {
                 />
             )}
             <span
-                className="univer-max-w-full univer-break-words univer-text-center univer-text-xs univer-leading-4"
+                className="univer-break-words univer-text-center univer-text-xs univer-leading-4"
             >
                 {menuItem.title ? localeService.t(menuItem.title) : menuSchema.key}
             </span>
@@ -157,7 +157,7 @@ export function UIQuickTileMenuGroup(props: IUIQuickMenuGroupProps) {
     }
 
     return (
-        <div className="univer-flex univer-flex-wrap univer-justify-around univer-gap-1.5 univer-py-1">
+        <div className="univer-item-center univer-grid univer-grid-cols-3 univer-gap-1.5 univer-py-1">
             {item.children.map((menuSchema) => (
                 <QuickTileMenuItem
                     key={menuSchema.key}

--- a/packages/ui/src/views/components/context-menu/ContextMenuPanel.tsx
+++ b/packages/ui/src/views/components/context-menu/ContextMenuPanel.tsx
@@ -130,7 +130,7 @@ export function ContextMenuPanel(props: IContextMenuPanelProps) {
             ref={setMenuElement}
             className={clsx(
                 `
-                  univer-box-border univer-grid univer-min-w-52 univer-max-w-fit univer-gap-1 univer-overflow-y-auto
+                  univer-box-border univer-grid univer-min-w-52 univer-max-w-full univer-gap-1 univer-overflow-y-auto
                   univer-overscroll-contain univer-rounded-md univer-bg-white univer-px-2 univer-py-1 univer-text-sm
                   univer-text-gray-900 univer-shadow-md
                   dark:!univer-bg-gray-700 dark:!univer-text-white


### PR DESCRIPTION
close #xxx

in the component UIQuickTileMenuGroup, title on icon has wrap on some local (ru-RU, vi-VN, ca-ES, sk-SK)

Before:
<img width="398" height="418" alt="image" src="https://github.com/user-attachments/assets/d1aa6e37-9aba-4da5-9be3-f24e9e2dfba9" />
<img width="398" height="418" alt="image" src="https://github.com/user-attachments/assets/a5bba6df-34c0-495a-84f9-a72b8425fd0c" />
<img width="398" height="418" alt="image" src="https://github.com/user-attachments/assets/8ca17e65-3107-4c54-b238-2c8976ad82a8" />
<img width="398" height="418" alt="image" src="https://github.com/user-attachments/assets/6c65f93c-7d69-4e33-951e-685867b6f92a" />

After:
<img width="243" height="316" alt="image" src="https://github.com/user-attachments/assets/9d9e1fef-0a19-42a9-accb-8ac87bf5711a" />
<img width="398" height="418" alt="image" src="https://github.com/user-attachments/assets/f370b98d-7771-4e97-b4fb-4124cf3f6141" />
<img width="398" height="418" alt="image" src="https://github.com/user-attachments/assets/3dbce921-f47f-423e-a410-335ea06e8875" />
<img width="398" height="418" alt="image" src="https://github.com/user-attachments/assets/e5eeb8f4-6c59-4adb-9dfd-d089f2b4a62e" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
