### PR TITLE
feat: fluent interface pattern on registerPlugin in Univer class

### DIFF
--- a/examples/src/docs/main.ts
+++ b/examples/src/docs/main.ts
@@ -44,26 +44,23 @@ const univer = new Univer({
         [LocaleType.ZH_CN]: zhCN,
     },
     logLevel: LogLevel.VERBOSE,
-});
-
-// core plugins
-univer.registerPlugin(UniverRenderEnginePlugin);
-univer.registerPlugin(UniverFormulaEnginePlugin);
-univer.registerPlugin(UniverUIPlugin, {
-    container: 'app',
-    ribbonType: 'classic',
-});
-
-univer.registerPlugin(UniverDocsPlugin);
-univer.registerPlugin(UniverDocsUIPlugin, {
-    container: 'univerdoc',
-});
-
-univer.registerPlugin(UniverDocsDrawingUIPlugin);
-univer.registerPlugin(UniverDocsThreadCommentUIPlugin);
-univer.registerPlugin(UniverDocsHyperLinkUIPlugin);
-univer.registerPlugin(UniverDocsMentionUIPlugin);
-univer.registerPlugin(UniverDocsQuickInsertUIPlugin);
+})
+    // core plugins
+    .registerPlugin(UniverRenderEnginePlugin)
+    .registerPlugin(UniverFormulaEnginePlugin)
+    .registerPlugin(UniverUIPlugin, {
+        container: 'app',
+        ribbonType: 'classic',
+    })
+    .registerPlugin(UniverDocsPlugin)
+    .registerPlugin(UniverDocsUIPlugin, {
+        container: 'univerdoc',
+    })
+    .registerPlugin(UniverDocsDrawingUIPlugin)
+    .registerPlugin(UniverDocsThreadCommentUIPlugin)
+    .registerPlugin(UniverDocsHyperLinkUIPlugin)
+    .registerPlugin(UniverDocsMentionUIPlugin)
+    .registerPlugin(UniverDocsQuickInsertUIPlugin);
 
 if (!IS_E2E) {
     univer.createUnit(UniverInstanceType.UNIVER_DOC, DEFAULT_DOCUMENT_DATA_SIMPLE);

--- a/packages/core/src/__tests__/univer-skeleton.spec.ts
+++ b/packages/core/src/__tests__/univer-skeleton.spec.ts
@@ -96,9 +96,60 @@ describe('Univer', () => {
             .mockImplementation(() => undefined);
 
         univer.registerPlugins([
-            [class FakePluginA {} as never, { enabled: true }],
-            [class FakePluginB {} as never],
+            [class FakePluginA { } as never, { enabled: true }],
+            [class FakePluginB { } as never],
         ] as never);
+
+        expect(registerPluginSpy).toHaveBeenCalledTimes(2);
+
+        registerPluginSpy.mockRestore();
+        univer.dispose();
+    });
+
+    it('should return this to support method chaining', () => {
+        const univer = new Univer();
+
+        const registerPluginSpy = vi
+            .spyOn((univer as any)._pluginService, 'registerPlugin')
+            .mockImplementation(() => undefined);
+
+        const result = univer.registerPlugin(class TestPlugin { } as never);
+
+        expect(result).toBe(univer);
+        expect(registerPluginSpy).toHaveBeenCalledTimes(1);
+
+        registerPluginSpy.mockRestore();
+        univer.dispose();
+    });
+
+    it('should allow chaining multiple registerPlugin calls', () => {
+        const univer = new Univer();
+
+        const registerPluginSpy = vi
+            .spyOn((univer as any)._pluginService, 'registerPlugin')
+            .mockImplementation(() => undefined);
+
+        const chainResult = univer
+            .registerPlugin(class FakePluginA { } as never)
+            .registerPlugin(class FakePluginB { } as never)
+            .registerPlugin(class FakePluginC { } as never);
+
+        expect(registerPluginSpy).toHaveBeenCalledTimes(3);
+        expect(chainResult).toBe(univer);
+
+        registerPluginSpy.mockRestore();
+        univer.dispose();
+    });
+
+    it('should maintain backward compatibility when return value is ignored', () => {
+        const univer = new Univer();
+
+        const registerPluginSpy = vi
+            .spyOn((univer as any)._pluginService, 'registerPlugin')
+            .mockImplementation(() => undefined);
+
+        univer.registerPlugin(class FakePluginA { } as never);
+        univer.registerPlugin(class FakePluginB { } as never);
 
         expect(registerPluginSpy).toHaveBeenCalledTimes(2);
 

--- a/packages/core/src/univer.ts
+++ b/packages/core/src/univer.ts
@@ -226,8 +226,10 @@ export class Univer implements IDisposable {
     }
 
     /** Register a plugin into univer. */
-    registerPlugin<T extends PluginCtor<Plugin>>(plugin: T, config?: ConstructorParameters<T>[0]): void {
+    registerPlugin<T extends PluginCtor<Plugin>>(plugin: T, config?: ConstructorParameters<T>[0]): this {
         this._pluginService.registerPlugin(plugin, config);
+
+        return this;
     }
 
     /**


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

The Univer class has a method for registering multiple plugins. It also allows for individual registration using the appropriate method, as documented in some places. It is proposed to expand the ability to use a fluent interface pattern similar to the RXJS method for registrations of the form 

univer
.registerPlugin(pluginA)
.registerPlugin(pluginB)


With this approach, it can increase some of the code's readability, and what's important is that it's not a breaking change, but only an additional feature.

I demonstrated this approach using the existing example from the documents.

up to you

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
