### PR TITLE
fix: optimize boundary cases where the width and height of the last row/column cannot be changed via UI

### DIFF
--- a/packages/sheets-ui/src/controllers/render-controllers/header-resize.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/header-resize.render-controller.ts
@@ -175,6 +175,8 @@ export class HeaderResizeRenderController extends Disposable implements IRenderM
                 scene,
                 skeleton
             );
+            const isLastRow = row === skeleton.worksheet.getRowCount() - 1;
+            const isLastColumn = column === skeleton.worksheet.getColumnCount() - 1;
 
             const transformCoord = getTransformCoord(evt.offsetX, evt.offsetY, scene, skeleton);
 
@@ -187,7 +189,9 @@ export class HeaderResizeRenderController extends Disposable implements IRenderM
             if (initialType === HEADER_RESIZE_TYPE.ROW) {
                 let top = startY - HEADER_MENU_SHAPE_WIDTH_HEIGHT_SCALE / 2;
 
-                if (
+                if (isLastRow && (endY - startY) <= HEADER_MENU_SHAPE_WIDTH_HEIGHT_SCALE / 2) {
+                    this._currentRow = row;
+                } else if (
                     transformCoord.y <= startY + HEADER_MENU_SHAPE_WIDTH_HEIGHT_SCALE / 2 &&
                     transformCoord.y >= startY
                 ) {
@@ -227,7 +231,9 @@ export class HeaderResizeRenderController extends Disposable implements IRenderM
             } else {
                 let left = startX - HEADER_MENU_SHAPE_WIDTH_HEIGHT_SCALE / 2;
 
-                if (
+                if (isLastColumn && (endX - startX) <= HEADER_MENU_SHAPE_WIDTH_HEIGHT_SCALE / 2) {
+                    this._currentColumn = column;
+                } else if (
                     transformCoord.x <= startX + HEADER_MENU_SHAPE_WIDTH_HEIGHT_SCALE / 2 &&
                     transformCoord.x >= startX
                 ) {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
- The last column width too small.
- The last row height too small.

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
