### PR TITLE
feat(sheets): add R1C1 formula facade API

### DIFF
--- a/packages/engine-formula/src/engine/utils/__tests__/r1c1-reference.spec.ts
+++ b/packages/engine-formula/src/engine/utils/__tests__/r1c1-reference.spec.ts
@@ -17,7 +17,7 @@
 import type { IRange } from '@univerjs/core';
 import { AbsoluteRefType } from '@univerjs/core';
 import { describe, expect, it } from 'vitest';
-import { deserializeRangeForR1C1, serializeRangeToR1C1 } from '../r1c1-reference';
+import { deserializeRangeForR1C1, normalizeFormulaR1C1ToA1, serializeRangeToR1C1 } from '../r1c1-reference';
 
 describe('Test Reference R1C1', () => {
     it('deserializeRangeForR1C1', () => {
@@ -58,6 +58,38 @@ describe('Test Reference R1C1', () => {
             },
             sheetName: 'sheet1',
             unitId: 'workbook1',
+        });
+
+        expect(deserializeRangeForR1C1('RC:R[1]C[2]', 4, 5)).toStrictEqual({
+            range: {
+                endAbsoluteRefType: 0,
+                endColumn: 7,
+                endRow: 5,
+                startAbsoluteRefType: 0,
+                startColumn: 5,
+                startRow: 4,
+            },
+            sheetName: '',
+            unitId: '',
+        });
+    });
+
+    describe('normalizeFormulaR1C1ToA1', () => {
+        it('converts absolute, relative, and mixed R1C1 references', () => {
+            expect(normalizeFormulaR1C1ToA1('=R1C1+R[1]C[-1]', 1, 1)).toBe('=$A$1+A3');
+            expect(normalizeFormulaR1C1ToA1('=R1C[-1]+R[1]C2', 2, 2)).toBe('=B$1+$B4');
+            expect(normalizeFormulaR1C1ToA1('=SUM(R[-1]C:R[-1]C[2])', 4, 1)).toBe('=SUM(B4:D4)');
+        });
+
+        it('converts sheet-qualified references and preserves string literals', () => {
+            expect(normalizeFormulaR1C1ToA1('="R1C1"&R1C1', 0, 0)).toBe('="R1C1"&$A$1');
+            expect(normalizeFormulaR1C1ToA1("='Other Sheet'!R1C1+[book]Sheet1!R2C3", 0, 0)).toBe("='Other Sheet'!$A$1+[book]Sheet1!$C$2");
+            expect(normalizeFormulaR1C1ToA1("='O''Brien'!R1C1", 0, 0)).toBe("='O''Brien'!$A$1");
+        });
+
+        it('does not convert R1C1-looking text in structured references or names', () => {
+            expect(normalizeFormulaR1C1ToA1('=Table1[R1C1]+R1C1', 0, 0)).toBe('=Table1[R1C1]+$A$1');
+            expect(normalizeFormulaR1C1ToA1('=Table1[[#All],[R1C1]]+R1C1Name+NameR1C1+R1C1', 0, 0)).toBe('=Table1[[#All],[R1C1]]+R1C1Name+NameR1C1+$A$1');
         });
     });
 
@@ -107,7 +139,7 @@ describe('Test Reference R1C1', () => {
             };
             expect(serializeRangeToR1C1(range)).toEqual('R2C2:R3C3');
         });
