### PR TITLE
feat(sheets): add facade range list api

### DIFF
--- a/packages/sheets-data-validation/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets-data-validation/src/facade/__tests__/f-range.spec.ts
@@ -20,7 +20,8 @@ import type { Injector } from '@univerjs/core';
 import type { FUniver } from '@univerjs/core/facade';
 import { DataValidationType, ICommandService } from '@univerjs/core';
 import { FormulaExecuteStageType, SetFormulaCalculationResultMutation } from '@univerjs/engine-formula';
-import { AddSheetDataValidationCommand, DataValidationCustomFormulaService } from '@univerjs/sheets-data-validation';
+import { SetRangeValuesCommand, SetRangeValuesMutation } from '@univerjs/sheets';
+import { AddSheetDataValidationCommand, ClearRangeDataValidationCommand, DataValidationCustomFormulaService } from '@univerjs/sheets-data-validation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFacadeTestBed } from './create-test-bed';
 
@@ -39,6 +40,9 @@ describe('Test FRange', () => {
 
         commandService = get(ICommandService);
         commandService.registerCommand(AddSheetDataValidationCommand);
+        commandService.registerCommand(ClearRangeDataValidationCommand);
+        commandService.registerCommand(SetRangeValuesCommand);
+        commandService.registerCommand(SetRangeValuesMutation);
         commandService.registerCommand(SetFormulaCalculationResultMutation);
 
         vi.stubGlobal('requestIdleCallback', ((callback: IdleRequestCallback) => {
@@ -69,6 +73,51 @@ describe('Test FRange', () => {
         expect(range3?.getDataValidations().length).toEqual(2);
 
         expect(activeSheet?.getDataValidations().length).toEqual(2);
+    });
+
+    it('RangeList set and clear data validations', async () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet()!;
+        const rule = univerAPI.newDataValidation().requireCheckbox().build();
+
+        activeSheet.getRangeList(['A1:A10', 'C1:C10']).setDataValidation(rule);
+
+        expect(activeSheet.getRange('A1').getDataValidation()?.getCriteriaType()).toEqual(DataValidationType.CHECKBOX);
+        expect(activeSheet.getRange('C1').getDataValidation()?.getCriteriaType()).toEqual(DataValidationType.CHECKBOX);
+        expect(activeSheet.getRange('A1:C10').getDataValidations().length).toEqual(1);
+
+        activeSheet.getRangeList(['A1:A10', 'C1:C10']).clearDataValidations();
+
+        expect(activeSheet.getRange('A1:C10').getDataValidations().length).toEqual(0);
+    });
+
+    it('RangeList inserts, checks, unchecks, and removes checkboxes', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet()!;
+
+        activeSheet.getRangeList(['A1:A2', 'C1:C2'])
+            .insertCheckboxes('Yes', 'No')
+            .check();
+
+        expect(activeSheet.getRange('A1').getValue()).toBe('Yes');
+        expect(activeSheet.getRange('C2').getValue()).toBe('Yes');
+        expect(activeSheet.getRange('A1').getDataValidation()?.getCriteriaType()).toBe(DataValidationType.CHECKBOX);
+
+        activeSheet.getRangeList(['A1:A2', 'C1:C2']).uncheck();
+
+        expect(activeSheet.getRange('A2').getValue()).toBe('No');
+        expect(activeSheet.getRange('C1').getValue()).toBe('No');
+
+        activeSheet.getRangeList(['A1:A2', 'C1:C2']).removeCheckboxes();
+
+        expect(activeSheet.getRange('A1:C2').getDataValidations()).toHaveLength(0);
+    });
+
+    it('RangeList refuses to remove non-checkbox data validations as checkboxes', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet()!;
+        const rule = univerAPI.newDataValidation().requireNumberEqualTo(1).build();
+
+        activeSheet.getRangeList(['A1']).setDataValidation(rule);
+
+        expect(() => activeSheet.getRangeList(['A1']).removeCheckboxes()).toThrow('Cannot remove checkboxes because the range contains non-checkbox data validation');
     });
 
     it('resolves onCalculationResultApplied after data-validation custom formula results are emitted', async () => {

--- a/packages/sheets-data-validation/src/facade/f-range-list.ts
+++ b/packages/sheets-data-validation/src/facade/f-range-list.ts
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CellValue, Nullable } from '@univerjs/core';
+import type { IAddSheetDataValidationCommandParams, IClearRangeDataValidationCommandParams } from '@univerjs/sheets-data-validation';
+import type { FRange } from '@univerjs/sheets/facade';
+import type { FDataValidation } from './f-data-validation';
+import type { IFRangeSheetsDataValidationMixin } from './f-range';
+import { DataValidationType } from '@univerjs/core';
+import { AddSheetDataValidationCommand, CHECKBOX_FORMULA_1, CHECKBOX_FORMULA_2, ClearRangeDataValidationCommand } from '@univerjs/sheets-data-validation';
+import { FRangeList } from '@univerjs/sheets/facade';
+import { FDataValidationBuilder } from './f-data-validation-builder';
+
+/**
+ * @ignore
+ */
+export interface IFRangeListSheetsDataValidationMixin {
+    /**
+     * Set one data validation rule to every range in the range list. Pass null to clear data validations.
+     * This follows Univer's data validation builder API instead of checkbox-specific convenience overloads.
+     * @param {Nullable<FDataValidation>} rule The data validation rule built by `FUniver.newDataValidation`, or null to clear.
+     * @returns {FRangeList} The FRangeList instance for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * const rule = univerAPI.newDataValidation().requireCheckbox().build();
+     * sheet.getRangeList(['A1:A10', 'C1:C10']).setDataValidation(rule);
+     * ```
+     */
+    setDataValidation(rule: Nullable<FDataValidation>): FRangeList;
+
+    /**
+     * Inserts checkbox data validations into every range in the range list.
+     * @param {string} [checkedValue] Optional checked value.
+     * @param {string} [uncheckedValue] Optional unchecked value.
+     * @returns {FRangeList} The FRangeList instance for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:A10', 'C1:C10']).insertCheckboxes('Yes', 'No');
+     * ```
+     */
+    insertCheckboxes(checkedValue?: string, uncheckedValue?: string): FRangeList;
+
+    /**
+     * Removes checkbox data validations from every range in the range list.
+     * @returns {FRangeList} The FRangeList instance for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:A10', 'C1:C10']).removeCheckboxes();
+     * ```
+     */
+    removeCheckboxes(): FRangeList;
+
+    /**
+     * Sets every checkbox in the range list to its checked value.
+     * @returns {FRangeList} The FRangeList instance for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:A10', 'C1:C10']).check();
+     * ```
+     */
+    check(): FRangeList;
+
+    /**
+     * Sets every checkbox in the range list to its unchecked value.
+     * @returns {FRangeList} The FRangeList instance for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:A10', 'C1:C10']).uncheck();
+     * ```
+     */
+    uncheck(): FRangeList;
+
+    /**
+     * Clear data validation rules from every range in the range list.
+     * @returns {FRangeList} The FRangeList instance for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:A10', 'C1:C10']).clearDataValidations();
+     * ```
+     */
+    clearDataValidations(): FRangeList;
+}
+
+export class FRangeListSheetsDataValidationMixin extends FRangeList implements IFRangeListSheetsDataValidationMixin {
+    override setDataValidation(rule: Nullable<FDataValidation>): FRangeList {
+        if (!rule) {
+            this.clearDataValidations();
+            return this;
+        }
+
+        for (const [key, ranges] of this._getRangeGroups()) {
+            const [unitId, subUnitId] = key.split(':');
+            const params: IAddSheetDataValidationCommandParams = {
+                unitId,
+                subUnitId,
+                rule: {
+                    ...rule.rule,
+                    ranges: ranges.map((range) => range.getRange()),
+                },
+            };
+
+            this._commandService.syncExecuteCommand(AddSheetDataValidationCommand.id, params);
+        }
+        return this;
+    }
+
+    override insertCheckboxes(checkedValue?: string, uncheckedValue?: string): FRangeList {
+        const rule = new FDataValidationBuilder()
+            .requireCheckbox(checkedValue, uncheckedValue)
+            .build();
+
+        return this.setDataValidation(rule);
+    }
+
+    override removeCheckboxes(): FRangeList {
+        this._assertOnlyCheckboxDataValidations();
+        return this.clearDataValidations();
+    }
+
+    override check(): FRangeList {
+        return this._setCheckboxValue(true);
+    }
+
+    override uncheck(): FRangeList {
+        return this._setCheckboxValue(false);
+    }
+
+    override clearDataValidations(): FRangeList {
+        for (const [key, ranges] of this._getRangeGroups()) {
+            const [unitId, subUnitId] = key.split(':');
+            this._commandService.syncExecuteCommand(ClearRangeDataValidationCommand.id, {
+                unitId,
+                subUnitId,
+                ranges: ranges.map((range) => range.getRange()),
+            } as IClearRangeDataValidationCommandParams);
+        }
+        return this;
+    }
+
+    private _setCheckboxValue(checked: boolean): FRangeList {
+        for (const range of this.getRanges()) {
+            range.setValue(this._getCheckboxValue(range, checked));
+        }
+
+        return this;
+    }
+
+    private _getCheckboxValue(range: FRange, checked: boolean): CellValue {
+        const validations = this._getDataValidations(range);
+        if (!validations.length) {
+            throw new Error('Cannot set checkbox value because the range does not contain checkbox data validation');
+        }
+
+        let checkboxValue: CellValue | undefined;
+        for (const validation of validations) {
+            if (validation.getCriteriaType() !== DataValidationType.CHECKBOX) {
+                throw new Error('Cannot set checkbox value because the range contains non-checkbox data validation');
+            }
+
+            const [, checkedValue = CHECKBOX_FORMULA_1, uncheckedValue = CHECKBOX_FORMULA_2] = validation.getCriteriaValues();
+            const nextValue = checked ? checkedValue : uncheckedValue;
+            if (checkboxValue !== undefined && String(checkboxValue) !== String(nextValue)) {
+                throw new Error('Cannot set checkbox value because the range contains checkbox data validations with different values');
+            }
+
+            checkboxValue = nextValue;
+        }
+
+        return checkboxValue ?? (checked ? CHECKBOX_FORMULA_1 : CHECKBOX_FORMULA_2);
+    }
+
+    private _assertOnlyCheckboxDataValidations(): void {
+        for (const range of this.getRanges()) {
+            const validations = this._getDataValidations(range);
+            if (validations.some((validation) => validation.getCriteriaType() !== DataValidationType.CHECKBOX)) {
+                throw new Error('Cannot remove checkboxes because the range contains non-checkbox data validation');
+            }
+        }
+    }
+
+    private _getDataValidations(range: FRange): FDataValidation[] {
+        return (range as FRange & IFRangeSheetsDataValidationMixin).getDataValidations();
+    }
+}
+
+FRangeList.extend(FRangeListSheetsDataValidationMixin);
+declare module '@univerjs/sheets/facade' {
+    // eslint-disable-next-line ts/naming-convention
+    interface FRangeList extends IFRangeListSheetsDataValidationMixin { }
+}

--- a/packages/sheets-data-validation/src/facade/index.ts
+++ b/packages/sheets-data-validation/src/facade/index.ts
@@ -15,6 +15,7 @@
  */
 
 import './f-range';
+import './f-range-list';
 import './f-univer';
 import './f-workbook';
 import './f-worksheet';
@@ -25,6 +26,7 @@ export { FDataValidationBuilder } from './f-data-validation-builder';
 
 export type * from './f-event';
 export type * from './f-range';
+export type * from './f-range-list';
 export type * from './f-univer';
 export type * from './f-workbook';
 export type * from './f-worksheet';

--- a/packages/sheets-note/src/facade/__tests__/sheets-note.facade.spec.ts
+++ b/packages/sheets-note/src/facade/__tests__/sheets-note.facade.spec.ts
@@ -175,5 +175,29 @@ describe('sheets-note facade mixins', () => {
         range.deleteNote();
         expect(range.getNote()).toBeUndefined();
         expect(sheet.getNotes()).toHaveLength(0);
+
+        range.setNote('alias note');
+        expect(range.getNote()?.note).toBe('alias note');
+
+        range.clearNote();
+        expect(range.getNote()).toBeUndefined();
+    });
+
+    it('sets and clears notes through FRangeList', () => {
+        const workbook = univerAPI.getActiveWorkbook();
+        expect(workbook).toBeTruthy();
+        const sheet = workbook!.getActiveSheet();
+
+        sheet.getRangeList(['A1', 'C1']).setNote('range list note');
+
+        expect(sheet.getRange('A1').getNote()?.note).toBe('range list note');
+        expect(sheet.getRange('C1').getNote()?.note).toBe('range list note');
+        expect(sheet.getNotes()).toHaveLength(2);
+
+        sheet.getRangeList(['A1', 'C1']).clearNote();
+
+        expect(sheet.getRange('A1').getNote()).toBeUndefined();
+        expect(sheet.getRange('C1').getNote()).toBeUndefined();
+        expect(sheet.getNotes()).toHaveLength(0);
     });
 });

--- a/packages/sheets-note/src/facade/f-range-list.ts
+++ b/packages/sheets-note/src/facade/f-range-list.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IFRangeSheetsNoteMixin } from './f-range';
+import { FRangeList } from '@univerjs/sheets/facade';
+
+/**
+ * @ignore
+ */
+export interface IFRangeListSheetsNoteMixin {
+    /**
+     * Set a plain text note on the top-left cell of every range in the range list.
+     * @param {string} note The note text.
+     * @returns {FRangeList} This range list for method chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1', 'C1']).setNote('Needs review');
+     * ```
+     */
+    setNote(note: string): FRangeList;
+
+    /**
+     * Clear the note on the top-left cell of every range in the range list.
+     * @returns {FRangeList} This range list for method chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1', 'C1']).clearNote();
+     * ```
+     */
+    clearNote(): FRangeList;
+}
+
+export class FRangeListSheetsNoteMixin extends FRangeList implements IFRangeListSheetsNoteMixin {
+    override setNote(note: string): FRangeList {
+        this.getRanges().forEach((range) => {
+            (range as typeof range & IFRangeSheetsNoteMixin).setNote(note);
+        });
+
+        return this;
+    }
+
+    override clearNote(): FRangeList {
+        this.getRanges().forEach((range) => {
+            (range as typeof range & IFRangeSheetsNoteMixin).clearNote();
+        });
+
+        return this;
+    }
+}
+
+FRangeList.extend(FRangeListSheetsNoteMixin);
+declare module '@univerjs/sheets/facade' {
+    // eslint-disable-next-line ts/naming-convention
+    interface FRangeList extends IFRangeListSheetsNoteMixin { }
+}

