### PR TITLE
fix: fix when cell wrapping is enabled, cell text must wrap to the next line after `\n`

### DIFF
--- a/packages/core/src/sheets/worksheet.ts
+++ b/packages/core/src/sheets/worksheet.ts
@@ -1387,7 +1387,7 @@ export function extractPureTextFromCell(cell: Nullable<ICellData>): string {
         if (cell.t === CellValueType.BOOLEAN) {
             return rawValue.toUpperCase();
         }
-        return rawValue.replace(/[\r\n]/g, '');
+        return rawValue.replace(/\r\n/g, '');
     };
 
     if (typeof rawValue === 'number') {

--- a/packages/core/src/sheets/worksheet.ts
+++ b/packages/core/src/sheets/worksheet.ts
@@ -1387,7 +1387,7 @@ export function extractPureTextFromCell(cell: Nullable<ICellData>): string {
         if (cell.t === CellValueType.BOOLEAN) {
             return rawValue.toUpperCase();
         }
-        return rawValue.replace(/\r\n/g, '');
+        return rawValue.replace(/\r/g, '');
     };
 
     if (typeof rawValue === 'number') {

--- a/packages/engine-render/src/components/docs/layout/__tests__/doc-simple-skeleton.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/__tests__/doc-simple-skeleton.spec.ts
@@ -90,4 +90,14 @@ describe('doc simple skeleton', () => {
         expect(lines.length).toBeGreaterThan(0);
         expect(skeleton.getTotalHeight()).toBeGreaterThanOrEqual(10);
     });
+
+    it('content with \n', () => {
+        const skeleton = new DocSimpleSkeleton('客户经理UM1\n客户经理UM2', '11pt Arial', true, 60, Infinity);
+        const lines = skeleton.calculate();
+        expect(lines.length).toBe(4);
+        expect(lines[0].text).toBe('客户经理');
+        expect(lines[1].text).toBe('UM1');
+        expect(lines[2].text).toBe('客户经理');
+        expect(lines[3].text).toBe('UM2');
+    });
 });

--- a/packages/engine-render/src/components/docs/layout/doc-simple-skeleton.ts
+++ b/packages/engine-render/src/components/docs/layout/doc-simple-skeleton.ts
@@ -15,6 +15,7 @@
  */
 
 import { LineBreaker } from './line-breaker';
