### PR TITLE
fix: optimize auto row height recalculation when clearing cell content or styles

### DIFF
--- a/packages/core/src/services/undoredo/__tests__/undoredo.service.spec.ts
+++ b/packages/core/src/services/undoredo/__tests__/undoredo.service.spec.ts
@@ -194,11 +194,11 @@ describe('LocalUndoRedoService', () => {
             id: 'fail',
         });
 
-        expect(commandService.syncExecuteCommand(UndoCommandId)).toBe(true);
-        expect(undoRedoService.pitchTopUndoElement()).toBeNull();
-        expect(undoRedoService.pitchTopRedoElement()?.id).toBe('fail');
+        expect(commandService.syncExecuteCommand(UndoCommandId)).toBe(false);
+        expect(undoRedoService.pitchTopUndoElement()?.id).toBe('fail');
+        expect(undoRedoService.pitchTopRedoElement()).toBeNull();
 
-        expect(commandService.syncExecuteCommand(RedoCommandId)).toBe(true);
+        expect(commandService.syncExecuteCommand(RedoCommandId)).toBe(false);
         expect(undoRedoService.pitchTopRedoElement()).toBeNull();
         expect(undoRedoService.pitchTopUndoElement()?.id).toBe('fail');
 

--- a/packages/core/src/services/undoredo/undoredo.service.ts
+++ b/packages/core/src/services/undoredo/undoredo.service.ts
@@ -128,7 +128,7 @@ export const UndoCommand = new (class extends MultiImplementationCommand impleme
 
         const commandService = accessor.get(ICommandService);
         const result = sequenceExecute(element.undoMutations, commandService);
-        if (result) {
+        if (result.result) {
             undoRedoService.popUndoToRedo();
 
             return true;
@@ -152,7 +152,7 @@ export const RedoCommand = new (class extends MultiImplementationCommand impleme
 
         const commandService = accessor.get(ICommandService);
         const result = sequenceExecute(element.redoMutations, commandService);
-        if (result) {
+        if (result.result) {
             undoRedoService.popRedoToUndo();
 
             return true;

--- a/packages/sheets-conditional-formatting-ui/src/__tests__/create-cf-ui-test-bed.ts
+++ b/packages/sheets-conditional-formatting-ui/src/__tests__/create-cf-ui-test-bed.ts
@@ -132,6 +132,7 @@ function createLocalSheetsTestBed(workbookData?: IWorkbookData, dependencies?: D
             dependencies?.forEach((dependency) => injector.add(dependency));
 
             injector.get(SheetInterceptorService);
+            injector.get(SheetSkeletonService);
             injector.get(WorkbookPermissionService);
             injector.get(WorksheetPermissionService);
         }

--- a/packages/sheets-drawing-ui/src/commands/commands/flip-drawings.command.ts
+++ b/packages/sheets-drawing-ui/src/commands/commands/flip-drawings.command.ts
@@ -155,7 +155,7 @@ export const FlipSheetDrawingCommand: ICommand = {
 
         const result = sequenceExecute([updateMutation], commandService);
 
-        if (result) {
+        if (result.result) {
             undoRedoService.pushUndoRedo({
                 unitID: opUnitId,
                 undoMutations: [undoUpdateMutation, { id: ClearSheetDrawingTransformerOperation.id, params: unitIds }],

--- a/packages/sheets-drawing/src/__tests__/create-sheets-drawing-test-bed.ts
+++ b/packages/sheets-drawing/src/__tests__/create-sheets-drawing-test-bed.ts
@@ -32,6 +32,7 @@ import {
     UniverInstanceType,
 } from '@univerjs/core';
 import { DrawingManagerService, IDrawingManagerService } from '@univerjs/drawing';
+import { IRenderManagerService, RenderManagerService } from '@univerjs/engine-render';
 import {
     CopySheetCommand,
     CopyWorksheetEndMutation,
@@ -101,6 +102,7 @@ export function createSheetsDrawingTestBed(workbookData?: IWorkbookData, depende
             this._injector.get(IUndoRedoService);
 
             ([
+                [IRenderManagerService, { useClass: RenderManagerService }],
                 [SheetInterceptorService],
                 [SheetLazyExecuteScheduleService],
                 [IDrawingManagerService, { useClass: DrawingManagerService }],

--- a/packages/sheets-drawing/src/commands/commands/insert-sheet-drawing.command.ts
+++ b/packages/sheets-drawing/src/commands/commands/insert-sheet-drawing.command.ts
@@ -88,7 +88,7 @@ export const InsertSheetDrawingCommand: ICommand = {
 
         const result = sequenceExecute(redoMutations, commandService);
 
-        if (result) {
+        if (result.result) {
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations,

--- a/packages/sheets-drawing/src/commands/commands/remove-sheet-drawing.command.ts
+++ b/packages/sheets-drawing/src/commands/commands/remove-sheet-drawing.command.ts
@@ -94,7 +94,7 @@ export const RemoveSheetDrawingCommand: ICommand = {
 
         const result = sequenceExecute(redoMutations, commandService);
 
-        if (result) {
+        if (result.result) {
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations,

--- a/packages/sheets-drawing/src/commands/commands/set-sheet-drawing.command.ts
+++ b/packages/sheets-drawing/src/commands/commands/set-sheet-drawing.command.ts
@@ -87,7 +87,7 @@ export const SetSheetDrawingCommand: ICommand<ISetDrawingCommandParams> = {
         ];
 
         const result = sequenceExecute(redoMutations, commandService);
-        if (result) {
+        if (result.result) {
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations,

--- a/packages/sheets-formula-ui/src/controllers/__tests__/formula-clipboard.controller.spec.ts
+++ b/packages/sheets-formula-ui/src/controllers/__tests__/formula-clipboard.controller.spec.ts
@@ -20,7 +20,7 @@ import type { ICellDataWithSpanInfo } from '@univerjs/sheets-ui';
 import { DisposableCollection, ICommandService, ILogService, Inject, Injector, IUniverInstanceService, LocaleService, LocaleType, LogLevel, ObjectMatrix, Plugin, RANGE_TYPE, UndoCommand, Univer, UniverInstanceType } from '@univerjs/core';
 import { CalculateFormulaService, DefinedNamesService, FormulaCurrentConfigService, FormulaDataModel, FormulaRuntimeService, HyperlinkEngineFormulaService, ICalculateFormulaService, IDefinedNamesService, IFormulaCurrentConfigService, IFormulaRuntimeService, IHyperlinkEngineFormulaService, LexerTreeBuilder, SetArrayFormulaDataMutation, SetFormulaDataMutation } from '@univerjs/engine-formula';
 import { IRenderManagerService, RenderManagerService } from '@univerjs/engine-render';
-import { discreteRangeToRange, MoveRangeMutation, SetRangeValuesMutation, SetSelectionsOperation, SetWorksheetRowAutoHeightMutation, SheetInterceptorService, SheetSkeletonService, SheetsSelectionsService } from '@univerjs/sheets';
+import { discreteRangeToRange, MoveRangeMutation, SetRangeValuesMutation, SetSelectionsOperation, SetWorksheetActiveOperation, SetWorksheetRowAutoHeightMutation, SheetInterceptorService, SheetSkeletonService, SheetsSelectionsService } from '@univerjs/sheets';
 import { UpdateFormulaController } from '@univerjs/sheets-formula';
 import { COPY_TYPE, IMarkSelectionService, ISheetClipboardService, ISheetSelectionRenderService, PREDEFINED_HOOK_NAME_PASTE, SheetClipboardController, SheetClipboardService, SheetSelectionRenderService, SheetSkeletonManagerService } from '@univerjs/sheets-ui';
 import { BrowserClipboardService, DesktopMessageService, IClipboardInterfaceService, IMessageService, INotificationService, IPlatformService, IUIPartsService, UIPartsService } from '@univerjs/ui';
@@ -280,6 +280,7 @@ describe('Test cut command with formulas', () => {
         commandService.registerCommand(SetWorksheetRowAutoHeightMutation);
         commandService.registerCommand(SetFormulaDataMutation);
         commandService.registerCommand(SetArrayFormulaDataMutation);
+        commandService.registerCommand(SetWorksheetActiveOperation);
         sheetClipboardService = get(ISheetClipboardService);
 
         get(UpdateFormulaController);

--- a/packages/sheets-hyper-link/src/commands/commands/update-hyper-link.command.ts
+++ b/packages/sheets-hyper-link/src/commands/commands/update-hyper-link.command.ts
@@ -150,7 +150,7 @@ export const UpdateHyperLinkCommand: ICommand<IUpdateHyperLinkCommandParams> = {
         }
 
         const res = sequenceExecute(redos, commandService);
-        if (res) {
+        if (res.result) {
             const isValid = await interceptorService.onValidateCell(workbook, worksheet, row, column);
             if (isValid === false) {
                 sequenceExecute(undos, commandService);

--- a/packages/sheets-table/src/commands/commands/add-sheet-table.command.ts
+++ b/packages/sheets-table/src/commands/commands/add-sheet-table.command.ts
@@ -79,14 +79,16 @@ export const AddSheetTableCommand: ICommand<IAddSheetTableCommandParams> = {
 
         const res = sequenceExecute(redos, commandService);
 
-        if (res) {
+        if (res.result) {
             undoRedoService.pushUndoRedo({
                 unitID: params.unitId,
                 undoMutations: undos,
                 redoMutations: redos,
             });
+
+            return true;
         }
 
-        return true;
+        return false;
     },
 };

--- a/packages/sheets-table/src/commands/commands/add-table-theme.command.ts
+++ b/packages/sheets-table/src/commands/commands/add-table-theme.command.ts
@@ -89,15 +89,17 @@ export const AddTableThemeCommand: ICommand<IAddTableThemeCommandParams> = {
 
         const commandService = accessor.get(ICommandService);
         const res = sequenceExecute(redos, commandService);
-        if (res) {
+        if (res.result) {
             const undoRedoService = accessor.get(IUndoRedoService);
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations: undos,
                 redoMutations: redos,
             });
+
+            return true;
         }
 
-        return true;
+        return false;
     },
 };

--- a/packages/sheets-table/src/commands/commands/delete-sheet-table.command.ts
+++ b/packages/sheets-table/src/commands/commands/delete-sheet-table.command.ts
@@ -60,14 +60,16 @@ export const DeleteSheetTableCommand: ICommand<IDeleteSheetTableParams> = {
 
         const res = sequenceExecute(redos, commandService);
 
-        if (res) {
+        if (res.result) {
             undoRedoService.pushUndoRedo({
                 unitID: params.unitId,
                 undoMutations: undos,
                 redoMutations: redos,
             });
+
+            return true;
         }
 
-        return true;
+        return false;
     },
 };

--- a/packages/sheets-table/src/commands/commands/remove-table-theme.command.ts
+++ b/packages/sheets-table/src/commands/commands/remove-table-theme.command.ts
@@ -65,15 +65,17 @@ export const RemoveTableThemeCommand: ICommand<IRemoveTableThemeCommandParams> =
 
         const commandService = accessor.get(ICommandService);
         const res = sequenceExecute(redos, commandService);
-        if (res) {
+        if (res.result) {
             const undoRedoService = accessor.get(IUndoRedoService);
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 redoMutations: redos,
                 undoMutations: undos,
             });
+
+            return true;
         }
 
-        return true;
+        return false;
     },
 };

--- a/packages/sheets-table/src/commands/commands/set-table-filter.command.ts
+++ b/packages/sheets-table/src/commands/commands/set-table-filter.command.ts
@@ -38,14 +38,16 @@ export const SetSheetTableFilterCommand: ICommand<ISetSheetTableParams> = {
 
         const res = sequenceExecute(redos, commandService);
 
-        if (res) {
+        if (res.result) {
             undoRedoService.pushUndoRedo({
                 unitID: params.unitId,
                 undoMutations: undos,
                 redoMutations: redos,
             });
+
+            return true;
         }
 
-        return true;
+        return false;
     },
 };

--- a/packages/sheets-table/src/commands/commands/sheet-table-row-col.command.ts
+++ b/packages/sheets-table/src/commands/commands/sheet-table-row-col.command.ts
@@ -180,16 +180,18 @@ export const SheetTableInsertRowCommand: ICommand<ISheetTableRowColOperationComm
         const commandService = accessor.get(ICommandService);
         const res = sequenceExecute(redos, commandService);
 
-        if (res) {
+        if (res.result) {
             const undoRedoService = accessor.get(IUndoRedoService);
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations: undos,
                 redoMutations: redos,
             });
+
+            return true;
         }
 
-        return true;
+        return false;
     },
 };
 
@@ -334,16 +336,18 @@ export const SheetTableInsertColCommand: ICommand<ISheetTableRowColOperationComm
         }
         const commandService = accessor.get(ICommandService);
         const res = sequenceExecute(redos, commandService);
-        if (res) {
+        if (res.result) {
             const undoRedoService = accessor.get(IUndoRedoService);
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations: undos,
                 redoMutations: redos,
             });
+
+            return true;
         }
 
-        return true;
+        return false;
     },
 };
 
@@ -439,16 +443,18 @@ export const SheetTableRemoveRowCommand: ICommand<ISheetTableRowColOperationComm
 
         const commandService = accessor.get(ICommandService);
         const res = sequenceExecute(redos, commandService);
-        if (res) {
+        if (res.result) {
             const undoRedoService = accessor.get(IUndoRedoService);
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations: undos,
                 redoMutations: redos,
             });
+
+            return true;
         }
 
-        return true;
+        return false;
     },
 };
 
@@ -557,15 +563,17 @@ export const SheetTableRemoveColCommand: ICommand<ISheetTableRowColOperationComm
 
         const commandService = accessor.get(ICommandService);
         const res = sequenceExecute(redos, commandService);
-        if (res) {
+        if (res.result) {
             const undoRedoService = accessor.get(IUndoRedoService);
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations: undos,
                 redoMutations: redos,
             });
+
+            return true;
         }
 
-        return true;
+        return false;
     },
 };

--- a/packages/sheets-ui/src/commands/commands/set-selection.command.ts
+++ b/packages/sheets-ui/src/commands/commands/set-selection.command.ts
@@ -524,8 +524,8 @@ export const SelectAllCommand: ICommand<ISelectAllCommandParams> = {
         }
 
         const commandService = accessor.get(ICommandService);
-        sequenceExecute(redos, commandService);
+        const result = sequenceExecute(redos, commandService);
 
-        return true;
+        return result.result;
     },
 };

--- a/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-service.spec.ts
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-service.spec.ts
@@ -24,6 +24,7 @@ import {
     RemoveWorksheetMergeMutation,
     SetRangeValuesMutation,
     SetSelectionsOperation,
+    SetWorksheetActiveOperation,
     SetWorksheetColWidthMutation,
     SetWorksheetRowAutoHeightMutation,
     SetWorksheetRowHeightMutation,
@@ -75,6 +76,7 @@ describe('Test clipboard', () => {
         commandService.registerCommand(SetSelectionsOperation);
         commandService.registerCommand(MoveRangeMutation);
         commandService.registerCommand(SetWorksheetRowAutoHeightMutation);
+        commandService.registerCommand(SetWorksheetActiveOperation);
 
         sheetClipboardService = get(ISheetClipboardService);
 

--- a/packages/sheets-ui/src/services/clipboard/clipboard.service.ts
+++ b/packages/sheets-ui/src/services/clipboard/clipboard.service.ts
@@ -381,7 +381,7 @@ export class SheetClipboardService extends Disposable implements ISheetClipboard
         const element = undoRedoService.pitchTopUndoElement();
         if (element) {
             const result = sequenceExecute(element.undoMutations, this._commandService);
-            if (result) {
+            if (result.result) {
                 undoRedoService.popUndoToRedo();
             }
         }

--- a/packages/sheets/src/commands/commands/__tests__/create-command-test-bed.ts
+++ b/packages/sheets/src/commands/commands/__tests__/create-command-test-bed.ts
@@ -113,6 +113,7 @@ export function createCommandTestBed(workbookData?: IWorkbookData, dependencies?
             dependencies?.forEach((d) => injector.add(d));
 
             this._injector.get(SheetInterceptorService);
+            this._injector.get(SheetSkeletonService);
             this._injector.get(WorkbookPermissionService);
             this._injector.get(WorksheetPermissionService);
         }

--- a/packages/sheets/src/commands/commands/__tests__/set-range-values.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-range-values.command.spec.ts
@@ -33,6 +33,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SheetsSelectionsService } from '../../../services/selections/selection.service';
 import { SetRangeValuesMutation } from '../../mutations/set-range-values.mutation';
+import { SetSelectionsOperation } from '../../operations/selection.operation';
 import { SetRangeValuesCommand } from '../set-range-values.command';
 import { createCommandTestBed } from './create-command-test-bed';
 
@@ -153,6 +154,7 @@ describe('Test set range values commands', () => {
         commandService = get(ICommandService);
         commandService.registerCommand(SetRangeValuesCommand);
         commandService.registerCommand(SetRangeValuesMutation);
+        commandService.registerCommand(SetSelectionsOperation);
 
         selectionManager = get(SheetsSelectionsService);
         selectionManager.addSelections([

--- a/packages/sheets/src/commands/commands/auto-fill.command.ts
+++ b/packages/sheets/src/commands/commands/auto-fill.command.ts
@@ -213,7 +213,7 @@ export const AutoClearContentCommand: ICommand = {
         ];
 
         const result = sequenceExecute(redos, commandService);
-        if (result) {
+        if (result.result) {
             const afterInterceptors = sheetInterceptorService.afterCommandExecute({
                 id: SetRangeValuesMutation.id,
                 params: clearMutationParams,

--- a/packages/sheets/src/commands/commands/clear-selection-all.command.ts
+++ b/packages/sheets/src/commands/commands/clear-selection-all.command.ts
@@ -20,7 +20,9 @@ import { CommandType, ICommandService, IUndoRedoService, IUniverInstanceService,
 import { generateNullCell, getVisibleRanges } from '../../basics/utils';
 import { SheetsSelectionsService } from '../../services/selections/selection.service';
 import { SheetInterceptorService } from '../../services/sheet-interceptor/sheet-interceptor.service';
+import { SheetSkeletonService } from '../../skeleton/skeleton.service';
 import { SetRangeValuesMutation, SetRangeValuesUndoMutationFactory } from '../mutations/set-range-values.mutation';
+import { getSuitableRangesInView } from './util';
 import { getSheetCommandTarget } from './utils/target-util';
 
 export interface IClearSelectionAllCommandParams {
@@ -41,19 +43,22 @@ export const ClearSelectionAllCommand: ICommand<IClearSelectionAllCommandParams>
 
         const selectionManagerService = accessor.get(SheetsSelectionsService);
         const { unitId, subUnitId } = target;
-        const selections = params?.ranges || selectionManagerService.getCurrentSelections()?.map((s) => s.range);
-        if (!selections?.length) return false;
+        const ranges = params?.ranges || selectionManagerService.getCurrentSelections()?.map((s) => s.range);
+        if (!ranges?.length) return false;
+
+        const sheetSkeletonService = accessor.get(SheetSkeletonService);
+        const skeleton = sheetSkeletonService.getSkeleton(unitId, subUnitId);
+        if (!skeleton) return false;
 
         const commandService = accessor.get(ICommandService);
         const undoRedoService = accessor.get(IUndoRedoService);
         const sheetInterceptorService = accessor.get(SheetInterceptorService);
 
-        const visibleRanges = getVisibleRanges(selections, accessor, unitId, subUnitId);
-
-        const sequenceExecuteList: IMutationInfo[] = [];
-        const sequenceExecuteUndoList: IMutationInfo[] = [];
+        const redoMutations: IMutationInfo[] = [];
+        const undoMutations: IMutationInfo[] = [];
 
         // clear style and content
+        const visibleRanges = getVisibleRanges(ranges, accessor, unitId, subUnitId);
         const clearMutationParams: ISetRangeValuesMutationParams = {
             subUnitId,
             unitId,
@@ -64,28 +69,42 @@ export const ClearSelectionAllCommand: ICommand<IClearSelectionAllCommandParams>
             clearMutationParams
         );
 
-        sequenceExecuteList.push({
+        redoMutations.push({
             id: SetRangeValuesMutation.id,
             params: clearMutationParams,
         });
-        sequenceExecuteUndoList.push({
+        undoMutations.push({
             id: SetRangeValuesMutation.id,
             params: undoClearMutationParams,
         });
 
+        // intercept
         const intercepted = sheetInterceptorService.onCommandExecute({ id: ClearSelectionAllCommand.id, params });
 
-        sequenceExecuteList.push(...intercepted.redos);
-        sequenceExecuteUndoList.unshift(...intercepted.undos);
-        const result = sequenceExecute(sequenceExecuteList, commandService);
+        redoMutations.push(...intercepted.redos);
+        undoMutations.unshift(...intercepted.undos);
 
-        if (result) {
+        const result = sequenceExecute(redoMutations, commandService);
+
+        // auto height
+        const { suitableRanges, remainingRanges } = getSuitableRangesInView(ranges, skeleton);
+        const { undos: autoHeightUndos, redos: autoHeightRedos } = sheetInterceptorService.generateMutationsOfAutoHeight({
+            unitId,
+            subUnitId,
+            ranges: suitableRanges,
+            autoHeightRanges: suitableRanges,
+            lazyAutoHeightRanges: remainingRanges,
+        });
+        const autoHeightExecuteResult = sequenceExecute(autoHeightRedos, commandService);
+
+        if (result.result && autoHeightExecuteResult.result) {
+            redoMutations.push(...autoHeightRedos);
+            undoMutations.push(...autoHeightUndos);
+
             undoRedoService.pushUndoRedo({
-                // If there are multiple mutations that form an encapsulated project, they must be encapsulated in the same undo redo element.
-                // Hooks can be used to hook the code of external controllers to add new actions.
                 unitID: unitId,
-                undoMutations: sequenceExecuteUndoList,
-                redoMutations: sequenceExecuteList,
+                undoMutations,
+                redoMutations,
             });
 
             return true;

--- a/packages/sheets/src/commands/commands/clear-selection-content.command.ts
+++ b/packages/sheets/src/commands/commands/clear-selection-content.command.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import type { ICommand, IRange } from '@univerjs/core';
+import type { ICommand, IMutationInfo, IRange } from '@univerjs/core';
 import type { ISetRangeValuesMutationParams } from '../mutations/set-range-values.mutation';
 import { CommandType, ICommandService, IUndoRedoService, IUniverInstanceService, sequenceExecute } from '@univerjs/core';
 import { generateNullCellValue, getVisibleRanges } from '../../basics/utils';
 import { SheetsSelectionsService } from '../../services/selections/selection.service';
 import { SheetInterceptorService } from '../../services/sheet-interceptor/sheet-interceptor.service';
+import { SheetSkeletonService } from '../../skeleton/skeleton.service';
 import { SetRangeValuesMutation, SetRangeValuesUndoMutationFactory } from '../mutations/set-range-values.mutation';
+import { getSuitableRangesInView } from './util';
 import { getSheetCommandTarget } from './utils/target-util';
 
 export interface IClearSelectionContentCommandParams {
@@ -46,12 +48,19 @@ export const ClearSelectionContentCommand: ICommand<IClearSelectionContentComman
         const ranges = params?.ranges || selectionManagerService.getCurrentSelections()?.map((s) => s.range);
         if (!ranges?.length) return false;
 
+        const sheetSkeletonService = accessor.get(SheetSkeletonService);
+        const skeleton = sheetSkeletonService.getSkeleton(unitId, subUnitId);
+        if (!skeleton) return false;
+
         const commandService = accessor.get(ICommandService);
         const undoRedoService = accessor.get(IUndoRedoService);
         const sheetInterceptorService = accessor.get(SheetInterceptorService);
 
-        const visibleRanges = getVisibleRanges(ranges, accessor, unitId, subUnitId);
+        const redoMutations: IMutationInfo[] = [];
+        const undoMutations: IMutationInfo[] = [];
 
+        // clear content
+        const visibleRanges = getVisibleRanges(ranges, accessor, unitId, subUnitId);
         const clearMutationParams: ISetRangeValuesMutationParams = {
             subUnitId,
             unitId,
@@ -62,18 +71,42 @@ export const ClearSelectionContentCommand: ICommand<IClearSelectionContentComman
             clearMutationParams
         );
 
-        const intercepted = sheetInterceptorService.onCommandExecute({ id: ClearSelectionContentCommand.id, params });
-        const redos = [{ id: SetRangeValuesMutation.id, params: clearMutationParams }, ...intercepted.redos];
-        const undos = [...intercepted.undos, { id: SetRangeValuesMutation.id, params: undoClearMutationParams }];
+        redoMutations.push({
+            id: SetRangeValuesMutation.id,
+            params: clearMutationParams,
+        });
+        undoMutations.push({
+            id: SetRangeValuesMutation.id,
+            params: undoClearMutationParams,
+        });
 
-        const result = sequenceExecute(redos, commandService).result;
-        if (result) {
+        // intercept
+        const intercepted = sheetInterceptorService.onCommandExecute({ id: ClearSelectionContentCommand.id, params });
+
+        redoMutations.push(...intercepted.redos);
+        undoMutations.unshift(...intercepted.undos);
+
+        const result = sequenceExecute(redoMutations, commandService);
+
+        // auto height
+        const { suitableRanges, remainingRanges } = getSuitableRangesInView(ranges, skeleton);
+        const { undos: autoHeightUndos, redos: autoHeightRedos } = sheetInterceptorService.generateMutationsOfAutoHeight({
+            unitId,
+            subUnitId,
+            ranges: suitableRanges,
+            autoHeightRanges: suitableRanges,
+            lazyAutoHeightRanges: remainingRanges,
+        });
+        const autoHeightExecuteResult = sequenceExecute(autoHeightRedos, commandService);
+
+        if (result.result && autoHeightExecuteResult.result) {
+            redoMutations.push(...autoHeightRedos);
+            undoMutations.push(...autoHeightUndos);
+
             undoRedoService.pushUndoRedo({
-                // If there are multiple mutations that form an encapsulated project, they must be encapsulated in the same undo redo element.
-                // Hooks can be used to hook the code of external controllers to add new actions.
                 unitID: unitId,
-                undoMutations: undos,
-                redoMutations: redos,
+                undoMutations,
+                redoMutations,
             });
 
             return true;

--- a/packages/sheets/src/commands/commands/clear-selection-format.command.ts
+++ b/packages/sheets/src/commands/commands/clear-selection-format.command.ts
@@ -20,7 +20,9 @@ import { CommandType, ICommandService, IUndoRedoService, IUniverInstanceService,
 import { generateNullCellStyle, getVisibleRanges } from '../../basics/utils';
 import { SheetsSelectionsService } from '../../services/selections/selection.service';
 import { SheetInterceptorService } from '../../services/sheet-interceptor/sheet-interceptor.service';
+import { SheetSkeletonService } from '../../skeleton/skeleton.service';
 import { SetRangeValuesMutation, SetRangeValuesUndoMutationFactory } from '../mutations/set-range-values.mutation';
+import { getSuitableRangesInView } from './util';
 import { getSheetCommandTarget } from './utils/target-util';
 
 export interface IClearSelectionFormatCommandParams {
@@ -46,16 +48,19 @@ export const ClearSelectionFormatCommand: ICommand<IClearSelectionFormatCommandP
         const ranges = params?.ranges || selectionManagerService.getCurrentSelections()?.map((s) => s.range);
         if (!ranges?.length) return false;
 
+        const sheetSkeletonService = accessor.get(SheetSkeletonService);
+        const skeleton = sheetSkeletonService.getSkeleton(unitId, subUnitId);
+        if (!skeleton) return false;
+
         const commandService = accessor.get(ICommandService);
         const undoRedoService = accessor.get(IUndoRedoService);
         const sheetInterceptorService = accessor.get(SheetInterceptorService);
 
-        const visibleRanges = getVisibleRanges(ranges, accessor, unitId, subUnitId);
-
-        const sequenceExecuteList: IMutationInfo[] = [];
-        const sequenceExecuteUndoList: IMutationInfo[] = [];
+        const redoMutations: IMutationInfo[] = [];
+        const undoMutations: IMutationInfo[] = [];
 
         // clear style
+        const visibleRanges = getVisibleRanges(ranges, accessor, unitId, subUnitId);
         const clearMutationParams: ISetRangeValuesMutationParams = {
             subUnitId,
             unitId,
@@ -66,30 +71,42 @@ export const ClearSelectionFormatCommand: ICommand<IClearSelectionFormatCommandP
             clearMutationParams
         );
 
-        sequenceExecuteList.push({
+        redoMutations.push({
             id: SetRangeValuesMutation.id,
             params: clearMutationParams,
         });
-        sequenceExecuteUndoList.push({
+        undoMutations.push({
             id: SetRangeValuesMutation.id,
             params: undoClearMutationParams,
         });
 
+        // intercept
         const intercepted = sheetInterceptorService.onCommandExecute({ id: ClearSelectionFormatCommand.id, params });
 
-        sequenceExecuteList.push(...intercepted.redos);
-        sequenceExecuteUndoList.unshift(...intercepted.undos);
+        redoMutations.push(...intercepted.redos);
+        undoMutations.unshift(...intercepted.undos);
 
-        const result = sequenceExecute(sequenceExecuteList, commandService);
+        const result = sequenceExecute(redoMutations, commandService);
 
-        // const result = commandService.syncExecuteCommand(SetRangeValuesMutation.id, clearMutationParams);
-        if (result) {
+        // auto height
+        const { suitableRanges, remainingRanges } = getSuitableRangesInView(ranges, skeleton);
+        const { undos: autoHeightUndos, redos: autoHeightRedos } = sheetInterceptorService.generateMutationsOfAutoHeight({
+            unitId,
+            subUnitId,
+            ranges: suitableRanges,
+            autoHeightRanges: suitableRanges,
+            lazyAutoHeightRanges: remainingRanges,
+        });
+        const autoHeightExecuteResult = sequenceExecute(autoHeightRedos, commandService);
+
+        if (result.result && autoHeightExecuteResult.result) {
+            redoMutations.push(...autoHeightRedos);
+            undoMutations.push(...autoHeightUndos);
+
             undoRedoService.pushUndoRedo({
-                // If there are multiple mutations that form an encapsulated project, they must be encapsulated in the same undo redo element.
-                // Hooks can be used to hook the code of external controllers to add new actions.
                 unitID: unitId,
-                undoMutations: sequenceExecuteUndoList,
-                redoMutations: sequenceExecuteList,
+                undoMutations,
+                redoMutations,
             });
 
             return true;

--- a/packages/sheets/src/commands/commands/insert-range-move-down.command.ts
+++ b/packages/sheets/src/commands/commands/insert-range-move-down.command.ts
@@ -162,7 +162,7 @@ export const InsertRangeMoveDownCommand: ICommand = {
 
         // execute do mutations and add undo mutations to undo stack if completed
         const result = sequenceExecute(redoMutations, commandService);
-        if (result) {
+        if (result.result) {
             const afterInterceptors = sheetInterceptorService.afterCommandExecute({
                 id: InsertRangeMoveDownCommand.id,
                 params: { range } as IInsertRangeMoveDownCommandParams,

--- a/packages/sheets/src/commands/commands/remove-defined-name.command.ts
+++ b/packages/sheets/src/commands/commands/remove-defined-name.command.ts
@@ -58,7 +58,7 @@ export const RemoveDefinedNameCommand: ICommand = {
 
         const result = sequenceExecute(redos, commandService);
 
-        if (result) {
+        if (result.result) {
             undoRedoService.pushUndoRedo({
                 unitID: params.unitId,
                 undoMutations: undos.filter(Boolean),

--- a/packages/sheets/src/commands/commands/remove-worksheet-merge.command.ts
+++ b/packages/sheets/src/commands/commands/remove-worksheet-merge.command.ts
@@ -124,7 +124,7 @@ export const RemoveWorksheetMergeCommand: ICommand = {
 
         const result = sequenceExecute(redoMutations, commandService);
 
-        if (result) {
+        if (result.result) {
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations,

--- a/packages/sheets/src/commands/commands/set-defined-name.command.ts
+++ b/packages/sheets/src/commands/commands/set-defined-name.command.ts
@@ -58,7 +58,7 @@ export const SetDefinedNameCommand: ICommand = {
 
         const result = sequenceExecute(redos, commandService);
 
-        if (result) {
+        if (result.result) {
             undoRedoService.pushUndoRedo({
                 unitID: params.unitId,
                 undoMutations: undos.filter(Boolean),

--- a/packages/sheets/src/commands/commands/set-protection.command.ts
+++ b/packages/sheets/src/commands/commands/set-protection.command.ts
@@ -81,7 +81,7 @@ export const SetProtectionCommand: ICommand<ISetProtectionParams> = {
 
         const result = sequenceExecute(redoMutations, commandService);
 
-        if (result) {
+        if (result.result) {
             undoRedoService.pushUndoRedo({
                 unitID: unitId,
                 undoMutations,

--- a/packages/sheets/src/commands/commands/set-range-values.command.ts
+++ b/packages/sheets/src/commands/commands/set-range-values.command.ts
@@ -30,7 +30,6 @@ import {
 import { SheetsSelectionsService } from '../../services/selections/selection.service';
 import { SheetInterceptorService } from '../../services/sheet-interceptor/sheet-interceptor.service';
 import { SetRangeValuesMutation, SetRangeValuesUndoMutationFactory } from '../mutations/set-range-values.mutation';
-import { SetSelectionsOperation } from '../operations/selection.operation';
 import { followSelectionOperation } from './utils/selection-utils';
 import { getSheetCommandTarget } from './utils/target-util';
 
@@ -133,15 +132,7 @@ export const SetRangeValuesCommand: ICommand = {
             ];
 
             if (currentSelections && currentSelections.length) {
-                undoMutations.push({
-                    id: SetSelectionsOperation.id,
-                    params: {
-                        unitId,
-                        subUnitId,
-                        selections: currentSelections,
-                        reveal: true,
-                    },
-                });
+                undoMutations.push(followSelectionOperation(currentSelections[currentSelections.length - 1], workbook, worksheet));
             }
 
             undoRedoService.pushUndoRedo({


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