--- a/packages/sheets-note/src/facade/f-range.ts
+++ b/packages/sheets-note/src/facade/f-range.ts
@@ -16,6 +16,7 @@
 
 import type { Nullable } from '@univerjs/core';
 import type { ISheetNote } from '@univerjs/sheets-note';
+import { generateRandomId } from '@univerjs/core';
 import { RemoveNoteMutation, SheetsNoteModel, UpdateNoteMutation } from '@univerjs/sheets-note';
 import { FRange } from '@univerjs/sheets/facade';
 
@@ -54,6 +55,20 @@ export interface IFRangeSheetsNoteMixin {
      * ```
      */
     createOrUpdateNote(note: ISheetNote): FRange;
+
+    /**
+     * Set a plain text note on the top-left cell in the range.
+     * @param {string} note The note text.
+     * @returns {FRange} This range for method chaining.
+     * @example
+     * ```ts
+     * const fWorkbook = univerAPI.getActiveWorkbook();
+     * const fWorksheet = fWorkbook.getActiveSheet();
+     * fWorksheet.getRange('A1').setNote('Needs review');
+     * ```
+     */
+    setNote(note: string): FRange;
+
     /**
      * Delete the annotation of the top-left cell in the range
      * @returns {FRange} This range for method chaining
@@ -72,9 +87,32 @@ export interface IFRangeSheetsNoteMixin {
      * ```
      */
     deleteNote(): FRange;
+
+    /**
+     * Clear the note on the top-left cell in the range.
+     * @returns {FRange} This range for method chaining.
+     * @example
+     * ```ts
+     * const fWorkbook = univerAPI.getActiveWorkbook();
+     * const fWorksheet = fWorkbook.getActiveSheet();
+     * fWorksheet.getRange('A1').clearNote();
+     * ```
+     */
+    clearNote(): FRange;
 }
 
 export class FRangeSheetsNoteMixin extends FRange implements IFRangeSheetsNoteMixin {
+    override setNote(note: string): FRange {
+        return this.createOrUpdateNote({
+            id: generateRandomId(),
+            row: this.getRow(),
+            col: this.getColumn(),
+            width: 160,
+            height: 72,
+            note,
+        });
+    }
+
     override createOrUpdateNote(note: ISheetNote): FRange {
         this._commandService.syncExecuteCommand(
             UpdateNoteMutation.id,
@@ -102,6 +140,10 @@ export class FRangeSheetsNoteMixin extends FRange implements IFRangeSheetsNoteMi
         );
 
         return this;
+    }
+
+    override clearNote(): FRange {
+        return this.deleteNote();
     }
 
     override getNote(): Nullable<ISheetNote> {

--- a/packages/sheets-note/src/facade/index.ts
+++ b/packages/sheets-note/src/facade/index.ts
@@ -16,10 +16,12 @@
 
 import './f-event';
 import './f-range';
+import './f-range-list';
 import './f-univer';
 import './f-worksheet';
 
 export * from './f-event';
 export * from './f-range';
+export * from './f-range-list';
 export * from './f-univer';
 export * from './f-worksheet';

--- a/packages/sheets-numfmt/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets-numfmt/src/facade/__tests__/f-range.spec.ts
@@ -18,6 +18,7 @@ import type { FUniver } from '@univerjs/core/facade';
 import { LifecycleStages } from '@univerjs/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createFacadeTestBed } from './create-test-bed';
+import '../index';
 
 describe('Test FRange', () => {
     let univerAPI: FUniver;
@@ -36,6 +37,20 @@ describe('Test FRange', () => {
                 range.setValue(1234.5678);
                 range.setNumberFormat('#,###');
                 expect(range.getValue()).toBe('1,234.5678');
+            }
+        });
+    });
+
+    it('RangeList setNumberFormat', () => {
+        univerAPI.addEvent(univerAPI.Event.LifeCycleChanged, ({ stage }) => {
+            if (stage === LifecycleStages.Rendered) {
+                const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+                activeSheet.getRange('A1').setValue(1234.5678);
+                activeSheet.getRange('C1').setValue(9876.5432);
+                activeSheet.getRangeList(['A1', 'C1']).setNumberFormat('#,###');
+
+                expect(activeSheet.getRange('A1').getValue()).toBe('1,234.5678');
+                expect(activeSheet.getRange('C1').getValue()).toBe('9,876.5432');
             }
         });
     });

--- a/packages/sheets-numfmt/src/facade/f-range-list.ts
+++ b/packages/sheets-numfmt/src/facade/f-range-list.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FRangeList } from '@univerjs/sheets/facade';
+
+/**
+ * @ignore
+ */
+export interface IFRangeListSheetsNumfmtMixin {
+    /**
+     * Set the number format of every range in the range list.
+     * @param {string} pattern The number format pattern.
+     * @returns {FRangeList} The FRangeList instance for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:A10', 'C1:C10']).setNumberFormat('#,##0.00');
+     * ```
+     */
+    setNumberFormat(pattern: string): FRangeList;
+}
+
+export class FRangeListSheetsNumfmtMixin extends FRangeList implements IFRangeListSheetsNumfmtMixin {
+    override setNumberFormat(pattern: string): FRangeList {
+        this.getRanges().forEach((range) => range.setNumberFormat(pattern));
+        return this;
+    }
+}
+
+FRangeList.extend(FRangeListSheetsNumfmtMixin);
+declare module '@univerjs/sheets/facade' {
+    // eslint-disable-next-line ts/naming-convention
+    interface FRangeList extends IFRangeListSheetsNumfmtMixin { }
+}

