### PR TITLE
refactor: migrate from deprecated getCurrentUnitForType to getCurrentUnitOfType

### DIFF
--- a/common/debugger/src/controllers/e2e/e2e.controller.ts
+++ b/common/debugger/src/controllers/e2e/e2e.controller.ts
@@ -133,7 +133,7 @@ export class E2EController extends Disposable {
     }
 
     private async _disposeDefaultSheetUnit(disposingTimeout: number = AWAIT_DISPOSING_TIMEOUT): Promise<void> {
-        const unit = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_SHEET);
+        const unit = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SHEET);
         const unitId = unit?.getUnitId();
         await this._univerInstanceService.disposeUnit(unitId || '');
         await awaitTime(disposingTimeout);

--- a/packages/core/src/services/instance/instance.service.ts
+++ b/packages/core/src/services/instance/instance.service.ts
@@ -78,8 +78,6 @@ export interface IUniverInstanceService {
     /** Get the currently focused unit. */
     getFocusedUnit(): Nullable<UnitModel>;
 
-    /** @deprecated Use `getCurrentUnitOfType` instead. */
-    getCurrentUnitForType<T extends UnitModel>(type: UniverInstanceType): Nullable<T>;
     getCurrentUnitOfType<T extends UnitModel>(type: UniverInstanceType): Nullable<T>;
     setCurrentUnitForType(unitId: string): void;
     getCurrentTypeOfUnit$<T extends UnitModel>(type: UniverInstanceType): Observable<Nullable<T>>;
@@ -168,12 +166,8 @@ export class UniverInstanceService extends Disposable implements IUniverInstance
         return this.currentUnits$.pipe(map((units) => units.get(type) ?? null), distinctUntilChanged()) as Observable<Nullable<T>>;
     }
 
