### PR TITLE
fix(sheets): paste images as cell images while editing

### DIFF
--- a/packages/docs-ui/src/services/clipboard/clipboard.service.ts
+++ b/packages/docs-ui/src/services/clipboard/clipboard.service.ts
@@ -35,6 +35,7 @@ import {
     ObjectRelativeFromH,
     ObjectRelativeFromV,
     PositionedObjectLayoutType,
+    SHEET_EDITOR_UNITS,
     SliceBodyType,
     toDisposable,
     Tools,
@@ -70,7 +71,7 @@ export interface IDocClipboardHook {
     onCopyProperty?(start: number, end: number): IClipboardPropertyItem;
     onCopyContent?(start: number, end: number): string;
     onBeforePaste?: (body: IDocumentBody) => IDocumentBody;
-    onBeforePasteImage?: (file: File) => Promise<{ source: string; imageSourceType: ImageSourceType } | null>;
+    onBeforePasteImage?: (file: File) => Promise<{ source: string; imageSourceType: ImageSourceType } | null | undefined>;
 }
 
 export interface IDocClipboardService {
@@ -168,7 +169,10 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
         let { html, text, files } = options;
         const currentDocInstance = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
         const docUnitId = currentDocInstance?.getUnitId() || '';
-        if (!html && !text && files.length) {
+        if (files.length && SHEET_EDITOR_UNITS.includes(docUnitId)) {
+            html = await this._createImagePasteHtml(files);
+            text = '';
+        } else if (!html && !text && files.length) {
             html = await this._createImagePasteHtml(files);
         }
         if (!html && !text) {
@@ -556,7 +560,7 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
         };
         // clipboardHooks should be redesigned to handle the ability of multiple hooks processing the same node
         // Refer to interceptor
-        const onBeforePasteImage = this._clipboardHooks.find((e) => e.onBeforePasteImage)?.onBeforePasteImage ?? fileToBase64;
+        const onBeforePasteImage = (file: File) => this._runBeforePasteImageHooks(file, fileToBase64);
 
         await Promise.all(files.map(async (file, index) => {
             const image = await onBeforePasteImage(file);
@@ -594,5 +598,16 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
         }));
         const html = this._umdToHtml.convert([doc]);
         return html;
+    }
+
+    private async _runBeforePasteImageHooks(file: File, fallback: (file: File) => Promise<{ source: string; imageSourceType: ImageSourceType }>) {
+        for (const hook of this._clipboardHooks) {
+            const image = await hook.onBeforePasteImage?.(file);
+            if (image !== undefined) {
+                return image;
+            }
+        }
+
+        return fallback(file);
     }
 }

--- a/packages/sheets-drawing-ui/src/commands/commands/insert-image.command.ts
+++ b/packages/sheets-drawing-ui/src/commands/commands/insert-image.command.ts
@@ -51,19 +51,30 @@ export const InsertFloatImageCommand: ICommand<IInsertImageCommandParams> = {
     },
 };
 
