### PR TITLE
fix(engine-formula): keep quoted dates as strings

### DIFF
--- a/packages/engine-formula/src/engine/analysis/__tests__/create-command-test-bed.ts
+++ b/packages/engine-formula/src/engine/analysis/__tests__/create-command-test-bed.ts
@@ -68,6 +68,8 @@ const TEST_WORKBOOK_DATA: IWorkbookData = {
         sheet1: {
             id: 'sheet1',
             name: 'Main',
+            rowCount: 5,
+            columnCount: 5,
             cellData: {
                 0: {
                     0: {
@@ -139,6 +141,12 @@ const TEST_WORKBOOK_DATA: IWorkbookData = {
                     4: {
                         v: -3,
                         t: CellValueType.NUMBER,
+                    },
+                },
+                4: {
+                    0: {
+                        v: '2025-01-01',
+                        t: CellValueType.STRING,
                     },
                 },
             },

--- a/packages/engine-formula/src/engine/analysis/__tests__/parser.spec.ts
+++ b/packages/engine-formula/src/engine/analysis/__tests__/parser.spec.ts
@@ -24,6 +24,7 @@ import { ErrorType } from '../../../basics/error-type';
 import { FUNCTION_NAMES_MATH } from '../../../functions/math/function-names';
 import { Pi } from '../../../functions/math/pi';
 import { Sum } from '../../../functions/math/sum';
+import { Compare } from '../../../functions/meta/compare';
 import { Divided } from '../../../functions/meta/divided';
 import { FUNCTION_NAMES_META } from '../../../functions/meta/function-names';
 import { Minus } from '../../../functions/meta/minus';
@@ -94,6 +95,7 @@ describe('Test indirect', () => {
             new Plus(FUNCTION_NAMES_META.PLUS),
             new Minus(FUNCTION_NAMES_META.MINUS),
             new Divided(FUNCTION_NAMES_META.DIVIDED),
+            new Compare(FUNCTION_NAMES_META.COMPARE),
             new Pi(FUNCTION_NAMES_MATH.PI),
             new Countif(FUNCTION_NAMES_STATISTICAL.COUNTIF)
         );
@@ -174,6 +176,16 @@ describe('Test indirect', () => {
             const result = interpreter.execute(generateExecuteAstNodeData(astNode as BaseAstNode));
 
             expect((result as ArrayValueObject).getFirstCell().getValue()).toStrictEqual(1);
+        });
+
+        it('should compare quoted date literals as strings', async () => {
+            const lexerNode = lexer.treeBuilder('=A5>="2026-01-01"');
+
+            const astNode = astTreeBuilder.parse(lexerNode as LexerNode);
+
+            const result = interpreter.execute(generateExecuteAstNodeData(astNode as BaseAstNode));
+
+            expect((result as ArrayValueObject).getFirstCell().getValue()).toBe(false);
         });
 
         it('Minus Minus Minus ref', async () => {

--- a/packages/engine-formula/src/engine/utils/numfmt-kit.ts
+++ b/packages/engine-formula/src/engine/utils/numfmt-kit.ts
@@ -336,10 +336,12 @@ const stringToNumberPatternCache = new FormulaAstLRU<{
 }>(100000);
 
 export function stringIsNumberPattern(input: string) {
-    let _input = input;
+    const _input = input;
 
     if (_input.startsWith('"') && _input.endsWith('"')) {
-        _input = _input.slice(1, -1);
+        return {
+            isNumberPattern: false,
+        };
     }
 
     const cacheValue = stringToNumberPatternCache.get(_input);

--- a/packages/engine-formula/src/engine/value-object/__tests__/array-value-object.spec.ts
+++ b/packages/engine-formula/src/engine/value-object/__tests__/array-value-object.spec.ts
@@ -426,6 +426,11 @@ describe('arrayValueObject test', () => {
             stringValueObject = ValueObjectFactory.create(' ');
 
             expect(stringValueObject.isString()).toBeTruthy();
+
+            stringValueObject = ValueObjectFactory.create('"2026-01-01"');
+
+            expect(stringValueObject.isString()).toBeTruthy();
+            expect(stringValueObject.getValue()).toBe('2026-01-01');
         });
 
         it('ValueObjectFactory create ErrorValueObject ', () => {


### PR DESCRIPTION
## What
- Do not parse explicitly quoted formula literals as date/number formats.
- Preserve lexical comparison for cell strings compared with quoted date strings.
- Add parser and value-object regression tests for quoted date strings.

- Closes #6392

- ## Test
- pnpm --filter @univerjs/engine-formula test -- src/engine/analysis/__tests__/parser.spec.ts src/engine/value-object/__tests__/array-value-object.spec.ts