### PR TITLE
fix(docs-ui): avoid duplicate sheet editor inserts after IME composition

### DIFF
--- a/packages/docs-ui/src/controllers/__tests__/doc-ime-input.controller.spec.ts
+++ b/packages/docs-ui/src/controllers/__tests__/doc-ime-input.controller.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RichTextEditingMutation } from '@univerjs/docs';
+import { Subject } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { IMEInputCommand } from '../../commands/commands/ime-input.command';
+import { DocIMEInputController } from '../render-controllers/doc-ime-input.controller';
+
+function waitNextTick() {
+    return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+function createRange() {
+    return {
+        startOffset: 0,
+        endOffset: 0,
+        collapsed: true,
+        segmentId: '',
+        style: null,
+    };
+}
+
+describe('doc ime input controller', () => {
+    it('skips duplicate writes when compositionend data matches the last update', async () => {
+        const onCompositionstart$ = new Subject<any>();
+        const onCompositionupdate$ = new Subject<any>();
+        const onCompositionend$ = new Subject<any>();
+        const activeRange = createRange();
+        let storedActiveRange: any = null;
+
+        const docSelectionRenderService = {
+            onCompositionstart$,
+            onCompositionupdate$,
+            onCompositionend$,
+        };
+        const docImeInputManagerService = {
+            setActiveRange: vi.fn((range) => {
+                storedActiveRange = range;
+            }),
+            getActiveRange: vi.fn(() => storedActiveRange),
+            clearUndoRedoMutationParamsCache: vi.fn(),
+        };
+        const commandService = {
+            executeCommand: vi.fn(() => Promise.resolve(true)),
+        };
+        const docStateEmitService = {
+            emitStateChangeInfo: vi.fn(),
+        };
+
+        new DocIMEInputController(
+            {
+                unitId: 'doc-unit',
+            } as never,
+            docSelectionRenderService as never,
+            docImeInputManagerService as never,
+            {
+                getSkeleton: vi.fn(() => ({})),
+            } as never,
+            docStateEmitService as never,
+            commandService as never
+        );
+
+        onCompositionstart$.next({
+            activeRange,
+        });
+        onCompositionupdate$.next({
+            event: { data: '한' },
+            activeRange,
+        });
+        await waitNextTick();
+        onCompositionend$.next({
+            event: { data: '한' },
+            activeRange,
+        });
+        await waitNextTick();
+
+        expect(commandService.executeCommand).toHaveBeenCalledTimes(1);
+        expect(commandService.executeCommand).toHaveBeenCalledWith(IMEInputCommand.id, {
+            unitId: 'doc-unit',
+            newText: '한',
+            oldTextLen: 0,
+            isCompositionStart: true,
+            isCompositionEnd: false,
+        });
+        expect(docStateEmitService.emitStateChangeInfo).toHaveBeenCalledWith({
+            commandId: RichTextEditingMutation.id,
+            unitId: 'doc-unit',
+            segmentId: '',
+            trigger: IMEInputCommand.id,
+            redoState: {
+                actions: [],
+                textRanges: [activeRange],
+            },
+            undoState: {
+                actions: [],
+                textRanges: [activeRange],
+            },
+            isCompositionEnd: true,
+        });
+        expect(docImeInputManagerService.clearUndoRedoMutationParamsCache).toHaveBeenCalledTimes(2);
+        expect(docImeInputManagerService.setActiveRange).toHaveBeenLastCalledWith(null);
+    });
+
+    it('keeps the compositionend write when the final data differs from the latest update', async () => {
+        const onCompositionstart$ = new Subject<any>();
+        const onCompositionupdate$ = new Subject<any>();
+        const onCompositionend$ = new Subject<any>();
+        const activeRange = createRange();
+        let storedActiveRange: any = null;
+
+        const docSelectionRenderService = {
+            onCompositionstart$,
+            onCompositionupdate$,
+            onCompositionend$,
+        };
+        const docImeInputManagerService = {
+            setActiveRange: vi.fn((range) => {
+                storedActiveRange = range;
+            }),
+            getActiveRange: vi.fn(() => storedActiveRange),
+            clearUndoRedoMutationParamsCache: vi.fn(),
+        };
+        const commandService = {
+            executeCommand: vi.fn(() => Promise.resolve(true)),
+        };
+        const docStateEmitService = {
+            emitStateChangeInfo: vi.fn(),
+        };
+
+        new DocIMEInputController(
+            {
+                unitId: 'doc-unit',
+            } as never,
+            docSelectionRenderService as never,
+            docImeInputManagerService as never,
+            {
+                getSkeleton: vi.fn(() => ({})),
+            } as never,
+            docStateEmitService as never,
+            commandService as never
+        );
+
+        onCompositionstart$.next({
+            activeRange,
+        });
+        onCompositionupdate$.next({
+            event: { data: 'ㅎ' },
+            activeRange,
+        });
+        await waitNextTick();
+        onCompositionend$.next({
+            event: { data: '한' },
+            activeRange,
+        });
+        await waitNextTick();
+
+        expect(commandService.executeCommand).toHaveBeenCalledTimes(2);
+        expect(commandService.executeCommand).toHaveBeenNthCalledWith(2, IMEInputCommand.id, {
+            unitId: 'doc-unit',
+            newText: '한',
+            oldTextLen: 1,
+            isCompositionStart: false,
+            isCompositionEnd: true,
+        });
+        expect(docStateEmitService.emitStateChangeInfo).not.toHaveBeenCalled();
+    });
+});

--- a/packages/docs-ui/src/controllers/render-controllers/doc-ime-input.controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc-ime-input.controller.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel, Nullable } from '@univerjs/core';
+import type { DocumentDataModel, JSONXActions, Nullable } from '@univerjs/core';
 import type { IRenderContext, IRenderModule } from '@univerjs/engine-render';
 import type { Subscription } from 'rxjs';
 import type { IEditorInputConfig } from '../../services/selection/doc-selection-render.service';