-export const InsertCellImageCommand: ICommand = {
+export const InsertCellImageCommand: ICommand<IInsertImageCommandParams> = {
     id: 'sheet.command.insert-cell-image',
     type: CommandType.COMMAND,
-    handler: (accessor) => {
+    handler: async (accessor, params) => {
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const renderManagerService = accessor.get(IRenderManagerService);
-
-        return getCurrentTypeOfRenderer(
+        const sheetDrawingUpdateController = getCurrentTypeOfRenderer(
             UniverInstanceType.UNIVER_SHEET,
             univerInstanceService,
             renderManagerService
         )
-            ?.with(SheetDrawingUpdateController)
-            .insertCellImage() ?? false;
+            ?.with(SheetDrawingUpdateController);
+
+        if (!sheetDrawingUpdateController) {
+            return false;
+        }
+
+        const files = params?.files;
+        if (files) {
+            const awaitFiles = files.map((file) => sheetDrawingUpdateController.insertCellImageByFile(file));
+
+            return (await Promise.all(awaitFiles)).every((result) => result);
+        }
+
+        return sheetDrawingUpdateController.insertCellImage() ?? false;
     },
 };

--- a/packages/sheets-drawing-ui/src/controllers/sheet-cell-image-copy-paste.controller.ts
+++ b/packages/sheets-drawing-ui/src/controllers/sheet-cell-image-copy-paste.controller.ts
@@ -16,27 +16,69 @@
 
 import type { DocumentDataModel, IDocDrawingBase } from '@univerjs/core';
 import type { IInnerPasteCommandParams } from '@univerjs/docs-ui';
-import { BuildTextUtils, createDocumentModelWithStyle, Disposable, DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY, DOCS_NORMAL_EDITOR_UNIT_ID_KEY, DOCS_ZEN_EDITOR_UNIT_ID_KEY, ICommandService, Inject, IUniverInstanceService, LocaleService, UniverInstanceType } from '@univerjs/core';
-import { InnerPasteCommand } from '@univerjs/docs-ui';
+import { BuildTextUtils, createDocumentModelWithStyle, Disposable, DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY, DOCS_NORMAL_EDITOR_UNIT_ID_KEY, DOCS_ZEN_EDITOR_UNIT_ID_KEY, ICommandService, Inject, Injector, IUniverInstanceService, LocaleService, UniverInstanceType } from '@univerjs/core';
+import { IDocClipboardService, InnerPasteCommand } from '@univerjs/docs-ui';
 import { getCurrentTypeOfRenderer, IRenderManagerService } from '@univerjs/engine-render';
 import { EditingRenderController, SetCellEditVisibleOperation } from '@univerjs/sheets-ui';
 import { IDialogService } from '@univerjs/ui';
+import { InsertCellImageCommand } from '../commands/commands/insert-image.command';
 
 const DISABLE_UNITS = [
     DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
     DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
     DOCS_ZEN_EDITOR_UNIT_ID_KEY,
 ];
+
+let suppressFloatImagePasteUntil = 0;
+
+export function suppressFloatImagePasteOnce() {
+    suppressFloatImagePasteUntil = Date.now() + 1000;
+}
+
+export function shouldSuppressFloatImagePasteOnce() {
+    if (Date.now() > suppressFloatImagePasteUntil) {
+        return false;
+    }
+
+    suppressFloatImagePasteUntil = 0;
+    return true;
+}
+
 export class SheetCellImageCopyPasteController extends Disposable {
     constructor(
         @ICommandService private readonly _commandService: ICommandService,
         @IUniverInstanceService private readonly _univerInstanceService: IUniverInstanceService,
+        @Inject(Injector) private readonly _injector: Injector,
         @IDialogService private readonly _dialogService: IDialogService,
         @IRenderManagerService private readonly _renderManagerService: IRenderManagerService,
         @Inject(LocaleService) private readonly _localeService: LocaleService
     ) {
         super();
+        this._initDocImageUploadHook();
         this._initDocImageCopyPasteHooks();
+    }
+
+    private _initDocImageUploadHook() {
+        if (!this._injector.has(IDocClipboardService)) {
+            return;
+        }
+
+        const docClipboardService = this._injector.get(IDocClipboardService);
+        this.disposeWithMe(docClipboardService.addClipboardHook({
+            onBeforePasteImage: async (file) => {
+                const currentDoc = this._univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+                const docUnitId = currentDoc?.getUnitId();
+                if (!docUnitId || !DISABLE_UNITS.includes(docUnitId) || docUnitId === DOCS_ZEN_EDITOR_UNIT_ID_KEY) {
+                    return undefined;
+                }
+
+                suppressFloatImagePasteOnce();
+                this._commandService.syncExecuteCommand(SetCellEditVisibleOperation.id, { visible: false });
+                await this._commandService.executeCommand(InsertCellImageCommand.id, { files: [file] });
+
+                return null;
+            },
+        }));
     }
 
     private _setCellImage(drwaing: IDocDrawingBase) {

--- a/packages/sheets-drawing-ui/src/controllers/sheet-drawing-copy-paste.controller.ts
+++ b/packages/sheets-drawing-ui/src/controllers/sheet-drawing-copy-paste.controller.ts
@@ -26,12 +26,14 @@ import { attachRangeWithCoord, discreteRangeToRange, SheetSkeletonService } from
 import { DrawingApplyType, RemoveSheetDrawingCommand, SetDrawingApplyMutation, SheetDrawingAnchorType, transformToAxisAlignPosition, transformToDrawingPosition } from '@univerjs/sheets-drawing';
 import {
     COPY_TYPE,
+    IEditorBridgeService,
     ISheetClipboardService,
     PREDEFINED_HOOK_NAME_PASTE,
     virtualizeDiscreteRanges,
 } from '@univerjs/sheets-ui';
 import { IClipboardInterfaceService } from '@univerjs/ui';
 import { InsertFloatImageCommand } from '../commands/commands/insert-image.command';
+import { shouldSuppressFloatImagePasteOnce } from './sheet-cell-image-copy-paste.controller';
 
 const IMAGE_PNG_MIME_TYPE = 'image/png';
 
@@ -101,7 +103,8 @@ export class SheetsDrawingCopyPasteController extends Disposable {
         @Inject(SheetSkeletonService) private readonly _sheetSkeletonService: SheetSkeletonService,
         @IDrawingManagerService private readonly _drawingService: IDrawingManagerService,
         @IClipboardInterfaceService private readonly _clipboardInterfaceService: IClipboardInterfaceService,
-        @ICommandService private readonly _commandService: ICommandService
+        @ICommandService private readonly _commandService: ICommandService,
+        @IEditorBridgeService private readonly _editorBridgeService: IEditorBridgeService
     ) {
         super();
         this._initCopyPaste();
@@ -182,7 +185,7 @@ export class SheetsDrawingCopyPasteController extends Disposable {
                 return mutations;
             },
 
-            onPastePlainText: (pasteTo: ISheetDiscreteRangeLocation, clipText: string) => {
+            onPastePlainText: (_pasteTo: ISheetDiscreteRangeLocation, _clipText: string) => {
                 return { undos: [], redos: [] };
             },
 
@@ -195,6 +198,10 @@ export class SheetsDrawingCopyPasteController extends Disposable {
             },
 
             onPasteFiles: (pasteTo: ISheetDiscreteRangeLocation, files) => {
+                if (this._editorBridgeService.isVisible().visible || shouldSuppressFloatImagePasteOnce()) {
+                    return { undos: [], redos: [] };
+                }
+
                 if (this._copyInfo) {
                     return this._generateSingleDrawingPasteMutations({ pasteTo, pasteType: PREDEFINED_HOOK_NAME_PASTE.DEFAULT_PASTE }, COPY_TYPE.COPY);
                 } else {


### PR DESCRIPTION
## What

Fixes image paste behavior in sheet cell editing mode. When the user pastes an image while a cell editor is active, the image now follows the same path as inserting a cell image instead of being embedded into the editor content as base64.

## Why

Previously, clipboard image files pasted during cell editing were handled by the docs editor paste flow. This could embed the image as base64 inside the cell content, increasing workbook size and differing from the normal "insert cell image" behavior. In some cases the same paste could also continue through the sheet file paste hook and insert a floating image, causing duplicate insertion.

## How

- Route image files pasted in sheet editor units through `InsertCellImageCommand` with the clipboard files.
- Let `InsertCellImageCommand` accept file parameters and reuse the existing `insertCellImageByFile` upload path.
- Allow docs image paste hooks to consume an image by returning `null`, preventing base64 inline insertion.
- Suppress the floating image paste hook for the same paste event when the edit-mode cell image path has already consumed the image.
- Preserve the existing non-editing sheet paste behavior, which continues to insert floating images.

## Validation

- Ran targeted eslint on the modified files. Existing warnings remain in `packages/docs-ui/src/services/clipboard/clipboard.service.ts`; no new errors were introduced.
