### PR TITLE
fix: set min value in page settings

### DIFF
--- a/packages/docs-ui/src/views/page-settings/index.tsx
+++ b/packages/docs-ui/src/views/page-settings/index.tsx
@@ -147,6 +147,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                             </label>
                             <InputNumber
                                 precision={2}
+                                min={0}
                                 max={settings.pageSise.height / 2}
                                 value={settings.margins.top}
                                 onChange={(e) => handleMarginChange('top', e)}
@@ -158,6 +159,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                             </label>
                             <InputNumber
                                 precision={2}
+                                min={0}
                                 max={settings.pageSise.height / 2}
                                 value={settings.margins.bottom}
                                 onChange={(e) => handleMarginChange('bottom', e)}
@@ -171,6 +173,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                             </label>
                             <InputNumber
                                 precision={2}
+                                min={0}
                                 max={settings.pageSise.width / 2}
                                 value={settings.margins.left}
                                 onChange={(e) => handleMarginChange('left', e)}
@@ -182,6 +185,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                             </label>
                             <InputNumber
                                 precision={2}
+                                min={0}
                                 max={settings.pageSise.width / 2}
                                 value={settings.margins.right}
                                 onChange={(e) => handleMarginChange('right', e)}


### PR DESCRIPTION
close #6838

added a minimum value when setting up pages, since it looks strange when using it

In LibreOffice, for example, when trying to enter a negative value, an error is displayed

<img width="765" height="517" alt="image" src="https://github.com/user-attachments/assets/c9e37fd8-5f6b-4587-8d1e-b08586b78fd0" />

Before:
<img width="2365" height="392" alt="image" src="https://github.com/user-attachments/assets/adfb932d-e73b-4d05-a2c9-f2aa097d9776" />

<img width="765" height="517" alt="image" src="https://github.com/user-attachments/assets/5ed70a9f-48b1-433e-989b-05da41db8170" />

After: 

does not allow entering negative values

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
