### PR TITLE
feat(outline): dimension transform

### DIFF
--- a/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
+++ b/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
@@ -355,6 +355,26 @@ describe('spreadsheet integration', () => {
         skeleton.dispose();
     });
 
+    it('renders sheet content from the header plus outline margin origin', () => {
+        const { spreadsheet, skeleton, scene, cacheCanvas, mainCanvas } = fixture;
+        const mainCtx = mainCanvas.getContext() as any;
+        const translateSpy = vi.spyOn(mainCtx, 'translateWithPrecision');
+        const transformerSpy = vi.spyOn(scene, 'updateTransformerZero');
+
+        skeleton.setMarginLeft(20);
+        skeleton.setMarginTop(16);
+
+        spreadsheet.render(mainCtx, createViewportInfo(scene, cacheCanvas, {
+            isDirty: 1,
+            isForceDirty: false,
+        }));
+
+        expect(translateSpy).toHaveBeenCalledWith(66, 44);
+        expect(transformerSpy).toHaveBeenCalledWith(66, 44);
+        expect(spreadsheet.isHit(Vector2.FromArray([65, 44]))).toBe(false);
+        expect(spreadsheet.isHit(Vector2.FromArray([67, 45]))).toBe(true);
+    });
+
     it('covers spreadsheet draw helpers and utility branches', () => {
         const { spreadsheet, skeleton, scene, cacheCanvas, mainCanvas } = fixture;
         const context = mainCanvas.getContext() as any;
@@ -418,8 +438,8 @@ describe('spreadsheet integration', () => {
             leftOrigin: 0,
             bufferEdgeX: 8,
             bufferEdgeY: 6,
-            rowHeaderWidth: skeleton.rowHeaderWidth,
-            columnHeaderHeight: skeleton.columnHeaderHeight,
+            rowHeaderWidthAndMarginLeft: skeleton.rowHeaderWidthAndMarginLeft,
+            columnHeaderHeightAndMarginTop: skeleton.columnHeaderHeightAndMarginTop,
             scaleX: 1,
             scaleY: 1,
         } as any);

--- a/packages/engine-render/src/components/sheets/column-header.ts
+++ b/packages/engine-render/src/components/sheets/column-header.ts
@@ -61,8 +61,9 @@ export class SpreadsheetColumnHeader extends SpreadsheetHeader {
 
         if (segment.startColumn === -1 && segment.endColumn === -1) return;
 
-        const { rowHeaderWidth } = spreadsheetSkeleton;
-        ctx.translateWithPrecision(rowHeaderWidth, 0);
+        const { columnHeaderHeight, columnHeaderHeightAndMarginTop, rowHeaderWidthAndMarginLeft } = spreadsheetSkeleton;
+        const marginTop = columnHeaderHeightAndMarginTop - columnHeaderHeight;
+        ctx.translateWithPrecision(rowHeaderWidthAndMarginLeft, marginTop);
 
         const extensions = this.getExtensionsByOrder();
         for (const extension of extensions) {
@@ -76,8 +77,13 @@ export class SpreadsheetColumnHeader extends SpreadsheetHeader {
         if (!skeleton) {
             return false;
         }
-        const { rowHeaderWidth, columnHeaderHeight } = skeleton;
-        if (oCoord.x > rowHeaderWidth && oCoord.y >= 0 && oCoord.y <= columnHeaderHeight) {
+        const { rowHeaderWidthAndMarginLeft, columnHeaderHeight, columnHeaderHeightAndMarginTop } = skeleton;
+        const marginTop = columnHeaderHeightAndMarginTop - columnHeaderHeight;
+        if (
+            oCoord.x > rowHeaderWidthAndMarginLeft &&
+            oCoord.y >= marginTop &&
+            oCoord.y <= columnHeaderHeightAndMarginTop
+        ) {
             return true;
         }
         return false;

--- a/packages/engine-render/src/components/sheets/interfaces.ts
+++ b/packages/engine-render/src/components/sheets/interfaces.ts
@@ -101,8 +101,8 @@ export interface IPaintForScrolling {
     leftOrigin: number;
     bufferEdgeX: number;
     bufferEdgeY: number;
-    rowHeaderWidth: number;
-    columnHeaderHeight: number;
+    rowHeaderWidthAndMarginLeft: number;
+    columnHeaderHeightAndMarginTop: number;
     scaleX: number;
     scaleY: number;
 }

--- a/packages/engine-render/src/components/sheets/row-header.ts
+++ b/packages/engine-render/src/components/sheets/row-header.ts
@@ -70,11 +70,12 @@ export class SpreadsheetRowHeader extends SpreadsheetHeader {
             return;
         }
 
-        const { columnHeaderHeight } = spreadsheetSkeleton;
+        const { columnHeaderHeightAndMarginTop, rowHeaderWidth, rowHeaderWidthAndMarginLeft } = spreadsheetSkeleton;
+        const marginLeft = rowHeaderWidthAndMarginLeft - rowHeaderWidth;
 
         // const { left: fixTranslateLeft, top: fixTranslateTop } = getTranslateInSpreadContextWithPixelRatio();
 
-        ctx.translateWithPrecision(0, columnHeaderHeight);
+        ctx.translateWithPrecision(marginLeft, columnHeaderHeightAndMarginTop);
 
         const extensions = this.getExtensionsByOrder();
         for (const extension of extensions) {
@@ -88,8 +89,13 @@ export class SpreadsheetRowHeader extends SpreadsheetHeader {
         if (!skeleton) {
             return false;
         }
-        const { rowHeaderWidth, columnHeaderHeight } = skeleton;
-        if (oCoord.x >= 0 && oCoord.x <= rowHeaderWidth && oCoord.y > columnHeaderHeight) {
+        const { rowHeaderWidth, rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop } = skeleton;
+        const marginLeft = rowHeaderWidthAndMarginLeft - rowHeaderWidth;
+        if (
+            oCoord.x >= marginLeft &&
+            oCoord.x <= rowHeaderWidthAndMarginLeft &&
+            oCoord.y > columnHeaderHeightAndMarginTop
+        ) {
             return true;
         }
         return false;

--- a/packages/engine-render/src/components/sheets/spreadsheet.ts
+++ b/packages/engine-render/src/components/sheets/spreadsheet.ts
@@ -181,8 +181,8 @@ export class Spreadsheet extends SheetComponent {
         if (!skeleton) {
             return false;
         }
-        const { rowHeaderWidth, columnHeaderHeight } = skeleton;
-        if (oCoord.x > rowHeaderWidth && oCoord.y > columnHeaderHeight) {
+        const { rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop } = skeleton;
+        if (oCoord.x > rowHeaderWidthAndMarginLeft && oCoord.y > columnHeaderHeightAndMarginTop) {
             return true;
         }
         return false;
@@ -253,7 +253,7 @@ export class Spreadsheet extends SheetComponent {
 
     renderByViewports(mainCtx: UniverRenderingContext2D, viewportInfo: IViewportInfo, spreadsheetSkeleton: SpreadsheetSkeleton) {
         const { diffBounds, diffX, diffY, viewPortPosition, cacheCanvas, leftOrigin, topOrigin, bufferEdgeX, bufferEdgeY, isDirty: isViewportDirty, isForceDirty: isViewportForceDirty } = viewportInfo as Required<IViewportInfo>;
-        const { rowHeaderWidth, columnHeaderHeight } = spreadsheetSkeleton;
+        const { rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop } = spreadsheetSkeleton;
         const { a: scaleX = 1, d: scaleY = 1 } = mainCtx.getTransform();
         const bufferEdgeSizeX = bufferEdgeX * scaleX / window.devicePixelRatio;
         const bufferEdgeSizeY = bufferEdgeY * scaleY / window.devicePixelRatio;
@@ -281,22 +281,22 @@ export class Spreadsheet extends SheetComponent {
                 bufferEdgeY,
                 scaleX,
                 scaleY,
-                columnHeaderHeight,
-                rowHeaderWidth,
+                columnHeaderHeightAndMarginTop,
+                rowHeaderWidthAndMarginLeft,
             });
         }
         // support for browser native zoom (only windows has this problem)
         const sourceLeft = bufferEdgeSizeX * Math.min(1, window.devicePixelRatio);
         const sourceTop = bufferEdgeSizeY * Math.min(1, window.devicePixelRatio);
         const { left, top, right, bottom } = viewPortPosition;
-        const dw = right - left + rowHeaderWidth;
-        const dh = bottom - top + columnHeaderHeight;
+        const dw = right - left + rowHeaderWidthAndMarginLeft;
+        const dh = bottom - top + columnHeaderHeightAndMarginTop;
         this._applyCache(cacheCanvas, mainCtx, sourceLeft, sourceTop, dw, dh, left, top, dw, dh);
         cacheCtx.restore();
     }
 
     paintNewAreaForScrolling(viewportInfo: IViewportInfo, param: IPaintForScrolling) {
-        const { cacheCanvas, cacheCtx, mainCtx, topOrigin, leftOrigin, bufferEdgeX, bufferEdgeY, scaleX, scaleY, columnHeaderHeight, rowHeaderWidth } = param;
+        const { cacheCanvas, cacheCtx, mainCtx, topOrigin, leftOrigin, bufferEdgeX, bufferEdgeY, scaleX, scaleY, columnHeaderHeightAndMarginTop, rowHeaderWidthAndMarginLeft } = param;
         const { shouldCacheUpdate, diffCacheBounds, diffX, diffY } = viewportInfo;
         cacheCtx.save();
         cacheCtx.setTransform(1, 0, 0, 1, 0, 0);
@@ -320,8 +320,8 @@ export class Spreadsheet extends SheetComponent {
 
                 // When this.draw, ctx.translate cell offset is relative to spreadsheet content
                 // But diffBounds includes rowHeader columnWidth, so the offset of row header and column header needs to be subtracted before drawing
-                const x = diffLeft - rowHeaderWidth;
-                const y = diffTop - columnHeaderHeight;
+                const x = diffLeft - rowHeaderWidthAndMarginLeft;
+                const y = diffTop - columnHeaderHeightAndMarginTop;
                 const w = diffRight - diffLeft;
                 const h = diffBottom - diffTop; // w and h must exactly match the diffarea size, otherwise when scrolling back, the clear area will be too large, causing valid content from the previous frame to be erased
 
@@ -399,10 +399,10 @@ export class Spreadsheet extends SheetComponent {
 
         mainCtx.save();
 
-        const { rowHeaderWidth, columnHeaderHeight } = spreadsheetSkeleton;
-        mainCtx.translateWithPrecision(rowHeaderWidth, columnHeaderHeight);
+        const { rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop } = spreadsheetSkeleton;
+        mainCtx.translateWithPrecision(rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop);
 
-        this.getScene()?.updateTransformerZero(spreadsheetSkeleton.rowHeaderWidth, spreadsheetSkeleton.columnHeaderHeight);
+        this.getScene()?.updateTransformerZero(rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop);
 
         const { viewportKey } = viewportInfo;
         // scene --> layer, getObjects --> viewport.render(object) --> spreadsheet

--- a/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-menu.render-controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-menu.render-controller.spec.ts
@@ -21,7 +21,7 @@ import { HeaderMenuRenderController } from '../header-menu.render-controller';
 import { createRenderTestBed, createTestEvent } from './render-test-bed';
 
 describe('HeaderMenuRenderController', () => {
-    it('positions the column menu arrow in the base column header area when outline gutter expands headers', () => {
+    it('positions the column menu arrow in the base column header area when outline uses margins', () => {
         const testBed = createRenderTestBed({
             dependencies: [
                 [IContextMenuService, { useValue: { triggerContextMenu: vi.fn() } }],
@@ -29,7 +29,8 @@ describe('HeaderMenuRenderController', () => {
         });
         const { context, injector, skeleton } = testBed;
 
-        skeleton.columnHeaderHeight = 60;
+        skeleton.columnHeaderHeight = 20;
+        skeleton.columnHeaderHeightAndMarginTop = 60;
         (skeleton.worksheet as any).getConfig = () => ({
             columnHeader: { height: 20 },
         });

--- a/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-resize.render-controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-resize.render-controller.spec.ts
@@ -55,12 +55,14 @@ describe('HeaderResizeRenderController', () => {
         testBed.univer.dispose();
     });
 
-    it('positions resize handles in the base header area when outline gutter expands headers', () => {
+    it('positions resize handles in the base header area when outline uses margins', () => {
         const testBed = createRenderTestBed();
         const { context, injector, skeleton } = testBed;
 
-        skeleton.rowHeaderWidth = 86;
-        skeleton.columnHeaderHeight = 60;
+        skeleton.rowHeaderWidth = 46;
+        skeleton.columnHeaderHeight = 20;
+        skeleton.rowHeaderWidthAndMarginLeft = 86;
+        skeleton.columnHeaderHeightAndMarginTop = 60;
         (skeleton.worksheet as any).getConfig = () => ({
             rowHeader: { width: 46 },
             columnHeader: { height: 20 },

--- a/packages/sheets-ui/src/controllers/render-controllers/__tests__/render-test-bed.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/__tests__/render-test-bed.ts
@@ -67,6 +67,8 @@ export interface IFakeViewport {
     transScroll2ViewportScrollValue(viewportScrollX: number, viewportScrollY: number): { x: number; y: number };
     enable(): void;
     disable(): void;
+    setMargin(marginLeft: number, marginTop: number): void;
+    setViewportSize(params: Partial<{ left: number; top: number; width: number; height: number }>): void;
     setPadding(padding: { startX: number; endX: number; startY: number; endY: number }): void;
     resetPadding(): void;
     resizeWhenFreezeChange(params: { left?: number; top?: number; right?: number; bottom?: number; width?: number; height?: number }): void;
@@ -118,6 +120,13 @@ export function createFakeViewport(viewportKey: string, options?: Partial<IFakeV
         disable: () => {
             viewport.isActive = false;
         },
+        setMargin: () => { },
+        setViewportSize: ({ left, top, width, height }) => {
+            if (typeof left === 'number') viewport.left = left;
+            if (typeof top === 'number') viewport.top = top;
+            if (typeof width === 'number') viewport.width = width;
+            if (typeof height === 'number') viewport.height = height;
+        },
         setPadding: (padding) => {
             viewport.padding = padding;
         },
@@ -155,6 +164,7 @@ export interface IFakeScene {
     enableLayerCache(...layers: number[]): void;
     makeDirty(dirty: boolean): void;
     getViewport(key: unknown): IFakeViewport | null;
+    getMainViewport(): IFakeViewport;
     getViewports(): IFakeViewport[];
     getActiveViewportByCoord(_coord: Vector2): IFakeViewport | null;
     findViewportByPosToScene(_coord: Vector2): IFakeViewport | null;
@@ -210,6 +220,7 @@ export function createFakeScene(
         enableLayerCache: () => { },
         makeDirty: () => { },
         getViewport: (key) => viewportMap.get(key) ?? null,
+        getMainViewport: () => viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_MAIN)!,
         getViewports: () => Array.from(viewportMap.values()),
         getActiveViewportByCoord: () => viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_MAIN) ?? null,
         findViewportByPosToScene: () => viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_MAIN) ?? null,

--- a/packages/sheets-ui/src/controllers/render-controllers/__tests__/skeleton.render-controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/__tests__/skeleton.render-controller.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SHEET_VIEWPORT_KEY } from '@univerjs/engine-render';
+import { describe, expect, it } from 'vitest';
+import { SheetSkeletonRenderController } from '../skeleton.render-controller';
+import { createRenderTestBed } from './render-test-bed';
+
+describe('SheetSkeletonRenderController', () => {
+    it('syncs viewport geometry from skeleton margins', () => {
+        const testBed = createRenderTestBed();
+        const { context, injector, skeleton, sheetSkeletonManagerService, viewportMap } = testBed;
+
+        skeleton.rowHeaderWidth = 46;
+        skeleton.columnHeaderHeight = 20;
+        skeleton.rowHeaderWidthAndMarginLeft = 86;
+        skeleton.columnHeaderHeightAndMarginTop = 60;
+
+        injector.createInstance(SheetSkeletonRenderController, context as any);
+        sheetSkeletonManagerService.emitCurrentSkeleton({ skeleton });
+
+        expect(viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_MAIN)?.left).toBe(86);
+        expect(viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_MAIN)?.top).toBe(60);
+        expect(viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_LEFT_TOP)?.width).toBe(86);
+        expect(viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_LEFT_TOP)?.height).toBe(60);
+        expect(viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_COLUMN_RIGHT)?.left).toBe(86);
+        expect(viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_COLUMN_RIGHT)?.height).toBe(60);
+        expect(viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_ROW_BOTTOM)?.width).toBe(86);
+        expect(viewportMap.get(SHEET_VIEWPORT_KEY.VIEW_ROW_BOTTOM)?.top).toBe(60);
+
+        testBed.univer.dispose();
+    });
+});

--- a/packages/sheets-ui/src/controllers/render-controllers/header-menu.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/header-menu.render-controller.ts
@@ -45,15 +45,11 @@ enum HEADER_HOVER_TYPE {
 }
 
 interface IHeaderBaseLayout {
+    rowBaseWidth: number;
+    rowGutterWidth: number;
     columnBaseHeight: number;
     columnGutterHeight: number;
 }
-
-interface IOutlineHeaderBaseSize {
-    columnHeaderHeight?: number;
-}
-
-const OUTLINE_HEADER_BASE_SIZE_KEY = '__univerSheetsOutlineHeaderBaseSize';
 
 /**
  * header highlight
@@ -140,8 +136,7 @@ export class HeaderMenuRenderController extends Disposable implements IRenderMod
                 return;
             }
 
-            const { rowHeaderWidth } = skeleton;
-            const { columnBaseHeight, columnGutterHeight } = getHeaderBaseLayout(skeleton);
+            const { rowBaseWidth, rowGutterWidth, columnBaseHeight, columnGutterHeight } = getHeaderBaseLayout(skeleton);
 
             const { startX, startY, endX, endY, column } = getCoordByOffset(
                 evt.offsetX,
@@ -152,9 +147,9 @@ export class HeaderMenuRenderController extends Disposable implements IRenderMod
 
             if (initialType === HEADER_HOVER_TYPE.ROW) {
                 this._hoverRect?.transformByState({
-                    width: rowHeaderWidth,
+                    width: rowBaseWidth,
                     height: endY - startY,
-                    left: 0,
+                    left: rowGutterWidth,
                     top: startY,
                 });
             } else {
@@ -313,26 +308,26 @@ export class HeaderMenuRenderController extends Disposable implements IRenderMod
 }
 
 function getHeaderBaseLayout(skeleton: {
+    rowHeaderWidth: number;
+    rowHeaderWidthAndMarginLeft: number;
     columnHeaderHeight: number;
-    worksheet: { getConfig?: () => { columnHeader?: { height?: number } } };
+    columnHeaderHeightAndMarginTop: number;
+    worksheet: { getConfig?: () => { rowHeader?: { width?: number }; columnHeader?: { height?: number } } };
 }): IHeaderBaseLayout {
     const config = skeleton.worksheet.getConfig?.();
-    const outlineBaseSize = getOutlineHeaderBaseSize(config);
-    const configuredColumnHeight = outlineBaseSize?.columnHeaderHeight ?? config?.columnHeader?.height;
+    const configuredRowWidth = config?.rowHeader?.width;
+    const configuredColumnHeight = config?.columnHeader?.height;
+    const rowBaseWidth = typeof configuredRowWidth === 'number' && configuredRowWidth > 0
+        ? Math.min(configuredRowWidth, skeleton.rowHeaderWidth)
+        : skeleton.rowHeaderWidth;
     const columnBaseHeight = typeof configuredColumnHeight === 'number' && configuredColumnHeight > 0
         ? Math.min(configuredColumnHeight, skeleton.columnHeaderHeight)
         : skeleton.columnHeaderHeight;
 
     return {
+        rowBaseWidth,
+        rowGutterWidth: Math.max(0, skeleton.rowHeaderWidthAndMarginLeft - rowBaseWidth),
         columnBaseHeight,
-        columnGutterHeight: Math.max(0, skeleton.columnHeaderHeight - columnBaseHeight),
+        columnGutterHeight: Math.max(0, skeleton.columnHeaderHeightAndMarginTop - columnBaseHeight),
     };
-}
-
-function getOutlineHeaderBaseSize(config: unknown): IOutlineHeaderBaseSize | undefined {
-    if (!config || typeof config !== 'object') {
-        return undefined;
-    }
-
-    return (config as Record<string, IOutlineHeaderBaseSize | undefined>)[OUTLINE_HEADER_BASE_SIZE_KEY];
 }

--- a/packages/sheets-ui/src/controllers/render-controllers/header-menu.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/header-menu.render-controller.ts
@@ -49,6 +49,12 @@ interface IHeaderBaseLayout {
     columnGutterHeight: number;
 }
 
+interface IOutlineHeaderBaseSize {
+    columnHeaderHeight?: number;
+}
+
+const OUTLINE_HEADER_BASE_SIZE_KEY = '__univerSheetsOutlineHeaderBaseSize';
+
 /**
  * header highlight
  * column menu: show, hover and mousedown event
@@ -310,7 +316,9 @@ function getHeaderBaseLayout(skeleton: {
     columnHeaderHeight: number;
     worksheet: { getConfig?: () => { columnHeader?: { height?: number } } };
 }): IHeaderBaseLayout {
-    const configuredColumnHeight = skeleton.worksheet.getConfig?.()?.columnHeader?.height;
+    const config = skeleton.worksheet.getConfig?.();
+    const outlineBaseSize = getOutlineHeaderBaseSize(config);
+    const configuredColumnHeight = outlineBaseSize?.columnHeaderHeight ?? config?.columnHeader?.height;
     const columnBaseHeight = typeof configuredColumnHeight === 'number' && configuredColumnHeight > 0
         ? Math.min(configuredColumnHeight, skeleton.columnHeaderHeight)
         : skeleton.columnHeaderHeight;
@@ -319,4 +327,12 @@ function getHeaderBaseLayout(skeleton: {
         columnBaseHeight,
         columnGutterHeight: Math.max(0, skeleton.columnHeaderHeight - columnBaseHeight),
     };
+}
+
+function getOutlineHeaderBaseSize(config: unknown): IOutlineHeaderBaseSize | undefined {
+    if (!config || typeof config !== 'object') {
+        return undefined;
+    }
+
+    return (config as Record<string, IOutlineHeaderBaseSize | undefined>)[OUTLINE_HEADER_BASE_SIZE_KEY];
 }

--- a/packages/sheets-ui/src/controllers/render-controllers/header-resize.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/header-resize.render-controller.ts
@@ -79,13 +79,6 @@ interface IHeaderBaseLayout {
     columnGutterHeight: number;
 }
 
-interface IOutlineHeaderBaseSize {
-    rowHeaderWidth?: number;
-    columnHeaderHeight?: number;
-}
-
-const OUTLINE_HEADER_BASE_SIZE_KEY = '__univerSheetsOutlineHeaderBaseSize';
-
 export class HeaderResizeRenderController extends Disposable implements IRenderModule {
     private _currentRow: number = 0;
 
@@ -356,15 +349,15 @@ export class HeaderResizeRenderController extends Disposable implements IRenderM
                 let moveChangeX = 0;
                 let moveChangeY = 0;
 
-                const { columnTotalWidth, rowHeaderWidth, rowTotalHeight, columnHeaderHeight } = skeleton;
+                const { columnTotalWidth, rowHeaderWidthAndMarginLeft, rowTotalHeight, columnHeaderHeightAndMarginTop } = skeleton;
 
-                const shapeWidth = canvasMaxWidth > columnTotalWidth + rowHeaderWidth
+                const shapeWidth = canvasMaxWidth > columnTotalWidth + rowHeaderWidthAndMarginLeft
                     ? canvasMaxWidth
-                    : columnTotalWidth + rowHeaderWidth;
+                    : columnTotalWidth + rowHeaderWidthAndMarginLeft;
 
-                const shapeHeight = canvasMaxHeight > rowTotalHeight + columnHeaderHeight
+                const shapeHeight = canvasMaxHeight > rowTotalHeight + columnHeaderHeightAndMarginTop
                     ? canvasMaxHeight
-                    : rowTotalHeight + columnHeaderHeight;
+                    : rowTotalHeight + columnHeaderHeightAndMarginTop;
 
                 const scale = Math.max(scaleX, scaleY);
 
@@ -578,13 +571,14 @@ export class HeaderResizeRenderController extends Disposable implements IRenderM
 
 function getHeaderBaseLayout(skeleton: {
     rowHeaderWidth: number;
+    rowHeaderWidthAndMarginLeft: number;
     columnHeaderHeight: number;
+    columnHeaderHeightAndMarginTop: number;
     worksheet: { getConfig?: () => { rowHeader?: { width?: number }; columnHeader?: { height?: number } } };
 }): IHeaderBaseLayout {
     const config = skeleton.worksheet.getConfig?.();
-    const outlineBaseSize = getOutlineHeaderBaseSize(config);
-    const configuredRowWidth = outlineBaseSize?.rowHeaderWidth ?? config?.rowHeader?.width;
-    const configuredColumnHeight = outlineBaseSize?.columnHeaderHeight ?? config?.columnHeader?.height;
+    const configuredRowWidth = config?.rowHeader?.width;
+    const configuredColumnHeight = config?.columnHeader?.height;
     const rowBaseWidth = typeof configuredRowWidth === 'number' && configuredRowWidth > 0
         ? Math.min(configuredRowWidth, skeleton.rowHeaderWidth)
         : skeleton.rowHeaderWidth;
@@ -594,16 +588,8 @@ function getHeaderBaseLayout(skeleton: {
 
     return {
         rowBaseWidth,
-        rowGutterWidth: Math.max(0, skeleton.rowHeaderWidth - rowBaseWidth),
+        rowGutterWidth: Math.max(0, skeleton.rowHeaderWidthAndMarginLeft - rowBaseWidth),
         columnBaseHeight,
-        columnGutterHeight: Math.max(0, skeleton.columnHeaderHeight - columnBaseHeight),
+        columnGutterHeight: Math.max(0, skeleton.columnHeaderHeightAndMarginTop - columnBaseHeight),
     };
-}
-
-function getOutlineHeaderBaseSize(config: unknown): IOutlineHeaderBaseSize | undefined {
-    if (!config || typeof config !== 'object') {
-        return undefined;
-    }
-
-    return (config as Record<string, IOutlineHeaderBaseSize | undefined>)[OUTLINE_HEADER_BASE_SIZE_KEY];
 }

--- a/packages/sheets-ui/src/controllers/render-controllers/header-resize.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/header-resize.render-controller.ts
@@ -79,6 +79,13 @@ interface IHeaderBaseLayout {
     columnGutterHeight: number;
 }
 
+interface IOutlineHeaderBaseSize {
+    rowHeaderWidth?: number;
+    columnHeaderHeight?: number;
+}
+
+const OUTLINE_HEADER_BASE_SIZE_KEY = '__univerSheetsOutlineHeaderBaseSize';
+
 export class HeaderResizeRenderController extends Disposable implements IRenderModule {
     private _currentRow: number = 0;
 
@@ -575,8 +582,9 @@ function getHeaderBaseLayout(skeleton: {
     worksheet: { getConfig?: () => { rowHeader?: { width?: number }; columnHeader?: { height?: number } } };
 }): IHeaderBaseLayout {
     const config = skeleton.worksheet.getConfig?.();
-    const configuredRowWidth = config?.rowHeader?.width;
-    const configuredColumnHeight = config?.columnHeader?.height;
+    const outlineBaseSize = getOutlineHeaderBaseSize(config);
+    const configuredRowWidth = outlineBaseSize?.rowHeaderWidth ?? config?.rowHeader?.width;
+    const configuredColumnHeight = outlineBaseSize?.columnHeaderHeight ?? config?.columnHeader?.height;
     const rowBaseWidth = typeof configuredRowWidth === 'number' && configuredRowWidth > 0
         ? Math.min(configuredRowWidth, skeleton.rowHeaderWidth)
         : skeleton.rowHeaderWidth;
@@ -590,4 +598,12 @@ function getHeaderBaseLayout(skeleton: {
         columnBaseHeight,
         columnGutterHeight: Math.max(0, skeleton.columnHeaderHeight - columnBaseHeight),
     };
+}
+
+function getOutlineHeaderBaseSize(config: unknown): IOutlineHeaderBaseSize | undefined {
+    if (!config || typeof config !== 'object') {
+        return undefined;
+    }
+
+    return (config as Record<string, IOutlineHeaderBaseSize | undefined>)[OUTLINE_HEADER_BASE_SIZE_KEY];
 }

--- a/packages/sheets-ui/src/controllers/render-controllers/skeleton.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/skeleton.render-controller.ts
@@ -18,7 +18,7 @@ import type { Nullable, Workbook } from '@univerjs/core';
 import type { IRenderContext, IRenderModule } from '@univerjs/engine-render';
 import type { ISheetSkeletonManagerParam } from '@univerjs/sheets';
 import { Disposable, Inject } from '@univerjs/core';
-import { IRenderManagerService } from '@univerjs/engine-render';
+import { IRenderManagerService, SHEET_VIEWPORT_KEY } from '@univerjs/engine-render';
 import { SheetSkeletonManagerService } from '../../services/sheet-skeleton-manager.service';
 
 export class SheetSkeletonRenderController extends Disposable implements IRenderModule {
@@ -60,5 +60,29 @@ export class SheetSkeletonRenderController extends Disposable implements IRender
             height: columnHeaderHeightAndMarginTop + rowTotalHeight,
         });
         scene.getMainViewport().setMargin(rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop);
+        scene.getMainViewport().setViewportSize({
+            left: rowHeaderWidthAndMarginLeft,
+            top: columnHeaderHeightAndMarginTop,
+        });
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_LEFT)?.setViewportSize({
+            left: rowHeaderWidthAndMarginLeft,
+            height: columnHeaderHeightAndMarginTop,
+        });
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_RIGHT)?.setViewportSize({
+            left: rowHeaderWidthAndMarginLeft,
+            height: columnHeaderHeightAndMarginTop,
+        });
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_ROW_BOTTOM)?.setViewportSize({
+            width: rowHeaderWidthAndMarginLeft,
+            top: columnHeaderHeightAndMarginTop,
+        });
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_ROW_TOP)?.setViewportSize({
+            width: rowHeaderWidthAndMarginLeft,
+            top: columnHeaderHeightAndMarginTop,
+        });
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_LEFT_TOP)?.setViewportSize({
+            width: rowHeaderWidthAndMarginLeft,
+            height: columnHeaderHeightAndMarginTop,
+        });
     }
 }

--- a/packages/sheets-ui/src/controllers/render-controllers/skeleton.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/skeleton.render-controller.ts
@@ -60,27 +60,27 @@ export class SheetSkeletonRenderController extends Disposable implements IRender
             height: columnHeaderHeightAndMarginTop + rowTotalHeight,
         });
         scene.getMainViewport().setMargin(rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop);
-        scene.getMainViewport().setViewportSize({
+        scene.getMainViewport().resizeWhenFreezeChange({
             left: rowHeaderWidthAndMarginLeft,
             top: columnHeaderHeightAndMarginTop,
         });
-        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_LEFT)?.setViewportSize({
-            left: rowHeaderWidthAndMarginLeft,
-            height: columnHeaderHeightAndMarginTop,
-        });
-        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_RIGHT)?.setViewportSize({
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_LEFT)?.resizeWhenFreezeChange({
             left: rowHeaderWidthAndMarginLeft,
             height: columnHeaderHeightAndMarginTop,
         });
-        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_ROW_BOTTOM)?.setViewportSize({
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_COLUMN_RIGHT)?.resizeWhenFreezeChange({
+            left: rowHeaderWidthAndMarginLeft,
+            height: columnHeaderHeightAndMarginTop,
+        });
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_ROW_BOTTOM)?.resizeWhenFreezeChange({
             width: rowHeaderWidthAndMarginLeft,
             top: columnHeaderHeightAndMarginTop,
         });
-        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_ROW_TOP)?.setViewportSize({
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_ROW_TOP)?.resizeWhenFreezeChange({
             width: rowHeaderWidthAndMarginLeft,
             top: columnHeaderHeightAndMarginTop,
         });
-        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_LEFT_TOP)?.setViewportSize({
+        scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_LEFT_TOP)?.resizeWhenFreezeChange({
             width: rowHeaderWidthAndMarginLeft,
             height: columnHeaderHeightAndMarginTop,
         });


### PR DESCRIPTION
## Description

This PR adds outline-aware rendering support for sheet row/column headers.

When dimension outline groups are displayed, the outline gutter should extend the visual sheet header area without changing the configured row header width or column header height. This PR separates the configured header size from the outline gutter size, then makes the render pipeline consume the combined header + gutter origin consistently.

## Changes

- Keep the configured row header width and column header height as the base header size.
- Store outline gutter size in the skeleton margin, so `rowHeaderWidthAndMarginLeft` and `columnHeaderHeightAndMarginTop` represent the full visual header area.
- Update row/column header rendering and hit testing to account for the outline gutter while keeping header controls aligned to the base header area.
- Sync scene and viewport geometry from skeleton margins, including main viewport, header viewports, and left-top viewport.
- Use `resizeWhenFreezeChange` when syncing viewport geometry so cache canvas and scrollbar positions are recalculated after skeleton or sheet tab changes.
- Update spreadsheet content rendering, cache redraw, incremental scroll rendering, hit testing, and transformer origin to use the outline-aware content origin.
- Add tests for:
  - outline-aware header resize/menu positioning
  - skeleton margin to viewport geometry sync
  - spreadsheet content render origin with outline margins
  
## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description, or there is no related issue.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes introduced in this PR.

## Testing

- `pnpm --filter @univerjs/engine-render test -- src/components/sheets/__tests__/spreadsheet.integration.spec.ts --runInBand`
- `pnpm --filter @univerjs/sheets-ui test -- src/controllers/render-controllers/__tests__/skeleton.render-controller.spec.ts --runInBand`
- `pnpm --filter @univerjs/sheets-ui test -- --runInBand`