-    getCurrentUnitForType<T extends UnitModel>(type: UniverInstanceType): Nullable<T> {
-        return this._currentUnits.get(type) as Nullable<T>;
-    }
-
     getCurrentUnitOfType<T extends UnitModel>(type: UniverInstanceType): Nullable<T> {
-        return this.getCurrentUnitForType(type);
+        return this._currentUnits.get(type) as Nullable<T>;
     }
 
     setCurrentUnitForType(unitId: string): void {
@@ -232,7 +226,7 @@ export class UniverInstanceService extends Disposable implements IUniverInstance
     }
 
     getCurrentUniverDocInstance(): Nullable<DocumentDataModel> {
-        return this.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC) as Nullable<DocumentDataModel>;
+        return this.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC) as Nullable<DocumentDataModel>;
     }
 
     getUniverDocInstance(unitId: string): Nullable<DocumentDataModel> {
@@ -333,7 +327,7 @@ export class UniverInstanceService extends Disposable implements IUniverInstance
     }
 
     private _tryResetCurrentOnRemoval(unitId: string, type: UniverInstanceType): void {
-        const current = this.getCurrentUnitForType(type);
+        const current = this.getCurrentUnitOfType(type);
         if (current?.getUnitId() === unitId) {
             this._currentUnits.set(type, null);
             this._currentUnits$.next(this._currentUnits);

--- a/packages/docs-hyper-link-ui/src/commands/operations/popup.operation.ts
+++ b/packages/docs-hyper-link-ui/src/commands/operations/popup.operation.ts
@@ -28,7 +28,7 @@ export const shouldDisableAddLink = (accessor: IAccessor) => {
     }
 
     const activeRange = textRanges[0];
-    const doc = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+    const doc = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
     if (!doc || !activeRange || activeRange.collapsed) {
         return true;
     }
@@ -57,7 +57,7 @@ export const ShowDocHyperLinkEditPopupOperation: ICommand<IShowDocHyperLinkEditP
             return false;
         }
         const hyperLinkService = accessor.get(DocHyperLinkPopupService);
-        const unitId = linkInfo?.unitId || univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC)?.getUnitId();
+        const unitId = linkInfo?.unitId || univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC)?.getUnitId();
 
         if (!unitId) {
             return false;

--- a/packages/docs-hyper-link-ui/src/views/hyper-link-edit/index.tsx
+++ b/packages/docs-hyper-link-ui/src/views/hyper-link-edit/index.tsx
@@ -53,7 +53,7 @@ export const DocHyperLinkEdit = () => {
     const isLegal = Tools.isLegalUrl(link);
     const doc = editing
         ? univerInstanceService.getUnit<DocumentDataModel>(editing.unitId, UniverInstanceType.UNIVER_DOC) :
-        univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
 
     useEffect(() => {
         const activeRange = docSelectionManagerService.getActiveTextRange();

--- a/packages/docs-thread-comment-ui/src/commands/operations/show-comment-panel.operation.ts
+++ b/packages/docs-thread-comment-ui/src/commands/operations/show-comment-panel.operation.ts
@@ -85,7 +85,7 @@ export const StartAddCommentOperation: ICommand = {
     handler(accessor) {
         const panelService = accessor.get(ThreadCommentPanelService);
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        const doc = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const doc = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const docSelectionManagerService = accessor.get(DocSelectionManagerService);
         const renderManagerService = accessor.get(IRenderManagerService);
         const userManagerService = accessor.get(UserManagerService);

--- a/packages/docs-thread-comment-ui/src/controllers/render-controllers/__tests__/render.controller.spec.ts
+++ b/packages/docs-thread-comment-ui/src/controllers/render-controllers/__tests__/render.controller.spec.ts
@@ -44,7 +44,7 @@ describe('DocThreadCommentRenderController', () => {
         };
 
         const univerInstanceService = {
-            getCurrentUnitForType: vi.fn(() => ({ getUnitId: () => 'doc-1' })),
+            getCurrentUnitOfType: vi.fn(() => ({ getUnitId: () => 'doc-1' })),
         };
 
         const commentUpdate$ = new Subject<any>();

--- a/packages/docs-thread-comment-ui/src/controllers/render-controllers/render.controller.ts
+++ b/packages/docs-thread-comment-ui/src/controllers/render-controllers/render.controller.ts
@@ -48,7 +48,7 @@ export class DocThreadCommentRenderController extends Disposable implements IRen
                 return;
             }
 
-            const unitId = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC)?.getUnitId();
+            const unitId = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC)?.getUnitId();
             if (unitId) {
                 this._docRenderController.reRender(unitId);
             }

--- a/packages/docs-ui/src/basics/custom-decoration-factory.ts
+++ b/packages/docs-ui/src/basics/custom-decoration-factory.ts
@@ -63,7 +63,7 @@ export function addCustomDecorationBySelectionFactory(accessor: IAccessor, param
 
     const documentDataModel = propUnitId ?
         univerInstanceService.getUnit<DocumentDataModel>(propUnitId, UniverInstanceType.UNIVER_DOC)
-        : univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        : univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
     if (!documentDataModel) {
         return false;
     }

--- a/packages/docs-ui/src/commands/commands/break-line.command.ts
+++ b/packages/docs-ui/src/commands/commands/break-line.command.ts
@@ -105,7 +105,7 @@ export const BreakLineCommand: ICommand<IBreakLineCommandParams> = {
 
         const { horizontalLine } = params ?? {};
         const { segmentId } = activeTextRange;
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const originBody = docDataModel?.getSelfOrHeaderFooterModel(segmentId ?? '').getBody();
 
         if (docDataModel == null || originBody == null) {

--- a/packages/docs-ui/src/commands/commands/doc-delete.command.ts
+++ b/packages/docs-ui/src/commands/commands/doc-delete.command.ts
@@ -153,7 +153,7 @@ export const MergeTwoParagraphCommand: ICommand<IMergeTwoParagraphParams> = {
             return false;
         }
         const { segmentId, style } = activeRange;
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const originBody = docDataModel?.getSelfOrHeaderFooterModel(segmentId).getBody();
         if (docDataModel == null || originBody == null) {
             return false;
@@ -273,7 +273,7 @@ export const RemoveHorizontalLineCommand: ICommand = {
             return false;
         }
         const { segmentId, style } = activeRange;
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const originBody = docDataModel?.getSelfOrHeaderFooterModel(segmentId).getBody();
         if (docDataModel == null || originBody == null) {
             return false;

--- a/packages/docs-ui/src/commands/commands/doc-paragraph-setting.command.ts
+++ b/packages/docs-ui/src/commands/commands/doc-paragraph-setting.command.ts
@@ -33,7 +33,7 @@ export const DocParagraphSettingCommand: ICommand<IDocParagraphSettingCommandPar
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const commandService = accessor.get(ICommandService);
 
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const docRanges = docSelectionManagerService.getDocRanges();
 
         if (!docDataModel || docRanges.length === 0 || !config) {

--- a/packages/docs-ui/src/commands/commands/doc-select-all.command.ts
+++ b/packages/docs-ui/src/commands/commands/doc-select-all.command.ts
@@ -27,7 +27,7 @@ export const DocSelectAllCommand: ICommand<ISelectAllCommandParams> = {
     handler: async (accessor) => {
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const docSelectionManagerService = accessor.get(DocSelectionManagerService);
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const docRanges = docSelectionManagerService.getDocRanges();
         const activeRange = docRanges.find((range) => range.isActive) ?? docRanges[0];
         if (docDataModel == null || activeRange == null) {

--- a/packages/docs-ui/src/commands/commands/inline-format.command.ts
+++ b/packages/docs-ui/src/commands/commands/inline-format.command.ts
@@ -262,7 +262,7 @@ export const SetInlineFormatCommand: ICommand<ISetInlineFormatCommandParams> = {
 
         const { segmentId } = docRanges[0];
 
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         if (docDataModel == null) {
             return false;
         }

--- a/packages/docs-ui/src/commands/commands/list.command.ts
+++ b/packages/docs-ui/src/commands/commands/list.command.ts
@@ -52,7 +52,7 @@ export const ListOperationCommand: ICommand<IListOperationCommandParams> = {
 
         const listType: string = params.listType;
 
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const docRanges = params.docRange ?? docSelectionManagerService.getDocRanges() ?? [];
 
         if (docDataModel == null || docRanges.length === 0) {
@@ -118,7 +118,7 @@ export const ChangeListTypeCommand: ICommand<IChangeListTypeCommandParams> = {
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const commandService = accessor.get(ICommandService);
         const { listType } = params;
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const activeRanges = params.docRange ?? docSelectionManagerService.getDocRanges();
         if (docDataModel == null || activeRanges == null || !activeRanges.length) {
             return false;
@@ -189,7 +189,7 @@ export const ChangeListNestingLevelCommand: ICommand<IChangeListNestingLevelComm
         const docSelectionManagerService = accessor.get(DocSelectionManagerService);
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const commandService = accessor.get(ICommandService);
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const activeRange = docSelectionManagerService.getActiveTextRange();
         if (docDataModel == null || activeRange == null) {
             return false;
@@ -301,7 +301,7 @@ export const ToggleCheckListCommand: ICommand<IToggleCheckListCommandParams> = {
         const commandService = accessor.get(ICommandService);
         const { index, segmentId, textRanges } = params;
 
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         if (docDataModel == null) {
             return false;
         }
@@ -382,7 +382,7 @@ export const QuickListCommand: ICommand<IQuickListCommandParams> = {
         const docSelectionManagerService = accessor.get(DocSelectionManagerService);
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const commandService = accessor.get(ICommandService);
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const activeRange = docSelectionManagerService.getActiveTextRange();
         if (docDataModel == null || activeRange == null) {
             return false;

--- a/packages/docs-ui/src/commands/commands/set-heading.command.ts
+++ b/packages/docs-ui/src/commands/commands/set-heading.command.ts
@@ -91,7 +91,7 @@ export const QuickHeadingCommand: ICommand<ISetParagraphNamedStyleCommandParams>
         const docSelectionManagerService = accessor.get(DocSelectionManagerService);
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const commandService = accessor.get(ICommandService);
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const activeRange = docSelectionManagerService.getActiveTextRange();
         if (docDataModel == null || activeRange == null || !activeRange.collapsed) {
             return false;

--- a/packages/docs-ui/src/commands/commands/table/doc-table-insert.command.ts
+++ b/packages/docs-ui/src/commands/commands/table/doc-table-insert.command.ts
@@ -112,7 +112,7 @@ export const DocTableInsertRowCommand: ICommand<IDocTableInsertRowCommandParams>
 
         const { segmentId } = rangeInfo;
 
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const body = docDataModel?.getSelfOrHeaderFooterModel(segmentId).getBody();
 
         if (docDataModel == null || body == null) {

--- a/packages/docs-ui/src/controllers/render-controllers/doc-selection-render.controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc-selection-render.controller.ts
@@ -121,7 +121,7 @@ export class DocSelectionRenderController extends Disposable implements IRenderM
             }
 
             // FIXME:@Jocs: editor status should not be coupled with the instance service.
-            const docDataModel = this._instanceSrv.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
+            const docDataModel = this._instanceSrv.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC);
             if (docDataModel?.getUnitId() !== unitId) {
                 this._instanceSrv.setCurrentUnitForType(unitId);
             }

--- a/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
@@ -82,7 +82,7 @@ export class DocRenderController extends RxDisposable implements IRenderModule {
         scene.attachControl();
 
         scene.onMouseWheel$.subscribeEvent((evt: unknown, state: EventState) => {
-            const currentDocUnit = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
+            const currentDocUnit = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC);
             if (currentDocUnit?.getUnitId() !== this._context.unitId) {
                 return;
             }

--- a/packages/docs-ui/src/facade/f-univer.ts
+++ b/packages/docs-ui/src/facade/f-univer.ts
@@ -52,7 +52,7 @@ export class FUniverDocsUIMixin extends FUniver implements IFUniverDocsUIMixin {
     }
 
     override getActiveDocument(): FDocument | null {
-        const document = this._univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const document = this._univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         if (!document) {
             return null;
         }

--- a/packages/docs-ui/src/menu/menu.ts
+++ b/packages/docs-ui/src/menu/menu.ts
@@ -983,13 +983,13 @@ export function DocSwitchModeMenuItemFactory(accessor: IAccessor): IMenuButtonIt
         activated$: new Observable<boolean>((subscriber) => {
             const subscription = commandService.onCommandExecuted((c) => {
                 if (c.id === RichTextEditingMutation.id) {
-                    const instance = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+                    const instance = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
 
                     subscriber.next(instance?.getSnapshot()?.documentStyle.documentFlavor === DocumentFlavor.MODERN);
                 }
             });
 
-            const instance = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+            const instance = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
 
             subscriber.next(instance?.getSnapshot()?.documentStyle.documentFlavor === DocumentFlavor.MODERN);
 
@@ -1072,7 +1072,7 @@ function getFontStyleAtCursor(accessor: IAccessor) {
     const textSelectionService = accessor.get(DocSelectionManagerService);
     const docMenuStyleService = accessor.get(DocMenuStyleService);
 
-    const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+    const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
     const docRanges = textSelectionService.getDocRanges();
     const activeRange = docRanges.find((r) => r.isActive) ?? docRanges[0];
 

--- a/packages/docs-ui/src/plugin.ts
+++ b/packages/docs-ui/src/plugin.ts
@@ -341,7 +341,7 @@ export class UniverDocsUIPlugin extends Plugin {
         const currentService = this._injector.get(IUniverInstanceService);
         const editorService = this._injector.get(IEditorService);
         try {
-            const doc = currentService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
+            const doc = currentService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC);
             if (!doc) return;
 
             const id = doc.getUnitId();

--- a/packages/docs-ui/src/services/__tests__/doc-services.spec.ts
+++ b/packages/docs-ui/src/services/__tests__/doc-services.spec.ts
@@ -172,7 +172,7 @@ describe('docs ui services', () => {
         const fallbackService = new DocMenuStyleService(
             selectionManager,
             {
-                getCurrentUnitForType: () => null,
+                getCurrentUnitOfType: () => null,
             } as never,
             {
                 getRenderById: vi.fn(() => null),
@@ -211,7 +211,7 @@ describe('docs ui services', () => {
         };
         const instanceService = {
             getAllUnitsForType: vi.fn(() => [existingDoc]),
-            getCurrentUnitForType: vi.fn(() => existingDoc),
+            getCurrentUnitOfType: vi.fn(() => existingDoc),
             getTypeOfUnitAdded$: vi.fn(() => added$),
             getTypeOfUnitDisposed$: vi.fn(() => disposed$),
         };

--- a/packages/docs-ui/src/services/clipboard/clipboard.service.ts
+++ b/packages/docs-ui/src/services/clipboard/clipboard.service.ts
@@ -166,7 +166,7 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
         files: File[];
     }): Promise<boolean> {
         let { html, text, files } = options;
-        const currentDocInstance = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
+        const currentDocInstance = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC);
         const docUnitId = currentDocInstance?.getUnitId() || '';
         if (!html && !text && files.length) {
             html = await this._createImagePasteHtml(files);
@@ -257,7 +257,7 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
 
         let body = normalizeBody(_body);
 
-        const unitId = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC)?.getUnitId();
+        const unitId = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC)?.getUnitId();
         if (!unitId) {
             return false;
         }
@@ -507,7 +507,7 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
         }
 
         if (!_unitId) {
-            const currentDocInstance = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
+            const currentDocInstance = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC);
             const docUnitId = currentDocInstance?.getUnitId() || '';
             _unitId = docUnitId;
         }

--- a/packages/docs-ui/src/services/doc-auto-format.service.ts
+++ b/packages/docs-ui/src/services/doc-auto-format.service.ts
@@ -80,7 +80,7 @@ export class DocAutoFormatService extends Disposable {
 
     onAutoFormat(id: string, params: Nullable<object>): ICommandInfo[] {
         const autoFormats = this._matches.get(id) ?? [];
-        const unit = this._univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const unit = this._univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         const docRanges = this._textSelectionManagerService.getDocRanges();
         const selection = docRanges.find((range) => range.isActive) ?? docRanges[0];
 

--- a/packages/docs-ui/src/services/doc-menu-style.service.ts
+++ b/packages/docs-ui/src/services/doc-menu-style.service.ts
@@ -65,7 +65,7 @@ export class DocMenuStyleService extends Disposable {
 
     getDefaultStyle(): ITextStyle {
         const docDataModel = this._univerInstanceService
-            .getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+            .getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
 
         if (docDataModel == null) {
             return {

--- a/packages/docs-ui/src/services/docs-render.service.ts
+++ b/packages/docs-ui/src/services/docs-render.service.ts
@@ -50,7 +50,7 @@ export class DocsRenderService extends RxDisposable {
 
     private _createRenderer(doc: DocumentDataModel) {
         const unitId = doc.getUnitId();
-        const workbookId = this._instanceSrv.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_DOC)?.getUnitId();
+        const workbookId = this._instanceSrv.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_DOC)?.getUnitId();
         this._renderManagerService.created$.subscribe((renderer) => {
             if (renderer.unitId === workbookId) {
                 renderer.engine.getCanvas().setId(DOC_MAIN_CANVAS_ID);

--- a/packages/docs-ui/src/services/editor/editor.ts
+++ b/packages/docs-ui/src/services/editor/editor.ts
@@ -236,7 +236,7 @@ export class Editor extends Disposable implements IEditor {
      * @deprecated use `IEditorService.focus` as instead. this is for internal usage.
      */
     focus() {
-        const curDoc = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
+        const curDoc = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC);
         const editorUnitId = this.getEditorId();
         // Step 1: set current editor to currentDocUnit.
         if (curDoc == null || curDoc.getUnitId() !== editorUnitId) {

--- a/packages/docs-ui/src/views/paragraph-setting/hook/utils.ts
+++ b/packages/docs-ui/src/views/paragraph-setting/hook/utils.ts
@@ -49,7 +49,7 @@ const useDocRanges = () => {
 
 export const useCurrentParagraph = () => {
     const univerInstanceService = useDependency(IUniverInstanceService);
-    const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+    const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
     const docRanges = useDocRanges();
 
     if (!docDataModel || docRanges.length === 0) {
@@ -68,7 +68,7 @@ export const useCurrentParagraph = () => {
 
 export const useCurrentSections = (currentParagraphs: IParagraph[]) => {
     const univerInstanceService = useDependency(IUniverInstanceService);
-    const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+    const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
     const docRanges = useDocRanges();
 
     if (!docDataModel || docRanges.length === 0) {
@@ -237,7 +237,7 @@ export const useFirstParagraphLineSpacing = (paragraph: IParagraph[]) => {
     const univerInstanceService = useDependency(IUniverInstanceService);
 
     const skeleton = useMemo(() => {
-        const docDataModel = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+        const docDataModel = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
         if (!docDataModel) {
             return undefined;
         }

--- a/packages/engine-formula/src/engine/utils/reference.ts
+++ b/packages/engine-formula/src/engine/utils/reference.ts
@@ -345,7 +345,7 @@ export function replaceRefPrefixString(token: string) {
 /**
  * implement getSheetIdByName
  * function getSheetIdByName(name: string) {
-        return univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getSheetBySheetName(name)?.getSheetId() || '';
+        return univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getSheetBySheetName(name)?.getSheetId() || '';
     }
  */
 export function getRangeWithRefsString(refString: string, getSheetIdByName: (name: string) => string): IUnitRangeWithName[] {

--- a/packages/engine-formula/src/services/__tests__/current-data.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/current-data.service.spec.ts
@@ -32,7 +32,7 @@ function createService() {
 
     const workbookById = new Map<string, unknown>();
     const univerInstanceService = {
-        getCurrentUnitForType: vi.fn(() => workbookForCurrentType),
+        getCurrentUnitOfType: vi.fn(() => workbookForCurrentType),
         getUnit: vi.fn((unitId: string) => workbookById.get(unitId)),
     };
     const localeService = {

--- a/packages/engine-formula/src/services/current-data.service.ts
+++ b/packages/engine-formula/src/services/current-data.service.ts
@@ -268,7 +268,7 @@ export class FormulaCurrentConfigService extends Disposable implements IFormulaC
     }
 
     getSheetsInfo() {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const { id, sheetOrder } = workbook.getSnapshot();
 
         return {
@@ -502,7 +502,7 @@ export class FormulaCurrentConfigService extends Disposable implements IFormulaC
     }
 
     private _loadSheetData() {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook?.getActiveSheet();
 
         this._executeUnitId = workbook?.getUnitId();

--- a/packages/sheets-conditional-formatting-ui/src/components/panel/rule-edit/ColorScale.tsx
+++ b/packages/sheets-conditional-formatting-ui/src/components/panel/rule-edit/ColorScale.tsx
@@ -33,8 +33,8 @@ const createOptionItem = (text: string, localeService: LocaleService) => ({ labe
 const TextInput = (props: { id: string; type: CFValueType | 'none'; value: number | string; onChange: (v: number | string) => void; className: string }) => {
     const { type, className, onChange, id, value } = props;
     const univerInstanceService = useDependency(IUniverInstanceService);
-    const unitId = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
-    const subUnitId = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()?.getSheetId();
+    const unitId = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
+    const subUnitId = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()?.getSheetId();
     const formulaInitValue = useMemo(() => {
         return String(value).startsWith('=') ? String(value) : '=';
     }, [value]);

--- a/packages/sheets-conditional-formatting-ui/src/components/panel/rule-edit/Formula.tsx
+++ b/packages/sheets-conditional-formatting-ui/src/components/panel/rule-edit/Formula.tsx
@@ -32,7 +32,7 @@ export const FormulaStyleEditor = (props: IStyleEditorProps) => {
     const { onChange, interceptorManager } = props;
     const localeService = useDependency(LocaleService);
     const univerInstanceService = useDependency(IUniverInstanceService);
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const worksheet = workbook.getActiveSheet();
 
     const rule = props.rule?.type === CFRuleType.highlightCell ? props.rule : undefined as IRankHighlightCell | IAverageHighlightCell | undefined;

--- a/packages/sheets-conditional-formatting-ui/src/components/panel/rule-edit/IconSet.tsx
+++ b/packages/sheets-conditional-formatting-ui/src/components/panel/rule-edit/IconSet.tsx
@@ -35,8 +35,8 @@ const TextInput = (props: { id: number; type: CFValueType; value: number | strin
     const { error, type, onChange } = props;
 
     const univerInstanceService = useDependency(IUniverInstanceService);
-    const unitId = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
-    const subUnitId = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()?.getSheetId();
+    const unitId = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
+    const subUnitId = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()?.getSheetId();
 
     const formulaEditorRef = useRef<IFormulaEditorRef>(null);
     const [isFocusFormulaEditor, setIsFocusFormulaEditor] = useState(false);

--- a/packages/sheets-conditional-formatting-ui/src/components/panel/rule-edit/index.tsx
+++ b/packages/sheets-conditional-formatting-ui/src/components/panel/rule-edit/index.tsx
@@ -39,8 +39,8 @@ interface IRuleEditProps {
     onCancel: () => void;
 }
 
-const getUnitId = (univerInstanceService: IUniverInstanceService) => univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
-const getSubUnitId = (univerInstanceService: IUniverInstanceService) => univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()?.getSheetId();
+const getUnitId = (univerInstanceService: IUniverInstanceService) => univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
+const getSubUnitId = (univerInstanceService: IUniverInstanceService) => univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()?.getSheetId();
 
 export const RuleEdit = (props: IRuleEditProps) => {
     const localeService = useDependency(LocaleService);
@@ -179,7 +179,7 @@ export const RuleEdit = (props: IRuleEditProps) => {
             return;
         }
         const getRanges = () => {
-            const worksheet = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet();
+            const worksheet = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet();
             if (!worksheet) {
                 throw new Error('No active sheet found');
             }

--- a/packages/sheets-conditional-formatting-ui/src/controllers/cf.auto-fill.controller.ts
+++ b/packages/sheets-conditional-formatting-ui/src/controllers/cf.auto-fill.controller.ts
@@ -46,8 +46,8 @@ export class ConditionalFormattingAutoFillController extends Disposable {
             matrixMap: Map<string, ObjectMatrix<1>>,
             mapFunc: (row: number, col: number) => ({ row: number; col: number })
         ) => {
-            const unitId = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
-            const subUnitId = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()?.getSheetId();
+            const unitId = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
+            const subUnitId = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()?.getSheetId();
             if (!unitId || !subUnitId) {
                 return;
             }
@@ -141,8 +141,8 @@ export class ConditionalFormattingAutoFillController extends Disposable {
         };
 
         const generalApplyFunc = (sourceRange: IDiscreteRange, targetRange: IDiscreteRange) => {
-            const unitId = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
-            const subUnitId = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet()?.getSheetId();
+            const unitId = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
+            const subUnitId = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet()?.getSheetId();
             const matrixMap: Map<string, ObjectMatrix<1>> = new Map();
 
             const redos: IMutationInfo[] = [];

--- a/packages/sheets-conditional-formatting-ui/src/controllers/cf.clear.controller.ts
+++ b/packages/sheets-conditional-formatting-ui/src/controllers/cf.clear.controller.ts
@@ -45,7 +45,7 @@ export class ConditionalFormattingClearController extends Disposable {
                     if (!ranges) {
                         return defaultV;
                     }
-                    const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                    const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                     const worksheet = workbook.getActiveSheet();
                     if (!worksheet) {
                         return defaultV;

--- a/packages/sheets-conditional-formatting-ui/src/controllers/cf.painter.controller.ts
+++ b/packages/sheets-conditional-formatting-ui/src/controllers/cf.painter.controller.ts
@@ -297,8 +297,8 @@ export class ConditionalFormattingPainterController extends Disposable {
                 switch (status) {
                     case FormatPainterStatus.INFINITE:
                     case FormatPainterStatus.ONCE: {
-                        const unitId = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
-                        const subUnitId = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet()?.getSheetId();
+                        const unitId = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
+                        const subUnitId = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet()?.getSheetId();
                         const selection = this._sheetsSelectionsService.getCurrentLastSelection();
                         const range = selection?.range;
                         if (unitId && subUnitId && range) {

--- a/packages/sheets-conditional-formatting-ui/src/controllers/cf.render.controller.ts
+++ b/packages/sheets-conditional-formatting-ui/src/controllers/cf.render.controller.ts
@@ -41,7 +41,7 @@ export class SheetsCfRenderController extends Disposable {
     }
 
     private _markDirtySkeleton() {
-        const unitId = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
+        const unitId = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
         this._renderManagerService.getRenderById(unitId)?.with(SheetSkeletonManagerService).reCalculate();
         this._renderManagerService.getRenderById(unitId)?.mainComponent?.makeDirty();
     }
@@ -52,7 +52,7 @@ export class SheetsCfRenderController extends Disposable {
                 bufferTime(16),
                 filter((v) => !!v.length),
                 filter((v) => {
-                    const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                    const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
                     if (!workbook) return false;
 
                     const worksheet = workbook.getActiveSheet();

--- a/packages/sheets-conditional-formatting-ui/src/controllers/cf.viewport.controller.ts
+++ b/packages/sheets-conditional-formatting-ui/src/controllers/cf.viewport.controller.ts
@@ -33,7 +33,7 @@ export class ConditionalFormattingViewportController extends Disposable {
     }
 
     private _init() {
-        const unit = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const unit = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         const bindUnit = (unit: Workbook) => {
             this._unitDisposable.dispose();
             this._unitDisposable = new DisposableCollection();

--- a/packages/sheets-conditional-formatting-ui/src/menu/manage-rule.ts
+++ b/packages/sheets-conditional-formatting-ui/src/menu/manage-rule.ts
@@ -122,7 +122,7 @@ export const FactoryManageConditionalFormattingRule = (accessor: IAccessor): IMe
         new Observable<null>((commandSubscribe) => {
             const disposable = commandService.onCommandExecuted((commandInfo) => {
                 const { id, params } = commandInfo;
-                const unitId = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
+                const unitId = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
                 if (commandList.includes(id) && (params as { unitId: string }).unitId === unitId) {
                     commandSubscribe.next(null);
                 }
@@ -131,7 +131,7 @@ export const FactoryManageConditionalFormattingRule = (accessor: IAccessor): IMe
         })
     ).pipe(debounceTime(16)).subscribe(() => {
         const ranges = selectionManagerService.getCurrentSelections()?.map((selection) => selection.range) || [];
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) return;
         const worksheet = workbook.getActiveSheet();
         if (!worksheet) return;
@@ -147,14 +147,14 @@ export const FactoryManageConditionalFormattingRule = (accessor: IAccessor): IMe
         new Observable<null>((commandSubscribe) => {
             const disposable = commandService.onCommandExecuted((commandInfo) => {
                 const { id, params } = commandInfo;
-                const unitId = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
+                const unitId = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
                 if (commandList.includes(id) && (params as { unitId: string }).unitId === unitId) {
                     commandSubscribe.next(null);
                 }
             });
             return () => disposable.dispose();
         }).pipe(debounceTime(16)).subscribe(() => {
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             if (!workbook) return;
             const worksheet = workbook.getActiveSheet();
             if (!worksheet) return;

--- a/packages/sheets-data-validation-ui/src/services/dropdown-manager.service.ts
+++ b/packages/sheets-data-validation-ui/src/services/dropdown-manager.service.ts
@@ -128,7 +128,7 @@ export class DataValidationDropdownManagerService extends Disposable {
     private _getDropdownByCell(unitId: string | undefined, subUnitId: string | undefined, row: number, col: number) {
         const workbook = unitId ?
             this._univerInstanceService.getUnit<Workbook>(unitId, UniverInstanceType.UNIVER_SHEET)
-            : this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            : this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return;
         }

--- a/packages/sheets-data-validation-ui/src/views/components/detail/index.tsx
+++ b/packages/sheets-data-validation-ui/src/views/components/detail/index.tsx
@@ -42,7 +42,7 @@ function getSheetIdByName(univerInstanceService: IUniverInstanceService, unitId:
     if (unitId) {
         return univerInstanceService.getUnit<Workbook>(unitId)?.getSheetBySheetName(name)?.getSheetId() || '';
     }
-    return univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getSheetBySheetName(name)?.getSheetId() || '';
+    return univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getSheetBySheetName(name)?.getSheetId() || '';
 }
 
 export function DataValidationDetail() {

--- a/packages/sheets-data-validation-ui/src/views/components/list/index.tsx
+++ b/packages/sheets-data-validation-ui/src/views/components/list/index.tsx
@@ -76,7 +76,7 @@ export function DataValidationList(props: { workbook: Workbook }) {
     };
 
     const getDvRulesByPermissionCorrect = (rules: ISheetDataValidationRule[]) => {
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet();
         const unitId = workbook.getUnitId();
         const subUnitId = worksheet.getSheetId();

--- a/packages/sheets-data-validation/src/controllers/dv-formula.controller.ts
+++ b/packages/sheets-data-validation/src/controllers/dv-formula.controller.ts
@@ -42,7 +42,7 @@ export class DataValidationFormulaController extends Disposable {
             }
             const { token } = node;
             const sequenceGrid = deserializeRangeWithSheetWithCache(token);
-            const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             let targetSheet: Nullable<Worksheet> = workbook.getActiveSheet();
             const unitId = workbook.getUnitId();
             if (sequenceGrid.sheetName) {

--- a/packages/sheets-data-validation/src/controllers/dv-sheet.controller.ts
+++ b/packages/sheets-data-validation/src/controllers/dv-sheet.controller.ts
@@ -40,7 +40,7 @@ export class SheetDataValidationSheetController extends Disposable {
                 getMutations: (commandInfo) => {
                     if (commandInfo.id === RemoveSheetCommand.id) {
                         const params = commandInfo.params as IRemoveSheetCommandParams;
-                        const unitId = params.unitId || this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
+                        const unitId = params.unitId || this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
                         const workbook = this._univerInstanceService.getUniverSheetInstance(unitId);
                         if (!workbook) {
                             return { redos: [], undos: [] };

--- a/packages/sheets-data-validation/src/controllers/dv.controller.ts
+++ b/packages/sheets-data-validation/src/controllers/dv.controller.ts
@@ -66,7 +66,7 @@ export class DataValidationController extends RxDisposable {
         this._sheetInterceptorService.interceptCommand({
             getMutations: (commandInfo) => {
                 if (commandInfo.id === ClearSelectionAllCommand.id) {
-                    const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                    const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                     const unitId = workbook.getUnitId();
                     const worksheet = workbook.getActiveSheet();
                     if (!worksheet) {

--- a/packages/sheets-data-validation/src/services/__tests__/dv-validator.service.spec.ts
+++ b/packages/sheets-data-validation/src/services/__tests__/dv-validator.service.spec.ts
@@ -71,7 +71,7 @@ function createService() {
     } as unknown as DataValidationCacheService;
     const univerInstanceService = {
         getUnit: vi.fn((unitId: string) => (unitId === 'unit-1' ? workbook : null)),
-        getCurrentUnitForType: vi.fn(() => workbook),
+        getCurrentUnitOfType: vi.fn(() => workbook),
     } as unknown as IUniverInstanceService;
     const lifecycleService = {
         lifecycle$,

--- a/packages/sheets-data-validation/src/services/dv-validator.service.ts
+++ b/packages/sheets-data-validation/src/services/dv-validator.service.ts
@@ -37,7 +37,7 @@ export class SheetsDataValidationValidatorService extends Disposable {
                 return;
             }
 
-            const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             const worksheet = workbook?.getActiveSheet();
 
             const map: Record<string, Record<string, IRange[]>> = {};

--- a/packages/sheets-data-validation/src/validators/list-validator.ts
+++ b/packages/sheets-data-validation/src/validators/list-validator.ts
@@ -191,7 +191,7 @@ export class ListValidator extends BaseDataValidator {
 
     private _getUnitAndSubUnit(currentUnitId?: string, currentSubUnitId?: string): { unitId: string; subUnitId: string } | null {
         const workbook = (currentUnitId ? this._univerInstanceService.getUniverSheetInstance(currentUnitId) : undefined)
-            ?? this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            ?? this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) return null;
 
         const worksheet = (currentSubUnitId ? workbook.getSheetBySheetId(currentSubUnitId) : undefined) ?? workbook.getActiveSheet();

--- a/packages/sheets-data-validation/src/validators/util.ts
+++ b/packages/sheets-data-validation/src/validators/util.ts
@@ -23,7 +23,7 @@ import { getCellValueOrigin } from '../utils/get-cell-data-origin';
 export function getSheetRangeValueSet(grid: IUnitRangeName, univerInstanceService: IUniverInstanceService, currUnitId: string, currSubUnitId: string) {
     const set = new Set<string>();
     const unitId = grid.unitId || currUnitId;
-    const workbook = univerInstanceService.getUniverSheetInstance(unitId) ?? univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getUniverSheetInstance(unitId) ?? univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const worksheet = workbook.getSheetBySheetName(grid.sheetName) ?? workbook.getSheetBySheetId(currSubUnitId) ?? workbook.getActiveSheet();
     Range.foreach(grid.range, (row, col) => {
         const data = worksheet?.getCellRaw(row, col);

--- a/packages/sheets-drawing-ui/src/controllers/sheet-drawing-permission.controller.ts
+++ b/packages/sheets-drawing-ui/src/controllers/sheet-drawing-permission.controller.ts
@@ -265,7 +265,7 @@ export class SheetDrawingPermissionController extends Disposable {
                     },
                     complete: () => {
                         this._sheetDrawingService.setDrawingVisible(true);
-                        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
                         const sheet = workbook?.getActiveSheet();
                         const unitId = workbook?.getUnitId();
                         const subUnitId = sheet?.getSheetId();
@@ -366,7 +366,7 @@ export class SheetDrawingPermissionController extends Disposable {
                         }
                     },
                     complete: () => {
-                        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
                         if (!workbook) {
                             return;
                         }

--- a/packages/sheets-drawing-ui/src/services/__tests__/batch-save-images.service.spec.ts
+++ b/packages/sheets-drawing-ui/src/services/__tests__/batch-save-images.service.spec.ts
@@ -67,7 +67,7 @@ function createService() {
 
     return new BatchSaveImagesService(
         {
-            getCurrentUnitForType: (type: UniverInstanceType) => (type === UniverInstanceType.UNIVER_SHEET ? workbook : null),
+            getCurrentUnitOfType: (type: UniverInstanceType) => (type === UniverInstanceType.UNIVER_SHEET ? workbook : null),
             getUnit: () => workbook,
         } as never,
         {

--- a/packages/sheets-drawing-ui/src/services/batch-save-images.service.ts
+++ b/packages/sheets-drawing-ui/src/services/batch-save-images.service.ts
@@ -269,7 +269,7 @@ export class BatchSaveImagesService extends Disposable implements IBatchSaveImag
     }
 
     getCellImagesInSelection(): ICellImageInfo[] {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) return [];
 
         const worksheet = workbook.getActiveSheet();
@@ -346,7 +346,7 @@ export class BatchSaveImagesService extends Disposable implements IBatchSaveImag
     }
 
     getDataColumns(): Array<{ index: number; label: string }> {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) return [];
 
         const worksheet = workbook.getActiveSheet();
@@ -505,7 +505,7 @@ export class BatchSaveImagesService extends Disposable implements IBatchSaveImag
     }
 
     generateFileName(imageInfo: ICellImageInfo, config: IBatchSaveImagesConfig): string {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         const extension = getFileExtension(imageInfo.source, imageInfo.imageSourceType);
         const parts: string[] = [];
 

--- a/packages/sheets-filter/src/commands/commands/sheets-filter.command.ts
+++ b/packages/sheets-filter/src/commands/commands/sheets-filter.command.ts
@@ -129,7 +129,7 @@ export const SmartToggleSheetsFilterCommand: ICommand = {
         const sheetsFilterService = accessor.get(SheetsFilterService);
         const commandService = accessor.get(ICommandService);
 
-        const currentWorkbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const currentWorkbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         const currentWorksheet = currentWorkbook?.getActiveSheet();
         if (!currentWorksheet || !currentWorkbook) return false;
 

--- a/packages/sheets-filter/src/controllers/__tests__/sheets-filter.controller.spec.ts
+++ b/packages/sheets-filter/src/controllers/__tests__/sheets-filter.controller.spec.ts
@@ -234,7 +234,7 @@ describe('test controller of sheets filter', () => {
             expect(result).toBeTruthy();
             expect((sheetsFilterService as SheetsFilterService).getFilterModel('test', 'sheet1')!.getRange())
                 .toEqual({ startRow: 3, startColumn: 0, endRow: 5, endColumn: 5 });
-            const workbook = instanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = instanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             expect(workbook.getSheetBySheetId('sheet1')?.getCell(0, 0)?.v).toBe('A2');
             expect(workbook.getSheetBySheetId('sheet1')?.getCell(1, 0)?.v).toBe('A1');
         });
@@ -388,7 +388,7 @@ describe('test controller of sheets filter', () => {
                 subUnitId: 'sheet1',
             });
             expect(res).toBeTruthy();
-            const workbook = instanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = instanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const sheet2 = workbook.getSheets()[1];
             const filterModel = (sheetsFilterService as SheetsFilterService).getFilterModel('test', sheet2.getSheetId());
             expect(filterModel).toBeTruthy();

--- a/packages/sheets-filter/src/models/__tests__/filter-model.spec.ts
+++ b/packages/sheets-filter/src/models/__tests__/filter-model.spec.ts
@@ -131,7 +131,7 @@ describe('Test filter model and related utils', () => {
             filterColumn = new FilterColumn(
                 'test',
                 'sheet1',
-                get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
+                get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
                 { colId: 0, customFilters: { customFilters: [{ operator: CustomFilterOperator.LESS_THAN, val: 123 }] } },
                 { getAlreadyFilteredOutRows() { return new Set(); } }
             );
@@ -151,7 +151,7 @@ describe('Test filter model and related utils', () => {
             filterColumn = new FilterColumn(
                 'test',
                 'sheet1',
-                get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
+                get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
                 { colId: 0, customFilters: { customFilters: [{ operator: CustomFilterOperator.LESS_THAN, val: 123 }] } },
                 { getAlreadyFilteredOutRows() { return new Set(); } }
             );
@@ -169,7 +169,7 @@ describe('Test filter model and related utils', () => {
             filterColumn = new FilterColumn(
                 'test',
                 'sheet1',
-                get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
+                get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
                 { colId: 0, customFilters: { customFilters: [{ operator: CustomFilterOperator.LESS_THAN, val: 123 }] } },
                 { getAlreadyFilteredOutRows() { return new Set(); } }
             );
@@ -190,7 +190,7 @@ describe('Test filter model and related utils', () => {
             filterColumn = new FilterColumn(
                 'test',
                 'sheet1',
-                get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
+                get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
                 { colId: 0, customFilters: { customFilters: [{ operator: CustomFilterOperator.LESS_THAN, val: 123 }] } },
                 { getAlreadyFilteredOutRows() { return new Set(); } }
             );
@@ -205,7 +205,7 @@ describe('Test filter model and related utils', () => {
             filterColumn = new FilterColumn(
                 'test',
                 'sheet1',
-                get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
+                get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!,
                 { colId: 0, customFilters: { customFilters: [{ operator: CustomFilterOperator.LESS_THAN, val: 123 }] } },
                 { getAlreadyFilteredOutRows() { return new Set([1]); } }
             );

--- a/packages/sheets-filter/src/services/sheet-filter.service.ts
+++ b/packages/sheets-filter/src/services/sheet-filter.service.ts
@@ -113,7 +113,7 @@ export class SheetsFilterService extends Disposable {
     private _updateActiveFilterModel(): void {
         let workbook: Nullable<Workbook>;
         try {
-            workbook = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_SHEET);
+            workbook = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SHEET);
             if (!workbook) {
                 this._activeFilterModel$.next(null);
                 return;

--- a/packages/sheets-formula-ui/src/views/formula-editor/hooks/use-reset-selection.ts
+++ b/packages/sheets-formula-ui/src/views/formula-editor/hooks/use-reset-selection.ts
@@ -27,7 +27,7 @@ export const useResetSelection = (isNeed: boolean, unitId: string, subUnitId: st
     const resetSelection = useCallback(() => {
         if (isNeed) {
             const selections = [...sheetsSelectionsService.getWorkbookSelections(unitId).getSelectionsOfWorksheet(subUnitId)];
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             const currentSheet = workbook?.getActiveSheet();
             if (workbook?.getUnitId() !== unitId) {
                 univerInstanceService.setCurrentUnitForType(unitId);

--- a/packages/sheets-formula-ui/src/views/range-selector/hooks/use-ranges-highlight.ts
+++ b/packages/sheets-formula-ui/src/views/range-selector/hooks/use-ranges-highlight.ts
@@ -63,7 +63,7 @@ export function useRangesHighlight(editor: Nullable<Editor>, focusing: boolean, 
         selections.forEach((selection) => {
             // selection.token;
             const range = deserializeRangeWithSheet(selection.token);
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             const worksheet = workbook?.getActiveSheet();
             // range is not in the current worksheet
             if ((!range.sheetName && subUnitId !== worksheet?.getSheetId()) || (range.sheetName && worksheet?.getName() !== range.sheetName)) {

--- a/packages/sheets-formula/src/controllers/update-defined-name.controller.ts
+++ b/packages/sheets-formula/src/controllers/update-defined-name.controller.ts
@@ -60,7 +60,7 @@ export class UpdateDefinedNameController extends Disposable {
                         };
                     }
 
-                    const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                    const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
 
                     if (workbook == null) {
                         return {

--- a/packages/sheets-formula/src/controllers/update-formula.controller.ts
+++ b/packages/sheets-formula/src/controllers/update-formula.controller.ts
@@ -314,7 +314,7 @@ export class UpdateFormulaController extends Disposable {
     }
 
     private _getUpdateFormula(command: ICommandInfo) {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
 
         if (!workbook) {
             return {

--- a/packages/sheets-formula/src/services/formula-ref-range.service.ts
+++ b/packages/sheets-formula/src/services/formula-ref-range.service.ts
@@ -82,7 +82,7 @@ export class FormulaRefRangeService extends Disposable {
 
     transformFormulaByEffectCommand(unitId: string, subUnitId: string, formula: string, params: EffectRefRangeParams) {
         const sequenceNodes = this._lexerTreeBuilder.sequenceNodesBuilder(formula);
-        const currentUnit = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const currentUnit = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const currentSheet = currentUnit.getActiveSheet();
         const currentUnitId = currentUnit.getUnitId();
         const currentSheetId = currentSheet.getSheetId();
@@ -137,7 +137,7 @@ export class FormulaRefRangeService extends Disposable {
         const sequenceNodes = this._lexerTreeBuilder.sequenceNodesBuilder(formula);
         const disposableCollection = new DisposableCollection();
         const handleChange = (params: EffectRefRangeParams) => {
-            const currentUnit = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const currentUnit = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const currentSheet = currentUnit.getActiveSheet();
             const currentUnitId = currentUnit.getUnitId();
             const currentSheetId = currentSheet.getSheetId();

--- a/packages/sheets-hyper-link-ui/src/commands/operations/__tests__/popup.operations.spec.ts
+++ b/packages/sheets-hyper-link-ui/src/commands/operations/__tests__/popup.operations.spec.ts
@@ -65,7 +65,6 @@ function createUniverInstanceService(options?: {
 }) {
     return {
         getCurrentUnitOfType: () => options?.workbook ?? null,
-        getCurrentUnitOfType: () => options?.workbook ?? null,
         getFocusedUnit: () => options?.focusedUnitId ? { getUnitId: () => options.focusedUnitId } : null,
     };
 }

--- a/packages/sheets-hyper-link-ui/src/commands/operations/__tests__/popup.operations.spec.ts
+++ b/packages/sheets-hyper-link-ui/src/commands/operations/__tests__/popup.operations.spec.ts
@@ -65,7 +65,7 @@ function createUniverInstanceService(options?: {
 }) {
     return {
         getCurrentUnitOfType: () => options?.workbook ?? null,
-        getCurrentUnitForType: () => options?.workbook ?? null,
+        getCurrentUnitOfType: () => options?.workbook ?? null,
         getFocusedUnit: () => options?.focusedUnitId ? { getUnitId: () => options.focusedUnitId } : null,
     };
 }

--- a/packages/sheets-hyper-link-ui/src/services/__tests__/resolver.service.spec.ts
+++ b/packages/sheets-hyper-link-ui/src/services/__tests__/resolver.service.spec.ts
@@ -42,7 +42,7 @@ describe('SheetsHyperLinkResolverService', () => {
 
         const resolver = new SheetsHyperLinkResolverService(
             {
-                getCurrentUnitForType: () => workbook,
+                getCurrentUnitOfType: () => workbook,
                 getUnit: () => workbook,
             } as any,
             { executeCommand } as any,
@@ -87,7 +87,7 @@ describe('SheetsHyperLinkResolverService', () => {
 
         const resolver = new SheetsHyperLinkResolverService(
             {
-                getCurrentUnitForType: () => workbook,
+                getCurrentUnitOfType: () => workbook,
                 getUnit: () => workbook,
             } as any,
             { executeCommand } as any,
@@ -121,7 +121,7 @@ describe('SheetsHyperLinkResolverService', () => {
 
         const resolver = new SheetsHyperLinkResolverService(
             {
-                getCurrentUnitForType: () => null,
+                getCurrentUnitOfType: () => null,
                 getUnit: () => null,
             } as any,
             { executeCommand: vi.fn() } as any,
@@ -161,7 +161,7 @@ describe('SheetsHyperLinkResolverService', () => {
         };
         const resolver = new SheetsHyperLinkResolverService(
             {
-                getCurrentUnitForType: () => workbook,
+                getCurrentUnitOfType: () => workbook,
                 getUnit: () => workbook,
             } as any,
             { executeCommand } as any,

--- a/packages/sheets-hyper-link-ui/src/services/resolver.service.ts
+++ b/packages/sheets-hyper-link-ui/src/services/resolver.service.ts
@@ -77,7 +77,7 @@ export class SheetsHyperLinkResolverService {
         // NOTE: should we always use current unit and active worksheet?
 
         const { gid, range, rangeid } = params;
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return;
         }

--- a/packages/sheets-hyper-link-ui/src/utils/__tests__/index.spec.ts
+++ b/packages/sheets-hyper-link-ui/src/utils/__tests__/index.spec.ts
@@ -66,7 +66,7 @@ describe('hyper-link utils', () => {
         expect(getShouldDisableCellLink(createAccessor([]), worksheet as any, 0, 0)).toBe(DisableLinkType.ALLOW_ON_EDITING);
 
         const currentAccessor = createAccessor([
-            [IUniverInstanceService, { getCurrentUnitForType: () => ({ getActiveSheet: () => worksheet }) }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => ({ getActiveSheet: () => worksheet }) }],
             [SheetsSelectionsService, { getCurrentSelections: () => [{ range: { startRow: 0, startColumn: 0 } }] }],
         ]);
 
@@ -76,14 +76,14 @@ describe('hyper-link utils', () => {
     it('should disable add-link when editor selection is missing and allow it with valid rich text context', () => {
         const noSelectionAccessor = createAccessor([
             [DocSelectionManagerService, { getTextRanges: () => [] }],
-            [IUniverInstanceService, { getCurrentUnitForType: () => null }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => null }],
         ]);
         expect(shouldDisableAddLink(noSelectionAccessor)).toBe(true);
 
         const validAccessor = createAccessor([
             [DocSelectionManagerService, { getTextRanges: () => [{ collapsed: false, segmentId: 'body' }] }],
             [IUniverInstanceService, {
-                getCurrentUnitForType: () => ({
+                getCurrentUnitOfType: () => ({
                     getSelfOrHeaderFooterModel: () => ({ getBody: () => ({ dataStream: 'hello\r\n' }) }),
                 }),
             }],

--- a/packages/sheets-hyper-link-ui/src/utils/index.ts
+++ b/packages/sheets-hyper-link-ui/src/utils/index.ts
@@ -55,7 +55,7 @@ export const getShouldDisableCellLink = (accessor: IAccessor, worksheet: Workshe
 };
 
 export const getShouldDisableCurrentCellLink = (accessor: IAccessor) => {
-    const unit = accessor.get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+    const unit = accessor.get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
     if (!unit) {
         return true;
     }
@@ -77,7 +77,7 @@ export const shouldDisableAddLink = (accessor: IAccessor) => {
         return true;
     }
 
-    const doc = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+    const doc = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
     if (!doc || textRanges.every((range) => range.collapsed)) {
         return true;
     }

--- a/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
+++ b/packages/sheets-hyper-link-ui/src/views/CellLinkEdit/index.tsx
@@ -139,7 +139,7 @@ export const CellLinkEdit = () => {
                         column: col,
                     };
                 } else {
-                    const doc = univerInstanceService.getCurrentUnitForType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
+                    const doc = univerInstanceService.getCurrentUnitOfType<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
                     const currentSelection = textSelectionService.getActiveTextRange();
                     const body = doc?.getBody();
                     const selection = currentSelection && body ? currentSelection : null;

--- a/packages/sheets-hyper-link/src/controllers/remove-sheet.controller.ts
+++ b/packages/sheets-hyper-link/src/controllers/remove-sheet.controller.ts
@@ -38,7 +38,7 @@ export class SheetsHyperLinkRemoveSheetController extends Disposable {
                 getMutations: (commandInfo) => {
                     if (commandInfo.id === RemoveSheetCommand.id) {
                         const params = commandInfo.params as IRemoveSheetCommandParams;
-                        const workbook = params.unitId ? this._univerInstanceService.getUnit<Workbook>(params.unitId) : this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                        const workbook = params.unitId ? this._univerInstanceService.getUnit<Workbook>(params.unitId) : this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
                         if (!workbook) {
                             return { redos: [], undos: [] };
                         }

--- a/packages/sheets-hyper-link/src/services/parser.service.ts
+++ b/packages/sheets-hyper-link/src/services/parser.service.ts
@@ -76,7 +76,7 @@ export class SheetsHyperLinkParserService {
         const { gid, range, rangeid, unitid } = params;
         const workbook = unitid ?
             this._univerInstanceService.getUnit<Workbook>(unitid, UniverInstanceType.UNIVER_SHEET)
-            : this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            : this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         const invalidLink = {
             type: SheetHyperLinkType.INVALID,
             name: this._localeService.t('hyperLink.message.refError'),

--- a/packages/sheets-note-ui/src/commands/operations/add-note-popup.operation.ts
+++ b/packages/sheets-note-ui/src/commands/operations/add-note-popup.operation.ts
@@ -31,7 +31,7 @@ export const AddNotePopupOperation: ICommand = {
         const notePopupService = accessor.get(SheetsNotePopupService);
         const univerInstanceService = accessor.get(IUniverInstanceService);
 
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return false;
         }

--- a/packages/sheets-note-ui/src/controllers/sheets-cell-content.controller.ts
+++ b/packages/sheets-note-ui/src/controllers/sheets-cell-content.controller.ts
@@ -68,7 +68,7 @@ export class SheetsCellContentController extends Disposable {
 
     private _initSkeletonChange() {
         const markSkeletonDirty = () => {
-            const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             if (!workbook) return;
             const unitId = workbook.getUnitId();
             const currentRender = this._renderManagerService.getRenderById(unitId);

--- a/packages/sheets-numfmt-ui/src/controllers/__tests__/cell-content.controller.spec.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/__tests__/cell-content.controller.spec.ts
@@ -51,7 +51,7 @@ describe('test cell-content', () => {
                 },
             },
         };
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         testBed.get(SheetsNumfmtCellContentController);
         const value = worksheet.getCell(0, 0);

--- a/packages/sheets-numfmt-ui/src/controllers/__tests__/editor.controller.spec.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/__tests__/editor.controller.spec.ts
@@ -65,7 +65,7 @@ describe('test editor', () => {
         const univerInstanceService = testBed.get(IUniverInstanceService);
         testBed.get(NumfmtEditorController);
         testBed.get(SheetsNumfmtCellContentController);
-        workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         worksheet = workbook.getActiveSheet()!;
     });
 

--- a/packages/sheets-numfmt-ui/src/controllers/numfmt.controller.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/numfmt.controller.ts
@@ -105,7 +105,7 @@ export class SheetNumfmtUIController extends Disposable {
             return false;
         }
 
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const sheet = workbook.getActiveSheet();
         if (!sheet) {
             return false;
@@ -170,7 +170,7 @@ export class SheetNumfmtUIController extends Disposable {
 
     private _forceUpdate(unitId?: string): void {
         const renderUnit = this._renderManagerService.getRenderById(
-            unitId ?? this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId()
+            unitId ?? this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId()
         );
 
         renderUnit?.with(SheetSkeletonManagerService).reCalculate();
@@ -239,7 +239,7 @@ export class SheetNumfmtUIController extends Disposable {
                         })
                     )
                     .subscribe(({ disposableCollection, selectionRanges }) => {
-                        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                         this.openPanel();
                         disposableCollection.add(
                             this._sheetInterceptorService.intercept(INTERCEPTOR_POINT.CELL_CONTENT, {

--- a/packages/sheets-numfmt-ui/src/controllers/numfmt.editor.controller.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/numfmt.editor.controller.ts
@@ -262,7 +262,7 @@ export class NumfmtEditorController extends Disposable {
                 getMutations(command) {
                     switch (command.id) {
                         case SetRangeValuesCommand.id: {
-                            const workbook = self._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                            const workbook = self._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                             const unitId = workbook.getUnitId();
                             const subUnitId = workbook.getActiveSheet()?.getSheetId();
                             if (!subUnitId) {

--- a/packages/sheets-sort-ui/src/services/sheets-sort-ui.service.tsx
+++ b/packages/sheets-sort-ui/src/services/sheets-sort-ui.service.tsx
@@ -228,7 +228,7 @@ export class SheetsSortUIService extends Disposable {
     }
 
     private async _detectSortLocation(extend?: boolean): Promise<Nullable<ISheetSortLocation>> {
-        const workbook = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_SHEET) as Workbook;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SHEET) as Workbook;
         const worksheet = workbook.getActiveSheet() as Worksheet;
         const unitId = workbook.getUnitId();
         const subUnitId = worksheet.getSheetId();

--- a/packages/sheets-thread-comment-ui/src/controllers/render-controllers/render.controller.ts
+++ b/packages/sheets-thread-comment-ui/src/controllers/render-controllers/render.controller.ts
@@ -67,7 +67,7 @@ export class SheetsThreadCommentRenderController extends Disposable {
 
     private _initSkeletonChange() {
         const markSkeletonDirty = () => {
-            const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             if (!workbook) return;
             const unitId = workbook.getUnitId();
             const currentRender = this._renderManagerService.getRenderById(unitId);

--- a/packages/sheets-thread-comment-ui/src/controllers/sheets-thread-comment-popup.controller.ts
+++ b/packages/sheets-thread-comment-ui/src/controllers/sheets-thread-comment-popup.controller.ts
@@ -150,7 +150,7 @@ export class SheetsThreadCommentPopupController extends Disposable {
                     return;
                 }
 
-                const currentUnit = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                const currentUnit = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
                 if (!currentUnit) {
                     return;
                 }
@@ -236,7 +236,7 @@ export class SheetsThreadCommentPopupController extends Disposable {
                 return null;
             }
 
-            const worksheet = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getSheetBySheetId(subUnitId);
+            const worksheet = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getSheetBySheetId(subUnitId);
 
             const mergeInfo = worksheet?.getMergedCell(row, column) ?? {
                 startColumn: column,

--- a/packages/sheets-thread-comment-ui/src/views/sheets-thread-comment-cell/index.tsx
+++ b/packages/sheets-thread-comment-ui/src/views/sheets-thread-comment-cell/index.tsx
@@ -38,7 +38,7 @@ export const SheetsThreadCommentCell = () => {
     };
 
     const getSubUnitName = (id: string) => {
-        return univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getSheetBySheetId(id)?.getName() ?? '';
+        return univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getSheetBySheetId(id)?.getName() ?? '';
     };
 
     return (

--- a/packages/sheets-thread-comment-ui/src/views/sheets-thread-comment-panel/index.tsx
+++ b/packages/sheets-thread-comment-ui/src/views/sheets-thread-comment-panel/index.tsx
@@ -30,7 +30,7 @@ export const SheetsThreadCommentPanel = () => {
     const markSelectionService = useDependency(IMarkSelectionService);
     const univerInstanceService = useDependency(IUniverInstanceService);
     const sheetsThreadCommentPopupService = useDependency(SheetsThreadCommentPopupService);
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const unitId = workbook.getUnitId();
     const commandService = useDependency(ICommandService);
     const subUnitId$ = useMemo(() => workbook.activeSheet$.pipe(map((i) => i?.getSheetId())), [workbook.activeSheet$]);

--- a/packages/sheets-ui/src/commands/commands/__tests__/add-worksheet-merge.command.spec.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/add-worksheet-merge.command.spec.ts
@@ -359,7 +359,7 @@ describe('Test add worksheet merge commands', () => {
         it('test clear util', () => {
             const commandService = get(ICommandService);
             const univerInstanceService = get(IUniverInstanceService);
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const worksheet = workbook.getActiveSheet();
             if (!worksheet) throw new Error('No active sheet found');
 
@@ -446,7 +446,7 @@ describe('Test add worksheet merge commands', () => {
 
         it('test merge range first cell is blank, second cell is percent number format', async () => {
             const univerInstanceService = get(IUniverInstanceService);
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const worksheet = workbook.getActiveSheet();
             if (!worksheet) throw new Error('No active sheet found');
 
@@ -510,7 +510,7 @@ describe('Test add worksheet merge commands', () => {
             ]);
             const commandService = get(ICommandService);
             const univerInstanceService = get(IUniverInstanceService);
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const worksheet = workbook.getActiveSheet();
             if (!worksheet) throw new Error('No active sheet found');
             const mergeData = worksheet.getConfig().mergeData;
@@ -606,7 +606,7 @@ describe('Test add worksheet merge commands', () => {
             ]);
             const commandService = get(ICommandService);
             const univerInstanceService = get(IUniverInstanceService);
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const worksheet = workbook.getActiveSheet();
             if (!worksheet) throw new Error('No active sheet found');
             const mergeData = worksheet.getConfig().mergeData;

--- a/packages/sheets-ui/src/commands/commands/__tests__/auto-fill.controller.spec.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/auto-fill.controller.spec.ts
@@ -348,7 +348,7 @@ describe('Test auto fill rules in controller', () => {
     describe('auto fill', () => {
         describe('auto fill the numbers', async () => {
             it('correct situation', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
                 // test number
 
@@ -390,7 +390,7 @@ describe('Test auto fill rules in controller', () => {
 
         describe('auto fill the extend numbers', async () => {
             it('correct situation', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
                 // test extend number
                 commandService.executeCommand(AutoFillCommand.id, {
@@ -414,7 +414,7 @@ describe('Test auto fill rules in controller', () => {
 
         describe('auto fill the chinese numbers', async () => {
             it('correct situation', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
                 // test chinese number
                 commandService.executeCommand(AutoFillCommand.id, {
@@ -438,7 +438,7 @@ describe('Test auto fill rules in controller', () => {
 
         describe('auto fill the chinese week', async () => {
             it('correct situation', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
 
                 // test chinese week
@@ -463,7 +463,7 @@ describe('Test auto fill rules in controller', () => {
 
         describe('auto fill the loop series', async () => {
             it('correct situation', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
                 // test loop series
                 commandService.executeCommand(AutoFillCommand.id, {
@@ -487,7 +487,7 @@ describe('Test auto fill rules in controller', () => {
 
         describe('auto fill the other string', async () => {
             it('correct situation', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
                 // test other string
                 commandService.executeCommand(AutoFillCommand.id, {
@@ -511,7 +511,7 @@ describe('Test auto fill rules in controller', () => {
 
         describe('auto fill the mixed mode', async () => {
             it('correct situation', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
                 // test mixed mode
                 commandService.executeCommand(AutoFillCommand.id, {
@@ -550,7 +550,7 @@ describe('Test auto fill rules in controller', () => {
 
         describe('auto fill the merged cell', async () => {
             it('test primary', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
 
                 const selectionManagerService = get(SheetsSelectionsService);
@@ -600,7 +600,7 @@ describe('Test auto fill rules in controller', () => {
 
         describe('auto fill clear', async () => {
             it('test primary will move to upper left corner', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
 
                 const selectionManagerService = get(SheetsSelectionsService);
@@ -652,7 +652,7 @@ describe('Test auto fill rules in controller', () => {
 
     describe('auto fill range is auto detected', async () => {
         it('correct situation', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             if (!workbook) throw new Error('This is an error');
             // test other string
             (autoFillController as any)._handleDbClickFill({
@@ -680,7 +680,7 @@ describe('Test auto fill rules in controller', () => {
 
     describe('auto fill in left direction', async () => {
         it('correct situation', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             if (!workbook) throw new Error('This is an error');
             // test other string
             commandService.executeCommand(AutoFillCommand.id, {
@@ -712,7 +712,7 @@ describe('Test auto fill rules in controller', () => {
 
     describe('auto fill with equal ratio & style', async () => {
         it('correct situation', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             if (!workbook) throw new Error('This is an error');
             // equal ratio
             commandService.executeCommand(AutoFillCommand.id, {
@@ -760,7 +760,7 @@ describe('Test auto fill rules in controller', () => {
 
     describe('auto fill without format', async () => {
         it('correct situation', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             if (!workbook) throw new Error('This is an error');
             // equal ratio
             commandService.executeCommand(AutoFillCommand.id, {
@@ -821,7 +821,7 @@ describe('Test auto fill rules in controller', () => {
 
     describe('auto fill from single cell', async () => {
         it('correct situation', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             if (!workbook) throw new Error('This is an error');
             // test right
             commandService.executeCommand(AutoFillCommand.id, {

--- a/packages/sheets-ui/src/commands/commands/__tests__/command-behavior.spec.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/command-behavior.spec.ts
@@ -275,7 +275,6 @@ describe('sheets-ui command behaviors', () => {
         };
         const univerInstanceService = {
             getCurrentUnitOfType: () => workbook,
-            getCurrentUnitOfType: () => workbook,
         };
 
         const accessor = createAccessor([
@@ -324,7 +323,7 @@ describe('sheets-ui command behaviors', () => {
     it('guards scroll commands when params or targets are missing', async () => {
         const accessor = createAccessor([
             [ICommandService, { executeCommand: vi.fn(), syncExecuteCommand: vi.fn() }],
-            [IUniverInstanceService, { getCurrentUnitOfType: () => null, getCurrentUnitOfType: () => null }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => null }],
             [IRenderManagerService, { getRenderById: vi.fn() }],
         ]);
 

--- a/packages/sheets-ui/src/commands/commands/__tests__/command-behavior.spec.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/command-behavior.spec.ts
@@ -275,7 +275,7 @@ describe('sheets-ui command behaviors', () => {
         };
         const univerInstanceService = {
             getCurrentUnitOfType: () => workbook,
-            getCurrentUnitForType: () => workbook,
+            getCurrentUnitOfType: () => workbook,
         };
 
         const accessor = createAccessor([
@@ -306,7 +306,7 @@ describe('sheets-ui command behaviors', () => {
 
         const scrollToRange = vi.fn(() => true);
         const scrollAccessor = createAccessor([
-            [IUniverInstanceService, { getCurrentUnitForType: () => ({ getUnitId: () => 'unit-1' }) }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => ({ getUnitId: () => 'unit-1' }) }],
             [IRenderManagerService, { getRenderById: () => ({ with: () => ({ scrollToRange }) }) }],
         ]);
         expect(ScrollToCellCommand.handler(scrollAccessor, { range: { startRow: 1, endRow: 1, startColumn: 2, endColumn: 2 } as any })).toBe(true);
@@ -324,7 +324,7 @@ describe('sheets-ui command behaviors', () => {
     it('guards scroll commands when params or targets are missing', async () => {
         const accessor = createAccessor([
             [ICommandService, { executeCommand: vi.fn(), syncExecuteCommand: vi.fn() }],
-            [IUniverInstanceService, { getCurrentUnitOfType: () => null, getCurrentUnitForType: () => null }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => null, getCurrentUnitOfType: () => null }],
             [IRenderManagerService, { getRenderById: vi.fn() }],
         ]);
 
@@ -477,7 +477,7 @@ describe('sheets-ui command behaviors', () => {
             [ICommandService, { executeCommand }],
             [IUndoRedoService, { pushUndoRedo }],
             [WorksheetProtectionRuleModel, { getRule: () => ({ permissionId: 'perm-1' }) }],
-            [IUniverInstanceService, { getCurrentUnitForType: () => workbook }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => workbook }],
         ]);
 
         expect(await DeleteWorksheetProtectionFormSheetBarCommand.handler(accessor, { ok: true } as any)).toBe(true);
@@ -494,7 +494,7 @@ describe('sheets-ui command behaviors', () => {
             [ICommandService, { executeCommand: vi.fn() }],
             [IUndoRedoService, { pushUndoRedo: vi.fn() }],
             [WorksheetProtectionRuleModel, { getRule: vi.fn() }],
-            [IUniverInstanceService, { getCurrentUnitForType: () => ({ getUnitId: () => 'unit-1', getActiveSheet: () => null }) }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => ({ getUnitId: () => 'unit-1', getActiveSheet: () => null }) }],
         ]);
         expect(await DeleteWorksheetProtectionFormSheetBarCommand.handler(noWorksheetAccessor, { ok: true } as any)).toBe(false);
         expect(await DeleteWorksheetProtectionFormSheetBarCommand.handler(noWorksheetAccessor, undefined as any)).toBe(false);
@@ -532,7 +532,7 @@ describe('sheets-ui command behaviors', () => {
 
         const accessorWithWorksheetRule = createAccessor([
             [ICommandService, { executeCommand }],
-            [IUniverInstanceService, { getCurrentUnitForType: () => workbook }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => workbook }],
             [IUndoRedoService, { pushUndoRedo }],
             [SheetsSelectionsService, { getCurrentLastSelection: () => ({ range: { startRow: 1, endRow: 1, startColumn: 1, endColumn: 1 } }) }],
             [WorksheetProtectionRuleModel, { getRule: () => ({ permissionId: 'sheet-perm' }) }],
@@ -554,7 +554,7 @@ describe('sheets-ui command behaviors', () => {
 
         const accessorWithRangeRule = createAccessor([
             [ICommandService, { executeCommand }],
-            [IUniverInstanceService, { getCurrentUnitForType: () => workbook }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => workbook }],
             [IUndoRedoService, { pushUndoRedo }],
             [SheetsSelectionsService, { getCurrentLastSelection: () => ({ range: { startRow: 1, endRow: 1, startColumn: 1, endColumn: 1 } }) }],
             [WorksheetProtectionRuleModel, { getRule: () => null }],
@@ -577,7 +577,7 @@ describe('sheets-ui command behaviors', () => {
 
         const accessorNoSelection = createAccessor([
             [ICommandService, { executeCommand }],
-            [IUniverInstanceService, { getCurrentUnitForType: () => workbook }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => workbook }],
             [IUndoRedoService, { pushUndoRedo }],
             [SheetsSelectionsService, { getCurrentLastSelection: () => null }],
             [WorksheetProtectionRuleModel, { getRule: () => null }],

--- a/packages/sheets-ui/src/commands/commands/__tests__/set-format-painter.command.spec.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/set-format-painter.command.spec.ts
@@ -245,7 +245,7 @@ describe('Test format painter rules in controller', () => {
     describe('format painter', () => {
         describe('format painter the numbers', async () => {
             it('correct situation', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
                 await commandService.executeCommand(SetSelectionsOperation.id, {
                     unitId: 'workbook-01',
@@ -366,7 +366,7 @@ describe('Test format painter rules in controller', () => {
                     subUnitId: 'sheet-0011',
                 })).toBeTruthy();
 
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
                 expect(workbook.getSheetBySheetId('sheet-0011')?.getCell(5, 0)?.s).toBe('yifA1t');
                 expect(workbook.getSheetBySheetId('sheet-0011')?.getCell(5, 1)?.s).toBe('M5JbP2');
@@ -402,7 +402,7 @@ describe('Test format painter rules in controller', () => {
                         subUnitId: 'sheet-0011',
                     })).toBeTruthy();
 
-                    const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                    const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                     if (!workbook) throw new Error('This is an error');
                     expect(workbook.getSheetBySheetId('sheet-0011')?.getCell(0, 0)?.s).toBe(undefined);
                 });

--- a/packages/sheets-ui/src/commands/commands/__tests__/set-frozen.command.spec.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/set-frozen.command.spec.ts
@@ -83,7 +83,7 @@ describe('Test commands used for change selections', () => {
 
     const getFreeze = () => {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet();
         return worksheet?.getConfig().freeze;
     };

--- a/packages/sheets-ui/src/commands/commands/__tests__/set-selections.command.spec.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/set-selections.command.spec.ts
@@ -111,14 +111,14 @@ describe('Test commands used for change selections', () => {
 
     function getRowCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getRowCount();
     }
 
     function getColCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getColumnCount();
     }
@@ -525,7 +525,7 @@ describe('Test commands used for change selections', () => {
 
         it('should return false when there is no active workbook target', async () => {
             const univerInstanceService = get(IUniverInstanceService);
-            vi.spyOn(univerInstanceService, 'getCurrentUnitForType').mockReturnValue(null as never);
+            vi.spyOn(univerInstanceService, 'getCurrentUnitOfType').mockReturnValue(null as never);
 
             await expect(commandService.executeCommand<IMoveSelectionCommandParams>(MoveSelectionCommand.id, {
                 direction: Direction.RIGHT,

--- a/packages/sheets-ui/src/commands/commands/range-protection.command.ts
+++ b/packages/sheets-ui/src/commands/commands/range-protection.command.ts
@@ -93,7 +93,7 @@ export const DeleteRangeProtectionFromContextMenuCommand: ICommand = {
         const selectionManagerService = accessor.get(SheetsSelectionsService);
         const worksheetRuleModel = accessor.get(WorksheetProtectionRuleModel);
 
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         const unitId = workbook.getUnitId();
         const subUnitId = worksheet.getSheetId();
@@ -144,7 +144,7 @@ export const SetRangeProtectionFromContextMenuCommand: ICommand = {
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const selectionManagerService = accessor.get(SheetsSelectionsService);
         const worksheetRuleModel = accessor.get(WorksheetProtectionRuleModel);
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         const unitId = workbook.getUnitId();
         const subUnitId = worksheet.getSheetId();

--- a/packages/sheets-ui/src/commands/commands/set-scroll.command.ts
+++ b/packages/sheets-ui/src/commands/commands/set-scroll.command.ts
@@ -166,7 +166,7 @@ export const ScrollToCellCommand: ICommand<IScrollToCellCommandParams> = {
         const instanceService = accessor.get(IUniverInstanceService);
         const renderManagerService = accessor.get(IRenderManagerService);
         const scrollController = renderManagerService
-            .getRenderById(instanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_SHEET)!.getUnitId())!
+            .getRenderById(instanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SHEET)!.getUnitId())!
             .with(SheetsScrollRenderController);
         return scrollController.scrollToRange(params!.range, params!.forceTop, params!.forceLeft);
     },

--- a/packages/sheets-ui/src/commands/commands/worksheet-protection.command.ts
+++ b/packages/sheets-ui/src/commands/commands/worksheet-protection.command.ts
@@ -33,7 +33,7 @@ export const DeleteWorksheetProtectionFormSheetBarCommand: ICommand = {
         const worksheetProtectionRuleModel = accessor.get(WorksheetProtectionRuleModel);
         const univerInstanceService = accessor.get(IUniverInstanceService);
 
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook?.getActiveSheet();
         const unitId = workbook.getUnitId();
 

--- a/packages/sheets-ui/src/commands/operations/__tests__/basic-operations.spec.ts
+++ b/packages/sheets-ui/src/commands/operations/__tests__/basic-operations.spec.ts
@@ -121,7 +121,7 @@ describe('sheets-ui basic operations', () => {
     it('ScrollToRangeOperation should guard params and call scroll controller', () => {
         const scrollToRange = vi.fn(() => true);
         const accessor = createAccessor([
-            [IUniverInstanceService, { getCurrentUnitForType: () => ({ getUnitId: () => 'u1' }) }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => ({ getUnitId: () => 'u1' }) }],
             [IRenderManagerService, { getRenderById: () => ({ with: () => ({ scrollToRange }) }) }],
         ]);
 

--- a/packages/sheets-ui/src/commands/operations/__tests__/cell-edit.operation.spec.ts
+++ b/packages/sheets-ui/src/commands/operations/__tests__/cell-edit.operation.spec.ts
@@ -40,7 +40,7 @@ describe('cell edit operations', () => {
         const changeVisible = vi.fn();
         const accessor = createAccessor([
             [IConfigService, { getConfig: vi.fn(() => ({ disableEdit: true })) }],
-            [IUniverInstanceService, { getCurrentUnitForType: vi.fn(() => ({ getUnitId: () => 'u1' })) }],
+            [IUniverInstanceService, { getCurrentUnitOfType: vi.fn(() => ({ getUnitId: () => 'u1' })) }],
             [IEditorBridgeService, { changeVisible }],
         ]);
 
@@ -52,7 +52,7 @@ describe('cell edit operations', () => {
     it('SetCellEditVisibleOperation returns false when no active workbook', () => {
         const accessor = createAccessor([
             [IConfigService, { getConfig: vi.fn(() => ({ disableEdit: false })) }],
-            [IUniverInstanceService, { getCurrentUnitForType: vi.fn(() => null) }],
+            [IUniverInstanceService, { getCurrentUnitOfType: vi.fn(() => null) }],
             [IEditorBridgeService, { changeVisible: vi.fn() }],
         ]);
 
@@ -63,7 +63,7 @@ describe('cell edit operations', () => {
         const changeVisible = vi.fn();
         const accessor = createAccessor([
             [IConfigService, { getConfig: vi.fn(() => ({ disableEdit: false })) }],
-            [IUniverInstanceService, { getCurrentUnitForType: vi.fn(() => ({ getUnitId: () => 'workbook-u1' })) }],
+            [IUniverInstanceService, { getCurrentUnitOfType: vi.fn(() => ({ getUnitId: () => 'workbook-u1' })) }],
             [IEditorBridgeService, { changeVisible }],
         ]);
 
@@ -75,7 +75,7 @@ describe('cell edit operations', () => {
         const syncExecuteCommand = vi.fn(() => true);
         const commandAccessor = createAccessor([
             [ICommandService, { syncExecuteCommand }],
-            [IUniverInstanceService, { getCurrentUnitForType: vi.fn(() => ({ getUnitId: () => 'wb-u2' })) }],
+            [IUniverInstanceService, { getCurrentUnitOfType: vi.fn(() => ({ getUnitId: () => 'wb-u2' })) }],
         ]);
 
         expect(SetCellEditVisibleWithF2Operation.handler(commandAccessor, { visible: true } as any)).toBe(true);
@@ -86,7 +86,7 @@ describe('cell edit operations', () => {
 
         const noWorkbookAccessor = createAccessor([
             [ICommandService, { syncExecuteCommand: vi.fn() }],
-            [IUniverInstanceService, { getCurrentUnitForType: vi.fn(() => null) }],
+            [IUniverInstanceService, { getCurrentUnitOfType: vi.fn(() => null) }],
         ]);
         expect(SetCellEditVisibleWithF2Operation.handler(noWorkbookAccessor, { visible: true } as any)).toBe(false);
     });

--- a/packages/sheets-ui/src/commands/operations/cell-edit.operation.ts
+++ b/packages/sheets-ui/src/commands/operations/cell-edit.operation.ts
@@ -38,7 +38,7 @@ export const SetCellEditVisibleOperation: IOperation<IEditorBridgeServiceVisible
 
         const { unitId } = params;
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return false;
         }
@@ -58,7 +58,7 @@ export const SetCellEditVisibleWithF2Operation: IOperation<IEditorBridgeServiceV
     handler: (accessor, params) => {
         const commandService = accessor.get(ICommandService);
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return false;
         }

--- a/packages/sheets-ui/src/commands/operations/scroll-to-range.operation.ts
+++ b/packages/sheets-ui/src/commands/operations/scroll-to-range.operation.ts
@@ -30,7 +30,7 @@ export const ScrollToRangeOperation: ICommand<IScrollToCellCommandParams> = {
         const instanceService = accessor.get(IUniverInstanceService);
         const renderManagerService = accessor.get(IRenderManagerService);
         const scrollController = renderManagerService
-            .getRenderById(instanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_SHEET)!.getUnitId())!
+            .getRenderById(instanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SHEET)!.getUnitId())!
             .with(SheetsScrollRenderController);
 
         return scrollController.scrollToRange(params.range, params.forceTop, params.forceLeft);

--- a/packages/sheets-ui/src/controllers/__tests__/auto-height.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/__tests__/auto-height.controller.spec.ts
@@ -39,7 +39,7 @@ describe('AutoHeightController', () => {
         } as unknown as Workbook;
 
         const univerInstanceService = {
-            getCurrentUnitForType: () => workbook,
+            getCurrentUnitOfType: () => workbook,
             getUnit: () => workbook,
         } as unknown as IUniverInstanceService;
 

--- a/packages/sheets-ui/src/controllers/__tests__/status-bar.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/__tests__/status-bar.controller.spec.ts
@@ -122,7 +122,7 @@ describe('StatusBarController', () => {
     });
 
     it('updates status bar values on selection changes and cell updates within selection', () => {
-        const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
 
         const statusBarService = get(IStatusBarService);

--- a/packages/sheets-ui/src/controllers/auto-height.controller.ts
+++ b/packages/sheets-ui/src/controllers/auto-height.controller.ts
@@ -75,7 +75,7 @@ export class AutoHeightController extends Disposable {
 
     getUndoRedoParamsOfAutoHeight(ranges: IRange[], subUnitIdParam?: string, currentCellHeights?: ObjectMatrix<number>): { redos: IMutationInfo[]; undos: IMutationInfo[] } {
         const { _univerInstanceService: univerInstanceService } = this;
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
 
         // Better NOT use `getActiveWorksheet` method, because users may manipulate another worksheet in active sheet.
         const unitId = workbook.getUnitId();

--- a/packages/sheets-ui/src/controllers/clipboard/clipboard.controller.ts
+++ b/packages/sheets-ui/src/controllers/clipboard/clipboard.controller.ts
@@ -740,7 +740,7 @@ export class SheetClipboardController extends RxDisposable {
                 label: 'specialPaste.besidesBorder',
             },
             onPasteCells: (pasteFrom, pasteTo, matrix, payload) => {
-                const workbook = self._instanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = self._instanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 const redoMutationsInfo: IMutationInfo[] = [];
                 const undoMutationsInfo: IMutationInfo[] = [];
                 const { range, unitId, subUnitId } = pasteTo;

--- a/packages/sheets-ui/src/controllers/defined-name/defined-name.controller.ts
+++ b/packages/sheets-ui/src/controllers/defined-name/defined-name.controller.ts
@@ -80,7 +80,7 @@ export class SheetsDefinedNameController extends Disposable {
         }
 
         const lastSelection = params[params.length - 1];
-        const workbook = this._instanceSrv.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._instanceSrv.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         const worksheet = workbook?.getActiveSheet();
         if (!worksheet) {
             return;

--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -230,7 +230,7 @@ export class EditingRenderController extends Disposable {
 
     private _initialCursorSync(d: DisposableCollection) {
         d.add(this._cellEditorManagerService.focus$.pipe(filter((f) => !!f)).subscribe(() => {
-            const currentDoc = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_DOC);
+            const currentDoc = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC);
             if (!currentDoc) return;
 
             const docSelectionRenderManager = this._renderManagerService.getRenderById(currentDoc?.getUnitId())?.with(DocSelectionRenderService);

--- a/packages/sheets-ui/src/controllers/format-painter/format-painter.controller.ts
+++ b/packages/sheets-ui/src/controllers/format-painter/format-painter.controller.ts
@@ -92,7 +92,7 @@ export class FormatPainterController extends Disposable {
         const range = selection?.range;
         if (!range) return null;
         const { startRow, endRow, startColumn, endColumn } = range;
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook?.getActiveSheet();
         if (!worksheet) return null;
         const cellData = worksheet.getCellMatrix();

--- a/packages/sheets-ui/src/controllers/permission/sheet-permission-interceptor-canvas-render.controller.ts
+++ b/packages/sheets-ui/src/controllers/permission/sheet-permission-interceptor-canvas-render.controller.ts
@@ -232,7 +232,7 @@ export class SheetPermissionInterceptorCanvasRenderController extends RxDisposab
         this.disposeWithMe(
             this._headerFreezeRenderController.interceptor.intercept(this._headerFreezeRenderController.interceptor.getInterceptPoints().FREEZE_PERMISSION_CHECK, {
                 handler: (_: Nullable<boolean>, __) => {
-                    const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                    const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
                     const worksheet = workbook?.getActiveSheet();
                     if (!worksheet || !workbook) {
                         return false;

--- a/packages/sheets-ui/src/controllers/permission/sheet-permission-interceptor-clipboard.controller.ts
+++ b/packages/sheets-ui/src/controllers/permission/sheet-permission-interceptor-clipboard.controller.ts
@@ -55,7 +55,7 @@ export class SheetPermissionInterceptorClipboardController extends Disposable {
                         endColumn: startRange.startColumn + ranges.endColumn,
                     };
 
-                    const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                    const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                     const worksheet = workbook.getActiveSheet();
                     if (!worksheet) {
                         return false;

--- a/packages/sheets-ui/src/controllers/status-bar.controller.ts
+++ b/packages/sheets-ui/src/controllers/status-bar.controller.ts
@@ -308,7 +308,7 @@ export class StatusBarController extends Disposable {
 
     // eslint-disable-next-line max-lines-per-function
     private _calculateSelection(selections: IRange[], primary: Nullable<ISelectionCell>) {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return this._clearResult();
         }
@@ -322,7 +322,7 @@ export class StatusBarController extends Disposable {
         const sheetData: ISheetData = {};
 
         this._univerInstanceService
-            .getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!
+            .getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!
             .getSheets()
             .forEach((sheet) => {
                 const sheetConfig = sheet.getConfig();

--- a/packages/sheets-ui/src/controllers/utils/__tests__/component-tools.spec.ts
+++ b/packages/sheets-ui/src/controllers/utils/__tests__/component-tools.spec.ts
@@ -35,7 +35,7 @@ function createSheetComponents() {
 describe('component tools', () => {
     it('getSheetObject returns null when no workbook or render is available', () => {
         const noWorkbookInstance = {
-            getCurrentUnitForType: vi.fn(() => null),
+            getCurrentUnitOfType: vi.fn(() => null),
         };
         const renderManager = {
             getRenderById: vi.fn(),
@@ -45,7 +45,7 @@ describe('component tools', () => {
 
         const workbook = { getUnitId: () => 'unit-1' };
         const noRenderInstance = {
-            getCurrentUnitForType: () => workbook,
+            getCurrentUnitOfType: () => workbook,
         };
         expect(getSheetObject(noRenderInstance as any, renderManager as any)).toBeNull();
         expect(renderManager.getRenderById).toHaveBeenCalledWith('unit-1');
@@ -61,7 +61,7 @@ describe('component tools', () => {
             engine: { id: 'engine' },
         };
         const instance = {
-            getCurrentUnitForType: () => workbook,
+            getCurrentUnitOfType: () => workbook,
         };
         const renderManager = {
             getRenderById: () => render,
@@ -89,7 +89,7 @@ describe('component tools', () => {
             engine: { id: 'engine' },
         };
         const instance = {
-            getCurrentUnitForType: () => workbook,
+            getCurrentUnitOfType: () => workbook,
         };
 
         const sheetObject = getSheetObject(instance as any, renderContext as any);

--- a/packages/sheets-ui/src/controllers/utils/component-tools.ts
+++ b/packages/sheets-ui/src/controllers/utils/component-tools.ts
@@ -57,7 +57,7 @@ export function getSheetObject(
 ): Nullable<ISheetObjectParam> {
     const workbook = univerInstanceService instanceof Workbook
         ? univerInstanceService
-        : univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        : univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
     if (!workbook) return null;
 
     const unitId = workbook.getUnitId();

--- a/packages/sheets-ui/src/facade/__tests__/f-sheet-hooks.spec.ts
+++ b/packages/sheets-ui/src/facade/__tests__/f-sheet-hooks.spec.ts
@@ -137,7 +137,7 @@ describe('Test FSheetHooks', () => {
         ]);
         get = testBed.get;
         injector = testBed.injector;
-        workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
 
         commandService = get(ICommandService);
         commandService.registerCommand(SetRangeValuesCommand);

--- a/packages/sheets-ui/src/menu/__tests__/menu-factories.spec.ts
+++ b/packages/sheets-ui/src/menu/__tests__/menu-factories.spec.ts
@@ -208,7 +208,7 @@ describe('menu factories', () => {
         commandService.registerCommand(ToggleGridlinesMutation);
 
         const menuItem = injector.invoke(ToggleGridlinesMenuFactory);
-        const worksheet = instanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet();
+        const worksheet = instanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet();
         const initial = await firstValueFrom(menuItem.activated$!.pipe(take(1)));
         expect(await firstValueFrom(menuItem.disabled$!.pipe(take(1)))).toBeTypeOf('boolean');
 

--- a/packages/sheets-ui/src/menu/__tests__/menu-util.spec.ts
+++ b/packages/sheets-ui/src/menu/__tests__/menu-util.spec.ts
@@ -149,7 +149,7 @@ function createMenuAccessor(option: Partial<IMenuAccessorOption> = {}) {
     };
 
     const pairs: Array<[unknown, unknown]> = [
-        [IUniverInstanceService, { getCurrentTypeOfUnit$: () => of(workbook), getCurrentUnitForType: () => workbook }],
+        [IUniverInstanceService, { getCurrentTypeOfUnit$: () => of(workbook), getCurrentUnitOfType: () => workbook }],
         [SheetsSelectionsService, selectionService],
         [RangeProtectionRuleModel, rangeProtectionRuleModel],
         [WorksheetProtectionRuleModel, worksheetProtectionRuleModel],

--- a/packages/sheets-ui/src/menu/__tests__/row-col.menu.spec.ts
+++ b/packages/sheets-ui/src/menu/__tests__/row-col.menu.spec.ts
@@ -78,21 +78,21 @@ describe('Test row col menu items', () => {
 
     function getRowCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getRowCount();
     }
 
     function getColCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getColumnCount();
     }
 
     async function selectRow(rowStart: number, rowEnd: number): Promise<boolean> {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         const endColumn = getColCount() - 1;
         return commandService.executeCommand<ISetSelectionsOperationParams, boolean>(SetSelectionsOperation.id, {
@@ -120,7 +120,7 @@ describe('Test row col menu items', () => {
 
     async function selectColumn(columnStart: number, columnEnd: number): Promise<boolean> {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         const endRow = getRowCount() - 1;
         return commandService.executeCommand<ISetSelectionsOperationParams, boolean>(SetSelectionsOperation.id, {

--- a/packages/sheets-ui/src/menu/gridlines.menu.ts
+++ b/packages/sheets-ui/src/menu/gridlines.menu.ts
@@ -33,7 +33,7 @@ export function ToggleGridlinesMenuFactory(accessor: IAccessor): IMenuButtonItem
         icon: 'HideGridlinesDoubleIcon',
         activated$: new Observable<boolean>((observer) => {
             const getValue = () => {
-                const workbook = instanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                const workbook = instanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
                 if (workbook) return workbook.getActiveSheet().getConfig().showGridlines === BooleanNumber.TRUE;
                 return false;
             };

--- a/packages/sheets-ui/src/menu/menu-util.ts
+++ b/packages/sheets-ui/src/menu/menu-util.ts
@@ -222,7 +222,7 @@ export function getBaseRangeMenuHidden$(accessor: IAccessor) {
             const range = selectionManagerService.getCurrentLastSelection()?.range;
             if (!range) return true;
 
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             const worksheet = workbook?.getActiveSheet();
             if (!workbook || !worksheet) {
                 return true;
@@ -256,7 +256,7 @@ export function getInsertAfterMenuHidden$(accessor: IAccessor, type: 'row' | 'co
             const range = selectionManagerService.getCurrentLastSelection()?.range;
             if (!range) return true;
 
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             const worksheet = workbook?.getActiveSheet();
             if (!workbook || !worksheet) {
                 return true;
@@ -298,7 +298,7 @@ export function getInsertBeforeMenuHidden$(accessor: IAccessor, type: 'row' | 'c
             const range = selectionManagerService.getCurrentLastSelection()?.range;
             if (!range) return true;
 
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             const worksheet = workbook?.getActiveSheet();
             if (!workbook || !worksheet) {
                 return true;
@@ -341,7 +341,7 @@ export function getDeleteMenuHidden$(accessor: IAccessor, type: 'row' | 'col') {
             const range = selectionManagerService.getCurrentLastSelection()?.range;
             if (!range) return true;
 
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             const worksheet = workbook?.getActiveSheet();
             if (!workbook || !worksheet) {
                 return true;
@@ -386,7 +386,7 @@ export function getCellMenuHidden$(accessor: IAccessor, type: 'row' | 'col') {
             const range = selectionManagerService.getCurrentLastSelection()?.range;
             if (!range) return true;
 
-            const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             const worksheet = workbook?.getActiveSheet();
             if (!workbook || !worksheet) {
                 return true;

--- a/packages/sheets-ui/src/menu/sheet.menu.ts
+++ b/packages/sheets-ui/src/menu/sheet.menu.ts
@@ -149,7 +149,7 @@ export function UnHideSheetMenuItemFactory(accessor: IAccessor): IMenuSelectorIt
     const univerInstanceService = accessor.get(IUniverInstanceService);
     const commandService = accessor.get(ICommandService);
 
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const hiddenList = workbook.getHiddenWorksheets().map((s) => ({
         label: workbook.getSheetBySheetId(s)?.getName() || '',
         value: s,
@@ -203,7 +203,7 @@ export function ShowMenuItemFactory(accessor: IAccessor): IMenuButtonItem {
         title: 'sheetConfig.unhide',
         disabled$: new Observable<boolean>((subscriber) => {
             function disableFunction() {
-                const worksheets = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getWorksheets();
+                const worksheets = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getWorksheets();
                     // loop through all worksheets Map to see if there is more than one sheet
                 const visibleSheets = Array.from(worksheets.values());
 
@@ -232,7 +232,7 @@ export function ShowMenuItemFactory(accessor: IAccessor): IMenuButtonItem {
 }
 
 function disableFunction(univerInstanceService: IUniverInstanceService, subscriber: Subscriber<boolean>) {
-    const worksheets = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getWorksheets();
+    const worksheets = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getWorksheets();
         // loop through all worksheets Map to see if there is more than one visible sheet
     const visibleSheets = Array.from(worksheets.values()).filter(
         (sheet) => sheet.getConfig().hidden === BooleanNumber.FALSE

--- a/packages/sheets-ui/src/services/__tests__/canvas-pop-manager.service.spec.ts
+++ b/packages/sheets-ui/src/services/__tests__/canvas-pop-manager.service.spec.ts
@@ -115,7 +115,6 @@ function createService() {
         { getRenderById: () => currentRender } as any,
         {
             getCurrentUnitOfType: () => workbook,
-            getCurrentUnitOfType: () => workbook,
             getUnit: () => workbook,
         } as any,
         {

--- a/packages/sheets-ui/src/services/__tests__/canvas-pop-manager.service.spec.ts
+++ b/packages/sheets-ui/src/services/__tests__/canvas-pop-manager.service.spec.ts
@@ -114,7 +114,7 @@ function createService() {
         popupService as any,
         { getRenderById: () => currentRender } as any,
         {
-            getCurrentUnitForType: () => workbook,
+            getCurrentUnitOfType: () => workbook,
             getCurrentUnitOfType: () => workbook,
             getUnit: () => workbook,
         } as any,

--- a/packages/sheets-ui/src/services/__tests__/drag-manager.service.spec.ts
+++ b/packages/sheets-ui/src/services/__tests__/drag-manager.service.spec.ts
@@ -29,7 +29,7 @@ vi.mock('../../common/utils', () => ({
     getHoverCellPosition: vi.fn(),
 }));
 
-type DragManagerInstanceServiceStub = Pick<IUniverInstanceService, 'getCurrentTypeOfUnit$' | 'getCurrentUnitForType'>;
+type DragManagerInstanceServiceStub = Pick<IUniverInstanceService, 'getCurrentTypeOfUnit$' | 'getCurrentUnitOfType'>;
 type DragManagerRenderManagerStub = Pick<IRenderManagerService, 'getRenderById'>;
 
 function createRender() {
@@ -60,7 +60,7 @@ function createUniverInstanceService(
         getCurrentTypeOfUnit$<T extends UnitModel<object, number>>(): Observable<Nullable<T>> {
             return currentType$.asObservable() as Observable<Nullable<T>>;
         },
-        getCurrentUnitForType<T extends UnitModel<object, number>>(): Nullable<T> {
+        getCurrentUnitOfType<T extends UnitModel<object, number>>(): Nullable<T> {
             return workbook as Nullable<T>;
         },
     };

--- a/packages/sheets-ui/src/services/__tests__/editor-bridge.service.spec.ts
+++ b/packages/sheets-ui/src/services/__tests__/editor-bridge.service.spec.ts
@@ -44,7 +44,7 @@ function createService(options?: { hasFocusEditor?: boolean }) {
         },
         univerInstanceService: {
             getTypeOfUnitDisposed$: vi.fn(() => unitDisposed$.asObservable()),
-            getCurrentUnitForType: vi.fn(() => workbook),
+            getCurrentUnitOfType: vi.fn(() => workbook),
         },
         editorService: {
             getFocusEditor: vi.fn(() => (options?.hasFocusEditor ? { id: 'existing' } : null)),

--- a/packages/sheets-ui/src/services/canvas-pop-manager.service.ts
+++ b/packages/sheets-ui/src/services/canvas-pop-manager.service.ts
@@ -259,7 +259,7 @@ export class SheetCanvasPopManagerService extends Disposable {
      * @returns disposable
      */
     attachPopupToObject(targetObject: BaseObject, popup: ICanvasPopup): INeedCheckDisposable {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet();
         if (!worksheet || (this._isSelectionMoving && !popup.showOnSelectionMoving)) {
             return {
@@ -328,7 +328,7 @@ export class SheetCanvasPopManagerService extends Disposable {
 
     // #region attach to position
     attachPopupByPosition(bound: IBoundRectNoAngle, popup: ICanvasPopup, location: ISheetLocationBase): Nullable<INeedCheckDisposable> {
-        let workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        let workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         let worksheet = workbook.getActiveSheet();
         if (!worksheet) {
             return null;
@@ -387,7 +387,7 @@ export class SheetCanvasPopManagerService extends Disposable {
 
     // #region attach to absolute position
     attachPopupToAbsolutePosition(bound: IBoundRectNoAngle, popup: ICanvasPopup, _unitId?: string, _subUnitId?: string) {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet();
         if (!worksheet) {
             return null;
@@ -530,7 +530,7 @@ export class SheetCanvasPopManagerService extends Disposable {
      * @param showOnSelectionMoving
      */
     attachRangePopup(range: IRange, popup: ICanvasPopup, _unitId?: string, _subUnitId?: string, viewport?: Viewport, showOnSelectionMoving = false): Nullable<INeedCheckDisposable> {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet();
         if (!worksheet) {
             return null;

--- a/packages/sheets-ui/src/services/clipboard/clipboard.service.ts
+++ b/packages/sheets-ui/src/services/clipboard/clipboard.service.ts
@@ -272,7 +272,7 @@ export class SheetClipboardService extends Disposable implements ISheetClipboard
             return false; // maybe we should notify user that there is no selection
         }
 
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         const worksheet = workbook?.getActiveSheet();
         if (!workbook || !worksheet) {
             return false;
@@ -587,7 +587,7 @@ export class SheetClipboardService extends Disposable implements ISheetClipboard
         if (result) {
             // add to undo redo services
             this._undoRedoService.pushUndoRedo({
-                unitID: this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId(),
+                unitID: this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId(),
                 undoMutations: undoMutationsInfo,
                 redoMutations: redoMutationsInfo,
             });
@@ -1080,7 +1080,7 @@ export class SheetClipboardService extends Disposable implements ISheetClipboard
     }
 
     private _getPastingTarget() {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet();
         const selection = this._selectionManagerService.getCurrentLastSelection();
         return {
@@ -1158,7 +1158,7 @@ export class SheetClipboardService extends Disposable implements ISheetClipboard
         const destinationRows = endRow - startRow + 1;
         const destinationColumns = endColumn - startColumn + 1;
 
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         const worksheet = workbook?.getActiveSheet();
         if (!worksheet) {
             return null;
@@ -1368,7 +1368,7 @@ export class SheetClipboardService extends Disposable implements ISheetClipboard
      * @param range
      */
     private _topLeftCellsMatch(rowCount: number, colCount: number, range: { topRow: number; leftCol: number }): boolean {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook?.getActiveSheet();
         if (!worksheet) {
             return false;

--- a/packages/sheets-ui/src/services/drag-manager.service.ts
+++ b/packages/sheets-ui/src/services/drag-manager.service.ts
@@ -67,7 +67,7 @@ export class DragManagerService extends Disposable {
     }
 
     private _calcActiveCell(offsetX: number, offsetY: number): Nullable<IHoverCellPosition> {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return null;
         }

--- a/packages/sheets-ui/src/services/mark-selection/mark-selection.service.ts
+++ b/packages/sheets-ui/src/services/mark-selection/mark-selection.service.ts
@@ -62,7 +62,7 @@ export class MarkSelectionService extends Disposable implements IMarkSelectionSe
     }
 
     addShape(selection: ISelectionWithStyle, exits: string[] = [], zIndex: number = DEFAULT_Z_INDEX): string | null {
-        const workbook = this._currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const subUnitId = workbook.getActiveSheet()?.getSheetId();
         if (!subUnitId) return null;
         const id = generateRandomId();
@@ -82,7 +82,7 @@ export class MarkSelectionService extends Disposable implements IMarkSelectionSe
     }
 
     addShapeWithNoFresh(selection: ISelectionWithStyle, exits: string[] = [], zIndex: number = DEFAULT_Z_INDEX): string | null {
-        const workbook = this._currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const subUnitId = workbook.getActiveSheet()?.getSheetId();
         if (!subUnitId) return null;
         const id = generateRandomId();
@@ -99,7 +99,7 @@ export class MarkSelectionService extends Disposable implements IMarkSelectionSe
     }
 
     refreshShapes(): void {
-        const currentSheet = this._currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const currentSheet = this._currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!currentSheet) return;
 
         const currentUnitId = currentSheet.getUnitId();

--- a/packages/sheets-ui/src/views/defined-name/DefinedNameInput.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameInput.tsx
@@ -51,7 +51,7 @@ export const DefinedNameInput = (props: IDefinedNameInputProps) => {
         id,
     } = props;
     const univerInstanceService = useDependency(IUniverInstanceService);
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const localeService = useDependency(LocaleService);
     const definedNamesService = useDependency(IDefinedNamesService);
     const superTableService = useDependency(ISuperTableService);

--- a/packages/sheets-ui/src/views/defined-name/DefinedNameOverlay.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameOverlay.tsx
@@ -32,7 +32,7 @@ export function DefinedNameOverlay({ search, isInputEvent }: { search: string; i
     const univerInstanceService = useDependency(IUniverInstanceService);
     const sidebarService = useDependency(ISidebarService);
 
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const unitId = workbook.getUnitId();
 
     const getDefinedNameMap = () => {

--- a/packages/sheets-ui/src/views/permission/panel-detail/PermissionDetailFooterPart.tsx
+++ b/packages/sheets-ui/src/views/permission/panel-detail/PermissionDetailFooterPart.tsx
@@ -49,7 +49,7 @@ export const PermissionDetailFooterPart = (props: IPermissionDetailFooterPartPro
     const sheetPermissionUserManagerService = useDependency(SheetPermissionUserManagerService);
     const univerInstanceService = useDependency(IUniverInstanceService);
 
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
     const worksheet = workbook?.getActiveSheet();
     if (!workbook || !worksheet) {
         return null;

--- a/packages/sheets-ui/src/views/permission/panel-detail/PermissionDetailMainPart.tsx
+++ b/packages/sheets-ui/src/views/permission/panel-detail/PermissionDetailMainPart.tsx
@@ -43,7 +43,7 @@ export const PermissionDetailMainPart = (props: IPermissionDetailMainPartProps) 
     const localeService = useDependency(LocaleService);
     const injector = useDependency(Injector);
 
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
     const worksheet = workbook?.getActiveSheet();
     if (!workbook || !worksheet) {
         return null;
@@ -57,7 +57,7 @@ export const PermissionDetailMainPart = (props: IPermissionDetailMainPartProps) 
             return;
         }
 
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         const worksheet = workbook?.getActiveSheet();
         if (!workbook || !worksheet) {
             return;

--- a/packages/sheets-ui/src/views/permission/panel-detail/PermissionDetailUserPart.tsx
+++ b/packages/sheets-ui/src/views/permission/panel-detail/PermissionDetailUserPart.tsx
@@ -44,7 +44,7 @@ export const PermissionDetailUserPart = (props: IPermissionDetailUserPartProps) 
     const univerInstanceService = useDependency(IUniverInstanceService);
     const selectUserList = useObservable(sheetPermissionUserManagerService.selectUserList$, sheetPermissionUserManagerService.selectUserList);
 
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
     const worksheet = workbook?.getActiveSheet();
     if (!workbook || !worksheet) {
         return null;

--- a/packages/sheets-ui/src/views/permission/permission-dialog/index.tsx
+++ b/packages/sheets-ui/src/views/permission/permission-dialog/index.tsx
@@ -40,7 +40,7 @@ export const SheetPermissionDialog = () => {
     const worksheetProtectionPointRuleModel = useDependency(WorksheetProtectionPointModel);
     const dialogService = useDependency(IDialogService);
     const permissionService = useDependency(IPermissionService);
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const worksheet = workbook.getActiveSheet();
     if (!worksheet) {
         throw new Error('No active sheet found');
@@ -107,7 +107,7 @@ export const SheetPermissionDialog = () => {
     }, []);
 
     const handleChangeActionPermission = async () => {
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook?.getActiveSheet();
         if (!worksheet) {
             throw new Error('No active sheet found');

--- a/packages/sheets-ui/src/views/permission/util.ts
+++ b/packages/sheets-ui/src/views/permission/util.ts
@@ -83,7 +83,7 @@ export const checkRangesIsWholeSheet = (ranges: IRange[], sheet: Worksheet) => {
 export const generateDefaultRule = (injector: Injector, fromSheetBar: boolean) => {
     const univerInstanceService = injector.get(IUniverInstanceService);
     const selectionManagerService = injector.get(SheetsSelectionsService);
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const worksheet = workbook.getActiveSheet();
 
     let unitType = UnitObject.SelectRange;
@@ -115,7 +115,7 @@ export const generateDefaultRule = (injector: Injector, fromSheetBar: boolean) =
 
 export const generateRuleByUnitType = (injector: Injector, rule: IPermissionPanelRule) => {
     const univerInstanceService = injector.get(IUniverInstanceService);
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const worksheet = workbook.getActiveSheet();
     const { unitType } = rule;
 

--- a/packages/sheets-ui/src/views/sheet-slider/ZoomSlider.tsx
+++ b/packages/sheets-ui/src/views/sheet-slider/ZoomSlider.tsx
@@ -65,7 +65,7 @@ export function ZoomSlider() {
 
     function handleChange(value: number) {
         setZoom(value);
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook?.getActiveSheet();
         if (worksheet == null) {
             return;

--- a/packages/sheets-zen-editor/src/commands/commands/__tests__/zen-editor.command.spec.ts
+++ b/packages/sheets-zen-editor/src/commands/commands/__tests__/zen-editor.command.spec.ts
@@ -111,7 +111,7 @@ describe('zen-editor commands', () => {
             [IZenZoneService, { close: vi.fn() }],
             [IEditorBridgeService, { refreshEditCellState }],
             [IUniverInstanceService, {
-                getCurrentUnitForType: () => ({ getUnitId: () => 'sheet-unit' }),
+                getCurrentUnitOfType: () => ({ getUnitId: () => 'sheet-unit' }),
                 focusUnit,
             }],
             [ISidebarService, { visible: false }],
@@ -126,7 +126,7 @@ describe('zen-editor commands', () => {
         const result = await CancelZenEditCommand.handler(createAccessor([
             [IZenZoneService, { close: vi.fn() }],
             [IEditorBridgeService, { refreshEditCellState: vi.fn() }],
-            [IUniverInstanceService, { getCurrentUnitForType: () => null, focusUnit: vi.fn() }],
+            [IUniverInstanceService, { getCurrentUnitOfType: () => null, focusUnit: vi.fn() }],
             [ISidebarService, { visible: false }],
         ]));
 
@@ -142,7 +142,7 @@ describe('zen-editor commands', () => {
             [IZenZoneService, { close: vi.fn() }],
             [IEditorBridgeService, { refreshEditCellState }],
             [IUniverInstanceService, {
-                getCurrentUnitForType: () => ({ getUnitId: () => 'sheet-unit' }),
+                getCurrentUnitOfType: () => ({ getUnitId: () => 'sheet-unit' }),
                 focusUnit,
             }],
             [IEditorService, {
@@ -180,7 +180,7 @@ describe('zen-editor commands', () => {
             [IZenZoneService, { close: vi.fn() }],
             [IEditorBridgeService, { refreshEditCellState: vi.fn() }],
             [IUniverInstanceService, {
-                getCurrentUnitForType: () => ({ getUnitId: () => 'sheet-unit' }),
+                getCurrentUnitOfType: () => ({ getUnitId: () => 'sheet-unit' }),
                 focusUnit: vi.fn(),
             }],
             [IEditorService, { getEditor: () => null }],

--- a/packages/sheets-zen-editor/src/commands/commands/zen-editor.command.ts
+++ b/packages/sheets-zen-editor/src/commands/commands/zen-editor.command.ts
@@ -101,7 +101,7 @@ export const CancelZenEditCommand: ICommand = {
         }
         zenZoneEditorService.close();
 
-        const currentSheetInstance = univerInstanceManager.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const currentSheetInstance = univerInstanceManager.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (currentSheetInstance) {
             univerInstanceManager.focusUnit(currentSheetInstance.getUnitId());
             editorBridgeService.refreshEditCellState();
@@ -139,7 +139,7 @@ export const ConfirmZenEditCommand: ICommand = {
 
         const renderManagerService = accessor.get(IRenderManagerService);
 
-        const currentSheetInstance = univerInstanceManager.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const currentSheetInstance = univerInstanceManager.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (currentSheetInstance) {
             const currentSheetId = currentSheetInstance.getUnitId();
 

--- a/packages/sheets/src/basics/__tests__/utils.spec.ts
+++ b/packages/sheets/src/basics/__tests__/utils.spec.ts
@@ -140,7 +140,7 @@ describe('Test utils', () => {
             getActiveSheet: () => worksheet,
         };
         const instanceService = {
-            getCurrentUnitForType: () => workbook,
+            getCurrentUnitOfType: () => workbook,
         };
 
         const [currentWorkbook, currentWorksheet] = getActiveWorksheet(instanceService as never);
@@ -172,7 +172,7 @@ describe('Test utils', () => {
         };
         const instanceService = {
             getUnit: () => workbook,
-            getCurrentUnitForType: () => workbook,
+            getCurrentUnitOfType: () => workbook,
         };
         const accessor = createAccessor((token) => {
             if (token === IUniverInstanceService) {
@@ -197,7 +197,7 @@ describe('Test utils', () => {
     it('Test rangeToDiscreteRange returns null without worksheet', () => {
         const instanceService = {
             getUnit: () => null,
-            getCurrentUnitForType: () => null,
+            getCurrentUnitOfType: () => null,
         };
         const accessor = createAccessor((token) => {
             if (token === IUniverInstanceService) {

--- a/packages/sheets/src/basics/utils.ts
+++ b/packages/sheets/src/basics/utils.ts
@@ -137,7 +137,7 @@ export function generateNullCellStyle(ranges: IRange[]): IObjectMatrixPrimitiveT
 }
 
 export function getActiveWorksheet(instanceService: UniverInstanceService): [Nullable<Workbook>, Nullable<Worksheet>] {
-    const workbook = instanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+    const workbook = instanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
     const worksheet = workbook?.getActiveSheet();
     return [workbook, worksheet];
 }
@@ -156,7 +156,7 @@ export function rangeToDiscreteRange(range: IRange, accessor: IAccessor, unitId?
     const univerInstanceService = accessor.get(IUniverInstanceService);
     const workbook = unitId
         ? univerInstanceService.getUnit<Workbook>(unitId, UniverInstanceType.UNIVER_SHEET)
-        : univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        : univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
     const worksheet = subUnitId ? workbook?.getSheetBySheetId(subUnitId) : workbook?.getActiveSheet();
     if (!worksheet) {
         return null;

--- a/packages/sheets/src/commands/commands/__tests__/copy-worksheet.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/copy-worksheet.command.spec.ts
@@ -61,7 +61,7 @@ describe('Test copy worksheet commands', () => {
     describe('copy sheet', () => {
         describe('copy the only sheet', async () => {
             it('correct situation', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
                 function getSheetCopyPart(sheet: Worksheet) {
                     const config = sheet.getConfig();
@@ -109,7 +109,7 @@ describe('Test copy worksheet commands', () => {
             });
 
             it('Function getCopyUniqueSheetName', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
 
                 const localeService = get(LocaleService);
@@ -124,7 +124,7 @@ describe('Test copy worksheet commands', () => {
             });
 
             it('split large sheet copy should schedule remaining mutations and disable redo', async () => {
-                const sourceWorkbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const sourceWorkbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 const sourceSheet = sourceWorkbook.getActiveSheet();
                 sourceSheet.getCellMatrix().setValue(1, 0, { v: 'B1' });
                 expect(sourceSheet.getConfig().cellData[1]).toBeDefined();
@@ -148,7 +148,7 @@ describe('Test copy worksheet commands', () => {
                     })
                 ).toBeTruthy();
 
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 expect(workbook.getSheetSize()).toBe(2);
                 expect(scheduleSpy).toHaveBeenCalledTimes(1);
 

--- a/packages/sheets/src/commands/commands/__tests__/insert-remove-rows-cols.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/insert-remove-rows-cols.command.spec.ts
@@ -149,14 +149,14 @@ describe('Test insert and remove rows cols commands', () => {
 
     function getRowCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getRowCount();
     }
 
     function getColCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getColumnCount();
     }
@@ -167,21 +167,21 @@ describe('Test insert and remove rows cols commands', () => {
 
     function getCellInfo(row: number, col: number): Nullable<ICellData> {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getCellMatrix().getValue(row, col);
     }
 
     function getMergedInfo(row: number, col: number): Nullable<IRange> {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getMergedCell(row, col);
     }
 
     function getMergeData() {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getMergeData();
     }

--- a/packages/sheets/src/commands/commands/__tests__/insert-sheet.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/insert-sheet.command.spec.ts
@@ -48,7 +48,7 @@ describe('Test insert worksheet commands', () => {
 
     describe('insert sheet', () => {
         it('should auto-generate incremental names when name is not provided', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const localeService = get(LocaleService);
             const sheetPrefix = localeService.t('sheets.tabs.sheet');
             expect(workbook.getSheetSize()).toBe(1);
@@ -71,7 +71,7 @@ describe('Test insert worksheet commands', () => {
         });
 
         it('should use provided name directly when it is unique', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
 
             await commandService.executeCommand(InsertSheetCommand.id, {
                 unitId: 'test',
@@ -83,7 +83,7 @@ describe('Test insert worksheet commands', () => {
         });
 
         it('should deduplicate name when provided name already exists', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
 
             await commandService.executeCommand(InsertSheetCommand.id, {
                 unitId: 'test',
@@ -95,7 +95,7 @@ describe('Test insert worksheet commands', () => {
         });
 
         it('should not be affected by mergeWorksheetSnapshotWithDefault default name', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const initialSize = workbook.getSheetSize();
 
             await commandService.executeCommand(InsertSheetCommand.id, {

--- a/packages/sheets/src/commands/commands/__tests__/move-range-commands.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/move-range-commands.spec.ts
@@ -153,14 +153,14 @@ describe('Test move range commands', () => {
 
     function getMergedInfo(row: number, col: number): Nullable<IRange> {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getMergedCell(row, col);
     }
 
     function getMergeData() {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getConfig().mergeData;
     }

--- a/packages/sheets/src/commands/commands/__tests__/move-rows-cols.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/move-rows-cols.command.spec.ts
@@ -112,42 +112,42 @@ describe('Test move rows cols', () => {
 
     function getRowCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getRowCount();
     }
 
     function getColCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getColumnCount();
     }
 
     function getCellInfo(row: number, col: number): Nullable<ICellData> {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getCellMatrix().getValue(row, col);
     }
 
     function getMergedInfo(row: number, col: number): Nullable<IRange> {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getMergedCell(row, col);
     }
 
     function getRowHeight(row: number): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getRowHeight(row);
     }
 
     function getColWidth(col: number): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getColumnWidth(col);
     }

--- a/packages/sheets/src/commands/commands/__tests__/range-template-command.sepc.ts
+++ b/packages/sheets/src/commands/commands/__tests__/range-template-command.sepc.ts
@@ -57,7 +57,7 @@ describe('Test set worksheet default style commands', () => {
 
     describe('set worksheet range style', () => {
         it('correct situation', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const worksheet = workbook.getSheetBySheetId('sheet1');
             if (!workbook) throw new Error('This is an error');
 
@@ -87,7 +87,7 @@ describe('Test set worksheet default style commands', () => {
         });
 
         it('ensure range theme style can not overwrite cell style', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             if (!workbook) throw new Error('This is an error');
 
             await commandService.executeCommand(SetStyleCommand.id, {

--- a/packages/sheets/src/commands/commands/__tests__/remove-rows-cols.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/remove-rows-cols.command.spec.ts
@@ -90,14 +90,14 @@ describe('Test remove rows cols', () => {
 
     function getColCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getColumnCount();
     }
 
     function getCellInfo(row: number, col: number): Nullable<ICellData> {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getCellMatrix().getValue(row, col);
     }

--- a/packages/sheets/src/commands/commands/__tests__/remove-sheet.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/remove-sheet.command.spec.ts
@@ -59,7 +59,7 @@ describe('Test remove worksheet commands', () => {
                 ).toBeFalsy();
             });
             it('will be working if there are more than one sheet', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
 
                 const targetActiveSheet = workbook.getActiveSheet();

--- a/packages/sheets/src/commands/commands/__tests__/remove-worksheet-merge.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/remove-worksheet-merge.command.spec.ts
@@ -90,7 +90,7 @@ describe('remove-worksheet-merge.command', () => {
     });
 
     function getActiveWorksheet() {
-        return get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet();
+        return get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet();
     }
 
     it('returns false for empty ranges or no merge intersection', async () => {

--- a/packages/sheets/src/commands/commands/__tests__/set-col-data.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-col-data.command.spec.ts
@@ -71,7 +71,7 @@ describe('test set column data commands', () => {
     let commandService: ICommandService;
 
     function getColumnData(column: number) {
-        const worksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const worksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         const columnManager = worksheet.getColumnManager();
         return columnManager.getColumn(column);
     }

--- a/packages/sheets/src/commands/commands/__tests__/set-col-width.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-col-width.command.spec.ts
@@ -31,12 +31,12 @@ describe('Test set col width commands', () => {
     let selectionsService: SheetsSelectionsService;
 
     function getColumnWidth(col: number): number {
-        const worksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const worksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         return worksheet.getColumnWidth(col);
     }
 
     function setSelection(start: number, end: number): void {
-        const worksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const worksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         const maxRow = worksheet.getMaxRows() - 1;
 
         selectionsService.setSelections([
@@ -58,7 +58,7 @@ describe('Test set col width commands', () => {
     }
 
     function addSelection(start: number, end: number): void {
-        const worksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const worksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         const maxRow = worksheet.getMaxRows() - 1;
 
         selectionsService.addSelections([
@@ -80,7 +80,7 @@ describe('Test set col width commands', () => {
         commandService.registerCommand(SetColWidthCommand);
         commandService.registerCommand(SetWorksheetColWidthMutation);
 
-        const worksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const worksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         const maxRow = worksheet.getMaxRows() - 1;
         selectionsService = get(SheetsSelectionsService);
 

--- a/packages/sheets/src/commands/commands/__tests__/set-frozen.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-frozen.command.spec.ts
@@ -106,7 +106,7 @@ describe('Test set frozen commands', () => {
     describe('set frozen', () => {
         describe('set frozen', async () => {
             it('correct situation: ', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
 
                 const targetActiveSheet = workbook.getActiveSheet()!;

--- a/packages/sheets/src/commands/commands/__tests__/set-gridlines.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-gridlines.command.spec.ts
@@ -42,7 +42,7 @@ describe('Test set worksheet default style commands', () => {
 
     describe('set worksheet grid line color', () => {
         it('correct situation', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const worksheet = workbook.getSheetBySheetId('sheet1');
             if (!workbook) throw new Error('This is an error');
 
@@ -67,7 +67,7 @@ describe('Test set worksheet default style commands', () => {
         });
     });
     it('reset worksheet grid line color', async () => {
-        const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getSheetBySheetId('sheet1');
         if (!workbook) throw new Error('This is an error');
 

--- a/packages/sheets/src/commands/commands/__tests__/set-range-values.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-range-values.command.spec.ts
@@ -482,7 +482,7 @@ describe('Test set range values commands', () => {
                     return params;
                 }
 
-                const unit = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                const unit = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
                 const subUnitId = unit?.getActiveSheet()?.getSheetId();
 
                 // current sheet is sheet1

--- a/packages/sheets/src/commands/commands/__tests__/set-row-col-visible.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-row-col-visible.command.spec.ts
@@ -66,26 +66,26 @@ describe('Test row col hide/unhine commands', () => {
 
     function getRowCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getRowCount();
     }
 
     function getColCount(): number {
         const currentService = get(IUniverInstanceService);
-        const workbook = currentService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = currentService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getColumnCount();
     }
 
     function getRowRawVisible(row: number): boolean {
-        const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getRowRawVisible(row);
     }
 
     function getColVisible(col: number): boolean {
-        const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet.getColVisible(col);
     }

--- a/packages/sheets/src/commands/commands/__tests__/set-row-data.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-row-data.command.spec.ts
@@ -70,7 +70,7 @@ describe('test set row data commands', () => {
     let commandService: ICommandService;
 
     function getRowData(row: number) {
-        const worksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const worksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         return worksheet.getRowManager().getRow(row);
     }
 

--- a/packages/sheets/src/commands/commands/__tests__/set-row-height.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-row-height.command.spec.ts
@@ -46,12 +46,12 @@ describe('Test set row height commands', () => {
     let commandService: ICommandService;
 
     function getRowHeight(row: number): number {
-        const worksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const worksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         return worksheet.getRowHeight(row);
     }
 
     function getRowIsAutoHeight(row: number): Nullable<BooleanNumber> {
-        const worksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const worksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         const rowManager = worksheet.getRowManager();
         const rowInfo = rowManager.getRow(row);
 
@@ -70,7 +70,7 @@ describe('Test set row height commands', () => {
         commandService.registerCommand(SetWorksheetRowHeightMutation);
         commandService.registerCommand(SetWorksheetRowIsAutoHeightMutation);
 
-        const worksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const worksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         const maxColumn = worksheet.getMaxColumns() - 1;
         const selectionManager = get(SheetsSelectionsService);
 

--- a/packages/sheets/src/commands/commands/__tests__/set-style.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-style.command.spec.ts
@@ -762,7 +762,7 @@ describe("Test commands used for updating cells' styles", () => {
 
     describe('set style with specific range', () => {
         it('should use the correct unitId and subUnitId when range is provided', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
 
             // Insert a new sheet
             expect(await commandService.executeCommand(InsertSheetCommand.id)).toBeTruthy();

--- a/packages/sheets/src/commands/commands/__tests__/set-worksheet-default-style.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-worksheet-default-style.command.spec.ts
@@ -42,7 +42,7 @@ describe('Test set worksheet default style commands', () => {
 
     describe('set worksheet default style', () => {
         it('correct situation', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             const worksheet = workbook.getSheetBySheetId('sheet1');
             if (!workbook) throw new Error('This is an error');
 

--- a/packages/sheets/src/commands/commands/__tests__/set-worksheet-hide.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-worksheet-hide.command.spec.ts
@@ -50,7 +50,7 @@ describe('Test set worksheet hide commands', () => {
 
     describe('Set worksheet hide', () => {
         it('will set current active worksheet hidden', async () => {
-            const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+            const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
             if (!workbook) throw new Error('This is an error');
 
             const targetActiveSheet = workbook.getActiveSheet();

--- a/packages/sheets/src/commands/commands/__tests__/set-worksheet-name.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-worksheet-name.command.spec.ts
@@ -43,7 +43,7 @@ describe('Test set worksheet name commands', () => {
     describe('set worksheet name', () => {
         describe('set worksheet name', async () => {
             it('correct situation: ', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
 
                 expect(

--- a/packages/sheets/src/commands/commands/__tests__/set-worksheet-order.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-worksheet-order.command.spec.ts
@@ -51,7 +51,7 @@ describe('Test set worksheet order commands', () => {
     describe('set worksheet order', () => {
         describe('set worksheet order', async () => {
             it('correct situation: ', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
 
                 const targetActiveSheet = workbook.getActiveSheet();

--- a/packages/sheets/src/commands/commands/__tests__/set-worksheet-show.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-worksheet-show.command.spec.ts
@@ -51,7 +51,7 @@ describe('Test set worksheet show commands', () => {
     describe('set sheet show', () => {
         describe('set sheet show after make it hidden', async () => {
             it('correct situation: ', async () => {
-                const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) throw new Error('This is an error');
 
                 const targetActiveSheet = workbook.getActiveSheet()!;

--- a/packages/sheets/src/commands/mutations/__tests__/remove-row-col.mutation.spec.ts
+++ b/packages/sheets/src/commands/mutations/__tests__/remove-row-col.mutation.spec.ts
@@ -35,13 +35,13 @@ describe('Test moving rows & cols', () => {
     let has: Injector['has'];
     const getWorksheet = () => {
         const univerInstanceService = get(IUniverInstanceService);
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return worksheet;
     };
     const getId = () => {
         const univerInstanceService = get(IUniverInstanceService);
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         return {
             unitId: workbook.getUnitId(),

--- a/packages/sheets/src/commands/mutations/move-range.mutation.ts
+++ b/packages/sheets/src/commands/mutations/move-range.mutation.ts
@@ -42,7 +42,7 @@ export const MoveRangeMutation: IMutation<IMoveRangeMutationParams, boolean> = {
         }
 
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return false;
         }

--- a/packages/sheets/src/controllers/__tests__/auto-fill.controller.spec.ts
+++ b/packages/sheets/src/controllers/__tests__/auto-fill.controller.spec.ts
@@ -98,7 +98,7 @@ describe('AutoFillController copy-fill shortcuts', () => {
         univer = testBed.univer;
         commandService = testBed.get(ICommandService);
         selectionService = testBed.get(SheetsSelectionsService);
-        workbook = testBed.get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        workbook = testBed.get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
 
         testBed.get(AutoFillController);
 

--- a/packages/sheets/src/controllers/__tests__/formula/create-function-test-bed.ts
+++ b/packages/sheets/src/controllers/__tests__/formula/create-function-test-bed.ts
@@ -251,7 +251,7 @@ export function createFunctionTestBed(workbookData?: IWorkbookData, dependencies
     logService.setLogLevel(LogLevel.SILENT); // change this to `true` to debug tests via logs
 
     const sheetData: ISheetData = {};
-    const workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
     const unitId = workbook.getUnitId();
     const sheetId = workbook.getActiveSheet()!.getSheetId();
     workbook.getSheets().forEach((sheet) => {

--- a/packages/sheets/src/controllers/merge-cell.controller.ts
+++ b/packages/sheets/src/controllers/merge-cell.controller.ts
@@ -156,7 +156,7 @@ export class MergeCellController extends Disposable {
                     case ClearSelectionAllCommand.id:
                     case ClearSelectionFormatCommand.id: {
                         // TODO@Gggpound: get by unit id and subUnitId
-                        const workbook = self._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                        const workbook = self._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                         const unitId = workbook.getUnitId();
                         const worksheet = workbook?.getActiveSheet();
                         if (!worksheet) {
@@ -1251,7 +1251,7 @@ function getWorkbook(univerInstanceService: IUniverInstanceService, unitId?: str
     if (unitId) {
         return univerInstanceService.getUniverSheetInstance(unitId);
     }
-    return univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+    return univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
 }
 
 function getWorksheet(workbook: Workbook, subUnitId?: string) {

--- a/packages/sheets/src/controllers/permission/sheet-permission-init.controller.ts
+++ b/packages/sheets/src/controllers/permission/sheet-permission-init.controller.ts
@@ -169,7 +169,7 @@ export class SheetPermissionInitController extends Disposable {
     }
 
     public async initWorkbookPermissionChange(_unitId?: string) {
-        const unitId = _unitId || this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
+        const unitId = _unitId || this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getUnitId();
         if (!unitId) {
             return;
         }

--- a/packages/sheets/src/facade/__tests__/f-worksheet.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-worksheet.spec.ts
@@ -230,7 +230,7 @@ describe('Test FWorksheet', () => {
         const sheet = await activeSheet?.hideRow(range);
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const hiddenRows = currentWorksheet?.getHiddenRows();
         expect(hiddenRows).toStrictEqual([{
             startRow: 0,
@@ -253,7 +253,7 @@ describe('Test FWorksheet', () => {
         const sheet = await activeSheet?.hideRows(0, 2);
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const hiddenRows = currentWorksheet?.getHiddenRows();
         expect(hiddenRows).toStrictEqual([{
             startRow: 0,
@@ -276,7 +276,7 @@ describe('Test FWorksheet', () => {
         const sheet = await activeSheet?.setRowHeight(0, 100);
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const currentRowHeight = currentWorksheet?.getRowManager().getRowHeight(0);
         expect(currentRowHeight).toBe(100);
     });
@@ -287,7 +287,7 @@ describe('Test FWorksheet', () => {
         const sheet = await activeSheet?.setRowHeights(0, 2, 100);
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const currentRowHeight = currentWorksheet?.getRowManager().getRowHeight(0, 2);
         expect(currentRowHeight).toBe(200);
     });
@@ -298,7 +298,7 @@ describe('Test FWorksheet', () => {
         const sheet = await activeSheet?.setRowHeightsForced(0, 2, 100);
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const currentRowHeight = currentWorksheet?.getRowManager().getRowHeight(0, 2);
         expect(currentRowHeight).toBe(200);
     });
@@ -313,7 +313,7 @@ describe('Test FWorksheet', () => {
         });
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const currentRowCustom = currentWorksheet?.getRowManager().getRow(0)?.custom;
         expect(currentRowCustom).toEqual({ color: 'red' });
     });
@@ -398,7 +398,7 @@ describe('Test FWorksheet', () => {
         const sheet = await activeSheet?.hideColumn(range);
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const hiddenCols = currentWorksheet?.getHiddenCols();
         expect(hiddenCols).toStrictEqual([{
             startRow: 0,
@@ -421,7 +421,7 @@ describe('Test FWorksheet', () => {
         const sheet = await activeSheet?.hideColumns(0, 2);
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const hiddenCols = currentWorksheet?.getHiddenCols();
         expect(hiddenCols).toStrictEqual([{
             startRow: 0,
@@ -444,7 +444,7 @@ describe('Test FWorksheet', () => {
         const sheet = await activeSheet?.setColumnWidth(0, 100);
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const currentColWidth = currentWorksheet?.getColumnManager().getColumnWidth(0);
         expect(currentColWidth).toBe(100);
     });
@@ -455,7 +455,7 @@ describe('Test FWorksheet', () => {
         const sheet = await activeSheet?.setColumnWidths(0, 2, 100);
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const currentColWidth = currentWorksheet?.getColumnManager().getColumnWidth(0);
         expect(currentColWidth).toBe(100);
         const currentColWidth2 = currentWorksheet?.getColumnManager().getColumnWidth(1);
@@ -472,7 +472,7 @@ describe('Test FWorksheet', () => {
         });
         expect(sheet).toBeDefined();
 
-        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const currentColCustom = currentWorksheet?.getColumnManager().getColumn(0)?.custom;
         expect(currentColCustom).toEqual({ color: 'red' });
     });

--- a/packages/sheets/src/facade/f-univer.ts
+++ b/packages/sheets/src/facade/f-univer.ts
@@ -686,7 +686,7 @@ export class FUniverSheetsMixin extends FUniver implements IFUniverSheetsMixin {
     }
 
     override getActiveWorkbook(): FWorkbook | null {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return null;
         }

--- a/packages/sheets/src/facade/f-workbook.ts
+++ b/packages/sheets/src/facade/f-workbook.ts
@@ -551,7 +551,7 @@ export class FWorkbook extends FBaseInitialable {
     onSelectionChange(callback: (selections: IRange[]) => void): IDisposable {
         return toDisposable(
             this._selectionManagerService.selectionMoveEnd$.subscribe((selections) => {
-                if (this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId() !== this.id) {
+                if (this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId() !== this.id) {
                     return;
                 }
 

--- a/packages/sheets/src/model/__tests__/range-protection.cache.spec.ts
+++ b/packages/sheets/src/model/__tests__/range-protection.cache.spec.ts
@@ -79,7 +79,7 @@ describe('RangeProtectionCache', () => {
         ruleModel = get(RangeProtectionRuleModel);
         permissionService = get(IPermissionService);
 
-        const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         unitId = workbook.getUnitId();
         subUnitId = workbook.getActiveSheet()!.getSheetId();
     });

--- a/packages/sheets/src/model/__tests__/range-theme-model.spec.ts
+++ b/packages/sheets/src/model/__tests__/range-theme-model.spec.ts
@@ -39,7 +39,7 @@ describe('SheetRangeThemeModel', () => {
         get = testBed.get;
         model = get(SheetRangeThemeModel);
 
-        const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         unitId = workbook.getUnitId();
         subUnitId = workbook.getActiveSheet()!.getSheetId();
     });

--- a/packages/sheets/src/services/__tests__/numfmt.service.test.ts
+++ b/packages/sheets/src/services/__tests__/numfmt.service.test.ts
@@ -45,7 +45,7 @@ describe('test numfmt service', () => {
 
         univerInstanceService = get(IUniverInstanceService);
         numfmtService = get(INumfmtService);
-        workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         styles = workbook.getStyles();
         sheet = workbook.getActiveSheet()!;
         unitId = workbook.getUnitId();

--- a/packages/sheets/src/services/__tests__/ref-range.setvice.spec.ts
+++ b/packages/sheets/src/services/__tests__/ref-range.setvice.spec.ts
@@ -63,7 +63,7 @@ describe('Test ref-range.service', () => {
         );
 
         const univerInstanceService = get(IUniverInstanceService);
-        workbook = univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         worksheet = workbook.getActiveSheet()!;
     });
     afterEach(() => {

--- a/packages/sheets/src/services/auto-fill/__tests__/auto-fill.service.spec.ts
+++ b/packages/sheets/src/services/auto-fill/__tests__/auto-fill.service.spec.ts
@@ -44,7 +44,7 @@ describe('AutoFillService', () => {
         commandService = get(ICommandService);
         commandService.registerCommand(SetSelectionsOperation);
 
-        const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         unitId = workbook.getUnitId();
         subUnitId = workbook.getActiveSheet()!.getSheetId();
     });
@@ -188,7 +188,7 @@ describe('AutoFillService', () => {
     });
 
     it('should skip auto-height mutation generation in NO_FORMAT mode', () => {
-        const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         const worksheet = workbook.getActiveSheet()!;
         service.applyType = AUTO_FILL_APPLY_TYPE.NO_FORMAT;
 

--- a/packages/sheets/src/services/permission/range-permission/__tests__/range-protection.ref-range.spec.ts
+++ b/packages/sheets/src/services/permission/range-permission/__tests__/range-protection.ref-range.spec.ts
@@ -81,7 +81,7 @@ describe('RangeProtectionRefRangeService', () => {
         ruleModel = get(RangeProtectionRuleModel);
         sheetInterceptorService = get(SheetInterceptorService);
 
-        const workbook = get(IUniverInstanceService).getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         unitId = workbook.getUnitId();
         subUnitId = workbook.getActiveSheet()!.getSheetId();
 

--- a/packages/sheets/src/services/permission/range-permission/range-protection.ref-range.ts
+++ b/packages/sheets/src/services/permission/range-permission/range-protection.ref-range.ts
@@ -71,7 +71,7 @@ export class RangeProtectionRefRangeService extends Disposable {
 
     private _onRefRangeChange() {
         const registerRefRange = (unitId: string, subUnitId: string) => {
-            const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+            const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
             if (!workbook) {
                 return;
             }
@@ -117,7 +117,7 @@ export class RangeProtectionRefRangeService extends Disposable {
             })
         );
 
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         if (workbook) {
             const sheet = workbook.getActiveSheet();
             if (!sheet) return;
@@ -389,7 +389,7 @@ export class RangeProtectionRefRangeService extends Disposable {
         this.disposeWithMe(this._commandService.onCommandExecuted((command: ICommandInfo) => {
             if (mutationIdArrByMove.includes(command.id)) {
                 if (!command.params) return;
-                const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
+                const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
                 if (!workbook) return;
                 const worksheet = workbook.getSheetBySheetId((command.params as IMoveRowsMutationParams).subUnitId);
                 if (!worksheet) return;

--- a/packages/sheets/src/services/selections/selection.service.ts
+++ b/packages/sheets/src/services/selections/selection.service.ts
@@ -29,7 +29,7 @@ import { SelectionMoveType } from './type';
  */
 export class SheetsSelectionsService extends RxDisposable {
     private get _currentSelectionPos(): Nullable<ISelectionManagerSearchParam> {
-        const workbook = this._instanceSrv.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._instanceSrv.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) return null;
 
         const worksheet = workbook.getActiveSheet();
@@ -295,7 +295,7 @@ export class SheetsSelectionsService extends RxDisposable {
         isAllValuesSame: boolean;
         value: Nullable<IStyleData[keyof IStyleData]>;
     } {
-        const worksheet = this._instanceSrv.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
+        const worksheet = this._instanceSrv.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const selections = this.getCurrentSelections();
         if (!worksheet || selections.length === 0) {
             return {

--- a/packages/sheets/src/services/sheet-interceptor/__tests__/sheet-interceptor.service.spec.ts
+++ b/packages/sheets/src/services/sheet-interceptor/__tests__/sheet-interceptor.service.spec.ts
@@ -41,19 +41,19 @@ describe('Test SheetInterceptorService', () => {
     function getCell(row: number, col: number, key: string, filter: (interceptor: IInterceptor<any, any>) => boolean): Nullable<ICellData>;
     function getCell(row: number, col: number, key?: string, filter?: (interceptor: IInterceptor<any, any>) => boolean): Nullable<ICellData> {
         const cus = get(IUniverInstanceService);
-        const sheet = cus.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const sheet = cus.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         return (key && filter) ? sheet.getCellWithFilteredInterceptors(row, col, key, filter) : sheet.getCell(row, col);
     }
 
     function getRowFiltered(row: number): boolean {
         const cus = get(IUniverInstanceService);
-        const sheet = cus.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const sheet = cus.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         return sheet.getRowFiltered(row);
     }
 
     function getRowVisible(row: number): boolean {
         const cus = get(IUniverInstanceService);
-        const sheet = cus.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
+        const sheet = cus.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getActiveSheet()!;
         return sheet.getRowVisible(row);
     }
 

--- a/packages/slides-ui/src/commands/operations/activate.operation.ts
+++ b/packages/slides-ui/src/commands/operations/activate.operation.ts
@@ -30,7 +30,7 @@ export const ActivateSlidePageOperation: IOperation<IActiveSlidePageOperationPar
         const unitId = params.unitId;
         const canvasView = accessor.get(CanvasView);
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        // const model = univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        // const model = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
 
         const model = univerInstanceService.getUnit<SlideDataModel>(unitId);
         const pageId = model?.getActivePage()?.id;

--- a/packages/slides-ui/src/commands/operations/append-slide.operation.ts
+++ b/packages/slides-ui/src/commands/operations/append-slide.operation.ts
@@ -30,7 +30,7 @@ export const AppendSlideOperation: IOperation<IAppendSlideOperationParams> = {
     handler: (accessor, params: IAppendSlideOperationParams) => {
         const unitId = params.unitId;
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        // const slideData = univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        // const slideData = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
 
         const slideData = univerInstanceService.getUnit<SlideDataModel>(unitId);
 

--- a/packages/slides-ui/src/commands/operations/delete-element.operation.ts
+++ b/packages/slides-ui/src/commands/operations/delete-element.operation.ts
@@ -32,7 +32,7 @@ export const DeleteSlideElementOperation: ICommand<IDeleteElementOperationParams
 
         const unitId = params.unitId;
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        // const slideData = univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        // const slideData = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
 
         const slideData = univerInstanceService.getUnit<SlideDataModel>(unitId);
 

--- a/packages/slides-ui/src/commands/operations/insert-image.operation.ts
+++ b/packages/slides-ui/src/commands/operations/insert-image.operation.ts
@@ -27,7 +27,7 @@ export const InsertSlideFloatImageCommand: ICommand<{}> = {
     type: CommandType.COMMAND,
     handler: async (accessor, params) => {
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        const unitId = univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_SLIDE)?.getUnitId();
+        const unitId = univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SLIDE)?.getUnitId();
         if (!unitId) return false;
 
         const fileOpenerService = accessor.get(ILocalFileService);

--- a/packages/slides-ui/src/commands/operations/insert-shape.operation.ts
+++ b/packages/slides-ui/src/commands/operations/insert-shape.operation.ts
@@ -45,7 +45,7 @@ export const InsertSlideShapeRectangleOperation: ICommand<IInsertShapeOperationP
         const id = generateRandomId(6);
 
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        // const slideData = univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        // const slideData = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
 
         const unitId = params.unitId;
         const slideData = univerInstanceService.getUnit<SlideDataModel>(unitId);
@@ -149,7 +149,7 @@ export const InsertSlideShapeEllipseOperation: ICommand<IInsertShapeOperationPar
         const id = generateRandomId(6);
 
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        // const slideData = univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        // const slideData = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
 
         const unitId = params.unitId;
         const slideData = univerInstanceService.getUnit<SlideDataModel>(unitId);

--- a/packages/slides-ui/src/commands/operations/insert-text.operation.ts
+++ b/packages/slides-ui/src/commands/operations/insert-text.operation.ts
@@ -51,7 +51,7 @@ export const SlideAddTextOperation: ICommand<ISlideAddTextParam> = {
         const textContent = params?.text || 'A New Text';
 
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        // const slideData = univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        // const slideData = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
 
         const slideData = univerInstanceService.getUnit<SlideDataModel>(unitId);
         if (!slideData) return false;

--- a/packages/slides-ui/src/commands/operations/update-element.operation.ts
+++ b/packages/slides-ui/src/commands/operations/update-element.operation.ts
@@ -30,7 +30,7 @@ export const UpdateSlideElementOperation: ICommand<IUpdateElementOperationParams
     handler: (accessor, params: IUpdateElementOperationParams) => {
         const { oKey, props } = params!;
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        // const slideData = univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        // const slideData = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
 
         const unitId = params?.unitId;
         const slideData = univerInstanceService.getUnit<SlideDataModel>(unitId);

--- a/packages/slides-ui/src/components/sidebar/Sidebar.tsx
+++ b/packages/slides-ui/src/components/sidebar/Sidebar.tsx
@@ -31,12 +31,12 @@ export default function RectSidebar() {
     const univerInstanceService = useDependency(IUniverInstanceService);
     const canvasView = useDependency(CanvasView);
 
-    const currentSlide = univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+    const currentSlide = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
     const pageId = currentSlide?.getActivePage()?.id;
 
     // see packages/sheets-ui/src/views/permission/permission-dialog/index.tsx@SheetPermissionDialog
     // see packages/sheets-conditional-formatting-ui/src/components/panel/rule-edit/index.tsx@getUnitId
-    // const unitId = univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_SLIDE)!.getUnitId();
+    // const unitId = univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SLIDE)!.getUnitId();
     const unitId = univerInstanceService.getFocusedUnit()?.getUnitId() || '';
 
     if (!pageId || !unitId) return null;

--- a/packages/slides-ui/src/components/slide-bar/SlideBar.tsx
+++ b/packages/slides-ui/src/components/slide-bar/SlideBar.tsx
@@ -35,7 +35,7 @@ export function SlideSideBar() {
     const localeService = useDependency(LocaleService);
 
     const slideBarRef = useRef<HTMLDivElement>(null);
-    const currentSlide = univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+    const currentSlide = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
 
     // const currentSlide = useObservable(
     //     () => univerInstanceService.getCurrentTypeOfUnit$<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE),

--- a/packages/slides-ui/src/controllers/slide-editor-bridge.render-controller.ts
+++ b/packages/slides-ui/src/controllers/slide-editor-bridge.render-controller.ts
@@ -136,7 +136,7 @@ export class SlideEditorBridgeRenderController extends RxDisposable implements I
             }));
         };
 
-        // const model = this._instanceSrv.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        // const model = this._instanceSrv.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
         // const pagesMap = model?.getPages() ?? {};
         // const pages = Object.values(pagesMap);
 
@@ -172,7 +172,7 @@ export class SlideEditorBridgeRenderController extends RxDisposable implements I
         this.setEditorVisible(false);
         const curRichText = this._curRichText;
 
-        const slideData = this._instanceSrv.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        const slideData = this._instanceSrv.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
         if (!slideData) return false;
         curRichText.refreshDocumentByDocData();
         curRichText.resizeToContentSize();

--- a/packages/slides-ui/src/controllers/slide.render-controller.ts
+++ b/packages/slides-ui/src/controllers/slide.render-controller.ts
@@ -147,7 +147,7 @@ export class SlideRenderController extends RxDisposable implements IRenderModule
      * @param mainScene
      */
     private _createSlide(mainScene: Scene) {
-        const model = this._univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE)!;
+        const model = this._univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE)!;
 
         const { width: sceneWidth, height: sceneHeight } = mainScene;
 
@@ -173,7 +173,7 @@ export class SlideRenderController extends RxDisposable implements IRenderModule
     }
 
     private _addBackgroundRect(scene: Scene, fill: IColorStyle) {
-        const model = this._univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE)!;
+        const model = this._univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE)!;
 
         const pageSize = model.getPageSize();
 
@@ -275,7 +275,7 @@ export class SlideRenderController extends RxDisposable implements IRenderModule
      * SlideDataModel is UnitModel
      */
     private _getCurrUnitModel() {
-        // return this._univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE)!;
+        // return this._univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE)!;
 
         return this._renderContext.unit as SlideDataModel;
     }

--- a/packages/slides-ui/src/menu/popup-menu.controller.ts
+++ b/packages/slides-ui/src/menu/popup-menu.controller.ts
@@ -75,7 +75,7 @@ export class SlidePopupMenuController extends RxDisposable {
 
     // eslint-disable-next-line max-lines-per-function
     private _popupMenuListener(unitId: string) {
-        const model = this._univerInstanceService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
+        const model = this._univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
         const pages = model?.getPages() ?? {};
 
         // eslint-disable-next-line max-lines-per-function

--- a/packages/slides-ui/src/plugin.ts
+++ b/packages/slides-ui/src/plugin.ts
@@ -131,7 +131,7 @@ export class UniverSlidesUIPlugin extends Plugin {
     private _markSlideAsFocused() {
         const currentService = this._univerInstanceService;
         try {
-            const slideDataModel = currentService.getCurrentUnitForType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE)!;
+            const slideDataModel = currentService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE)!;
             currentService.focusUnit(slideDataModel.getUnitId());
         } catch (e) {
         }

--- a/packages/slides-ui/src/services/slide-popup-manager.service.ts
+++ b/packages/slides-ui/src/services/slide-popup-manager.service.ts
@@ -120,7 +120,7 @@ export class SlideCanvasPopMangerService extends Disposable {
     }
 
     attachPopupToObject(targetObject: BaseObject, popup: ISlideCanvasPopup): IDisposable {
-        const workbook = this._univerInstanceService.getCurrentUnitForType(UniverInstanceType.UNIVER_SLIDE)!;
+        const workbook = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SLIDE)!;
         const unitId = workbook.getUnitId();
         // const subUnitId =
 

--- a/packages/ui/src/facade/f-shortcut.ts
+++ b/packages/ui/src/facade/f-shortcut.ts
@@ -102,7 +102,7 @@ export class FShortcut extends FBase {
      * ```
      */
     triggerShortcut(e: KeyboardEvent): IShortcutItem<object> | undefined {
-        const workbook = this._univerInstanceService.getCurrentUnitForType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+        const workbook = this._univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
         if (!workbook) {
             return;
         }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
