### PR TITLE
fix(docs-ui): update page-settings locale keys to use docs-ui namespace

### DIFF
--- a/packages/docs-ui/src/views/page-settings/index.tsx
+++ b/packages/docs-ui/src/views/page-settings/index.tsx
@@ -172,7 +172,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                         })}
                         onClick={() => handleModeChange(mode)}
                     >
-                        {localeService.t(mode === DocumentFlavor.MODERN ? 'page-settings.modern-mode' : 'page-settings.classic-mode')}
+                        {localeService.t(mode === DocumentFlavor.MODERN ? 'docs-ui.page-settings.modern-mode' : 'docs-ui.page-settings.classic-mode')}
                     </button>
                 ))}
             </div>
@@ -180,7 +180,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
             {settings.mode === DocumentFlavor.MODERN
                 ? (
                     <div className="univer-flex univer-flex-col univer-gap-2.5">
-                        <SettingsLabel>{localeService.t('page-settings.modern-width')}</SettingsLabel>
+                        <SettingsLabel>{localeService.t('docs-ui.page-settings.modern-width')}</SettingsLabel>
                         <div className="univer-grid univer-grid-cols-3 univer-gap-2">
                             {MODERN_WIDTH_OPTIONS.map((option) => (
                                 <button
@@ -198,7 +198,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                                     })}
                                     onClick={() => handleModernWidthChange(option)}
                                 >
-                                    <span>{localeService.t(`page-settings.modern-width-${option}`)}</span>
+                                    <span>{localeService.t(`docs-ui.page-settings.modern-width-${option}`)}</span>
                                     <span className="univer-text-xs univer-font-normal univer-text-gray-400">
                                         {MODERN_DOCUMENT_WIDTH[option]}
                                         px
@@ -211,23 +211,23 @@ export function PageSettings(props: IConfirmChildrenProps) {
                 : (
                     <>
                         <div className="univer-flex univer-flex-col univer-gap-2">
-                            <SettingsLabel>{localeService.t('page-settings.paper-size')}</SettingsLabel>
+                            <SettingsLabel>{localeService.t('docs-ui.page-settings.paper-size')}</SettingsLabel>
                             <Select
                                 value={settings.paperSize}
                                 onChange={handlePaperSizeChange}
                                 options={PAPER_TYPES.map((p) => ({
-                                    label: localeService.t(`page-settings.page-size.${p.toLocaleLowerCase()}`),
+                                    label: localeService.t(`docs-ui.page-settings.page-size.${p.toLocaleLowerCase()}`),
                                     value: p,
                                 }))}
                             />
                         </div>
 
                         <div className="univer-flex univer-flex-col univer-gap-2">
-                            <SettingsLabel>{localeService.t('page-settings.custom-paper-size')}</SettingsLabel>
+                            <SettingsLabel>{localeService.t('docs-ui.page-settings.custom-paper-size')}</SettingsLabel>
                             <div className="univer-flex univer-flex-col univer-gap-2.5">
                                 <div className="univer-flex univer-gap-2.5">
                                     <div className="univer-flex univer-flex-1 univer-flex-col univer-gap-2">
-                                        <SettingsLabel muted>{localeService.t('page-settings.top')}</SettingsLabel>
+                                        <SettingsLabel muted>{localeService.t('docs-ui.page-settings.top')}</SettingsLabel>
                                         <InputNumber
                                             precision={2}
                                             min={0}
@@ -237,7 +237,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                                         />
                                     </div>
                                     <div className="univer-flex univer-flex-1 univer-flex-col univer-gap-2">
-                                        <SettingsLabel muted>{localeService.t('page-settings.bottom')}</SettingsLabel>
+                                        <SettingsLabel muted>{localeService.t('docs-ui.page-settings.bottom')}</SettingsLabel>
                                         <InputNumber
                                             precision={2}
                                             min={0}
@@ -249,7 +249,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                                 </div>
                                 <div className="univer-flex univer-gap-2.5">
                                     <div className="univer-flex univer-flex-1 univer-flex-col univer-gap-2">
-                                        <SettingsLabel muted>{localeService.t('page-settings.left')}</SettingsLabel>
+                                        <SettingsLabel muted>{localeService.t('docs-ui.page-settings.left')}</SettingsLabel>
                                         <InputNumber
                                             precision={2}
                                             min={0}
@@ -259,7 +259,7 @@ export function PageSettings(props: IConfirmChildrenProps) {
                                         />
                                     </div>
                                     <div className="univer-flex univer-flex-1 univer-flex-col univer-gap-2">
-                                        <SettingsLabel muted>{localeService.t('page-settings.right')}</SettingsLabel>
+                                        <SettingsLabel muted>{localeService.t('docs-ui.page-settings.right')}</SettingsLabel>
                                         <InputNumber
                                             precision={2}
                                             min={0}

--- a/packages/sheets-thread-comment-ui/src/locale/ar-SA.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/ar-SA.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'إضافة تعليق',
             commentManagement: 'إدارة التعليقات',
         },
+        panel: {
+            title: 'تعليق',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/ca-ES.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/ca-ES.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Afegeix un comentari',
             commentManagement: 'Gestió de comentaris',
         },
+        panel: {
+            title: 'Comentari',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/de-DE.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/de-DE.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Kommentar hinzufügen',
             commentManagement: 'Kommentarverwaltung',
         },
+        panel: {
+            title: 'Kommentar',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/en-US.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/en-US.ts
@@ -20,6 +20,9 @@ const locale = {
             addComment: 'Add Comment',
             commentManagement: 'Comment Management',
         },
+        panel: {
+            title: 'Comment',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/es-ES.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/es-ES.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Añadir comentario',
             commentManagement: 'Gestión de comentarios',
         },
+        panel: {
+            title: 'Comentario',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/fa-IR.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/fa-IR.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'افزودن نظر',
             commentManagement: 'مدیریت نظر',
         },
+        panel: {
+            title: 'نظر',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/fr-FR.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/fr-FR.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Ajouter un commentaire',
             commentManagement: 'Gestion des commentaires',
         },
+        panel: {
+            title: 'Commentaire',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/id-ID.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/id-ID.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Tambah Komentar',
             commentManagement: 'Manajemen Komentar',
         },
+        panel: {
+            title: 'Komentar',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/it-IT.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/it-IT.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Aggiungi commento',
             commentManagement: 'Gestione commenti',
         },
+        panel: {
+            title: 'Commento',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/ja-JP.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/ja-JP.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'コメントを追加',
             commentManagement: 'コメント管理',
         },
+        panel: {
+            title: 'コメント',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/ko-KR.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/ko-KR.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: '댓글 추가',
             commentManagement: '댓글 관리',
         },
+        panel: {
+            title: '댓글',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/pl-PL.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/pl-PL.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Dodaj komentarz',
             commentManagement: 'Zarządzanie komentarzami',
         },
+        panel: {
+            title: 'Komentarz',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/pt-BR.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/pt-BR.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Adicionar Comentário',
             commentManagement: 'Gerenciamento de Comentários',
         },
+        panel: {
+            title: 'Comentário',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/ru-RU.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/ru-RU.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Добавить комментарий',
             commentManagement: 'Управление комментариями',
         },
+        panel: {
+            title: 'Комментарий',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/sk-SK.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/sk-SK.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Pridať komentár',
             commentManagement: 'Správa komentárov',
         },
+        panel: {
+            title: 'Komentár',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/vi-VN.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/vi-VN.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: 'Thêm bình luận',
             commentManagement: 'Quản lý bình luận',
         },
+        panel: {
+            title: 'Bình luận',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/zh-CN.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/zh-CN.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: '添加评论',
             commentManagement: '评论管理',
         },
+        panel: {
+            title: '评论',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/zh-HK.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/zh-HK.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: '新增評論',
             commentManagement: '評論管理',
         },
+        panel: {
+            title: '評論',
+        },
     },
 };
 

--- a/packages/sheets-thread-comment-ui/src/locale/zh-TW.ts
+++ b/packages/sheets-thread-comment-ui/src/locale/zh-TW.ts
@@ -22,6 +22,9 @@ const locale: typeof enUS = {
             addComment: '新增評論',
             commentManagement: '評論管理',
         },
+        panel: {
+            title: '評論',
+        },
     },
 };
 


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