@@ -24,8 +24,7 @@ import {
     Inject,
     Tools,
 } from '@univerjs/core';
-
-import { DocSkeletonManagerService } from '@univerjs/docs';
+import { DocSkeletonManagerService, DocStateEmitService, RichTextEditingMutation } from '@univerjs/docs';
 import { IMEInputCommand } from '../../commands/commands/ime-input.command';
 import { DocIMEInputManagerService } from '../../services/doc-ime-input-manager.service';
 import { DocSelectionRenderService } from '../../services/selection/doc-selection-render.service';
@@ -46,6 +45,7 @@ export class DocIMEInputController extends Disposable implements IRenderModule {
         @Inject(DocSelectionRenderService) private readonly _docSelectionRenderService: DocSelectionRenderService,
         @Inject(DocIMEInputManagerService) private readonly _docImeInputManagerService: DocIMEInputManagerService,
         @Inject(DocSkeletonManagerService) private readonly _docSkeletonManagerService: DocSkeletonManagerService,
+        @Inject(DocStateEmitService) private readonly _docStateEmitService: DocStateEmitService,
         @ICommandService private readonly _commandService: ICommandService
     ) {
         super();
@@ -120,6 +120,16 @@ export class DocIMEInputController extends Disposable implements IRenderModule {
             return;
         }
 
+        /**
+         * IME composition is canceled when the composition content is the same as the previous one on composition end.
+         * In this case, we need to finalize the composition and reset the IME state.
+         */
+        if (!isUpdate && content === this._previousIMEContent) {
+            this._finalizeComposition();
+            this._resetIME();
+            return;
+        }
+
         await this._commandService.executeCommand(IMEInputCommand.id, {
             unitId,
             newText: content,
@@ -137,6 +147,31 @@ export class DocIMEInputController extends Disposable implements IRenderModule {
         } else {
             this._resetIME();
         }
+    }
+
+    // When the composition is canceled, we need to emit the state change info to update the selection and other states.
+    private _finalizeComposition() {
+        const previousActiveRange = this._docImeInputManagerService.getActiveRange();
+
+        if (previousActiveRange == null) {
+            return;
+        }
+
+        this._docStateEmitService.emitStateChangeInfo({
+            commandId: RichTextEditingMutation.id,
+            unitId: this._context.unitId,
+            segmentId: previousActiveRange.segmentId,
+            trigger: IMEInputCommand.id,
+            redoState: {
+                actions: [] as JSONXActions,
+                textRanges: [previousActiveRange],
+            },
+            undoState: {
+                actions: [] as JSONXActions,
+                textRanges: [previousActiveRange],
+            },
+            isCompositionEnd: true,
+        });
     }
 
     private _resetIME() {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #2826

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
