### PR TITLE
fix(sheet): outline header overlays

### DIFF
--- a/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-unhide.render-controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-unhide.render-controller.spec.ts
@@ -52,6 +52,32 @@ describe('HeaderUnhideRenderController', () => {
         testBed.univer.dispose();
     });
 
+    it('keeps hidden column icons at the bottom of column headers when outline adds top padding', () => {
+        const testBed = createRenderTestBed();
+        const { context, injector, sheet, sheetSkeletonManagerService, skeleton } = testBed;
+        const worksheet = sheet.getActiveSheet()!;
+
+        skeleton.columnHeaderHeight = 20;
+        skeleton.columnHeaderHeightAndMarginTop = 60;
+        vi.spyOn(worksheet, 'getHiddenRows').mockReturnValue([]);
+        vi.spyOn(worksheet, 'getHiddenCols').mockReturnValue([
+            { startColumn: 6, endColumn: 6, startRow: 0, endRow: 0 },
+        ]);
+
+        const controller = injector.createInstance(HeaderUnhideRenderController, context as any);
+
+        sheetSkeletonManagerService.emitCurrentSkeleton({
+            unitId: sheet.getUnitId(),
+            sheetId: worksheet.getSheetId(),
+        });
+
+        const shapes = (controller as any)._shapes;
+        expect(shapes.cols).toHaveLength(1);
+        expect(shapes.cols[0].top).toBe(60 - 12);
+
+        testBed.univer.dispose();
+    });
+
     it('filters hidden row ranges through the shared unhide range service', () => {
         const testBed = createRenderTestBed();
         const { context, injector, sheet, sheetSkeletonManagerService, skeleton } = testBed;

--- a/packages/sheets-ui/src/controllers/render-controllers/__tests__/sheet.render-controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/__tests__/sheet.render-controller.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getLeftTopPlaceholderSize } from '../sheet.render-controller';
+
+describe('SheetRenderController', () => {
+    it('sizes the select-all placeholder from header margins', () => {
+        expect(getLeftTopPlaceholderSize({
+            rowHeaderWidth: 46,
+            columnHeaderHeight: 20,
+            rowHeaderWidthAndMarginLeft: 86,
+            columnHeaderHeightAndMarginTop: 60,
+        })).toEqual({
+            width: 86,
+            height: 60,
+        });
+    });
+});

--- a/packages/sheets-ui/src/controllers/render-controllers/header-unhide.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/header-unhide.render-controller.ts
@@ -167,7 +167,7 @@ export class HeaderUnhideRenderController extends RxDisposable {
                     hovered: false,
                     hasPrevious,
                     hasNext,
-                    top: skeleton.columnHeaderHeight - UNHIDE_ICON_SIZE,
+                    top: Math.max(skeleton.columnHeaderHeight, skeleton.columnHeaderHeightAndMarginTop) - UNHIDE_ICON_SIZE,
                     left: position.startX - (hasPrevious ? UNHIDE_ICON_SIZE : 0),
                 },
                 () => this._commandService.executeCommand<ISetSpecificColsVisibleCommandParams>(

--- a/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/sheet.render-controller.ts
@@ -379,13 +379,13 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
             const spreadsheetColumnHeader = components.get(SHEET_VIEW_KEY.COLUMN) as SpreadsheetColumnHeader;
             const spreadsheetLeftTopPlaceholder = components.get(SHEET_VIEW_KEY.LEFT_TOP) as Rect;
 
-            const { rowHeaderWidth, columnHeaderHeight } = spreadsheetSkeleton;
+            const leftTopPlaceholderSize = getLeftTopPlaceholderSize(spreadsheetSkeleton);
             spreadsheet?.updateSkeleton(spreadsheetSkeleton);
             spreadsheetRowHeader?.updateSkeleton(spreadsheetSkeleton);
             spreadsheetColumnHeader?.updateSkeleton(spreadsheetSkeleton);
             spreadsheetLeftTopPlaceholder?.transformByState({
-                width: rowHeaderWidth,
-                height: columnHeaderHeight,
+                width: leftTopPlaceholderSize.width,
+                height: leftTopPlaceholderSize.height,
             });
 
             // no need to update freezelineRect, freeze render controller has handled.
@@ -566,4 +566,16 @@ export class SheetRenderController extends RxDisposable implements IRenderModule
     private _spreadsheetViewports(scene: Scene) {
         return scene.getViewports().filter((v) => ['viewMain', 'viewMainLeftTop', 'viewMainTop', 'viewMainLeft'].includes(v.viewportKey));
     }
+}
+
+export function getLeftTopPlaceholderSize(skeleton: {
+    rowHeaderWidth: number;
+    columnHeaderHeight: number;
+    rowHeaderWidthAndMarginLeft?: number;
+    columnHeaderHeightAndMarginTop?: number;
+}): { width: number; height: number } {
+    return {
+        width: skeleton.rowHeaderWidthAndMarginLeft ?? skeleton.rowHeaderWidth,
+        height: skeleton.columnHeaderHeightAndMarginTop ?? skeleton.columnHeaderHeight,
+    };
 }

--- a/packages/sheets-ui/src/services/selection/__tests__/selection-control.spec.ts
+++ b/packages/sheets-ui/src/services/selection/__tests__/selection-control.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import type { ThemeService } from '@univerjs/core';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { SelectionControl } from '../selection-control';
 
 function createFakeScene() {
@@ -34,6 +34,13 @@ function createFakeThemeService() {
 }
 
 describe('SelectionControl', () => {
+    beforeAll(() => {
+        vi.stubGlobal('window', {
+            cancelAnimationFrame: vi.fn(),
+            requestAnimationFrame: vi.fn(() => 1),
+        });
+    });
+
     it('updates range and shows/hides autofill based on primary', () => {
         const scene = createFakeScene();
         const themeService = createFakeThemeService();
@@ -85,5 +92,39 @@ describe('SelectionControl', () => {
         expect(control.fillControl.visible).toBe(true);
 
         // Avoid disposing here: engine-render shapes expect a real Scene tree.
+    });
+
+    it('keeps header highlights aligned with outline header padding', () => {
+        const scene = createFakeScene();
+        const themeService = createFakeThemeService();
+        const control = new SelectionControl(scene, 1, themeService, {
+            rowHeaderWidth: 46,
+            columnHeaderHeight: 20,
+        });
+
+        control.updateRangeBySelectionWithCoord({
+            rangeWithCoord: {
+                startRow: 3,
+                endRow: 5,
+                startColumn: 1,
+                endColumn: 2,
+                startX: 126,
+                startY: 108,
+                endX: 246,
+                endY: 168,
+            },
+            primaryWithCoord: null,
+            style: null,
+        }, {
+            rowHeaderWidth: 46,
+            rowHeaderWidthAndMarginLeft: 86,
+            columnHeaderHeight: 20,
+            columnHeaderHeightAndMarginTop: 60,
+        } as any);
+
+        expect((control as any)._rowHeaderGroup.left).toBe(40);
+        expect((control as any)._rowHeaderGroup.top).toBe(108);
+        expect((control as any)._columnHeaderGroup.left).toBe(126);
+        expect((control as any)._columnHeaderGroup.top).toBe(40);
     });
 });

--- a/packages/sheets-ui/src/services/selection/base-selection-render.service.ts
+++ b/packages/sheets-ui/src/services/selection/base-selection-render.service.ts
@@ -240,11 +240,18 @@ export class BaseSelectionRenderService extends Disposable implements ISheetSele
 
     newSelectionControl(scene: Scene, skeleton: SpreadsheetSkeleton, selection: ISelectionWithStyle): SelectionControl {
         const zIndex = this.getSelectionControls().length;
-        const { rowHeaderWidth, columnHeaderHeight } = skeleton;
+        const {
+            rowHeaderWidth,
+            rowHeaderWidthAndMarginLeft,
+            columnHeaderHeight,
+            columnHeaderHeightAndMarginTop,
+        } = skeleton;
         const control = new SelectionControl(scene, zIndex, this._selectionTheme, {
             highlightHeader: this._highlightHeader,
             rowHeaderWidth,
             columnHeaderHeight,
+            rowHeaderOffsetX: Math.max(0, rowHeaderWidthAndMarginLeft - rowHeaderWidth),
+            columnHeaderOffsetY: Math.max(0, columnHeaderHeightAndMarginTop - columnHeaderHeight),
         });
         this._selectionControls.push(control);
         const selectionWithCoord = attachSelectionWithCoord(selection, skeleton);

--- a/packages/sheets-ui/src/services/selection/mobile-selection-render.service.ts
+++ b/packages/sheets-ui/src/services/selection/mobile-selection-render.service.ts
@@ -386,16 +386,23 @@ export class MobileSheetsSelectionRenderService extends BaseSelectionRenderServi
      */
     override newSelectionControl(scene: Scene, skeleton: SpreadsheetSkeleton, selection: ISelectionWithStyle): MobileSelectionControl {
         const selectionControls = this.getSelectionControls();
-        const { rowHeaderWidth, columnHeaderHeight } = skeleton;
+        const {
+            rowHeaderWidth,
+            rowHeaderWidthAndMarginLeft,
+            columnHeaderHeight,
+            columnHeaderHeightAndMarginTop,
+        } = skeleton;
         const rangeType = selection.range.rangeType;
         const control = new MobileSelectionControl(scene, selectionControls.length, this._themeService, {
             highlightHeader: this._highlightHeader,
             rowHeaderWidth,
             columnHeaderHeight,
+            rowHeaderOffsetX: Math.max(0, rowHeaderWidthAndMarginLeft - rowHeaderWidth),
+            columnHeaderOffsetY: Math.max(0, columnHeaderHeightAndMarginTop - columnHeaderHeight),
             rangeType,
         });
         const selectionWithCoord = attachSelectionWithCoord(selection, skeleton);
-        control.updateRangeBySelectionWithCoord(selectionWithCoord);
+        control.updateRangeBySelectionWithCoord(selectionWithCoord, skeleton);
         this._selectionControls.push(control);
 
         const { expandingModeForTopLeft, expandingModeForBottomRight } = (() => {

--- a/packages/sheets-ui/src/services/selection/mobile-selection-shape.ts
+++ b/packages/sheets-ui/src/services/selection/mobile-selection-shape.ts
@@ -44,6 +44,8 @@ export class MobileSelectionControl extends SelectionControl {
             enableAutoFill?: boolean;
             rowHeaderWidth: number;
             columnHeaderHeight: number;
+            rowHeaderOffsetX?: number;
+            columnHeaderOffsetY?: number;
             rangeType?: RANGE_TYPE;
         }
     ) {

--- a/packages/sheets-ui/src/services/selection/selection-control.ts
+++ b/packages/sheets-ui/src/services/selection/selection-control.ts
@@ -131,6 +131,8 @@ export class SelectionControl extends Disposable {
     private _currentStyle: ISelectionStyle;
     protected _rowHeaderWidth: number = 0;
     protected _columnHeaderHeight: number = 0;
+    protected _rowHeaderOffsetX: number = 0;
+    protected _columnHeaderOffsetY: number = 0;
 
     protected _widgetRects: Rect[] = [];
     protected _controlExtension: Nullable<SelectionShapeExtension>;
@@ -160,6 +162,8 @@ export class SelectionControl extends Disposable {
             enableAutoFill?: boolean;
             rowHeaderWidth: number;
             columnHeaderHeight: number;
+            rowHeaderOffsetX?: number;
+            columnHeaderOffsetY?: number;
             rangeType?: RANGE_TYPE;
         }
     ) {
@@ -168,6 +172,8 @@ export class SelectionControl extends Disposable {
         this._highlightHeader = options?.highlightHeader ?? true;
         this._rowHeaderWidth = options?.rowHeaderWidth ?? 0;
         this._columnHeaderHeight = options?.columnHeaderHeight ?? 0;
+        this._rowHeaderOffsetX = options?.rowHeaderOffsetX ?? 0;
+        this._columnHeaderOffsetY = options?.columnHeaderOffsetY ?? 0;
         this._initializeSheetBody();
         this._initialHeader();
     }
@@ -697,6 +703,8 @@ export class SelectionControl extends Disposable {
             // if row is over one million, row header width would be bigger than default value.
             this._rowHeaderWidth = sk.rowHeaderWidth;
             this._columnHeaderHeight = sk.columnHeaderHeight;
+            this._rowHeaderOffsetX = Math.max(0, sk.rowHeaderWidthAndMarginLeft - sk.rowHeaderWidth);
+            this._columnHeaderOffsetY = Math.max(0, sk.columnHeaderHeightAndMarginTop - sk.columnHeaderHeight);
         }
         this._selectionRenderModel.setValue(selectionWthCoord.rangeWithCoord, selectionWthCoord.primaryWithCoord);
         // if primaryWithCoord is undefined, that means keeps the previous value.
@@ -725,6 +733,8 @@ export class SelectionControl extends Disposable {
     ): void {
         this._rowHeaderWidth = rowHeaderWidth;
         this._columnHeaderHeight = columnHeaderHeight;
+        this._rowHeaderOffsetX = 0;
+        this._columnHeaderOffsetY = 0;
         this.updateRangeBySelectionWithCoord({
             rangeWithCoord: newSelectionRange,
             primaryWithCoord: primaryCell,
@@ -882,6 +892,8 @@ export class SelectionControl extends Disposable {
         columnHeaderStrokeWidth /= scale;
         const rowHeaderWidth = this._rowHeaderWidth;
         const columnHeaderHeight = this._columnHeaderHeight;
+        const rowHeaderOffsetX = this._rowHeaderOffsetX;
+        const columnHeaderOffsetY = this._columnHeaderOffsetY;
 
         if (this._highlightHeader && columnHeaderHeight > 0) {
             let highlightTitleColor = columnHeaderFill;
@@ -903,7 +915,7 @@ export class SelectionControl extends Disposable {
             });
 
             this._columnHeaderGroup.show();
-            this._columnHeaderGroup.translate(startX, 0);
+            this._columnHeaderGroup.translate(startX, columnHeaderOffsetY);
         } else {
             this._columnHeaderGroup.hide();
         }
@@ -930,7 +942,7 @@ export class SelectionControl extends Disposable {
             });
 
             this._rowHeaderGroup.show();
-            this._rowHeaderGroup.translate(0, startY);
+            this._rowHeaderGroup.translate(rowHeaderOffsetX, startY);
         } else {
             this._rowHeaderGroup.hide();
         }


### PR DESCRIPTION
## Summary
- Align sheet selection header highlights with outline-added row/column header padding.
- Size the select-all left-top placeholder from the padded header extents so outline padding remains clickable.
- Position hidden-column unhide icons against the padded column header bottom.

## Root Cause
Outline increases `rowHeaderWidthAndMarginLeft` and `columnHeaderHeightAndMarginTop`, but several header overlay components still used the base `rowHeaderWidth` / `columnHeaderHeight`, leaving visual and hit-test offsets.

## Validation
- `vitest run submodules/univer/packages/sheets-ui/src/services/selection/__tests__/selection-control.spec.ts submodules/univer/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-unhide.render-controller.spec.ts submodules/univer/packages/sheets-ui/src/controllers/render-controllers/__tests__/sheet.render-controller.spec.ts submodules/univer/packages/sheets-ui/src/controllers/render-controllers/__tests__/skeleton.render-controller.spec.ts`
- `eslint` on changed sheets-ui files: 0 errors, existing warnings only
- `turbo typecheck --filter @univerjs/sheets-ui`