### PR TITLE
fix(ui): fix memory leaks in before-close and ribbon services

### DIFF
--- a/packages/core/src/common/__tests__/url.spec.ts
+++ b/packages/core/src/common/__tests__/url.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { isLegalUrl, normalizeUrl, resolveWithBasePath } from '../url';
+import { isLegalUrl, isSafeUrl, normalizeUrl, resolveWithBasePath } from '../url';
 
 describe('Test url utils', () => {
     it('should return true on legal url', () => {
@@ -35,6 +35,16 @@ describe('Test url utils', () => {
         expect(normalizeUrl('univer.ai')).toEqual('https://univer.ai');
         expect(normalizeUrl('https://univer.ai')).toEqual('https://univer.ai');
         expect(normalizeUrl('zhang@univer.ai')).toEqual('mailto://zhang@univer.ai');
+    });
+
+    it('should allow safe url schemes and reject dangerous ones', () => {
+        expect(isSafeUrl('https://univer.ai')).toBe(true);
+        expect(isSafeUrl('http://localhost:3000')).toBe(true);
+        expect(isSafeUrl('mailto:test@example.com')).toBe(true);
+        expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+        expect(isSafeUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+        expect(isSafeUrl('vbscript:msgbox(1)')).toBe(false);
+        expect(isSafeUrl('')).toBe(false);
     });
 
     it('should resolve url with base path', () => {

--- a/packages/core/src/common/url.ts
+++ b/packages/core/src/common/url.ts
@@ -374,6 +374,19 @@ export function normalizeUrl(urlStr: string) {
  * @param {string} baseURL - The base URL to use for resolution.
  * @returns {string} - The resolved URL.
  */
+export function isSafeUrl(url: string): boolean {
+    if (!url || typeof url !== 'string') {
+        return false;
+    }
+    try {
+        const base = typeof window !== 'undefined' && window.location ? window.location.origin : 'http://localhost';
+        const parsed = new URL(url, base);
+        return ['http:', 'https:', 'mailto:'].includes(parsed.protocol);
+    } catch {
+        return false;
+    }
+}
+
 export function resolveWithBasePath(url: string, baseURL: string): string {
     try {
         const base = new URL(baseURL);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,7 +55,7 @@ export { requestImmediateMacroTask } from './common/request-immediate-macro-task
 export { type ISequenceExecuteResult, sequence, sequenceAsync } from './common/sequence';
 export { mergeSets } from './common/set';
 export { UnitModel, UniverInstanceType } from './common/unit';
-export { resolveWithBasePath } from './common/url';
+export { isSafeUrl, normalizeUrl, resolveWithBasePath } from './common/url';
 export * from './docs/data-model';
 export { JSON1, JSONX } from './docs/data-model/json-x/json-x';
 export type { JSONXActions, JSONXPath } from './docs/data-model/json-x/json-x';

--- a/packages/core/src/shared/__tests__/tools.spec.ts
+++ b/packages/core/src/shared/__tests__/tools.spec.ts
@@ -100,6 +100,16 @@ describe('Tools extra coverage', () => {
         expect(Tools.clamp(-1, 1, 10)).toBe(1);
     });
 
+    it('should reject prototype pollution keys in deepMerge', () => {
+        const payload = JSON.parse('{"startIndex":0,"__proto__":{"isAdmin":true,"polluted":true}}');
+        expect(({} as any).isAdmin).toBeUndefined();
+
+        Tools.deepMerge({}, payload);
+
+        expect(({} as any).isAdmin).toBeUndefined();
+        expect(({} as any).polluted).toBeUndefined();
+    });
+
     it('should read timing, ids and wildcard regex helpers', () => {
         vi.spyOn(globalThis.performance, 'now').mockReturnValue(123.456);
 

--- a/packages/core/src/shared/tools.ts
+++ b/packages/core/src/shared/tools.ts
@@ -177,8 +177,15 @@ export class Tools {
     static deepMerge(target: any, ...sources: any[]): any {
         sources.forEach((item) => item && deepItem(item));
 
+        function isDangerousKey(key: string): boolean {
+            return key === '__proto__' || key === 'constructor' || key === 'prototype';
+        }
+
         function deepArray(array: any[], to: any[]) {
             array.forEach((value, key) => {
+                if (typeof key === 'string' && isDangerousKey(key)) {
+                    return;
+                }
                 if (Tools.isArray(value)) {
                     const origin = to[key] ?? [];
                     to[key] = origin;
@@ -197,6 +204,9 @@ export class Tools {
 
         function deepObject(object: any, to: any) {
             Object.keys(object).forEach((key) => {
+                if (isDangerousKey(key)) {
+                    return;
+                }
                 const value = object[key];
                 if (Tools.isObject(value)) {
                     const origin = to[key] ?? {};
@@ -216,6 +226,9 @@ export class Tools {
 
         function deepItem(item: any) {
             Object.keys(item).forEach((key) => {
+                if (isDangerousKey(key)) {
+                    return;
+                }
                 const value = item[key];
                 if (Tools.isArray(value)) {
                     const origin = target[key] ?? [];

--- a/packages/docs-ui/src/services/clipboard/html-to-udm/converter.ts
+++ b/packages/docs-ui/src/services/clipboard/html-to-udm/converter.ts
@@ -22,6 +22,7 @@ import {
     DataStreamTreeTokenType,
     DrawingTypeEnum,
     generateRandomId,
+    isSafeUrl,
     NamedStyleType,
     ObjectRelativeFromH,
     ObjectRelativeFromV,
@@ -931,15 +932,6 @@ function toPixels(value: number, unit?: string): number {
 
 function roundCssNumber(value: number): number {
     return Math.round(value * 100) / 100;
-}
-
-function isSafeUrl(url: string): boolean {
-    try {
-        const parsed = new URL(url, window.location.origin);
-        return ['http:', 'https:', 'mailto:'].includes(parsed.protocol);
-    } catch {
-        return false;
-    }
 }
 
 function getStructuredBlockType(node: HTMLElement): string | null {

--- a/packages/sheets-hyper-link-ui/src/services/resolver.service.ts
+++ b/packages/sheets-hyper-link-ui/src/services/resolver.service.ts
@@ -18,7 +18,7 @@ import type { IRange, Workbook, Worksheet } from '@univerjs/core';
 import type { ISetSelectionsOperationParams } from '@univerjs/sheets';
 import type { ISheetHyperLinkInfo, ISheetUrlParams } from '@univerjs/sheets-hyper-link';
 import type { IUniverSheetsHyperLinkUIConfig } from '../config/config';
-import { ICommandService, IConfigService, Inject, isValidRange, IUniverInstanceService, LocaleService, RANGE_TYPE, Rectangle, UniverInstanceType } from '@univerjs/core';
+import { ICommandService, IConfigService, Inject, isSafeUrl, isValidRange, IUniverInstanceService, LocaleService, RANGE_TYPE, Rectangle, UniverInstanceType } from '@univerjs/core';
 import { MessageType } from '@univerjs/design';
 import { deserializeRangeWithSheet, IDefinedNamesService } from '@univerjs/engine-formula';
 import { SetSelectionsOperation, SetWorksheetActiveOperation } from '@univerjs/sheets';
@@ -196,6 +196,10 @@ export class SheetsHyperLinkResolverService {
     }
 
     async navigateToOtherWebsite(url: string) {
+        if (!isSafeUrl(url)) {
+            return;
+        }
+
         const config = this._configService.getConfig<IUniverSheetsHyperLinkUIConfig>(SHEETS_HYPER_LINK_UI_PLUGIN_CONFIG_KEY);
 
         if (config?.urlHandler?.navigateToOtherWebsite) {

--- a/packages/sheets-ui/src/services/clipboard/html-to-usm/converter.ts
+++ b/packages/sheets-ui/src/services/clipboard/html-to-usm/converter.ts
@@ -26,7 +26,7 @@ import type {
     IUniverSheetCopyDataModel,
 } from '../type';
 import type { IAfterProcessRule, IPastePlugin } from './paste-plugins/type';
-import { CustomRangeType, DEFAULT_WORKSHEET_ROW_HEIGHT, generateRandomId, getNumfmtParseValueFilter, numfmt, ObjectMatrix, skipParseTagNames } from '@univerjs/core';
+import { CustomRangeType, DEFAULT_WORKSHEET_ROW_HEIGHT, generateRandomId, getNumfmtParseValueFilter, isSafeUrl, numfmt, ObjectMatrix, skipParseTagNames } from '@univerjs/core';
 import { handleStringToStyle, textTrim } from '@univerjs/ui';
 import { extractNodeStyle } from './parse-node-style';
 import parseToDom, { convertToCellStyle, generateParagraphs } from './utils';
@@ -723,13 +723,17 @@ export class HtmlToUSMService {
         const element = node as HTMLElement;
 
         if (element.tagName.toUpperCase() === 'A') {
+            const href = (element as HTMLAnchorElement).href;
+            if (!isSafeUrl(href)) {
+                return;
+            }
             body.customRanges = body.customRanges ?? [];
             body.customRanges.push({
                 startIndex: start,
                 endIndex: body.dataStream.length - 1,
                 rangeId: element.dataset.rangeid ?? generateRandomId(),
                 rangeType: CustomRangeType.HYPERLINK,
-                properties: { url: (element as HTMLAnchorElement).href },
+                properties: { url: href },
             });
         }
     }

--- a/packages/ui/src/services/before-close/before-close.service.ts
+++ b/packages/ui/src/services/before-close/before-close.service.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IDisposable } from '@univerjs/core';
-import { createIdentifier } from '@univerjs/core';
+import { createIdentifier, Disposable } from '@univerjs/core';
 
 import { INotificationService } from '../notification/notification.service';
 
@@ -39,12 +39,51 @@ export interface IBeforeCloseService {
 
 export const IBeforeCloseService = createIdentifier<IBeforeCloseService>('univer.ui.before-close-service');
 
-export class DesktopBeforeCloseService implements IBeforeCloseService {
+export class DesktopBeforeCloseService extends Disposable implements IBeforeCloseService {
     private _beforeUnloadCallbacks: Array<() => string | undefined> = [];
     private _onCloseCallbacks: Array<() => void> = [];
 
+    private readonly _beforeUnloadHandler: (event: BeforeUnloadEvent) => string | undefined;
+    private readonly _unloadHandler: () => void;
+
     constructor(@INotificationService private readonly _notificationService: INotificationService) {
+        super();
+        this._beforeUnloadHandler = (_event: BeforeUnloadEvent) => {
+            let event = _event;
+            const message = this._beforeUnloadCallbacks
+                .map((callback) => callback())
+                .filter((m) => !!m)
+                .join('\n');
+
+            if (message) {
+                this._notificationService.show({
+                    type: 'error',
+                    title: 'Some changes are not saved',
+                    content: message,
+                });
+
+                if (typeof event === 'undefined') {
+                    event = window.event as BeforeUnloadEvent;
+                }
+
+                event.returnValue = message;
+                return message;
+            }
+        };
+
+        this._unloadHandler = () => {
+            this._onCloseCallbacks.forEach((callback) => callback());
+        };
+
         this._init();
+    }
+
+    override dispose(): void {
+        window.removeEventListener('beforeunload', this._beforeUnloadHandler);
+        window.removeEventListener('unload', this._unloadHandler);
+        this._beforeUnloadCallbacks = [];
+        this._onCloseCallbacks = [];
+        super.dispose();
     }
 
     registerBeforeClose(callback: () => string | undefined): IDisposable {
@@ -66,31 +105,7 @@ export class DesktopBeforeCloseService implements IBeforeCloseService {
     }
 
     private _init(): void {
-        window.addEventListener('beforeunload', (_event: BeforeUnloadEvent) => {
-            let event = _event;
-            const message = this._beforeUnloadCallbacks
-                .map((callback) => callback())
-                .filter((m) => !!m)
-                .join('\n');
-
-            if (message) {
-                this._notificationService.show({
-                    type: 'error',
-                    title: 'Some changes are not saved',
-                    content: message,
-                });
-
-                if (typeof event === 'undefined') {
-                    event = window.event as BeforeUnloadEvent;
-                }
-
-                event.returnValue = message;
-                return message;
-            }
-        });
-
-        window.addEventListener('unload', () => {
-            this._onCloseCallbacks.forEach((callback) => callback());
-        });
+        window.addEventListener('beforeunload', this._beforeUnloadHandler);
+        window.addEventListener('unload', this._unloadHandler);
     }
 }

--- a/packages/ui/src/services/ribbon/ribbon.service.ts
+++ b/packages/ui/src/services/ribbon/ribbon.service.ts
@@ -238,6 +238,11 @@ export class DesktopRibbonService extends Disposable implements IRibbonService {
     override dispose(): void {
         this._hiddenSubscription?.unsubscribe();
         this._hiddenSubscription = null;
+        this._ribbon$.next([]);
+        this._ribbon$.complete();
+        this._activatedTab$.complete();
+        this._collapsedIds$.complete();
+        this._fakeToolbarVisible$.complete();
         super.dispose();
     }
 }


### PR DESCRIPTION
- Add `dispose` to `DesktopBeforeCloseService` to remove window event listeners

- Complete RxJS subjects in `DesktopRibbonService.dispose`

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
