### PR TITLE
fix(docs): added support for spacing rule = exact, in paragraph settings

### DIFF
--- a/packages/docs-ui/src/locale/ca-ES.ts
+++ b/packages/docs-ui/src/locale/ca-ES.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: 'Espai entre línies',
             multiSpace: 'Espai múltiple',
             fixedValue: 'Valor fix (px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/en-US.ts
+++ b/packages/docs-ui/src/locale/en-US.ts
@@ -95,6 +95,7 @@ const locale = {
             lineSpace: 'Line Space',
             multiSpace: 'Multi Space',
             fixedValue: 'Fixed Value(px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/es-ES.ts
+++ b/packages/docs-ui/src/locale/es-ES.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: 'Espacio entre líneas',
             multiSpace: 'Espacio múltiple',
             fixedValue: 'Valor fijo (px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/fa-IR.ts
+++ b/packages/docs-ui/src/locale/fa-IR.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: 'فاصله خط',
             multiSpace: 'فاصله چندگانه',
             fixedValue: 'مقدار ثابت(px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/fr-FR.ts
+++ b/packages/docs-ui/src/locale/fr-FR.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: 'Espacement de ligne',
             multiSpace: 'Espacement multiple',
             fixedValue: 'Valeur fixe(px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/ja-JP.ts
+++ b/packages/docs-ui/src/locale/ja-JP.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: '行間',
             multiSpace: '複数行間',
             fixedValue: '固定値(px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/ko-KR.ts
+++ b/packages/docs-ui/src/locale/ko-KR.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: '줄 간격',
             multiSpace: '복수 줄 간격',
             fixedValue: '고정 값(px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/ru-RU.ts
+++ b/packages/docs-ui/src/locale/ru-RU.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: 'Высота строки',
             multiSpace: 'Двойной отступ',
             fixedValue: 'Фиксированное значение (px)',
+            exactValue: 'Точное значение',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/sk-SK.ts
+++ b/packages/docs-ui/src/locale/sk-SK.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: 'Riadkovanie',
             multiSpace: 'Viacnásobné',
             fixedValue: 'Pevná hodnota (px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/vi-VN.ts
+++ b/packages/docs-ui/src/locale/vi-VN.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: 'Line Space',
             multiSpace: 'Multi Space',
             fixedValue: 'Fixed Value(px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/zh-CN.ts
+++ b/packages/docs-ui/src/locale/zh-CN.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: '行距',
             multiSpace: '多倍行距',
             fixedValue: '固定值(px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/locale/zh-TW.ts
+++ b/packages/docs-ui/src/locale/zh-TW.ts
@@ -97,6 +97,7 @@ const locale: typeof enUS = {
             lineSpace: 'Line Space',
             multiSpace: 'Multi Space',
             fixedValue: 'Fixed Value(px)',
+            exactValue: 'Exact Value',
         },
     },
     rightClick: {

--- a/packages/docs-ui/src/views/paragraph-setting/Setting.tsx
+++ b/packages/docs-ui/src/views/paragraph-setting/Setting.tsx
@@ -183,6 +183,7 @@ export function ParagraphSetting() {
                             options={[
                                 { label: localeService.t('doc.paragraphSetting.multiSpace'), value: `${SpacingRule.AUTO}` },
                                 { label: localeService.t('doc.paragraphSetting.fixedValue'), value: `${SpacingRule.AT_LEAST}` },
+                                { label: localeService.t('doc.paragraphSetting.exactValue'), value: `${SpacingRule.EXACT}` },
                             ]}
                             onChange={(v) => setSpacingRule(Number(v))}
                         />


### PR DESCRIPTION
close #xxx

Added support for SpacingRule.EXACT, in paragraph settings

https://github.com/user-attachments/assets/7358968d-84f4-4407-b00f-6e8f85b8828e



Open the paragraph settings and click on the first dropdown in the line space section. There you will see a new option.

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
