### PR TITLE
fix(docs-ui): skip resize after editor render disposed

### DIFF
--- a/packages/docs-drawing-ui/src/__tests__/create-doc-ui-test-bed.ts
+++ b/packages/docs-drawing-ui/src/__tests__/create-doc-ui-test-bed.ts
@@ -133,6 +133,7 @@ class MockRenderManagerService implements Pick<IRenderManagerService, 'getRender
     getRenderById(): Nullable<IRender> {
         return {
             with: <T>(identifier: DependencyIdentifier<T>) => this._injector.get(identifier),
+            isDisposed: () => false,
         } as unknown as IRender;
     }
 }

--- a/packages/docs-hyper-link-ui/src/__tests__/create-doc-ui-test-bed.ts
+++ b/packages/docs-hyper-link-ui/src/__tests__/create-doc-ui-test-bed.ts
@@ -133,6 +133,7 @@ class MockRenderManagerService implements Pick<IRenderManagerService, 'getRender
     getRenderById(): Nullable<IRender> {
         return {
             with: <T>(identifier: DependencyIdentifier<T>) => this._injector.get(identifier),
+            isDisposed: () => false,
         } as unknown as IRender;
     }
 }

--- a/packages/docs-mention-ui/src/__tests__/create-doc-ui-test-bed.ts
+++ b/packages/docs-mention-ui/src/__tests__/create-doc-ui-test-bed.ts
@@ -133,6 +133,7 @@ class MockRenderManagerService implements Pick<IRenderManagerService, 'getRender
     getRenderById(): Nullable<IRender> {
         return {
             with: <T>(identifier: DependencyIdentifier<T>) => this._injector.get(identifier),
+            isDisposed: () => false,
         } as unknown as IRender;
     }
 }

--- a/packages/docs-ui/src/commands/commands/__tests__/create-command-test-bed.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/create-command-test-bed.ts
@@ -179,6 +179,7 @@ export class MockRenderManagerService implements Pick<IRenderManagerService, 'ge
     getRenderById(_unitId: string): Nullable<IRender> {
         return {
             with: <T>(identifier: DependencyIdentifier<T>) => this._injector.get(identifier),
+            isDisposed: () => false,
         } as unknown as IRender;
     }
 }

--- a/packages/docs-ui/src/views/rich-text-editor/hooks/use-resize.ts
+++ b/packages/docs-ui/src/views/rich-text-editor/hooks/use-resize.ts
@@ -49,7 +49,7 @@ export const useResize = (editor?: Editor, isSingle = true, autoScrollbar?: bool
         // eslint-disable-next-line complexity
         return debounce(() => {
             if (!autoScrollbar) return;
-            if (!editor || !autoScrollbar) {
+            if (!editor || !autoScrollbar || editor.render.isDisposed()) {
                 return;
             }
 

--- a/packages/engine-render/src/render-manager/render-unit.ts
+++ b/packages/engine-render/src/render-manager/render-unit.ts
@@ -55,6 +55,8 @@ export interface IRender {
      * Activate the render unit, means the render unit would be updated and rendered.
      */
     activate(): void;
+
+    isDisposed(): boolean;
 }
 
 /**
@@ -66,7 +68,7 @@ export interface IRenderModule extends IDisposable { }
  * Necessary context for a render module.This interface would be the first argument of render modules' constructor
  * functions.
  */
-export interface IRenderContext<T extends UnitModel = UnitModel> extends Omit<IRender, 'with'> {
+export interface IRenderContext<T extends UnitModel = UnitModel> extends Omit<IRender, 'with' | 'isDisposed'> {
     unit: T;
     type: UniverInstanceType;
 }
@@ -136,6 +138,10 @@ export class RenderUnit extends Disposable implements IRender {
         //@ts-ignore
         this._renderContext.unit = null;
         this._renderContext.components.clear();
+    }
+
+    isDisposed(): boolean {
+        return this._disposed;
     }
 
     /**

--- a/packages/sheets-formula-ui/src/controllers/__tests__/formula-clipboard.controller.spec.ts
+++ b/packages/sheets-formula-ui/src/controllers/__tests__/formula-clipboard.controller.spec.ts
@@ -175,6 +175,7 @@ export function clipboardTestBed(workbookData?: IWorkbookData, dependencies?: De
         activated$: new BehaviorSubject(true),
         activate: () => {},
         deactivate: () => {},
+        isDisposed: () => false,
     });
 
     return {

--- a/packages/sheets-ui/src/commands/commands/__tests__/create-selection-command-test-bed.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/create-selection-command-test-bed.ts
@@ -226,6 +226,7 @@ export function createFrozenCommandTestBed(workbookData?: IWorkbookData) {
         activated$: new BehaviorSubject(true),
         activate: () => {},
         deactivate: () => {},
+        isDisposed: () => false,
     });
 
     return {

--- a/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-test-bed.ts
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-test-bed.ts
@@ -623,6 +623,7 @@ export function clipboardTestBed(workbookData?: IWorkbookData, dependencies?: De
         activated$: new BehaviorSubject(true),
         activate: () => {},
         deactivate: () => {},
+        isDisposed: () => false,
     });
 
     return {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
