### PR TITLE
fix(engine-formula): resolve Excel compatibility function prefixes

### DIFF
--- a/packages/engine-formula/src/services/__tests__/function.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/function.service.spec.ts
@@ -35,6 +35,16 @@ describe('FunctionService', () => {
         expect(service.hasExecutor('AVERAGE')).toBe(false);
     });
 
+    it('should resolve Excel compatibility prefixed executors', () => {
+        const service = new FunctionService();
+        const stdevExecutor = { name: 'STDEV.S' };
+
+        service.registerExecutors(stdevExecutor as never);
+
+        expect(service.hasExecutor('_xlfn.STDEV.S')).toBe(true);
+        expect(service.getExecutor('_xlfn.STDEV.S')).toBe(stdevExecutor);
+    });
+
     it('should register descriptions and cleanup by disposable', () => {
         const service = new FunctionService();
         const sumDescription = {
@@ -55,6 +65,8 @@ describe('FunctionService', () => {
         const disposable = service.registerDescriptions(sumDescription as never, avgDescription as never);
         expect(service.hasDescription('SUM')).toBe(true);
         expect(service.getDescription('AVERAGE')?.description).toBe('avg');
+        expect(service.hasDescription('_xlfn.AVERAGE')).toBe(true);
+        expect(service.getDescription('_xlfn.AVERAGE')?.description).toBe('avg');
         expect(service.getDescriptions().size).toBe(2);
 
         disposable.dispose();

--- a/packages/engine-formula/src/services/function.service.ts
+++ b/packages/engine-formula/src/services/function.service.ts
@@ -20,6 +20,16 @@ import type { BaseFunction } from '../functions/base-function';
 import { createIdentifier, Disposable, toDisposable } from '@univerjs/core';
 import { FORMULA_AST_CACHE } from '../engine/utils/generate-ast-node';
 
+const COMPATIBILITY_FUNCTION_PREFIXES = ['_xlfn.', '_xlws.', '_xludf.'];
+
+function normalizeFunctionToken(functionToken: IFunctionNames): IFunctionNames {
+    const token = `${functionToken}`;
+    const lowerToken = token.toLowerCase();
+    const prefix = COMPATIBILITY_FUNCTION_PREFIXES.find((prefix) => lowerToken.startsWith(prefix));
+
+    return (prefix ? token.slice(prefix.length) : token) as IFunctionNames;
+}
+
 export interface IFunctionService {
     /**
      * Use register to register a function, new CustomFunction(inject, name)
@@ -83,11 +93,11 @@ export class FunctionService extends Disposable implements IFunctionService {
     }
 
     getExecutor(functionToken: IFunctionNames) {
-        return this._functionExecutors.get(functionToken);
+        return this._functionExecutors.get(functionToken) ?? this._functionExecutors.get(normalizeFunctionToken(functionToken));
     }
 
     hasExecutor(functionToken: IFunctionNames) {
-        return this._functionExecutors.has(functionToken);
+        return this._functionExecutors.has(functionToken) || this._functionExecutors.has(normalizeFunctionToken(functionToken));
     }
 
     unregisterExecutors(...functionTokens: IFunctionNames[]) {
@@ -116,11 +126,11 @@ export class FunctionService extends Disposable implements IFunctionService {
     }
 
     getDescription(functionToken: IFunctionNames) {
-        return this._functionDescriptions.get(functionToken);
+        return this._functionDescriptions.get(functionToken) ?? this._functionDescriptions.get(normalizeFunctionToken(functionToken));
     }
 
     hasDescription(functionToken: IFunctionNames) {
-        return this._functionDescriptions.has(functionToken);
+        return this._functionDescriptions.has(functionToken) || this._functionDescriptions.has(normalizeFunctionToken(functionToken));
     }
 
     unregisterDescriptions(...functionTokens: IFunctionNames[]) {


### PR DESCRIPTION
## What
- Resolve registered functions even when imported formulas include Excel compatibility prefixes such as _xlfn.
- Apply the same lookup behavior to function descriptions.
- Add service tests for prefixed executor and description lookups.

- Closes #4815

- ## Test
- pnpm --filter @univerjs/engine-formula test -- src/services/__tests__/function.service.spec.ts