### PR TITLE
fix(sheets-ui): allow inline format shortcuts to fire inside cell editor

### DIFF
--- a/packages/sheets-ui/src/controllers/shortcuts/style.shortcut.ts
+++ b/packages/sheets-ui/src/controllers/shortcuts/style.shortcut.ts
@@ -23,13 +23,13 @@ import {
     SetRangeStrickThroughCommand,
     SetRangeUnderlineCommand,
 } from '../../commands/commands/inline-format.command';
-import { whenSheetEditorFocused } from './utils';
+import { whenSheetFocusedInlineFormat } from './utils';
 
 export const SetBoldShortcutItem: IShortcutItem = {
     id: SetRangeBoldCommand.id,
     description: 'shortcut.sheet.set-bold',
     group: '4_sheet-edit',
-    preconditions: (contextService) => whenSheetEditorFocused(contextService),
+    preconditions: (contextService) => whenSheetFocusedInlineFormat(contextService),
     binding: KeyCode.B | MetaKeys.CTRL_COMMAND,
 };
 
@@ -37,7 +37,7 @@ export const SetItalicShortcutItem: IShortcutItem = {
     id: SetRangeItalicCommand.id,
     description: 'shortcut.sheet.set-italic',
     group: '4_sheet-edit',
-    preconditions: (contextService) => whenSheetEditorFocused(contextService),
+    preconditions: (contextService) => whenSheetFocusedInlineFormat(contextService),
     binding: KeyCode.I | MetaKeys.CTRL_COMMAND,
 };
 
@@ -45,7 +45,7 @@ export const SetUnderlineShortcutItem: IShortcutItem = {
     id: SetRangeUnderlineCommand.id,
     description: 'shortcut.sheet.set-underline',
     group: '4_sheet-edit',
-    preconditions: (contextService) => whenSheetEditorFocused(contextService),
+    preconditions: (contextService) => whenSheetFocusedInlineFormat(contextService),
     binding: KeyCode.U | MetaKeys.CTRL_COMMAND,
 };
 
@@ -53,6 +53,6 @@ export const SetStrikeThroughShortcutItem: IShortcutItem = {
     id: SetRangeStrickThroughCommand.id,
     description: 'shortcut.sheet.set-strike-through',
     group: '4_sheet-edit',
-    preconditions: (contextService) => whenSheetEditorFocused(contextService),
+    preconditions: (contextService) => whenSheetFocusedInlineFormat(contextService),
     binding: KeyCode.X | MetaKeys.SHIFT | MetaKeys.CTRL_COMMAND,
 };

--- a/packages/sheets-ui/src/controllers/shortcuts/utils.ts
+++ b/packages/sheets-ui/src/controllers/shortcuts/utils.ts
@@ -43,6 +43,21 @@ export function whenSheetEditorFocused(contextService: IContextService): boolean
     );
 }
 
+/**
+ * Requires the currently focused unit to be Workbook, regardless of whether the cell editor is activated.
+ * Used by inline-format shortcuts (bold/italic/underline/strikethrough) so they can also fire
+ * inside the cell editor — the corresponding command will route to the docs inline-format command
+ * when EDITOR_ACTIVATED is true.
+ * @param contextService
+ */
+export function whenSheetFocusedInlineFormat(contextService: IContextService): boolean {
+    return (
+        contextService.getContextValue(FOCUSING_SHEET) &&
+        contextService.getContextValue(FOCUSING_UNIVER_EDITOR) &&
+        !contextService.getContextValue(FOCUSING_COMMON_DRAWINGS)
+    );
+}
+
 export function whenSheetEditorFocusedAndFxNotFocused(contextService: IContextService): boolean {
     return (
         contextService.getContextValue(FOCUSING_SHEET) &&


### PR DESCRIPTION
<!-- Feel free to delete this if there is no related issue. -->

## Description

Inline-format shortcuts (Bold / Italic / Underline / Strike-through) on sheets currently use `whenSheetEditorFocused` as their precondition, which requires `EDITOR_ACTIVATED` to be **false**. As a result, once the cell editor is activated, pressing `Ctrl/Cmd+B`, `Ctrl/Cmd+I`, `Ctrl/Cmd+U` or `Ctrl/Cmd+Shift+X` does nothing — even though the underlying `SetRangeBold/Italic/Underline/StrikeThroughCommand` already routes to the docs inline-format command when the cell editor is active.

This PR introduces a dedicated precondition `whenSheetFocusedInlineFormat` for these four shortcuts. It only requires the focus to be inside a sheet's editor (and not on a floating drawing), without forbidding the cell editor from being activated. The command itself decides which path to dispatch.

## How to test

1. Open a worksheet and double-click a cell to enter the cell editor.
2. Select part of the text inside the editor.
3. Press `Ctrl/Cmd+B`, `Ctrl/Cmd+I`, `Ctrl/Cmd+U`, `Ctrl/Cmd+Shift+X` and verify the corresponding inline format is applied to the selected text.
4. Press `Esc` to leave the editor, select a range of cells, and verify the same shortcuts still toggle the cell-level formatting as before.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [ ] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).