### PR TITLE
fix(engine-render): add .js extension to opentype.js deep import for Node.js ESM compatibility

### DIFF
--- a/packages/engine-render/src/components/docs/layout/shaping-engine/__tests__/text-shaping-engine.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/shaping-engine/__tests__/text-shaping-engine.spec.ts
@@ -57,7 +57,7 @@ const h = vi.hoisted(() => {
     };
 });
 
-vi.mock('opentype.js/dist/opentype.module', () => ({
+vi.mock('opentype.js/dist/opentype.module.js', () => ({
     parse: h.parse,
 }));
 

--- a/packages/engine-render/src/components/docs/layout/shaping-engine/text-shaping.ts
+++ b/packages/engine-render/src/components/docs/layout/shaping-engine/text-shaping.ts
@@ -18,7 +18,7 @@ import type { IDocumentBody, IStyleBase, Nullable } from '@univerjs/core';
 import type Opentype from 'opentype.js';
 import { BooleanNumber } from '@univerjs/core';
 // @ts-ignore
-import { parse } from 'opentype.js/dist/opentype.module';
+import { parse } from 'opentype.js/dist/opentype.module.js';
 import { DEFAULT_FONTFACE_PLANE } from '../../../../basics/const';
 import { getFirstGrapheme, isEmojiGrapheme } from '../../../../basics/tools';
 import { fontLibrary } from './font-library';


### PR DESCRIPTION


The import path  lacks the  extension,
which causes  in Node.js ESM environments after the build toolchain migrated from vite to tsdown (externalizing dependencies).

Fixes #6833

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
