### PR TITLE
fix(sheets): prevent crash when accessing worksheet after skeleton disposed

### DIFF
--- a/packages/core/src/sheets/__tests__/sheet-skeleton.integration.spec.ts
+++ b/packages/core/src/sheets/__tests__/sheet-skeleton.integration.spec.ts
@@ -283,4 +283,24 @@ describe('SheetSkeleton integration', () => {
             },
         });
     });
+
+    it('should not throw when getCellWithCoordByIndex is called after skeleton is disposed', () => {
+        const testBed = createCoreTestBed(workbookDataFactory());
+        const injector = testBed.univer.__getInjector();
+        const worksheet = testBed.sheet.getActiveSheet()!;
+        const skeleton = new SheetSkeleton(
+            worksheet,
+            testBed.sheet.getStyles(),
+            injector.get(LocaleService),
+            injector.get(IContextService),
+            injector.get(IConfigService),
+            injector as Injector
+        ).calculate()!;
+
+        disposables.push(() => testBed.univer.dispose());
+
+        skeleton.dispose();
+
+        expect(() => skeleton.getCellWithCoordByIndex(0, 0)).not.toThrow();
+    });
 });

--- a/packages/core/src/sheets/sheet-skeleton.ts
+++ b/packages/core/src/sheets/sheet-skeleton.ts
@@ -845,7 +845,7 @@ export class SheetSkeleton extends Skeleton {
             column,
             rowHeightAccumulation,
             columnWidthAccumulation,
-            this.worksheet.getCellInfoInMergeData(row, column)
+            this.worksheet?.getCellInfoInMergeData(row, column)
         );
         const { isMerged, isMergedMainCell } = primary;
         let { startY, endY, startX, endX, mergeInfo } = primary;

--- a/packages/sheets-drawing-ui/src/services/canvas-float-dom-manager.service.ts
+++ b/packages/sheets-drawing-ui/src/services/canvas-float-dom-manager.service.ts
@@ -967,12 +967,13 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
             }));
             const skm = this._renderManagerService.getRenderById(unitId)?.with(SheetSkeletonManagerService);
 
-            skm?.currentSkeleton$.subscribe((skeleton) => {
+            const skeletonSubscription = skm?.currentSkeleton$.subscribe((skeleton) => {
                 if (!skeleton) return;
                 if (skeletonParam.sheetId !== skeleton.sheetId) {
                     this._removeDom(id, true);
                 }
             });
+            skeletonSubscription && disposableCollection.add(skeletonSubscription);
 
             const listener = domRect.onTransformChange$.subscribeEvent(() => {
                 const newPosition = calcSheetFloatDomPosition(domRect, renderObject.renderUnit.scene, skeletonParam.skeleton, target.worksheet, floatDomInfo);


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #6696

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
