### PR TITLE
fix(sheets-filter): register facade commands without UI

### DIFF
--- a/packages/sheets-filter-ui/src/commands/commands/__tests__/sheets-filter.command.spec.ts
+++ b/packages/sheets-filter-ui/src/commands/commands/__tests__/sheets-filter.command.spec.ts
@@ -22,7 +22,7 @@ import { AuthzIoLocalService, IAuthzIoService, ICommandService, Inject, Injector
 import { ActiveDirtyManagerService, IActiveDirtyManagerService, ISheetRowFilteredService, SheetRowFilteredService } from '@univerjs/engine-formula';
 import { MarkDirtyFilterChangeMutation, RangeProtectionRuleModel, RefRangeService, SetRangeValuesCommand, SetRangeValuesMutation, SheetInterceptorService, SheetRangeThemeModel, SheetsSelectionsService, WorkbookPermissionService, WorksheetPermissionService, WorksheetProtectionPointModel, WorksheetProtectionRuleModel, ZebraCrossingCacheController } from '@univerjs/sheets';
 import { SetSheetsFilterRangeMutation, SheetsFilterService, UniverSheetsFilterPlugin } from '@univerjs/sheets-filter';
-import { ClearSheetsFilterCriteriaCommand, ReCalcSheetsFilterCommand, RemoveSheetFilterCommand, SetSheetFilterRangeCommand, SetSheetsFilterCriteriaCommand, SmartToggleSheetsFilterCommand } from '@univerjs/sheets-filter/commands/commands/sheets-filter.command.js';
+import { ClearSheetsFilterCriteriaCommand, ReCalcSheetsFilterCommand, SetSheetsFilterCriteriaCommand, SmartToggleSheetsFilterCommand } from '@univerjs/sheets-filter/commands/commands/sheets-filter.command.js';
 import { IMessageService } from '@univerjs/ui';
 import { MockMessageService } from '@univerjs/ui/services/message/__testing__/mock-message.service.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -121,12 +121,7 @@ function createFilterCommandTestBed() {
     [
         SetRangeValuesCommand,
         SetRangeValuesMutation,
-        RemoveSheetFilterCommand,
-        SetSheetFilterRangeCommand,
         SmartToggleSheetsFilterCommand,
-        SetSheetsFilterCriteriaCommand,
-        ClearSheetsFilterCriteriaCommand,
-        ReCalcSheetsFilterCommand,
         MarkDirtyFilterChangeMutation,
     ].forEach((command) => commandService.registerCommand(command));
 
@@ -137,7 +132,6 @@ function createFilterCommandTestBed() {
 }
 
 describe('test sheets filter commands', () => {
-    let univer: Univer;
     let get: Injector['get'];
     let commandService: ICommandService;
     let sheetsFilterService: SheetsFilterService;
@@ -145,7 +139,6 @@ describe('test sheets filter commands', () => {
 
     beforeEach(() => {
         const testBed = createFilterCommandTestBed();
-        univer = testBed.univer;
         get = testBed.get;
 
         commandService = get(ICommandService);

--- a/packages/sheets-filter-ui/src/controllers/sheets-filter-ui-desktop.controller.ts
+++ b/packages/sheets-filter-ui/src/controllers/sheets-filter-ui-desktop.controller.ts
@@ -19,7 +19,7 @@ import { ICommandService, IContextService, Inject, Injector, LocaleService } fro
 import { MessageType } from '@univerjs/design';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { FilterIcon } from '@univerjs/icons';
-import { ClearSheetsFilterCriteriaCommand, ReCalcSheetsFilterCommand, RemoveSheetFilterCommand, SetSheetFilterRangeCommand, SetSheetsFilterCriteriaCommand, SheetsFilterService, SmartToggleSheetsFilterCommand } from '@univerjs/sheets-filter';
+import { SheetsFilterService, SmartToggleSheetsFilterCommand } from '@univerjs/sheets-filter';
 import { SheetCanvasPopManagerService, SheetsRenderService } from '@univerjs/sheets-ui';
 import { ComponentManager, IMenuManagerService, IMessageService, IShortcutService } from '@univerjs/ui';
 import { distinctUntilChanged } from 'rxjs';
@@ -76,11 +76,6 @@ export class SheetsFilterUIDesktopController extends SheetsFilterUIMobileControl
     private _initCommands(): void {
         [
             SmartToggleSheetsFilterCommand,
-            RemoveSheetFilterCommand,
-            SetSheetFilterRangeCommand,
-            SetSheetsFilterCriteriaCommand,
-            ClearSheetsFilterCriteriaCommand,
-            ReCalcSheetsFilterCommand,
             ChangeFilterByOperation,
             OpenFilterPanelOperation,
             CloseFilterPanelOperation,

--- a/packages/sheets-filter-ui/src/menu/__tests__/sheets-filter.menu.spec.ts
+++ b/packages/sheets-filter-ui/src/menu/__tests__/sheets-filter.menu.spec.ts
@@ -20,7 +20,7 @@ import { AuthzIoLocalService, DisposableCollection, IAuthzIoService, ICommandSer
 import { ActiveDirtyManagerService, IActiveDirtyManagerService, ISheetRowFilteredService, SheetRowFilteredService } from '@univerjs/engine-formula';
 import { ExclusiveRangeService, IExclusiveRangeService, RangeProtectionRuleModel, RefRangeService, SetWorksheetActiveOperation, SheetInterceptorService, SheetRangeThemeModel, SheetsSelectionsService, WorkbookPermissionService, WorksheetPermissionService, WorksheetProtectionPointModel, WorksheetProtectionRuleModel, ZebraCrossingCacheController } from '@univerjs/sheets';
 import { RemoveSheetsFilterMutation, SetSheetsFilterCriteriaMutation, SetSheetsFilterRangeMutation, UniverSheetsFilterPlugin } from '@univerjs/sheets-filter';
-import { ClearSheetsFilterCriteriaCommand, ReCalcSheetsFilterCommand, SmartToggleSheetsFilterCommand } from '@univerjs/sheets-filter/commands/commands/sheets-filter.command.js';
+import { SmartToggleSheetsFilterCommand } from '@univerjs/sheets-filter/commands/commands/sheets-filter.command.js';
 import { IMenuManagerService, IPlatformService, IShortcutService, MenuManagerService, PlatformService, ShortcutService } from '@univerjs/ui';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CloseFilterPanelOperation, OpenFilterPanelOperation } from '../../commands/operations/sheets-filter.operation';
@@ -86,8 +86,6 @@ function createSheetsFilterMenuTestBed() {
             const commandService = injector.get(ICommandService);
             [
                 SmartToggleSheetsFilterCommand,
-                ClearSheetsFilterCriteriaCommand,
-                ReCalcSheetsFilterCommand,
                 OpenFilterPanelOperation,
                 CloseFilterPanelOperation,
             ].forEach((command) => commandService.registerCommand(command));

--- a/packages/sheets-filter-ui/src/services/__tests__/sheets-filter-panel.service.spec.ts
+++ b/packages/sheets-filter-ui/src/services/__tests__/sheets-filter-panel.service.spec.ts
@@ -23,7 +23,6 @@ import { awaitTime, CommandType, ICommandService, Inject, Injector, LocaleServic
 import { ActiveDirtyManagerService, IActiveDirtyManagerService, ISheetRowFilteredService, SheetRowFilteredService } from '@univerjs/engine-formula';
 import { MarkDirtyFilterChangeMutation, RefRangeService, SheetInterceptorService, SheetRangeThemeModel, SheetsSelectionsService, ZebraCrossingCacheController } from '@univerjs/sheets';
 import { CustomFilterOperator, FilterBy, SheetsFilterService, UniverSheetsFilterPlugin } from '@univerjs/sheets-filter';
-import { SetSheetsFilterCriteriaCommand } from '@univerjs/sheets-filter/commands/commands/sheets-filter.command.js';
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest';
 import { E_ITEMS, ITEMS, ITEMS_WITH_EMPTY, WithCustomFilterModelFactory, WithMergedCellFilterFactory, WithMultiEmptyCellsModelFactory, WithTwoFilterColumnsFactory, WithValuesAndEmptyFilterModelFactory, WithValuesFilterModelFactory } from '../../__testing__/data';
 import { CloseFilterPanelOperation, OpenFilterPanelOperation } from '../../commands/operations/sheets-filter.operation';
@@ -115,7 +114,6 @@ function createSheetsFilterPanelServiceTestBed(workbookData: IWorkbookData) {
     [
         OpenFilterPanelOperation,
         CloseFilterPanelOperation,
-        SetSheetsFilterCriteriaCommand,
         SetCellEditVisibleOperation,
         MarkDirtyFilterChangeMutation,
     ].forEach((command) => commandService.registerCommand(command));

--- a/packages/sheets-filter/src/controllers/sheets-filter.controller.ts
+++ b/packages/sheets-filter/src/controllers/sheets-filter.controller.ts
@@ -22,6 +22,7 @@ import type { FilterColumn } from '../models/filter-model';
 import { Disposable, DisposableCollection, ICommandService, Inject, IUniverInstanceService, moveMatrixArray, Optional, Rectangle } from '@univerjs/core';
 import { DataSyncPrimaryController } from '@univerjs/rpc';
 import { CopySheetCommand, EffectRefRangId, expandToContinuousRange, getSheetCommandTarget, InsertColCommand, InsertRowCommand, InsertRowMutation, INTERCEPTOR_POINT, MoveRangeCommand, MoveRowsCommand, RefRangeService, RemoveColCommand, RemoveRowCommand, RemoveRowMutation, RemoveSheetCommand, SetRangeValuesMutation, SetWorksheetActiveOperation, SheetInterceptorService, ZebraCrossingCacheController } from '@univerjs/sheets';
+import { ClearSheetsFilterCriteriaCommand, ReCalcSheetsFilterCommand, RemoveSheetFilterCommand, SetSheetFilterRangeCommand, SetSheetsFilterCriteriaCommand } from '../commands/commands/sheets-filter.command';
 import { ReCalcSheetsFilterMutation, RemoveSheetsFilterMutation, SetSheetsFilterCriteriaMutation, SetSheetsFilterRangeMutation } from '../commands/mutations/sheets-filter.mutation';
 import { SheetsFilterService } from '../services/sheet-filter.service';
 import { mergeSetFilterCriteria } from '../utils';
@@ -62,6 +63,16 @@ export class SheetsFilterController extends Disposable {
     }
 
     private _initCommands(): void {
+        [
+            SetSheetFilterRangeCommand,
+            RemoveSheetFilterCommand,
+            SetSheetsFilterCriteriaCommand,
+            ClearSheetsFilterCriteriaCommand,
+            ReCalcSheetsFilterCommand,
+        ].forEach((command) => {
+            this.disposeWithMe(this._commandService.registerCommand(command));
+        });
+
         [
             SetSheetsFilterCriteriaMutation,
             SetSheetsFilterRangeMutation,
@@ -405,14 +416,9 @@ export class SheetsFilterController extends Disposable {
             if (!worksheet) {
                 return this._handleNull();
             }
-            const hiddenRows = [];
-            for (let r = removeStartRow; r <= removeEndRow; r++) {
-                if (worksheet.getRowFiltered(r)) {
-                    hiddenRows.push(r);
-                }
-            }
+            const hiddenRowCount = this._getFilteredRowCount(worksheet, removeStartRow, removeEndRow);
             const afterStartRow = Math.min(startRow, removeStartRow);
-            const afterEndRow = afterStartRow + (endRow - startRow) - count + hiddenRows.length;
+            const afterEndRow = afterStartRow + (endRow - startRow) - count + hiddenRowCount;
             const setFilterRangeMutationParams: ISetSheetsFilterRangeMutationParams = {
                 unitId,
                 subUnitId,
@@ -429,6 +435,16 @@ export class SheetsFilterController extends Disposable {
             undos: mergeSetFilterCriteria(undos),
             redos: mergeSetFilterCriteria(redos),
         };
+    }
+
+    private _getFilteredRowCount(worksheet: { getRowFiltered(row: number): boolean }, startRow: number, endRow: number): number {
+        let count = 0;
+        for (let row = startRow; row <= endRow; row++) {
+            if (worksheet.getRowFiltered(row)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     // eslint-disable-next-line max-lines-per-function

--- a/packages/sheets-filter/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets-filter/src/facade/__tests__/f-range.spec.ts
@@ -14,36 +14,22 @@
  * limitations under the License.
  */
 
-import type { Injector, IRange } from '@univerjs/core';
+import type { IRange } from '@univerjs/core';
 import type { FUniver } from '@univerjs/core/facade';
-import { ICommandService } from '@univerjs/core';
-import { ClearSheetsFilterCriteriaCommand, RemoveSheetFilterCommand, SetSheetFilterRangeCommand, SetSheetsFilterCriteriaCommand } from '@univerjs/sheets-filter';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createFacadeTestBed } from './create-test-bed';
 
 describe('Test FRange', () => {
-    let get: Injector['get'];
-    let commandService: ICommandService;
     let univerAPI: FUniver;
 
     beforeEach(() => {
         const testBed = createFacadeTestBed();
-        get = testBed.get;
 
         univerAPI = testBed.univerAPI;
-
-        commandService = get(ICommandService);
     });
 
     describe('FFilter', () => {
-        beforeEach(() => {
-            commandService.registerCommand(SetSheetsFilterCriteriaCommand);
-            commandService.registerCommand(ClearSheetsFilterCriteriaCommand);
-            commandService.registerCommand(SetSheetFilterRangeCommand);
-            commandService.registerCommand(RemoveSheetFilterCommand);
-        });
-
-        it('create, modify and clear filters with Facade API', async () => {
+        it('create, modify and clear filters with Facade API without UI plugin', async () => {
             const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
             expect(activeSheet.getFilter()).toBeNull();
             expect(activeSheet.getRange(0, 0, 1, 1).getFilter()).toBeNull();


### PR DESCRIPTION
<!-- No related issue. -->

## What changed

This PR moves the non-UI filter commands required by the sheets filter Facade API from `@univerjs/sheets-filter-ui` into the core `@univerjs/sheets-filter` plugin controller.

The UI controller now only registers UI-owned commands and operations, such as `SmartToggleSheetsFilterCommand`, `OpenFilterPanelOperation`, and `CloseFilterPanelOperation`.

## Why

`@univerjs/sheets-filter/facade` exposes headless-usable APIs such as `FRange.createFilter()` and `FFilter.setColumnFilterCriteria()`, but the commands they execute were only registered by `@univerjs/sheets-filter-ui` or by unit tests that manually registered those commands.

That made the previous tests misleading: they verified the Facade call chain after manual command registration, but they did not verify that installing `UniverSheetsFilterPlugin` alone makes the Facade API usable.

In a headless runtime, `range.createFilter()` fails before this change because `sheet.command.set-filter-range` is not registered.

## Fix

- Register the Facade-required, non-UI filter commands from `SheetsFilterController`:
  - `SetSheetFilterRangeCommand`
  - `RemoveSheetFilterCommand`
  - `SetSheetsFilterCriteriaCommand`
  - `ClearSheetsFilterCriteriaCommand`
  - `ReCalcSheetsFilterCommand`
- Remove those registrations from `SheetsFilterUIDesktopController` to avoid duplicate ownership.
- Update the Facade test so it no longer manually registers filter commands and still does not install the UI plugin.
- Update filter UI tests to rely on the core plugin for core filter command registration.

## Scope note

This fixes the headless plugin registration blocker for the existing filter Facade API. It does not add a new higher-level filter criteria builder or source-generation API.

## Validation

- `pnpm exec eslint packages/sheets-filter/src/controllers/sheets-filter.controller.ts packages/sheets-filter/src/facade/__tests__/f-range.spec.ts packages/sheets-filter-ui/src/controllers/sheets-filter-ui-desktop.controller.ts packages/sheets-filter-ui/src/commands/commands/__tests__/sheets-filter.command.spec.ts packages/sheets-filter-ui/src/menu/__tests__/sheets-filter.menu.spec.ts packages/sheets-filter-ui/src/services/__tests__/sheets-filter-panel.service.spec.ts --max-warnings=0`
- `pnpm --filter @univerjs/sheets-filter typecheck`
- `pnpm --filter @univerjs/sheets-filter-ui typecheck`
- `pnpm --filter @univerjs/sheets-filter coverage`
- `pnpm --filter @univerjs/sheets-filter-ui coverage`
- `pnpm lint` exits 0. The repository still reports existing warnings outside this PR's changed files.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
