### PR TITLE
feat(docs): replaced the hardcoded icons in the paragraph settings

### DIFF
--- a/packages/docs-ui/src/views/paragraph-setting/Setting.tsx
+++ b/packages/docs-ui/src/views/paragraph-setting/Setting.tsx
@@ -16,8 +16,7 @@
 
 import { HorizontalAlign, LocaleService, SpacingRule } from '@univerjs/core';
 import { borderClassName, clsx, InputNumber, Select, Tooltip } from '@univerjs/design';
-import { AlignTextBothIcon, HorizontallyIcon, LeftJustifyingIcon, RightJustifyingIcon } from '@univerjs/icons';
-import { useDependency } from '@univerjs/ui';
+import { ComponentManager, useDependency } from '@univerjs/ui';
 import { useMemo, useRef } from 'react';
 import {
     useCurrentParagraph,
@@ -64,6 +63,12 @@ const AutoFocusInputNumber = (props: {
 };
 export function ParagraphSetting() {
     const localeService = useDependency(LocaleService);
+    const componentManager = useDependency(ComponentManager);
+
+    const LeftJustifyingIcon = componentManager.get('LeftJustifyingIcon');
+    const HorizontallyIcon = componentManager.get('HorizontallyIcon');
+    const RightJustifyingIcon = componentManager.get('RightJustifyingIcon');
+    const AlignTextBothIcon = componentManager.get('AlignTextBothIcon');
 
     const alignmentOptions = useMemo(() => [
         { label: localeService.t('toolbar.alignLeft'), value: String(HorizontalAlign.LEFT), icon: <LeftJustifyingIcon /> },


### PR DESCRIPTION
Replaced the hardcoded icons in the paragraph settings with icons from the component manager.
<img width="369" height="184" alt="Screenshot From 2026-03-14 09-21-27" src="https://github.com/user-attachments/assets/3b5207c5-1bfa-4c3c-b900-bfac35cfccd5" />

Before:
The icon components were imported and used directly.

After:
The icon components are used from the ComponentManager.

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