-        it('should handle all absolute references', () => {
+        it('should handle relative row and column references', () => {
             const range: IRange = {
                 startRow: 1,
                 startColumn: 1,
@@ -118,7 +150,7 @@ describe('Test Reference R1C1', () => {
             };
             expect(serializeRangeToR1C1(range)).toEqual('R[2]C[2]:R[3]C[3]');
         });
-        it('should handle all absolute references', () => {
+        it('should default omitted absolute ref types to all absolute references', () => {
             const range: IRange = {
                 startRow: 1,
                 startColumn: 1,

--- a/packages/engine-formula/src/engine/utils/r1c1-reference.ts
+++ b/packages/engine-formula/src/engine/utils/r1c1-reference.ts
@@ -16,23 +16,103 @@
 
 import type { IRange, IUnitRangeName } from '@univerjs/core';
 import { AbsoluteRefType } from '@univerjs/core';
-import { handleRefStringInfo } from './reference';
+import { serializeRangeToRefString, unquoteSheetName } from './reference';
 
-const $relativeRegex = /[\[\]]/g;
+const $relativeRegex = /[\[\]]/;
+const $relativeReplaceRegex = /[\[\]]/g;
+const $formulaR1C1ReferenceRegex = /(?:(?:'(?:(?:'')|[^'])+'|(?:\[[^\]\r\n]+\])?[A-Za-z_][A-Za-z0-9_.]*)!)?R(?:\[-?\d+\]|\d*)C(?:\[-?\d+\]|\d*)(?::R(?:\[-?\d+\]|\d*)C(?:\[-?\d+\]|\d*))?/iy;
+const $workbookSheetPrefixRegex = /^\[([^\]\r\n]+)\](.*)$/;
 
 function handleR1C1(rowOrColumnString: string, current: number) {
+    if (rowOrColumnString === '') {
+        return current;
+    }
+
     if ($relativeRegex.test(rowOrColumnString)) {
-        const index = Number(rowOrColumnString.replace($relativeRegex, ''));
+        const index = Number(rowOrColumnString.replace($relativeReplaceRegex, ''));
         return current + index;
     }
 
     return Number(rowOrColumnString) - 1;
 }
 
-function singleReference(refBody: string, currentRow = 0, currentColumn = 0) {
-    refBody = refBody.toLocaleUpperCase();
+function getAbsoluteRefTypeForR1C1(rowString: string, columnString: string): AbsoluteRefType {
+    const rowAbsolute = rowString !== '' && !$relativeRegex.test(rowString);
+    const columnAbsolute = columnString !== '' && !$relativeRegex.test(columnString);
 
-    const refBodyArray = refBody.split(/[RC]/);
+    if (rowAbsolute && columnAbsolute) {
+        return AbsoluteRefType.ALL;
+    }
+
+    if (rowAbsolute) {
+        return AbsoluteRefType.ROW;
+    }
+
+    if (columnAbsolute) {
+        return AbsoluteRefType.COLUMN;
+    }
+
+    return AbsoluteRefType.NONE;
+}
+
+function splitR1C1RefString(refString: string) {
+    let quoteOpened = false;
+    let sheetNameIndex = -1;
+
+    for (let index = 0; index < refString.length; index++) {
+        const char = refString[index];
+        if (char === "'") {
+            if (quoteOpened && refString[index + 1] === "'") {
+                index++;
+                continue;
+            }
+
+            quoteOpened = !quoteOpened;
+            continue;
+        }
+
+        if (char === '!' && !quoteOpened) {
+            sheetNameIndex = index;
+            break;
+        }
+    }
+
+    if (sheetNameIndex === -1) {
+        return {
+            refBody: refString,
+            sheetName: '',
+            unitId: '',
+        };
+    }
+
+    let prefix = refString.substring(0, sheetNameIndex);
+    const refBody = refString.substring(sheetNameIndex + 1);
+    if (prefix[0] === "'" && prefix[prefix.length - 1] === "'") {
+        prefix = prefix.substring(1, prefix.length - 1);
+    }
+
+    prefix = unquoteSheetName(prefix);
+
+    const unitMatch = $workbookSheetPrefixRegex.exec(prefix);
+    if (unitMatch) {
+        return {
+            refBody,
+            unitId: unquoteSheetName(unitMatch[1]),
+            sheetName: unitMatch[2],
+        };
+    }
+
+    return {
+        refBody,
+        sheetName: prefix,
+        unitId: '',
+    };
+}
+
+function singleReference(refBody: string, currentRow = 0, currentColumn = 0, preserveAbsoluteRefType = false) {
+    const normalizedRefBody = refBody.toLocaleUpperCase();
+
+    const refBodyArray = normalizedRefBody.split(/[RC]/);
 
     const rowString = refBodyArray[1];
 
@@ -45,17 +125,17 @@ function singleReference(refBody: string, currentRow = 0, currentColumn = 0) {
     return {
         row,
         column,
-        absoluteRefType: AbsoluteRefType.NONE,
+        absoluteRefType: preserveAbsoluteRefType ? getAbsoluteRefTypeForR1C1(rowString, columnString) : AbsoluteRefType.NONE,
     };
 }
 
-export function deserializeRangeForR1C1(refString: string, currentRow = 0, currentColumn = 0): IUnitRangeName {
-    const { refBody, sheetName, unitId } = handleRefStringInfo(refString);
+export function deserializeRangeForR1C1(refString: string, currentRow = 0, currentColumn = 0, preserveAbsoluteRefType = false): IUnitRangeName {
+    const { refBody, sheetName, unitId } = splitR1C1RefString(refString);
 
     const colonIndex = refBody.indexOf(':');
 
     if (colonIndex === -1) {
-        const grid = singleReference(refBody, currentRow, currentColumn);
+        const grid = singleReference(refBody, currentRow, currentColumn, preserveAbsoluteRefType);
 
         const row = grid.row;
 
@@ -90,9 +170,9 @@ export function deserializeRangeForR1C1(refString: string, currentRow = 0, curre
 
     const refEndString = refBody.substring(colonIndex + 1);
 
-    const startGrid = singleReference(refStartString, currentRow, currentColumn);
+    const startGrid = singleReference(refStartString, currentRow, currentColumn, preserveAbsoluteRefType);
 
-    const endGrid = singleReference(refEndString, currentRow, currentColumn);
+    const endGrid = singleReference(refEndString, currentRow, currentColumn, preserveAbsoluteRefType);
 
     const startRow = startGrid.row;
 
@@ -123,6 +203,104 @@ export function deserializeRangeForR1C1(refString: string, currentRow = 0, curre
     };
 }
 
+function isFormulaIdentifierPart(char: string | undefined): boolean {
+    return char != null && /[A-Za-z0-9_.$]/.test(char);
+}
+
+function readDoubleQuotedString(formulaString: string, startIndex: number): number {
+    let index = startIndex + 1;
+
+    while (index < formulaString.length) {
+        if (formulaString[index] !== '"') {
+            index++;
+            continue;
+        }
+
+        if (formulaString[index + 1] === '"') {
+            index += 2;
+            continue;
+        }
+
+        return index + 1;
+    }
+
+    return formulaString.length;
+}
+
+function readSquareBracketExpression(formulaString: string, startIndex: number): number {
+    let index = startIndex + 1;
+
+    while (index < formulaString.length) {
+        if (formulaString[index] === ']') {
+            return index + 1;
+        }
+
+        index++;
+    }
+
+    return formulaString.length;
+}
+
+/**
+ * Normalizes R1C1 references in a formula string to A1 references for a target cell.
+ *
+ * This keeps formula strings executable by Univer's current A1 formula pipeline while
+ * preserving R1C1 absolute/relative semantics against the supplied zero-based row/column.
+ *
+ * @param formulaString Formula text, with or without a leading equals sign.
+ * @param currentRow Zero-based row of the target cell.
+ * @param currentColumn Zero-based column of the target cell.
+ * @returns Formula text with R1C1 references converted to A1 references.
+ *
+ * @example
+ * ```ts
+ * normalizeFormulaR1C1ToA1('=SUM(R[-1]C:R[-1]C[2])', 4, 1);
+ * // '=SUM(B4:D4)'
+ * ```
+ */
+export function normalizeFormulaR1C1ToA1(formulaString: string, currentRow = 0, currentColumn = 0): string {
+    const chunks: string[] = [];
+    let index = 0;
+
+    while (index < formulaString.length) {
+        const char = formulaString[index];
+
+        if (char === '"') {
+            const endIndex = readDoubleQuotedString(formulaString, index);
+            chunks.push(formulaString.slice(index, endIndex));
+            index = endIndex;
+            continue;
+        }
+
+        $formulaR1C1ReferenceRegex.lastIndex = index;
+        const matched = $formulaR1C1ReferenceRegex.exec(formulaString);
+        if (!matched && char === '[') {
+            const endIndex = readSquareBracketExpression(formulaString, index);
+            chunks.push(formulaString.slice(index, endIndex));
+            index = endIndex;
+            continue;
+        }
+
+        if (matched) {
+            const token = matched[0];
+            const previousChar = formulaString[index - 1];
+            const nextChar = formulaString[index + token.length];
+
+            if (!isFormulaIdentifierPart(previousChar) && !isFormulaIdentifierPart(nextChar)) {
+                const rangeName = deserializeRangeForR1C1(token, currentRow, currentColumn, true);
+                chunks.push(serializeRangeToRefString(rangeName));
+                index += token.length;
+                continue;
+            }
+        }
+
+        chunks.push(char);
+        index++;
+    }
+
+    return chunks.join('');
+}
+
 export function serializeRangeToR1C1(range: IRange): string {
     const startRowRef = getR1C1Ref(range.startRow, range.startAbsoluteRefType, true);
     const startColumnRef = getR1C1Ref(range.startColumn, range.startAbsoluteRefType, false);
@@ -137,15 +315,15 @@ export function serializeRangeToR1C1(range: IRange): string {
 }
 
 function getR1C1Ref(index: number, absoluteRefType: AbsoluteRefType = AbsoluteRefType.ALL, isRow: boolean): string {
-    index += 1;
+    const oneBasedIndex = index + 1;
     switch (absoluteRefType) {
         case AbsoluteRefType.ALL:
-            return `${index}`;
+            return `${oneBasedIndex}`;
         case AbsoluteRefType.ROW:
-            return isRow ? `${index}` : `[${index}]`;
+            return isRow ? `${oneBasedIndex}` : `[${oneBasedIndex}]`;
         case AbsoluteRefType.COLUMN:
-            return isRow ? `[${index}]` : `${index}`;
+            return isRow ? `[${oneBasedIndex}]` : `${oneBasedIndex}`;
         case AbsoluteRefType.NONE:
-            return `[${index}]`;
+            return `[${oneBasedIndex}]`;
     }
 }

--- a/packages/engine-formula/src/index.ts
+++ b/packages/engine-formula/src/index.ts
@@ -120,7 +120,7 @@ export { extractFormulaError } from './engine/utils/cell';
 export { generateAstNode } from './engine/utils/generate-ast-node';
 export { strip, stripErrorMargin } from './engine/utils/math-kit';
 export { handleNumfmtInCell } from './engine/utils/numfmt-kit';
-export { deserializeRangeForR1C1 } from './engine/utils/r1c1-reference';
+export { deserializeRangeForR1C1, normalizeFormulaR1C1ToA1 } from './engine/utils/r1c1-reference';
 export {
     deserializeRangeWithSheet,
     getAbsoluteRefTypeWithSingleString,

--- a/packages/sheets/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-range.spec.ts
@@ -302,6 +302,49 @@ describe('Test FRange', () => {
         ]);
     });
 
+    it('Range setFormulaR1C1 resolves references against target cells', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+
+        activeSheet.getRange('B2').setFormulaR1C1('=SUM(R[-1]C:R[-1]C[2])');
+        expect(activeSheet.getRange('B2').getFormula()).toBe('=SUM(B1:D1)');
+
+        activeSheet.getRange('C3:D4').setFormulaR1C1('=R1C1+R[-1]C[-1]');
+        expect(activeSheet.getRange('C3:D4').getFormulas()).toEqual([
+            ['=$A$1+B2', '=$A$1+C2'],
+            ['=$A$1+B3', '=$A$1+C3'],
+        ]);
+    });
+
+    it('Range setFormulaR1C1 preserves string literals and sheet-qualified references', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+
+        activeSheet.getRange('A1').setFormulaR1C1('="R1C1"&Sheet2!R2C3');
+
+        expect(activeSheet.getRange('A1').getFormula()).toBe('="R1C1"&Sheet2!$C$2');
+    });
+
+    it('Range setFormulasR1C1 resolves each formula against its target cell', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+
+        activeSheet.getRange('B2:C3').setFormulasR1C1([
+            ['=R[-1]C', '=R[-1]C[-1]'],
+            ['=R[-1]C', '=R[-1]C[-1]'],
+        ]);
+
+        expect(activeSheet.getRange('B2:C3').getFormulas()).toEqual([
+            ['=B1', '=B1'],
+            ['=B2', '=B2'],
+        ]);
+    });
+
+    it('Range setFormulasR1C1 requires matching range dimensions', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+
+        expect(() => activeSheet.getRange('B2:C3').setFormulasR1C1([
+            ['=R[-1]C'],
+        ])).toThrow('The number of rows and columns in formulas must match the range dimensions');
+    });
+
     it('Range getWrap', async () => {
         const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
         const range = activeSheet?.getRange(0, 0);

--- a/packages/sheets/src/facade/f-range.ts
+++ b/packages/sheets/src/facade/f-range.ts
@@ -34,7 +34,7 @@ import type { IFacadeClearOptions } from './f-worksheet';
 import type { FHorizontalAlignment, FVerticalAlignment } from './utils';
 import { BooleanNumber, covertCellValue, covertCellValues, DEFAULT_STYLES, Dimension, ICommandService, Inject, Injector, isNullCell, Rectangle, RichTextValue, TextStyleValue, WrapStrategy } from '@univerjs/core';
 import { FBaseInitialable } from '@univerjs/core/facade';
-import { FormulaDataModel, serializeRange, serializeRangeWithSheet } from '@univerjs/engine-formula';
+import { FormulaDataModel, normalizeFormulaR1C1ToA1, serializeRange, serializeRangeWithSheet } from '@univerjs/engine-formula';
 import {
     addMergeCellsUtil,
     AutoFillCommand,
@@ -2658,6 +2658,26 @@ export class FRange extends FBaseInitialable {
     }
 
     /**
+     * Updates the formula for this range using R1C1 notation.
+     * Relative references are resolved against each target cell in the range.
+     * @param {string} formula - A string representing the R1C1 formula to set for the cell.
+     * @returns {FRange} This range instance for chaining.
+     * @example
+     * ```ts
+     * const fWorkbook = univerAPI.getActiveWorkbook();
+     * const fWorksheet = fWorkbook.getActiveSheet();
+     * const fRange = fWorksheet.getRange('B2');
+     * fRange.setFormulaR1C1('=SUM(R[-1]C:R[-1]C[2])');
+     * console.log(fRange.getFormula()); // '=SUM(B1:D1)'
+     * ```
+     */
+    setFormulaR1C1(formula: string): FRange {
+        return this.setFormulasR1C1(
+            Array.from({ length: this.getHeight() }, () => Array.from({ length: this.getWidth() }, () => formula))
+        );
+    }
+
+    /**
      * Sets a rectangular grid of formulas (must match dimensions of this range). The given formulas must be in A1 notation.
      * @param {string[][]} formulas - A two-dimensional string array of formulas.
      * @returns {FRange} This range instance for chaining.
@@ -2675,6 +2695,32 @@ export class FRange extends FBaseInitialable {
      */
     setFormulas(formulas: string[][]): FRange {
         return this.setValues(formulas.map((row) => row.map((formula) => ({ f: formula }))));
+    }
+
+    /**
+     * Sets a rectangular grid of formulas using R1C1 notation. Each formula is resolved against its target cell in this range.
+     * @param {string[][]} formulas - A two-dimensional string array of R1C1 formulas.
+     * @returns {FRange} This range instance for chaining.
+     * @example
+     * ```ts
+     * const fWorkbook = univerAPI.getActiveWorkbook();
+     * const fWorksheet = fWorkbook.getActiveSheet();
+     * const fRange = fWorksheet.getRange('B2:C3');
+     * fRange.setFormulasR1C1([
+     *   ['=R[-1]C', '=R[-1]C'],
+     *   ['=R[-1]C', '=R[-1]C'],
+     * ]);
+     * console.log(fRange.getFormulas()); // [['=B1', '=C1'], ['=B2', '=C2']]
+     * ```
+     */
+    setFormulasR1C1(formulas: string[][]): FRange {
+        if (formulas.length !== this.getHeight() || formulas.some((row) => row.length !== this.getWidth())) {
+            throw new Error('The number of rows and columns in formulas must match the range dimensions');
+        }
+
+        return this.setFormulas(formulas.map((formulaRow, row) => formulaRow.map((formula, column) =>
+            normalizeFormulaR1C1ToA1(formula, this.getRow() + row, this.getColumn() + column)
+        )));
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add `normalizeFormulaR1C1ToA1()` in `@univerjs/engine-formula` to normalize R1C1 references in a formula string into A1 references for a target cell.
- Improve `deserializeRangeForR1C1()` so common R1C1 forms such as `RC`, `R1C`, `RC1`, and relative references like `R[1]C[-1]` parse correctly without treating `[1]` as a workbook id.
- Add `FRange.setFormulaR1C1(formula)` and `FRange.setFormulasR1C1(formulas)`, resolving relative references against each target cell.

## Design Notes

This PR intentionally implements R1C1 at the `FRange` formula layer first. Once the RangeList API PR lands, `FRangeList.setFormulaR1C1()` and `FRangeList.setFormulasR1C1()` can safely delegate to these `FRange` APIs without inventing a separate execution path.

The normalizer skips double-quoted string literals, skips R1C1-looking text inside structured-reference brackets, and supports sheet/workbook-qualified R1C1 references. It normalizes to A1 because the current Univer facade formula write path already accepts A1 formulas.

This is not a full parser-level R1C1 reference-style mode. A future formula-engine PR can move this lower into lexer/reference-token handling if we decide to support R1C1 natively in the AST pipeline.

## Tests

- `pnpm --filter @univerjs/engine-formula test src/engine/utils/__tests__/r1c1-reference.spec.ts`
- `pnpm --filter @univerjs/engine-formula typecheck`
- `pnpm --filter @univerjs/sheets test src/facade/__tests__/f-range.spec.ts`
- `pnpm --filter @univerjs/sheets typecheck`
- `pnpm exec eslint packages/engine-formula/src/engine/utils/r1c1-reference.ts packages/engine-formula/src/engine/utils/__tests__/r1c1-reference.spec.ts packages/engine-formula/src/index.ts packages/sheets/src/facade/f-range.ts packages/sheets/src/facade/__tests__/f-range.spec.ts`
- `git diff --check`

Note: targeted eslint exits with 0 and reports only existing warnings in `packages/sheets/src/facade/f-range.ts` / `f-range.spec.ts`.