+import { BreakPointType } from './line-breaker/break';
 import { FontCache } from './shaping-engine/font-cache';
 
 export interface ILineInfo {
@@ -82,154 +83,177 @@ export class DocSimpleSkeleton {
             if (!breakPoint) {
                 break;
             }
-            const { position } = breakPoint;
-            const text = this._text.slice(lastPosition, position);
-            const textSize = FontCache.getMeasureText(text, this._fontStyle);
+            const { position, type } = breakPoint;
+            const rawText = this._text.slice(lastPosition, position);
+            const isMandatoryBreak = type === BreakPointType.Mandatory;
+            const text = isMandatoryBreak ? rawText.replace(/[\r\n]+$/, '') : rawText; // Remove line breaks for mandatory breaks
 
-            // Check if adding this text would exceed the width
-            if ((textSize.width + currentLine.width) > this._width) {
-                if (textSize.width > this._width) {
-                    // Push current line if it has content
-                    if (currentLine.text.length > 0) {
-                        this._lines.push(currentLine);
-                        totalHeight += currentLine.height;
-                        if (totalHeight > this._height) {
-                            break;
-                        }
-                        // Reset current line
-                        currentLine = {
-                            text: '',
-                            width: 0,
-                            height: 0,
-                            baseline: 0,
-                        };
-                    }
+            if (text.length > 0) {
+                const textSize = FontCache.getMeasureText(text, this._fontStyle);
 
-                    // Character-based line breaking processing
-                    let remainingText = text;
-                    while (remainingText.length > 0) {
-                        let charCount = 0;
-                        let lineText = '';
-                        let lineWidth = 0;
-
-                        // Heuristic search starting from cached break length
-                        let startGuess = Math.min(this._lastBreakLength, remainingText.length);
-                        if (startGuess === 0) {
-                            startGuess = Math.min(10, remainingText.length); // Default guess for first time
+                // Check if adding this text would exceed the width
+                if ((textSize.width + currentLine.width) > this._width) {
+                    if (textSize.width > this._width) {
+                        // Push current line if it has content
+                        if (currentLine.text.length > 0) {
+                            this._lines.push(currentLine);
+                            totalHeight += currentLine.height;
+                            if (totalHeight > this._height) {
+                                break;
+                            }
+                            // Reset current line
+                            currentLine = {
+                                text: '',
+                                width: 0,
+                                height: 0,
+                                baseline: 0,
+                            };
                         }
 
-                        // First, try the cached length
-                        let testText = remainingText.slice(0, startGuess);
-                        let testSize = FontCache.getMeasureText(testText, this._fontStyle);
+                        // Character-based line breaking processing
+                        let remainingText = text;
+                        while (remainingText.length > 0) {
+                            let charCount = 0;
+                            let lineText = '';
+                            let lineWidth = 0;
 
-                        if (testSize.width + currentLine.width <= this._width) {
-                            // The guess fits, search forward for the maximum
-                            charCount = startGuess;
-                            for (let i = startGuess + 1; i <= remainingText.length; i++) {
-                                testText = remainingText.slice(0, i);
-                                testSize = FontCache.getMeasureText(testText, this._fontStyle);
+                            // Heuristic search starting from cached break length
+                            let startGuess = Math.min(this._lastBreakLength, remainingText.length);
+                            if (startGuess === 0) {
+                                startGuess = Math.min(10, remainingText.length); // Default guess for first time
+                            }
 
-                                if (testSize.width + currentLine.width <= this._width) {
-                                    charCount = i;
-                                } else {
-                                    break;
+                            // First, try the cached length
+                            let testText = remainingText.slice(0, startGuess);
+                            let testSize = FontCache.getMeasureText(testText, this._fontStyle);
+
+                            if (testSize.width + currentLine.width <= this._width) {
+                                // The guess fits, search forward for the maximum
+                                charCount = startGuess;
+                                for (let i = startGuess + 1; i <= remainingText.length; i++) {
+                                    testText = remainingText.slice(0, i);
+                                    testSize = FontCache.getMeasureText(testText, this._fontStyle);
+
+                                    if (testSize.width + currentLine.width <= this._width) {
+                                        charCount = i;
+                                    } else {
+                                        break;
+                                    }
+                                }
+                            } else {
+                                // The guess is too big, search backward
+                                charCount = 0;
+                                for (let i = startGuess - 1; i >= 1; i--) {
+                                    testText = remainingText.slice(0, i);
+                                    testSize = FontCache.getMeasureText(testText, this._fontStyle);
+
+                                    if (testSize.width + currentLine.width <= this._width) {
+                                        charCount = i;
+                                        break;
+                                    }
                                 }
                             }
+
+                            // Update the cache with the successful break length
+                            if (charCount > 0) {
+                                this._lastBreakLength = charCount;
+                            }
+
+                            if (charCount > 0) {
+                                lineText = remainingText.slice(0, charCount);
+                                const textSize = FontCache.getMeasureText(lineText, this._fontStyle);
+                                lineWidth = textSize.width;
+                            }
+
+                            // If no character can fit, force add one character to avoid infinite loop
+                            if (charCount === 0 && currentLine.text.length === 0) {
+                                charCount = 1;
+                                lineText = remainingText[0];
+                                const charSize = FontCache.getMeasureText(lineText, this._fontStyle);
+                                lineWidth = charSize.width;
+                            }
+
+                            if (charCount > 0) {
+                                // Add to current line
+                                currentLine.text += lineText;
+                                currentLine.width += lineWidth;
+                                const textSize = FontCache.getMeasureText(currentLine.text, this._fontStyle);
+                                currentLine.height = textSize.fontBoundingBoxAscent + textSize.fontBoundingBoxDescent;
+                                currentLine.baseline = textSize.fontBoundingBoxAscent;
+
+                                // Remove processed characters
+                                remainingText = remainingText.slice(charCount);
+
+                                // If there's remaining text, need to wrap to next line
+                                if (remainingText.length > 0) {
+                                    this._lines.push(currentLine);
+                                    totalHeight += currentLine.height;
+                                    if (totalHeight > this._height) {
+                                        break;
+                                    }
+                                    // Reset current line
+                                    currentLine = {
+                                        text: '',
+                                        width: 0,
+                                        height: 0,
+                                        baseline: 0,
+                                    };
+                                }
+                            } else {
+                                // Cannot continue processing, exit loop
+                                break;
+                            }
+                        }
+                    } else {
+                        if (currentLine.text.length > 0) {
+                            // Push the current line first
+                            this._lines.push(currentLine);
+                            totalHeight += currentLine.height;
+                            if (totalHeight > this._height) {
+                                break;
+                            }
+                            // Reset current line and add the new text
+                            currentLine = {
+                                text,
+                                width: textSize.width,
+                                height: textSize.fontBoundingBoxAscent + textSize.fontBoundingBoxDescent,
+                                baseline: textSize.fontBoundingBoxAscent,
+                            };
                         } else {
-                            // The guess is too big, search backward
-                            charCount = 0;
-                            for (let i = startGuess - 1; i >= 1; i--) {
-                                testText = remainingText.slice(0, i);
-                                testSize = FontCache.getMeasureText(testText, this._fontStyle);
-
-                                if (testSize.width + currentLine.width <= this._width) {
-                                    charCount = i;
-                                    break;
-                                }
-                            }
-                        }
-
-                        // Update the cache with the successful break length
-                        if (charCount > 0) {
-                            this._lastBreakLength = charCount;
-                        }
-
-                        if (charCount > 0) {
-                            lineText = remainingText.slice(0, charCount);
-                            const textSize = FontCache.getMeasureText(lineText, this._fontStyle);
-                            lineWidth = textSize.width;
-                        }
-
-                        // If no character can fit, force add one character to avoid infinite loop
-                        if (charCount === 0 && currentLine.text.length === 0) {
-                            charCount = 1;
-                            lineText = remainingText[0];
-                            const charSize = FontCache.getMeasureText(lineText, this._fontStyle);
-                            lineWidth = charSize.width;
-                        }
-
-                        if (charCount > 0) {
-                            // Add to current line
-                            currentLine.text += lineText;
-                            currentLine.width += lineWidth;
-                            const textSize = FontCache.getMeasureText(currentLine.text, this._fontStyle);
-                            currentLine.height = textSize.fontBoundingBoxAscent + textSize.fontBoundingBoxDescent;
-                            currentLine.baseline = textSize.fontBoundingBoxAscent;
-
-                            // Remove processed characters
-                            remainingText = remainingText.slice(charCount);
-
-                            // If there's remaining text, need to wrap to next line
-                            if (remainingText.length > 0) {
-                                this._lines.push(currentLine);
-                                totalHeight += currentLine.height;
-                                if (totalHeight > this._height) {
-                                    break;
-                                }
-                                // Reset current line
-                                currentLine = {
-                                    text: '',
-                                    width: 0,
-                                    height: 0,
-                                    baseline: 0,
-                                };
-                            }
-                        } else {
-                            // Cannot continue processing, exit loop
-                            break;
+                            // If current line is empty, we have to add this text anyway (single word too long)
+                            currentLine = {
+                                text,
+                                width: textSize.width,
+                                height: textSize.fontBoundingBoxAscent + textSize.fontBoundingBoxDescent,
+                                baseline: textSize.fontBoundingBoxAscent,
+                            };
                         }
                     }
                 } else {
-                    if (currentLine.text.length > 0) {
-                        // Push the current line first
-                        this._lines.push(currentLine);
-                        totalHeight += currentLine.height;
-                        if (totalHeight > this._height) {
-                            break;
-                        }
-                        // Reset current line and add the new text
-                        currentLine = {
-                            text,
-                            width: textSize.width,
-                            height: textSize.fontBoundingBoxAscent + textSize.fontBoundingBoxDescent,
-                            baseline: textSize.fontBoundingBoxAscent,
-                        };
-                    } else {
-                        // If current line is empty, we have to add this text anyway (single word too long)
-                        currentLine = {
-                            text,
-                            width: textSize.width,
-                            height: textSize.fontBoundingBoxAscent + textSize.fontBoundingBoxDescent,
-                            baseline: textSize.fontBoundingBoxAscent,
-                        };
-                    }
+                    // Add text to current line
+                    currentLine.text = currentLine.text + text;
+                    currentLine.width = currentLine.width + textSize.width;
+                    currentLine.baseline = textSize.fontBoundingBoxAscent;
+                    currentLine.height = textSize.fontBoundingBoxAscent + textSize.fontBoundingBoxDescent;
                 }
-            } else {
-                // Add text to current line
-                currentLine.text = currentLine.text + text;
-                currentLine.width = currentLine.width + textSize.width;
-                currentLine.baseline = textSize.fontBoundingBoxAscent;
-                currentLine.height = textSize.fontBoundingBoxAscent + textSize.fontBoundingBoxDescent;
+            }
+
+            // For excel, when cell text is wrapped, \n should be treated as mandatory line break, so we need to break the line here.
+            if (isMandatoryBreak) {
+                this._lines.push(currentLine);
+                totalHeight += currentLine.height;
+
+                if (totalHeight > this._height) {
+                    break;
+                }
+
+                // Reset current line for the next line after mandatory break
+                currentLine = {
+                    text: '',
+                    width: 0,
+                    height: 0,
+                    baseline: 0,
+                };
             }
 
             lastPosition = position;

--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -600,7 +600,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
 
             if (style?.tb === WrapStrategy.WRAP) {
                 const skeleton = new DocSimpleSkeleton(
-                    `${cell!.v!}`,
+                    extractPureTextFromCell(cell),
                     getFontStyleString(style).fontCache,
                     style?.tb === WrapStrategy.WRAP,
                     colWidth - paddingLeft - paddingRight,


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<img width="1887" height="545" alt="image" src="https://github.com/user-attachments/assets/ca31dea3-046e-4f83-ab1d-580ccbecdc07" />


<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
