### PR TITLE
fix: skip CJK-Latin spacing for spreadsheet cells

### DIFF
--- a/packages/engine-render/src/components/docs/layout/block/paragraph/shaping.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/shaping.ts
@@ -352,7 +352,10 @@ export function shaping(
     }
 
     // Add some spacing between Han characters and western characters.
-    addCJKLatinSpacing(shapedTextList);
+    // Skip for spreadsheet cells to avoid excessive spacing in cell editing and rendering.
+    if (sectionBreakConfig.renderConfig?.cellValueType == null) {
+        addCJKLatinSpacing(shapedTextList);
+    }
 
     return shapedTextList;
 }

--- a/packages/sheets-ui/src/services/editor/cell-editor-resize.service.ts
+++ b/packages/sheets-ui/src/services/editor/cell-editor-resize.service.ts
@@ -204,7 +204,6 @@ export class SheetCellEditorResizeService extends Disposable {
          */
         documentDataModel?.updateDocumentRenderConfig({
             horizontalAlign: HorizontalAlign.UNSPECIFIED,
-            cellValueType: undefined,
         });
 
         return {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #3099

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