--- a/packages/sheets-numfmt/src/facade/index.ts
+++ b/packages/sheets-numfmt/src/facade/index.ts
@@ -15,7 +15,9 @@
  */
 
 import './f-range';
+import './f-range-list';
 import './f-workbook';
 
 export type * from './f-range';
+export type * from './f-range-list';
 export type * from './f-workbook';

--- a/packages/sheets/src/facade/__tests__/f-range-list.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-range-list.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ICellData, Injector, IStyleData, Nullable } from '@univerjs/core';
+import type { FUniver } from '@univerjs/core/facade';
+import { ICommandService, IUniverInstanceService, TextDirection, WrapStrategy } from '@univerjs/core';
+import { ClearSelectionContentCommand, ClearSelectionFormatCommand, InsertSheetCommand, InsertSheetMutation, SetHorizontalTextAlignCommand, SetRangeValuesCommand, SetRangeValuesMutation, SetSelectionsOperation, SetStyleCommand, SetTextWrapCommand, SetVerticalTextAlignCommand, SetWorksheetActiveOperation } from '@univerjs/sheets';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createFacadeTestBed } from './create-test-bed';
+
+describe('Test FRangeList', () => {
+    let get: Injector['get'];
+    let univerAPI: FUniver;
+    let getValueByPosition: (
+        startRow: number,
+        startColumn: number,
+        endRow: number,
+        endColumn: number
+    ) => Nullable<ICellData>;
+    let getStyleByPosition: (
+        startRow: number,
+        startColumn: number,
+        endRow: number,
+        endColumn: number
+    ) => Nullable<IStyleData>;
+
+    beforeEach(() => {
+        const testBed = createFacadeTestBed();
+        get = testBed.get;
+        univerAPI = testBed.univerAPI;
+
+        const commandService = get(ICommandService);
+        commandService.registerCommand(SetRangeValuesCommand);
+        commandService.registerCommand(SetRangeValuesMutation);
+        commandService.registerCommand(ClearSelectionContentCommand);
+        commandService.registerCommand(ClearSelectionFormatCommand);
+        commandService.registerCommand(SetStyleCommand);
+        commandService.registerCommand(SetVerticalTextAlignCommand);
+        commandService.registerCommand(SetHorizontalTextAlignCommand);
+        commandService.registerCommand(SetTextWrapCommand);
+        commandService.registerCommand(InsertSheetCommand);
+        commandService.registerCommand(InsertSheetMutation);
+        commandService.registerCommand(SetSelectionsOperation);
+        commandService.registerCommand(SetWorksheetActiveOperation);
+
+        getValueByPosition = (
+            startRow: number,
+            startColumn: number,
+            endRow: number,
+            endColumn: number
+        ): Nullable<ICellData> =>
+            get(IUniverInstanceService)
+                .getUniverSheetInstance('test')
+                ?.getSheetBySheetId('sheet1')
+                ?.getRange(startRow, startColumn, endRow, endColumn)
+                .getValue();
+
+        getStyleByPosition = (
+            startRow: number,
+            startColumn: number,
+            endRow: number,
+            endColumn: number
+        ): Nullable<IStyleData> => {
+            const value = getValueByPosition(startRow, startColumn, endRow, endColumn);
+            const styles = get(IUniverInstanceService).getUniverSheetInstance('test')?.getStyles();
+            if (value && styles) {
+                return styles.getStyleByCell(value);
+            }
+        };
+    });
+
+    it('Worksheet getRangeList returns ranges in A1 order', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+        const rangeList = activeSheet.getRangeList(['A1:B2', 'D1:E2']);
+
+        expect(rangeList.getRanges().map((range) => range.getA1Notation())).toEqual(['A1:B2', 'D1:E2']);
+    });
+
+    it('RangeList applies chainable style operations to non-contiguous ranges', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+
+        activeSheet.getRangeList(['A1:B2', 'D1:E2'])
+            .setBackgroundColor('#fce4d6')
+            .setFontWeight('bold');
+
+        expect(getStyleByPosition(0, 0, 0, 0)?.bg?.rgb).toBe('#fce4d6');
+        expect(getStyleByPosition(1, 1, 1, 1)?.bg?.rgb).toBe('#fce4d6');
+        expect(getStyleByPosition(0, 3, 0, 3)?.bg?.rgb).toBe('#fce4d6');
+        expect(getStyleByPosition(1, 4, 1, 4)?.bg?.rgb).toBe('#fce4d6');
+        expect(getStyleByPosition(0, 0, 0, 0)?.bl).toBe(1);
+        expect(getStyleByPosition(1, 4, 1, 4)?.bl).toBe(1);
+
+        activeSheet.getRangeList(['A3:B3', 'D3:E3'])
+            .setTextDirection(TextDirection.RIGHT_TO_LEFT);
+
+        expect(getStyleByPosition(2, 0, 2, 0)?.td).toBe(TextDirection.RIGHT_TO_LEFT);
+        expect(getStyleByPosition(2, 4, 2, 4)?.td).toBe(TextDirection.RIGHT_TO_LEFT);
+    });
+
+    it('RangeList applies value, formula, wrapping, and clear operations', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+
+        activeSheet.getRangeList(['A1', 'C1'])
+            .setValue('Ready')
+            .setWrap(true);
+
+        expect(activeSheet.getRange('A1').getValue()).toBe('Ready');
+        expect(activeSheet.getRange('C1').getValue()).toBe('Ready');
+        expect(getStyleByPosition(0, 0, 0, 0)?.tb).toBe(WrapStrategy.WRAP);
+        expect(getStyleByPosition(0, 2, 0, 2)?.tb).toBe(WrapStrategy.WRAP);
+
+        activeSheet.getRangeList(['A2', 'C2'])
+            .setFormula('=SUM(A1:C1)')
+            .setWrap(true);
+        expect(activeSheet.getRange('A2').getFormula()).toBe('=SUM(A1:C1)');
+        expect(activeSheet.getRange('C2').getFormula()).toBe('=SUM(A1:C1)');
+        expect(getStyleByPosition(1, 0, 1, 0)?.tb).toBe(WrapStrategy.WRAP);
+        expect(getStyleByPosition(1, 2, 1, 2)?.tb).toBe(WrapStrategy.WRAP);
+
+        const contentRangeList = activeSheet.getRangeList(['A1', 'C1']);
+        const formatRangeList = activeSheet.getRangeList(['A2', 'C2']);
+        expect(contentRangeList.clearContent()).toBe(contentRangeList);
+        expect(formatRangeList.clearFormat()).toBe(formatRangeList);
+    });
+
+    it('RangeList supports RGB background convenience and activation', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+
+        activeSheet.getRangeList(['D4', 'B2:C4'])
+            .setBackgroundRGB(255, 0, 0)
+            .activate();
+
+        expect(getStyleByPosition(3, 3, 3, 3)?.bg?.rgb).toBe('#ff0000');
+        expect(getStyleByPosition(1, 1, 1, 1)?.bg?.rgb).toBe('#ff0000');
+        expect(activeSheet.getSelection()?.getActiveRange()?.getA1Notation()).toBe('B2:C4');
+        expect(activeSheet.getSelection()?.getActiveRangeList().map((range) => range.getA1Notation())).toEqual(['D4', 'B2:C4']);
+    });
+
+    it('Worksheet getRangeList rejects empty lists', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+
+        expect(() => activeSheet.getRangeList([])).toThrow('Range list cannot be empty');
+    });
+
+    it('Worksheet getRangeList supports sheet-qualified ranges on other sheets', () => {
+        const workbook = univerAPI.getActiveWorkbook()!;
+        const activeSheet = workbook.getActiveSheet();
+        const sheet2 = workbook.insertSheet('sheet2');
+
+        activeSheet.getRangeList(['A1', 'sheet2!C1']).setValue('range value');
+
+        expect(activeSheet.getRange('A1').getValue()).toBe('range value');
+        expect(sheet2.getRange('C1').getValue()).toBe('range value');
+    });
+
+    it('RangeList activate requires all ranges to belong to one sheet', () => {
+        const workbook = univerAPI.getActiveWorkbook()!;
+        const activeSheet = workbook.getActiveSheet();
+        workbook.insertSheet('sheet2');
+
+        expect(() => activeSheet.getRangeList(['A1', 'sheet2!A1']).activate()).toThrow('Cannot activate a range list across multiple worksheets');
+    });
+});

