### PR TITLE
fix: remove scroll bar on sheets context menu

### DIFF
--- a/packages/ui/src/views/components/context-menu/ContextMenuPanel.tsx
+++ b/packages/ui/src/views/components/context-menu/ContextMenuPanel.tsx
@@ -542,7 +542,7 @@ function ContextMenuMenuItem(props: IContextMenuMenuItemProps) {
                                                 `
                                                   univer-relative univer-flex univer-min-h-8 univer-w-full
                                                   univer-items-center univer-rounded-md univer-border-none
-                                                  univer-bg-transparent univer-px-2 univer-text-left univer-text-sm
+                                                  univer-bg-transparent univer-text-left univer-text-sm
                                                   dark:!univer-text-white
                                                 `,
                                                 option.disabled


### PR DESCRIPTION
close #xxx

<!-- A description of the proposed changes. -->

We noticed an unnecessary scroll when trying to change the color of the sheet, but I couldn't find any places where this part is also called, other than this feature.

At the same time, it seems we have not observed such a problem before, but I have not found a reason that could lead to this

Before:
<img width="1830" height="1005" alt="image" src="https://github.com/user-attachments/assets/0b1e7abd-02a1-46c9-8577-1ac09a1362c6" />

After: 
<img width="1830" height="1005" alt="image" src="https://github.com/user-attachments/assets/b4584d90-5323-4867-83d8-cd76bd645103" />

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
