### PR TITLE
fix(sheets-data-validation): preserve commas in list values

### DIFF
--- a/packages/sheets-data-validation/src/facade/__tests__/f-data-validation-builder.spec.ts
+++ b/packages/sheets-data-validation/src/facade/__tests__/f-data-validation-builder.spec.ts
@@ -17,6 +17,7 @@
 import type { FUniver } from '@univerjs/core/facade';
 import { DataValidationOperator, DataValidationType } from '@univerjs/core';
 import { FDataValidationBuilder } from '@univerjs/sheets-data-validation/facade/f-data-validation-builder.js';
+import { deserializeListOptions } from '@univerjs/sheets-data-validation/validators/util.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createFacadeTestBed } from './create-test-bed';
 
@@ -187,14 +188,26 @@ describe('Test FDataValidationBuilder', () => {
         const builder = new FDataValidationBuilder();
         builder.requireValueInList(['1', '2', '3']);
         expect(builder.build().getCriteriaType()).toEqual(DataValidationType.LIST);
-        expect(builder.getCriteriaValues()).toEqual([undefined, '1,2,3', undefined]);
+        expect(builder.getCriteriaValues()).toEqual([undefined, '["1","2","3"]', undefined]);
     });
 
     it('should build value in list-multiple', () => {
         const builder = new FDataValidationBuilder();
         builder.requireValueInList(['1', '2', '3'], true);
         expect(builder.build().getCriteriaType()).toEqual(DataValidationType.LIST_MULTIPLE);
-        expect(builder.getCriteriaValues()).toEqual([undefined, '1,2,3', undefined]);
+        expect(builder.getCriteriaValues()).toEqual([undefined, '["1","2","3"]', undefined]);
+    });
+
+    it('should keep commas inside list values', () => {
+        const builder = new FDataValidationBuilder();
+        builder.requireValueInList(['Part 1 (blue)', 'Part 2 (green, short)']);
+        const [, formula1] = builder.getCriteriaValues();
+
+        expect(deserializeListOptions(formula1!)).toEqual(['Part 1 (blue)', 'Part 2 (green, short)']);
+    });
+
+    it('should deserialize legacy comma separated list values', () => {
+        expect(deserializeListOptions('1,2,3')).toEqual(['1', '2', '3']);
     });
 
     it('should build value in range', () => {

--- a/packages/sheets-data-validation/src/facade/f-data-validation-builder.ts
+++ b/packages/sheets-data-validation/src/facade/f-data-validation-builder.ts
@@ -791,7 +791,7 @@ export class FDataValidationBuilder {
      */
     requireValueInList(values: string[], multiple?: boolean, showDropdown?: boolean): FDataValidationBuilder {
         this._rule.type = multiple ? DataValidationType.LIST_MULTIPLE : DataValidationType.LIST;
-        this._rule.formula1 = values.join(',');
+        this._rule.formula1 = JSON.stringify(values.filter(Boolean));
         this._rule.formula2 = undefined;
         this._rule.showDropDown = showDropdown ?? true;
 

--- a/packages/sheets-data-validation/src/validators/util.ts
+++ b/packages/sheets-data-validation/src/validators/util.ts
@@ -50,10 +50,19 @@ export function getSheetRangeValueSet(grid: IUnitRangeName, univerInstanceServic
 }
 
 export function serializeListOptions(options: string[]) {
-    return options.filter(Boolean).join(',');
+    return JSON.stringify(options.filter(Boolean));
 }
 
 export function deserializeListOptions(optionsStr: string) {
+    try {
+        const options = JSON.parse(optionsStr);
+        if (Array.isArray(options) && options.every((option) => typeof option === 'string')) {
+            return options.filter(Boolean);
+        }
+    } catch {
+        // Fallback for data saved by older versions.
+    }
+
     return optionsStr.split(',').filter(Boolean);
 }
 


### PR DESCRIPTION
## What
- Store explicit data validation list values as JSON arrays so item labels can contain commas.
- Keep reading legacy comma-separated list values for existing workbooks.
- Add facade builder tests for comma-containing values and legacy parsing.

- Closes #5119

- ## Test
- pnpm --filter @univerjs/sheets-data-validation test -- --runInBand