### PR TITLE
fix: active alignment style

### DIFF
--- a/packages/docs-ui/src/views/paragraph-setting/Setting.tsx
+++ b/packages/docs-ui/src/views/paragraph-setting/Setting.tsx
@@ -110,7 +110,7 @@ export function ParagraphSetting() {
                                   univer-flex univer-cursor-pointer univer-items-center univer-justify-center
                                   univer-rounded univer-bg-none univer-px-3 univer-py-1
                                 `, {
-                                    'univer-bg-blend-color-dodge/90': horizontalAlignValue === item.value,
+                                    'univer-bg-gray-200 dark:!univer-bg-gray-500': horizontalAlignValue === item.value,
                                 })}
                                 onClick={() => setHorizontalAlign(item.value)}
                             >


### PR DESCRIPTION
close #6761

Before:
<img width="472" height="258" alt="image" src="https://github.com/user-attachments/assets/30928fa3-8299-4cde-be7a-c0379c6fcae1" />

After: 
<img width="1213" height="531" alt="image" src="https://github.com/user-attachments/assets/9bc36c74-4b62-4e1a-9e02-af34bd16a665" />

<img width="1213" height="531" alt="image" src="https://github.com/user-attachments/assets/ae38ea72-1e4b-42ab-9015-e95d1f941214" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
