### PR TITLE
fix(shape): skip popup menu for sheet shapes

### DIFF
--- a/packages/sheets-drawing-ui/src/menu/drawing-popup-menu.controller.ts
+++ b/packages/sheets-drawing-ui/src/menu/drawing-popup-menu.controller.ts
@@ -139,7 +139,7 @@ export class DrawingPopupMenuController extends RxDisposable {
 
             const oKey = object.oKey;
             const drawingParam = this._drawingManagerService.getDrawingOKey(oKey);
-            if (!drawingParam) {
+            if (!drawingParam || drawingParam.drawingType === DrawingTypeEnum.DRAWING_SHAPE) {
                 return;
             }
 


### PR DESCRIPTION
## Summary
- skip the legacy sheets drawing popup menu for shape drawings
- align sheets behavior with docs so shape-editor owns the shape floating toolbar

## Test
- pnpm --dir submodules/univer exec eslint packages/sheets-drawing-ui/src/menu/drawing-popup-menu.controller.ts --quiet