### PR TITLE
fix(engine-formula): skip embedded refs for other formulas

### DIFF
--- a/packages/engine-formula/src/engine/dependency/formula-dependency.ts
+++ b/packages/engine-formula/src/engine/dependency/formula-dependency.ts
@@ -720,7 +720,8 @@ export class FormulaDependencyGenerator extends Disposable implements IFormulaDe
                 tree.rowCount,
                 tree.columnCount,
                 tree.subUnitId,
-                tree.unitId
+                tree.unitId,
+                tree.type
             );
 
             const rangeList = await this._getRangeListByNode({
@@ -1039,7 +1040,8 @@ export class FormulaDependencyGenerator extends Disposable implements IFormulaDe
             tree.rowCount,
             tree.columnCount,
             tree.subUnitId,
-            tree.unitId
+            tree.unitId,
+            tree.type
         );
 
         const dirtyRanges: IUnitRange[] = [];
@@ -1092,7 +1094,8 @@ export class FormulaDependencyGenerator extends Disposable implements IFormulaDe
                 tree.rowCount,
                 tree.columnCount,
                 tree.subUnitId,
-                tree.unitId
+                tree.unitId,
+                tree.type
             );
 
             let value: FunctionVariantType;

--- a/packages/engine-formula/src/services/__tests__/runtime.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/runtime.service.spec.ts
@@ -17,6 +17,7 @@
 import { ObjectMatrix } from '@univerjs/core';
 import { describe, expect, it } from 'vitest';
 import { ErrorType } from '../../basics/error-type';
+import { FormulaDependencyTreeType } from '../../engine/dependency/dependency-tree';
 import { createNewArray } from '../../engine/utils/array-object';
 import { NumberValueObject, StringValueObject } from '../../engine/value-object/primitive-object';
 import { FormulaExecutedStateType, FormulaExecuteStageType, FormulaRuntimeService } from '../runtime.service';
@@ -400,6 +401,18 @@ describe('FormulaRuntimeService', () => {
         expect(runtime.getRuntimeFeatureRange()['feature-a']).toEqual({ unit: { sheet: [] } });
         expect(runtime.getRuntimeFeatureCellData()['feature-a']).toEqual({ unit: {} });
         expect(runtime.getDependencyTreeModelData()).toEqual([{ treeId: 1 }]);
+    });
+
+    it('should collect embedded array refs only for normal worksheet formulas', () => {
+        const { runtime } = createRuntimeService();
+
+        runtime.setCurrent(1, 2, 20, 20, 'sheet', 'unit', FormulaDependencyTreeType.OTHER_FORMULA);
+        runtime.setUnitArrayFormulaEmbeddedMap();
+        expect(runtime.getUnitArrayFormulaEmbeddedMap().unit?.sheet?.[1]?.[2]).toBeUndefined();
+
+        runtime.setCurrent(4, 5, 20, 20, 'sheet', 'unit', FormulaDependencyTreeType.NORMAL_FORMULA);
+        runtime.setUnitArrayFormulaEmbeddedMap();
+        expect(runtime.getUnitArrayFormulaEmbeddedMap().unit?.sheet?.[4]?.[5]).toBe(true);
     });
 
     it('should evaluate helper methods for range, overlap and dirty checks', () => {

--- a/packages/engine-formula/src/services/calculate-formula.service.ts
+++ b/packages/engine-formula/src/services/calculate-formula.service.ts
@@ -341,7 +341,8 @@ export class CalculateFormulaService extends Disposable implements ICalculateFor
                 tree.rowCount,
                 tree.columnCount,
                 tree.subUnitId,
-                tree.unitId
+                tree.unitId,
+                tree.type
             );
 
             let value: FunctionVariantType;

--- a/packages/engine-formula/src/services/runtime.service.ts
+++ b/packages/engine-formula/src/services/runtime.service.ts
@@ -33,6 +33,7 @@ import { createIdentifier, Disposable, isNullCell, ObjectMatrix } from '@univerj
 import { isInDirtyRange } from '../basics/dirty';
 import { ErrorType } from '../basics/error-type';
 import { CELL_INVERTED_INDEX_CACHE } from '../basics/inverted-index-cache';
+import { FormulaDependencyTreeType } from '../engine/dependency/dependency-tree';
 import { FORMULA_REF_TO_ARRAY_CACHE } from '../engine/reference-object/base-reference-object';
 import { getRuntimeFeatureCell } from '../engine/utils/get-runtime-feature-cell';
 import { clearNumberFormatTypeCache, clearStringToNumberPatternCache } from '../engine/utils/numfmt-kit';
@@ -112,7 +113,8 @@ export interface IFormulaRuntimeService {
         rowCount: number,
         columnCount: number,
         sheetId: string,
-        unitId: string
+        unitId: string,
+        formulaType?: FormulaDependencyTreeType
     ): void;
 
     registerFunctionDefinitionPrivacyVar(lambdaId: string, lambdaVar: Map<string, Nullable<BaseAstNode>>): void;
@@ -211,6 +213,7 @@ export class FormulaRuntimeService extends Disposable implements IFormulaRuntime
 
     private _currentSubUnitId: string = '';
     private _currentUnitId: string = '';
+    private _currentFormulaType: FormulaDependencyTreeType = FormulaDependencyTreeType.NORMAL_FORMULA;
 
     private _runtimeData: IRuntimeUnitDataType = {};
 
@@ -405,13 +408,22 @@ export class FormulaRuntimeService extends Disposable implements IFormulaRuntime
         clearReferenceToRangeCache();
     }
 
-    setCurrent(row: number, column: number, rowCount: number, columnCount: number, sheetId: string, unitId: string) {
+    setCurrent(
+        row: number,
+        column: number,
+        rowCount: number,
+        columnCount: number,
+        sheetId: string,
+        unitId: string,
+        formulaType: FormulaDependencyTreeType = FormulaDependencyTreeType.NORMAL_FORMULA
+    ) {
         this._currentRow = row;
         this._currentColumn = column;
         this._currentRowCount = rowCount;
         this._currentColumnCount = columnCount;
         this._currentSubUnitId = sheetId;
         this._currentUnitId = unitId;
+        this._currentFormulaType = formulaType;
     }
 
     clearFunctionDefinitionPrivacyVar() {
@@ -722,6 +734,11 @@ export class FormulaRuntimeService extends Disposable implements IFormulaRuntime
         const sheetId = this._currentSubUnitId;
         const rowIndex = this._currentRow;
         const columnIndex = this._currentColumn;
+
+        // Embedded array refs are worksheet cell metadata; other formula results stay in unitOtherData.
+        if (this._currentFormulaType !== FormulaDependencyTreeType.NORMAL_FORMULA) {
+            return;
+        }
 
         const arrayFormulaEmbeddedMap = this._unitArrayFormulaEmbeddedMap;
         if (arrayFormulaEmbeddedMap[unitId] == null) {


### PR DESCRIPTION
## Summary

- Track the current dependency tree formula type in formula runtime context.
- Only collect embedded array formula refs for normal worksheet formulas.
- Pass formula dependency type through calculation and dependency analysis paths.
- Add a runtime regression test for OTHER_FORMULA vs NORMAL_FORMULA embedded ref collection.

Closes #6984

## Validation

- pnpm exec vitest run packages/engine-formula/src/services/__tests__/runtime.service.spec.ts
- pnpm --filter @univerjs/engine-formula typecheck