--- a/packages/sheets/src/facade/__tests__/f-workbook.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-workbook.spec.ts
@@ -77,6 +77,17 @@ describe('Test FWorkbook', () => {
         expect(activeSheet).not.toBeNull();
     });
 
+    it('Workbook getRangeList uses the active sheet', () => {
+        const workbook = univerAPI.getActiveWorkbook()!;
+
+        const rangeList = workbook.getRangeList(['A1:B2', 'D1:E2']);
+        rangeList.setBackgroundColor('#fce4d6');
+
+        expect(rangeList.getRanges().map((range) => range.getA1Notation())).toEqual(['A1:B2', 'D1:E2']);
+        expect(getValueByPosition(0, 0, 0, 0)?.s).not.toBeUndefined();
+        expect(getValueByPosition(0, 3, 0, 3)?.s).not.toBeUndefined();
+    });
+
     it('Workbook insertSheet, deleteSheet, and setActiveSheet', async () => {
         const workbook = univerAPI.getActiveWorkbook();
 

--- a/packages/sheets/src/facade/f-range-list.ts
+++ b/packages/sheets/src/facade/f-range-list.ts
@@ -1,0 +1,497 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BorderStyleTypes, BorderType, CellValue, ICellData, TextDirection, Workbook, Worksheet, WrapStrategy } from '@univerjs/core';
+import type { FontLine, FontStyle, FontWeight, FRange } from './f-range';
+import type { IFacadeClearOptions } from './f-worksheet';
+import type { FHorizontalAlignment, FVerticalAlignment } from './utils';
+import { ICommandService, Inject, Injector } from '@univerjs/core';
+import { FBaseInitialable } from '@univerjs/core/facade';
+import { ClearSelectionAllCommand, ClearSelectionContentCommand, ClearSelectionFormatCommand, getPrimaryForRange, RemoveWorksheetMergeCommand, SetBorderBasicCommand, SetSelectionsOperation } from '@univerjs/sheets';
+
+/**
+ * Represents a list of ranges on the same worksheet. It mirrors the Google Sheets RangeList
+ * shape for applying the same operation to non-contiguous ranges.
+ *
+ * @example
+ * ```ts
+ * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+ * sheet.getRangeList(['A1:B2', 'D1:E2'])
+ *   .setBackgroundColor('#fce4d6')
+ *   .setFontWeight('bold');
+ * ```
+ * @hideconstructor
+ */
+export class FRangeList extends FBaseInitialable {
+    static { this._enableManualInit(); }
+
+    constructor(
+        protected readonly _workbook: Workbook,
+        protected readonly _ranges: FRange[],
+        @Inject(Injector) protected override readonly _injector: Injector,
+        @ICommandService protected readonly _commandService: ICommandService
+    ) {
+        super(_injector);
+        this._runInitializers(this._injector, this._workbook, this._ranges);
+    }
+
+    /**
+     * Returns the ranges represented by this list.
+     * @returns {FRange[]} The ranges in this list.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * const rangeList = sheet.getRangeList(['A1:B2', 'D1:E2']);
+     * console.log(rangeList.getRanges().map((range) => range.getA1Notation()));
+     * ```
+     */
+    getRanges(): FRange[] {
+        return [...this._ranges];
+    }
+
+    /**
+     * Selects this list of ranges. The last range becomes the active range.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['D4', 'B2:C4']).activate();
+     * ```
+     */
+    activate(): FRangeList {
+        const worksheet = this._getSingleWorksheet('activate');
+        const lastIndex = this._ranges.length - 1;
+        this._ranges[0].activate();
+        this._commandService.syncExecuteCommand(SetSelectionsOperation.id, {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: worksheet.getSheetId(),
+            selections: this._ranges.map((range, index) => ({
+                range: range.getRange(),
+                primary: index === lastIndex ? getPrimaryForRange(range.getRange(), worksheet) : null,
+                style: null,
+            })),
+        });
+        return this;
+    }
+
+    /**
+     * Breaks apart merged cells in each range in this list.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).breakApart();
+     * ```
+     */
+    breakApart(): FRangeList {
+        return this._forEachRangeGroup((unitId, subUnitId, ranges) => {
+            this._commandService.syncExecuteCommand(RemoveWorksheetMergeCommand.id, {
+                unitId,
+                subUnitId,
+                ranges: ranges.map((range) => range.getRange()),
+            });
+        });
+    }
+
+    /**
+     * Clears contents and formats in each range in this list.
+     * @param {IFacadeClearOptions} [options] Univer clear options. Currently supports the same options as FRange.clear.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A:A', 'C:C']).clear({ contentsOnly: true });
+     * ```
+     */
+    clear(options?: IFacadeClearOptions): FRangeList {
+        if (options && options.contentsOnly && !options.formatOnly) {
+            return this.clearContent();
+        }
+
+        if (options && options.formatOnly && !options.contentsOnly) {
+            return this.clearFormat();
+        }
+
+        return this._forEachRangeGroup((unitId, subUnitId, ranges) => {
+            this._commandService.syncExecuteCommand(ClearSelectionAllCommand.id, {
+                unitId,
+                subUnitId,
+                ranges: ranges.map((range) => range.getRange()),
+                options,
+            });
+        });
+    }
+
+    /**
+     * Clears contents in each range in this list while preserving formatting.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A:A', 'C:C']).clearContent();
+     * ```
+     */
+    clearContent(): FRangeList {
+        return this._forEachRangeGroup((unitId, subUnitId, ranges) => {
+            this._commandService.syncExecuteCommand(ClearSelectionContentCommand.id, {
+                unitId,
+                subUnitId,
+                ranges: ranges.map((range) => range.getRange()),
+            });
+        });
+    }
+
+    /**
+     * Clears formats in each range in this list while preserving contents.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A:A', 'C:C']).clearFormat();
+     * ```
+     */
+    clearFormat(): FRangeList {
+        return this._forEachRangeGroup((unitId, subUnitId, ranges) => {
+            this._commandService.syncExecuteCommand(ClearSelectionFormatCommand.id, {
+                unitId,
+                subUnitId,
+                ranges: ranges.map((range) => range.getRange()),
+            });
+        });
+    }
+
+    /**
+     * Sets basic border properties for each range in this list.
+     * This follows Univer's BorderType and BorderStyleTypes API rather than boolean-edge overloads.
+     * @param {BorderType} type The type of border to apply.
+     * @param {BorderStyleTypes} style The border style.
+     * @param {string} [color] Optional border color in CSS notation.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2'])
+     *   .setBorder(univerAPI.Enum.BorderType.ALL, univerAPI.Enum.BorderStyleTypes.THIN, '#ff0000');
+     * ```
+     */
+    setBorder(type: BorderType, style: BorderStyleTypes, color?: string): FRangeList {
+        return this._forEachRangeGroup((unitId, subUnitId, ranges) => {
+            this._commandService.syncExecuteCommand(SetBorderBasicCommand.id, {
+                unitId,
+                subUnitId,
+                ranges: ranges.map((range) => range.getRange()),
+                value: {
+                    type,
+                    style,
+                    color,
+                },
+            });
+        });
+    }
+
+    /**
+     * Sets the background color for each range in this list.
+     * @param {string} color The background color.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setBackgroundColor('#fce4d6');
+     * ```
+     */
+    setBackgroundColor(color: string): FRangeList {
+        return this._forEachRange((range) => range.setBackgroundColor(color));
+    }
+
+    /**
+     * Sets the background color for each range in this list.
+     * @param {string} color The background color.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setBackground('#fce4d6');
+     * ```
+     */
+    setBackground(color: string): FRangeList {
+        return this.setBackgroundColor(color);
+    }
+
+    /**
+     * Sets the background color for each range in this list from RGB channel values.
+     * @param {number} red The red channel, from 0 to 255.
+     * @param {number} green The green channel, from 0 to 255.
+     * @param {number} blue The blue channel, from 0 to 255.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setBackgroundRGB(255, 0, 0);
+     * ```
+     */
+    setBackgroundRGB(red: number, green: number, blue: number): FRangeList {
+        return this.setBackgroundColor(this._rgbToHex(red, green, blue));
+    }
+
+    /**
+     * Sets text rotation for each range in this list.
+     * @param {number} rotation The rotation angle in degrees.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setTextRotation(45);
+     * ```
+     */
+    setTextRotation(rotation: number): FRangeList {
+        return this._forEachRange((range) => range.setTextRotation(rotation));
+    }
+
+    /**
+     * Sets text direction for each range in this list.
+     * @param {TextDirection} direction The text direction.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2'])
+     *   .setTextDirection(univerAPI.Enum.TextDirection.RIGHT_TO_LEFT);
+     * ```
+     */
+    setTextDirection(direction: TextDirection): FRangeList {
+        return this._forEachRange((range) => range.setTextDirection(direction));
+    }
+
+    /**
+     * Sets one value for every cell in each range in this list.
+     * @param {CellValue | ICellData} value The value or standard cell data to set.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:A10', 'C1:C10']).setValue('Ready');
+     * ```
+     */
+    setValue(value: CellValue | ICellData): FRangeList {
+        return this._forEachRange((range) => range.setValue(value));
+    }
+
+    /**
+     * Sets the same A1-notation formula for each range in this list.
+     * @param {string} formula The formula to set.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A11', 'C11']).setFormula('=SUM(A1:A10)');
+     * ```
+     */
+    setFormula(formula: string): FRangeList {
+        return this._forEachRange((range) => range.setFormula(formula));
+    }
+
+    /**
+     * Sets text wrapping for each range in this list.
+     * @param {boolean} isWrapEnabled Whether to enable wrapping.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setWrap(true);
+     * ```
+     */
+    setWrap(isWrapEnabled: boolean): FRangeList {
+        return this._forEachRange((range) => range.setWrap(isWrapEnabled));
+    }
+
+    /**
+     * Sets text wrapping strategy for each range in this list.
+     * @param {WrapStrategy} strategy The text wrapping strategy.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setWrapStrategy(univerAPI.Enum.WrapStrategy.WRAP);
+     * ```
+     */
+    setWrapStrategy(strategy: WrapStrategy): FRangeList {
+        return this._forEachRange((range) => range.setWrapStrategy(strategy));
+    }
+
+    /**
+     * Sets vertical alignment for each range in this list.
+     * @param {FVerticalAlignment} alignment The vertical alignment.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setVerticalAlignment('middle');
+     * ```
+     */
+    setVerticalAlignment(alignment: FVerticalAlignment): FRangeList {
+        return this._forEachRange((range) => range.setVerticalAlignment(alignment));
+    }
+
+    /**
+     * Sets horizontal alignment for each range in this list.
+     * @param {FHorizontalAlignment} alignment The horizontal alignment.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setHorizontalAlignment('center');
+     * ```
+     */
+    setHorizontalAlignment(alignment: FHorizontalAlignment): FRangeList {
+        return this._forEachRange((range) => range.setHorizontalAlignment(alignment));
+    }
+
+    /**
+     * Sets font weight for each range in this list.
+     * @param {FontWeight | null} fontWeight The font weight, or null to reset.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setFontWeight('bold');
+     * ```
+     */
+    setFontWeight(fontWeight: FontWeight | null): FRangeList {
+        return this._forEachRange((range) => range.setFontWeight(fontWeight));
+    }
+
+    /**
+     * Sets font style for each range in this list.
+     * @param {FontStyle | null} fontStyle The font style, or null to reset.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setFontStyle('italic');
+     * ```
+     */
+    setFontStyle(fontStyle: FontStyle | null): FRangeList {
+        return this._forEachRange((range) => range.setFontStyle(fontStyle));
+    }
+
+    /**
+     * Sets font line for each range in this list.
+     * @param {FontLine | null} fontLine The font line style, or null to reset.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setFontLine('underline');
+     * ```
+     */
+    setFontLine(fontLine: FontLine | null): FRangeList {
+        return this._forEachRange((range) => range.setFontLine(fontLine));
+    }
+
+    /**
+     * Sets font family for each range in this list.
+     * @param {string | null} fontFamily The font family, or null to reset.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setFontFamily('Arial');
+     * ```
+     */
+    setFontFamily(fontFamily: string | null): FRangeList {
+        return this._forEachRange((range) => range.setFontFamily(fontFamily));
+    }
+
+    /**
+     * Sets font size for each range in this list.
+     * @param {number | null} size The font size, or null to reset.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setFontSize(12);
+     * ```
+     */
+    setFontSize(size: number | null): FRangeList {
+        return this._forEachRange((range) => range.setFontSize(size));
+    }
+
+    /**
+     * Sets font color for each range in this list.
+     * @param {string | null} color The font color, or null to reset.
+     * @returns {FRangeList} This range list, for chaining.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:B2', 'D1:E2']).setFontColor('#ff0000');
+     * ```
+     */
+    setFontColor(color: string | null): FRangeList {
+        return this._forEachRange((range) => range.setFontColor(color));
+    }
+
+    private _rgbToHex(red: number, green: number, blue: number): string {
+        return [red, green, blue].map((channel) => {
+            if (!Number.isInteger(channel) || channel < 0 || channel > 255) {
+                throw new Error('RGB channel values must be integers from 0 to 255');
+            }
+
+            return channel.toString(16).padStart(2, '0');
+        }).join('').replace(/^/, '#');
+    }
+
+    private _getSingleWorksheet(action: string): Worksheet {
+        const firstRange = this._ranges[0];
+        const sheetId = firstRange.getSheetId();
+        const worksheet = this._workbook.getSheetBySheetId(sheetId);
+        if (!worksheet) {
+            throw new Error('Range sheet not found');
+        }
+
+        const hasMultipleSheets = this._ranges.some((range) => range.getUnitId() !== firstRange.getUnitId() || range.getSheetId() !== sheetId);
+        if (hasMultipleSheets) {
+            throw new Error(`Cannot ${action} a range list across multiple worksheets`);
+        }
+
+        return worksheet;
+    }
+
+    private _forEachRange(callback: (range: FRange) => void): FRangeList {
+        this._ranges.forEach(callback);
+        return this;
+    }
+
+    protected _forEachRangeGroup(callback: (unitId: string, subUnitId: string, ranges: FRange[]) => void): FRangeList {
+        for (const [key, ranges] of this._getRangeGroups()) {
+            const [unitId, subUnitId] = key.split(':');
+            callback(unitId, subUnitId, ranges);
+        }
+
+        return this;
+    }
+
+    protected _getRangeGroups(): Map<string, FRange[]> {
+        const groups = new Map<string, FRange[]>();
+        for (const range of this._ranges) {
+            const key = `${range.getUnitId()}:${range.getSheetId()}`;
+            const ranges = groups.get(key) ?? [];
+            ranges.push(range);
+            groups.set(key, ranges);
+        }
+
+        return groups;
+    }
+}

--- a/packages/sheets/src/facade/f-range.ts
+++ b/packages/sheets/src/facade/f-range.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { AbsoluteRefType, BorderStyleTypes, BorderType, CellValue, CustomData, ICellData, IColorStyle, IDocumentData, IObjectMatrixPrimitiveType, IRange, IStyleData, ITextDecoration, Nullable, Workbook, Worksheet } from '@univerjs/core';
+import type { AbsoluteRefType, BorderStyleTypes, BorderType, CellValue, CustomData, ICellData, IColorStyle, IDocumentData, IObjectMatrixPrimitiveType, IRange, IStyleData, ITextDecoration, Nullable, TextDirection, Workbook, Worksheet } from '@univerjs/core';
 import type {
     AUTO_FILL_APPLY_TYPE,
     IMergeCellsUtilOptions,
@@ -1185,6 +1185,32 @@ export class FRange extends FBaseInitialable {
             range: this._range,
             value: rotation,
         } as ISetTextRotationCommandParams);
+        return this;
+    }
+
+    /**
+     * Sets the text direction for the given range.
+     * @param {TextDirection} direction The text direction.
+     * @returns {FRange} This range, for chaining.
+     * @example
+     * ```ts
+     * const fWorkbook = univerAPI.getActiveWorkbook();
+     * const fWorksheet = fWorkbook.getActiveSheet();
+     * const fRange = fWorksheet.getRange('A1:B2');
+     * fRange.setTextDirection(univerAPI.Enum.TextDirection.RIGHT_TO_LEFT);
+     * ```
+     */
+    setTextDirection(direction: TextDirection): FRange {
+        this._commandService.syncExecuteCommand(SetStyleCommand.id, {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: this._worksheet.getSheetId(),
+            range: this._range,
+            style: {
+                type: 'td',
+                value: direction,
+            },
+        } as ISetStyleCommandParams<TextDirection>);
+
         return this;
     }
 

--- a/packages/sheets/src/facade/f-workbook.ts
+++ b/packages/sheets/src/facade/f-workbook.ts
@@ -18,6 +18,7 @@ import type { CommandListener, CustomData, ICommandInfo, IDisposable, IRange, IS
 import type { ISetDefinedNameMutationParam } from '@univerjs/engine-formula';
 import type { IRangeThemeStyleJSON, ISetSelectionsOperationParams, ISheetCommandSharedParams } from '@univerjs/sheets';
 import type { FontLine as _FontLine } from './f-range';
+import type { FRangeList } from './f-range-list';
 import {
     ICommandService,
     ILogService,
@@ -199,6 +200,24 @@ export class FWorkbook extends FBaseInitialable {
     getActiveSheet(): FWorksheet {
         const activeSheet = this._workbook.getActiveSheet();
         return this._injector.createInstance(FWorksheet, this, this._workbook, activeSheet);
+    }
+
+    /**
+     * Returns a range list. Unqualified ranges are resolved against the active sheet.
+     * Sheet-qualified ranges may target another worksheet.
+     * This API currently documents A1 notation only; R1C1 notation is not claimed.
+     * @param {string[]} a1Notations A non-empty list of ranges in A1 notation.
+     * @returns {FRangeList} A range list representing the specified ranges.
+     * @example
+     * ```ts
+     * const workbook = univerAPI.getActiveWorkbook();
+     * workbook.getRangeList(['A1:D4', 'F1:H4'])
+     *   .setBackgroundColor('#fce4d6')
+     *   .setFontWeight('bold');
+     * ```
+     */
+    getRangeList(a1Notations: string[]): FRangeList {
+        return this.getActiveSheet().getRangeList(a1Notations);
     }
 
     /**

--- a/packages/sheets/src/facade/f-worksheet.ts
+++ b/packages/sheets/src/facade/f-worksheet.ts
@@ -24,6 +24,7 @@ import { deserializeRangeWithSheet } from '@univerjs/engine-formula';
 import { AppendRowCommand, CancelFrozenCommand, ClearSelectionAllCommand, ClearSelectionContentCommand, ClearSelectionFormatCommand, copyRangeStyles, InsertColByRangeCommand, InsertRowByRangeCommand, MoveColsCommand, MoveRowsCommand, RemoveColByRangeCommand, RemoveRowByRangeCommand, SetColDataCommand, SetColHiddenCommand, SetColWidthCommand, SetFrozenCommand, SetGridlinesColorCommand, SetRowDataCommand, SetRowHeightCommand, SetRowHiddenCommand, SetSpecificColsVisibleCommand, SetSpecificRowsVisibleCommand, SetTabColorCommand, SetTextWrapCommand, SetWorksheetColumnCountCommand, SetWorksheetDefaultStyleMutation, SetWorksheetHideCommand, SetWorksheetNameCommand, SetWorksheetRowCountCommand, SetWorksheetRowIsAutoHeightCommand, SetWorksheetRowIsAutoHeightMutation, SetWorksheetShowCommand, SheetsSelectionsService, ToggleGridlinesCommand } from '@univerjs/sheets';
 import { FDefinedNameBuilder } from './f-defined-name';
 import { FRange } from './f-range';
+import { FRangeList } from './f-range-list';
 import { FSelection } from './f-selection';
 import { FWorksheetPermission } from './permission/f-worksheet-permission';
 import { covertToColRange, covertToRowRange } from './utils';
@@ -418,6 +419,29 @@ export class FWorksheet extends FBaseInitialable {
         }
 
         return this._injector.createInstance(FRange, this._workbook, sheet, range);
+    }
+
+    /**
+     * Returns a range list containing the ranges specified by A1 notation.
+     * This API currently documents A1 notation only; R1C1 notation is not claimed.
+     * Unqualified ranges are resolved against this worksheet. Sheet-qualified ranges may target another worksheet.
+     * @param {string[]} a1Notations A non-empty list of ranges in A1 notation.
+     * @returns {FRangeList} A range list representing the specified ranges.
+     * @example
+     * ```ts
+     * const sheet = univerAPI.getActiveWorkbook().getActiveSheet();
+     * sheet.getRangeList(['A1:D4', 'F1:H4'])
+     *   .setBackgroundColor('#fce4d6')
+     *   .setFontWeight('bold');
+     * ```
+     */
+    getRangeList(a1Notations: string[]): FRangeList {
+        if (a1Notations.length === 0) {
+            throw new Error('Range list cannot be empty');
+        }
+
+        const ranges = a1Notations.map((a1Notation) => this.getRange(a1Notation));
+        return this._injector.createInstance(FRangeList, this._workbook, ranges);
     }
 
     /**

--- a/packages/sheets/src/facade/index.ts
+++ b/packages/sheets/src/facade/index.ts
@@ -20,6 +20,7 @@ import './f-enum';
 export * from './f-enum';
 export * from './f-event';
 export { FRange } from './f-range';
+export { FRangeList } from './f-range-list';
 export { FSelection } from './f-selection';
 export { FSheetHooks } from './f-sheet-hooks';
 export { FWorkbook } from './f-workbook';


### PR DESCRIPTION
## Summary

- Add `FRangeList` facade support for applying the same operation to non-contiguous ranges.
- Add `FWorksheet.getRangeList(a1Notations)` and `FWorkbook.getRangeList(a1Notations)`; unqualified A1 notations resolve against the caller sheet / active sheet, while sheet-qualified A1 notations may target another sheet.
- Add package-specific mixins for `sheets-numfmt`, `sheets-data-validation`, and `sheets-note`, so RangeList keeps Univer package boundaries while supporting number formats, data validations, checkboxes, and notes.

## Google Apps Script RangeList Alignment

Reference: Google Apps Script `RangeList` / `getRangeList(a1Notations)` public reference. Google documents are licensed under CC BY 4.0 and sample code under Apache 2.0. This PR is an Apache 2.0 open-source implementation in Univer, using the public API surface as a migration-friendly compatibility reference while keeping Univer-style enums and package boundaries.

Supported in this PR:

- [x] `FWorksheet.getRangeList(a1Notations: string[])`
- [x] `FWorkbook.getRangeList(a1Notations: string[])` for the active sheet
- [x] `FRangeList.getRanges()`
- [x] `activate()`
- [x] `breakApart()`
- [x] `check()` / `uncheck()` via sheets-data-validation facade mixin
- [x] `clear()` / `clear(options)` with Univer clear options
- [x] `clearContent()`
- [x] `clearDataValidations()` via sheets-data-validation facade mixin
- [x] `clearFormat()`
- [x] `clearNote()` via sheets-note facade mixin
- [x] `insertCheckboxes()` overloads and `removeCheckboxes()` via sheets-data-validation facade mixin
- [x] `setBackground(color)` / `setBackgroundColor(color)`
- [x] `setBackgroundRGB(red, green, blue)`
- [x] `setBorder(type, style, color?)` using Univer `BorderType` / `BorderStyleTypes`
- [x] `setDataValidation(rule)` using Univer data validation builder API
- [x] `setFontColor(color)`
- [x] `setFontFamily(fontFamily)`
- [x] `setFontLine(fontLine)`
- [x] `setFontSize(size)`
- [x] `setFontStyle(fontStyle)`
- [x] `setFontWeight(fontWeight)`
- [x] `setFormula(formula)` for A1 formulas
- [x] `setHorizontalAlignment(alignment)`
- [x] `setNote(note)` via sheets-note facade mixin
- [x] `setNumberFormat(pattern)` via sheets-numfmt facade mixin
- [x] `setTextDirection(direction)` using Univer `TextDirection`
- [x] `setTextRotation(rotation)`
- [x] `setValue(value)`
- [x] `setVerticalAlignment(alignment)`
- [x] `setWrap(isWrapEnabled)`
- [x] `setWrapStrategy(strategy)`

Follow-up TODOs from Google RangeList API surface:

- [ ] `setFormulaR1C1(formula)` - Univer has R1C1 range parse/serialize utilities, but this API needs formula-string-level R1C1 reference conversion relative to each target cell before it can be exposed safely.
- [ ] `setShowHyperlink(showHyperlink)` - no direct Univer facade/display-flag equivalent identified in the current hyperlink facade surface.
- [ ] `setVerticalText(isVertical)` - no direct Univer sheets facade equivalent identified yet.
- [ ] `trimWhitespace()` - implement separately with explicit value/rich-text/formula semantics.

Known differences from Google Apps Script:

- `getRangeList()` currently documents and tests A1 notation. R1C1 formula support is intentionally not claimed in this PR.
- `activate()` throws for cross-sheet range lists because active selection is a single-sheet UI state. Other operations may dispatch across sheet-qualified ranges by grouping or delegating per range.
- `setBorder()` follows Univer's enum-based `FRange.setBorder(type, style, color?)` API instead of Google Apps Script boolean-edge overloads.
- `clear(options)` follows Univer's current `IFacadeClearOptions` shape.
- `check()` / `uncheck()` write the existing checkbox rule's checked/unchecked value and throw if the target contains non-checkbox data validation or mixed checkbox values.
- `removeCheckboxes()` refuses to clear ranges that contain non-checkbox data validation, avoiding accidental deletion of unrelated validation rules.
- `setNote()` / `clearNote()` target the top-left cell of each range, matching the existing sheets-note facade note model.
- `clearDataValidations()`, `setDataValidation()`, checkbox methods, note methods, and number format methods are provided by package-specific facade mixins.

## Implementation Notes

- Low-risk grouped execution is used where existing commands already accept range arrays: border, merge break-apart, clear operations, and data validation operations.
- Other style/value/formula operations currently delegate per `FRange`; they can be optimized later by extending the underlying command layer without changing the facade API.

## Tests

- `pnpm --filter @univerjs/sheets typecheck`
- `pnpm --filter @univerjs/sheets test src/facade/__tests__/f-range-list.spec.ts src/facade/__tests__/f-workbook.spec.ts`
- `pnpm --filter @univerjs/sheets-numfmt typecheck`
- `pnpm --filter @univerjs/sheets-numfmt test src/facade/__tests__/f-range.spec.ts`
- `pnpm --filter @univerjs/sheets-data-validation typecheck`
- `pnpm --filter @univerjs/sheets-data-validation test src/facade/__tests__/f-range.spec.ts`
- `pnpm --filter @univerjs/sheets-note typecheck`
- `pnpm --filter @univerjs/sheets-note test src/facade/__tests__/sheets-note.facade.spec.ts`
- `pnpm exec eslint packages/sheets/src/facade/f-range.ts packages/sheets/src/facade/f-range-list.ts packages/sheets/src/facade/f-workbook.ts packages/sheets/src/facade/f-worksheet.ts packages/sheets/src/facade/index.ts packages/sheets/src/facade/__tests__/f-range-list.spec.ts packages/sheets/src/facade/__tests__/f-workbook.spec.ts packages/sheets-numfmt/src/facade/f-range-list.ts packages/sheets-numfmt/src/facade/index.ts packages/sheets-numfmt/src/facade/__tests__/f-range.spec.ts packages/sheets-data-validation/src/facade/f-range-list.ts packages/sheets-data-validation/src/facade/index.ts packages/sheets-data-validation/src/facade/__tests__/f-range.spec.ts packages/sheets-note/src/facade/f-range.ts packages/sheets-note/src/facade/f-range-list.ts packages/sheets-note/src/facade/index.ts packages/sheets-note/src/facade/__tests__/sheets-note.facade.spec.ts`
- `git diff --check`
