### PR TITLE
feat(rtl): add end-to-end RTL and bidirectional text support

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -203,7 +203,7 @@ export { Styles } from './sheets/styles';
 export * from './sheets/typedef';
 export type { IPosition } from './sheets/typedef';
 export { addLinkToDocumentModel, getEmptyCell, isNotNullOrUndefined, isRangesEqual, isUnitRangesEqual } from './sheets/util';
-export { createDocumentModelWithStyle } from './sheets/util';
+export { createDocumentModelWithStyle, extractOtherStyle, getFontFormat, type ICellStyle } from './sheets/util';
 export { SheetViewModel } from './sheets/view-model';
 export { getWorksheetUID, Workbook } from './sheets/workbook';
 export { extractPureTextFromCell, getDisplayValueFromCell, getOriginCellValue, Worksheet } from './sheets/worksheet';

--- a/packages/core/src/shared/__tests__/text-direction.spec.ts
+++ b/packages/core/src/shared/__tests__/text-direction.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { hasRTLCharacter, isFirstStrongCharRTL } from '../text-direction';
+
+describe('isFirstStrongCharRTL', () => {
+    it('returns false for empty / nullish input', () => {
+        expect(isFirstStrongCharRTL('')).toBe(false);
+        expect(isFirstStrongCharRTL(null)).toBe(false);
+        expect(isFirstStrongCharRTL(undefined)).toBe(false);
+    });
+
+    it('returns false for pure ASCII text', () => {
+        expect(isFirstStrongCharRTL('Hello world')).toBe(false);
+        expect(isFirstStrongCharRTL('123 abc')).toBe(false);
+    });
+
+    it('returns true for text starting with Arabic', () => {
+        expect(isFirstStrongCharRTL('مرحبا')).toBe(true);
+        expect(isFirstStrongCharRTL('كتاب')).toBe(true);
+    });
+
+    it('returns true for text starting with Hebrew', () => {
+        expect(isFirstStrongCharRTL('שלום')).toBe(true);
+        expect(isFirstStrongCharRTL('עברית')).toBe(true);
+    });
+
+    it('skips leading neutrals/digits/punctuation', () => {
+        // Digits, punctuation, whitespace don't count as strong; the first
+        // strong character is the Arabic letter.
+        expect(isFirstStrongCharRTL('   كتاب')).toBe(true);
+        expect(isFirstStrongCharRTL('123 كتاب')).toBe(true);
+        expect(isFirstStrongCharRTL('"كتاب"')).toBe(true);
+    });
+
+    it('returns false when leading neutrals are followed by Latin', () => {
+        expect(isFirstStrongCharRTL('   Hello')).toBe(false);
+        expect(isFirstStrongCharRTL('123 Hello')).toBe(false);
+    });
+
+    it('returns false for CJK-leading strings (CJK is strong LTR per bidi)', () => {
+        expect(isFirstStrongCharRTL('中文')).toBe(false);
+        expect(isFirstStrongCharRTL('日本語')).toBe(false);
+        expect(isFirstStrongCharRTL('한국어')).toBe(false);
+    });
+});
+
+describe('hasRTLCharacter', () => {
+    it('detects RTL anywhere in the string', () => {
+        expect(hasRTLCharacter('Hello كتاب world')).toBe(true);
+        expect(hasRTLCharacter('Hello world')).toBe(false);
+        expect(hasRTLCharacter('')).toBe(false);
+        expect(hasRTLCharacter(null)).toBe(false);
+    });
+});

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -53,5 +53,6 @@ export * from './row-col-iter';
 export * from './sequence';
 export * from './shape';
 export * from './sort-rules';
+export * from './text-direction';
 export * from './tools';
 export * from './types';

--- a/packages/core/src/shared/text-direction.ts
+++ b/packages/core/src/shared/text-direction.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Detect whether a piece of text "feels" right-to-left, following the
+ * Unicode bidi P2/P3 rules ("first strong character").
+ *
+ * Spreadsheets (Excel / Google Sheets / Numbers) all auto-flip the
+ * alignment of a cell whose content starts with an RTL character even
+ * when no explicit text direction is configured. This helper centralises
+ * that decision so it stays consistent across:
+ *
+ *  - the canvas sheet renderer (cell display),
+ *  - the cell editor (alignment + container `dir`),
+ *  - the hidden contenteditable used to capture IME input.
+ *
+ * Only "strong" RTL ranges count; whitespace, punctuation, digits and
+ * neutral characters are skipped. If no strong character is found we
+ * default to LTR.
+ *
+ * RTL ranges considered (covers Hebrew, Arabic, Syriac, NKo, Thaana,
+ * Samaritan, Mandaic, Arabic Supplement, plus the presentation forms):
+ *  - U+0590..U+08FF
+ *  - U+FB1D..U+FDFF
+ *  - U+FE70..U+FEFF
+ *
+ * @param text The text to inspect. Empty / nullish inputs return `false`.
+ * @returns `true` when the first strong character is RTL.
+ */
+export function isFirstStrongCharRTL(text: string | null | undefined): boolean {
+    if (!text) {
+        return false;
+    }
+
+    for (let i = 0; i < text.length; i++) {
+        const code = text.charCodeAt(i);
+
+        // Strong LTR: basic Latin letters, extended Latin, Greek, Cyrillic,
+        // Han, Hangul, Hiragana, Katakana, … (everything up to U+0590).
+        // We treat the first letter in this range as strong LTR and stop.
+        const isLatinUpper = code >= 0x0041 && code <= 0x005A;
+        const isLatinLower = code >= 0x0061 && code <= 0x007A;
+        if (isLatinUpper || isLatinLower) {
+            return false;
+        }
+
+        // Strong RTL ranges.
+        if (code >= 0x0590 && code <= 0x08FF) return true;
+        if (code >= 0xFB1D && code <= 0xFDFF) return true;
+        if (code >= 0xFE70 && code <= 0xFEFF) return true;
+
+        // CJK / Kana / Hangul ranges - strong LTR per the bidi spec.
+        if (code >= 0x3040 && code <= 0x9FFF) return false;
+        if (code >= 0xAC00 && code <= 0xD7AF) return false;
+        if (code >= 0xF900 && code <= 0xFAFF) return false;
+    }
+
+    return false;
+}
+
+/**
+ * Lightweight test for "does this text contain any RTL character?".
+ * Useful for fast-paths that only care whether bidi processing might
+ * matter at all (e.g. avoid running the bidi algorithm on pure-ASCII).
+ */
+export function hasRTLCharacter(text: string | null | undefined): boolean {
+    if (!text) return false;
+    for (let i = 0; i < text.length; i++) {
+        const code = text.charCodeAt(i);
+        if (code >= 0x0590 && code <= 0x08FF) return true;
+        if (code >= 0xFB1D && code <= 0xFDFF) return true;
+        if (code >= 0xFE70 && code <= 0xFEFF) return true;
+    }
+    return false;
+}

--- a/packages/core/src/sheets/__tests__/util.spec.ts
+++ b/packages/core/src/sheets/__tests__/util.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { BaselineOffset, BooleanNumber, HorizontalAlign, VerticalAlign, WrapStrategy } from '../../types/enum';
+import { BaselineOffset, BooleanNumber, HorizontalAlign, TextDirection, VerticalAlign, WrapStrategy } from '../../types/enum';
 import { CustomRangeType, DocumentFlavor } from '../../types/interfaces';
 import {
     addLinkToDocumentModel,
@@ -59,6 +59,27 @@ describe('sheet util helpers', () => {
             },
         });
         expect(documentModel.getDrawingsOrder()).toEqual([]);
+    });
+
+    it('should propagate RTL textDirection to paragraph.direction and renderConfig', () => {
+        const documentModel = createDocumentModelWithStyle('שלום', { ff: 'Inter' }, {
+            textDirection: TextDirection.RIGHT_TO_LEFT,
+            horizontalAlign: HorizontalAlign.UNSPECIFIED,
+        });
+        const snapshot = documentModel.getSnapshot();
+        expect(snapshot.body!.paragraphs![0].paragraphStyle!.direction)
+            .toBe(TextDirection.RIGHT_TO_LEFT);
+        expect(snapshot.documentStyle!.renderConfig!.textDirection)
+            .toBe(TextDirection.RIGHT_TO_LEFT);
+    });
+
+    it('should leave paragraph.direction unset when no textDirection is provided', () => {
+        const documentModel = createDocumentModelWithStyle('hello', {}, {});
+        const snapshot = documentModel.getSnapshot();
+        expect(snapshot.body!.paragraphs![0].paragraphStyle!.direction)
+            .toBeUndefined();
+        expect(snapshot.documentStyle!.renderConfig!.textDirection)
+            .toBeUndefined();
     });
 
     it('should extract cell style fragments and enrich document links once', () => {

--- a/packages/core/src/sheets/__tests__/worksheet.spec.ts
+++ b/packages/core/src/sheets/__tests__/worksheet.spec.ts
@@ -19,7 +19,7 @@ import type { IRange, IWorkbookData } from '../typedef';
 import type { Worksheet } from '../worksheet';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { DisposableCollection } from '../../shared/lifecycle';
-import { CellValueType } from '../../types/enum';
+import { CellValueType, TextDirection } from '../../types/enum';
 import { LocaleType } from '../../types/enum/locale-type';
 import { RANGE_TYPE } from '../typedef';
 import { extractPureTextFromCell } from '../worksheet';
@@ -322,6 +322,120 @@ describe('test worksheet', () => {
                     },
                 },
             });
+        });
+    });
+
+    describe('per-paragraph RTL auto-detection in rich-text cells', () => {
+        // The fixture below mimics a multi-line / list cell so we can
+        // verify each paragraph gets its own direction based on its first-
+        // strong character. The actual paragraph break character (`\r`)
+        // sits at each `startIndex`; the slice between previous break and
+        // current `startIndex` is the paragraph's content.
+        beforeEach(() => {
+            prepare();
+            caseDisposable = new DisposableCollection();
+        });
+
+        function makeRichTextCellWithThreeLines() {
+            const lines = ['كتاب', 'مرحبا', 'Hello'];
+            let cursor = 0;
+            const paragraphs = lines.map((line) => {
+                cursor += line.length;
+                const entry = { startIndex: cursor, paragraphStyle: {} };
+                cursor += 1;
+                return entry;
+            });
+            return {
+                p: {
+                    id: '__paragraph_test__',
+                    body: {
+                        dataStream: `${lines.join('\r')}\r\n`,
+                        paragraphs,
+                    },
+                    documentStyle: {},
+                },
+            } as any;
+        }
+
+        it('flips each paragraph independently from its own first-strong char', () => {
+            const cell = makeRichTextCellWithThreeLines();
+            const model = worksheet.getCellDocumentModel(cell, {});
+            const paragraphs = model?.documentModel?.getBody()?.paragraphs ?? [];
+            expect(paragraphs[0]?.paragraphStyle?.direction).toBe(TextDirection.RIGHT_TO_LEFT);
+            expect(paragraphs[1]?.paragraphStyle?.direction).toBe(TextDirection.RIGHT_TO_LEFT);
+            expect(paragraphs[2]?.paragraphStyle?.direction).toBe(TextDirection.LEFT_TO_RIGHT);
+        });
+
+        it('does not mutate the source `cell.p` snapshot when injecting direction', () => {
+            const cell = makeRichTextCellWithThreeLines();
+            worksheet.getCellDocumentModel(cell, {});
+            // The snapshot the renderer was given must stay clean so the
+            // next render (potentially with different content) can re-run
+            // first-strong detection.
+            for (const p of cell.p.body.paragraphs) {
+                expect(p.paragraphStyle).toEqual({});
+            }
+        });
+
+        it('lets explicit cell-level `style.td` override per-paragraph auto-detection', () => {
+            const cell = makeRichTextCellWithThreeLines();
+            const model = worksheet.getCellDocumentModel(cell, { td: TextDirection.LEFT_TO_RIGHT });
+            const paragraphs = model?.documentModel?.getBody()?.paragraphs ?? [];
+            for (const p of paragraphs) {
+                expect(p.paragraphStyle?.direction).toBe(TextDirection.LEFT_TO_RIGHT);
+            }
+        });
+
+        it('lets an empty paragraph inherit the previous paragraph\'s direction', () => {
+            // Two paragraphs: a non-empty RTL one and a freshly-split
+            // empty one (what BreakLine creates when the user presses
+            // Enter at the end of an Arabic line). Without inheritance,
+            // the empty paragraph would silently fall back to LTR and
+            // the caret would jump to the wrong visual edge.
+            const lines = ['كتاب', ''];
+            let cursor = 0;
+            const paragraphs = lines.map((line) => {
+                cursor += line.length;
+                const entry = { startIndex: cursor, paragraphStyle: {} };
+                cursor += 1;
+                return entry;
+            });
+            const cell = {
+                p: {
+                    id: '__paragraph_test__',
+                    body: {
+                        dataStream: `${lines.join('\r')}\r\n`,
+                        paragraphs,
+                    },
+                    documentStyle: {},
+                },
+            } as any;
+            const model = worksheet.getCellDocumentModel(cell, {});
+            const resolved = model?.documentModel?.getBody()?.paragraphs ?? [];
+            expect(resolved[0]?.paragraphStyle?.direction).toBe(TextDirection.RIGHT_TO_LEFT);
+            expect(resolved[1]?.paragraphStyle?.direction).toBe(TextDirection.RIGHT_TO_LEFT);
+        });
+
+        it('preserves an already-declared paragraph direction from the model', () => {
+            // An author / clipboard paste might pin a specific paragraph
+            // to a direction. That declaration should always win, even
+            // when the paragraph's first-strong character disagrees.
+            const cell = {
+                p: {
+                    id: '__paragraph_test__',
+                    body: {
+                        dataStream: 'Hello\r\n',
+                        paragraphs: [{
+                            startIndex: 5,
+                            paragraphStyle: { direction: TextDirection.RIGHT_TO_LEFT },
+                        }],
+                    },
+                    documentStyle: {},
+                },
+            } as any;
+            const model = worksheet.getCellDocumentModel(cell, {});
+            const paragraphs = model?.documentModel?.getBody()?.paragraphs ?? [];
+            expect(paragraphs[0]?.paragraphStyle?.direction).toBe(TextDirection.RIGHT_TO_LEFT);
         });
     });
 });

--- a/packages/core/src/sheets/sheet-skeleton.ts
+++ b/packages/core/src/sheets/sheet-skeleton.ts
@@ -45,7 +45,7 @@ import { ColorKit, isCellCoverable, ObjectMatrix, Rectangle, searchArray, Tools 
 import { ImageCacheMap } from '../shared/cache/image-cache';
 import { getIntersectRange } from '../shared/range';
 import { Skeleton } from '../skeleton';
-import { BooleanNumber, HorizontalAlign } from '../types/enum';
+import { BooleanNumber, HorizontalAlign, TextDirection } from '../types/enum';
 import { DocumentFlavor } from '../types/interfaces';
 
 /**
@@ -1151,7 +1151,8 @@ export class SheetSkeleton extends Skeleton {
         documentData: IDocumentData,
         horizontalAlign: HorizontalAlign,
         paddingData: IPaddingData,
-        renderConfig?: IDocumentRenderConfig
+        renderConfig?: IDocumentRenderConfig,
+        textDirection?: TextDirection
     ): Nullable<DocumentDataModel> {
         if (!renderConfig) {
             return;
@@ -1191,6 +1192,16 @@ export class SheetSkeleton extends Skeleton {
             }
 
             paragraph.paragraphStyle.horizontalAlign = horizontalAlign;
+            // Only fall back to the cell-level text direction when the cell
+            // declared a non-UNSPECIFIED direction AND the paragraph itself
+            // does not declare one (rich-text paragraphs may set their own).
+            if (
+                textDirection != null
+                && textDirection !== TextDirection.UNSPECIFIED
+                && paragraph.paragraphStyle.direction == null
+            ) {
+                paragraph.paragraphStyle.direction = textDirection;
+            }
         }
 
         return new DocumentDataModel(documentData);

--- a/packages/core/src/sheets/typedef.ts
+++ b/packages/core/src/sheets/typedef.ts
@@ -727,10 +727,43 @@ export enum RANGE_DIRECTION {
     FORWARD = 'forward',
 }
 
+/**
+ * Caret affinity at a direction boundary.
+ *
+ * The same logical character offset corresponds to two visual positions
+ * whenever the offset lies on an LTR↔RTL boundary (see Unicode UAX#9 §5
+ * "Cursor Movement" and W3C css-text §8 "Caret"). Univer uses this hint
+ * to pick which visual position the caret should render at.
+ *
+ * - `downstream` (default): caret hugs the **leading** edge of the glyph
+ *   at `startOffset` — i.e. the visual position of "before the next
+ *   character in logical order". This matches the W3C Recommendation
+ *   and the muscle-memory of having just inserted that character.
+ * - `upstream`: caret hugs the **trailing** edge of the glyph at
+ *   `startOffset - 1` — "after the previous character in logical order".
+ *   Useful when the user arrived at the boundary from the upstream run
+ *   (e.g. arrow-leftward from an LTR run into an RTL run); rendering on
+ *   the upstream side keeps the caret visually adjacent to where it
+ *   came from.
+ *
+ * Operations should set affinity explicitly when they know which side
+ * the user was just on (Backspace/Delete, arrow keys, paste). Insertions
+ * default to `downstream` because the just-typed glyph is the "after"
+ * side of the caret.
+ */
+export type ICaretAffinity = 'upstream' | 'downstream';
+
 export interface ITextRange extends ITextRangeStart {
     endOffset: number;
     collapsed: boolean;
     direction?: RANGE_DIRECTION;
+    /**
+     * Caret affinity hint for direction-boundary disambiguation. See
+     * {@link ICaretAffinity}. Defaults to `downstream` when absent.
+     * Only meaningful when `collapsed === true`; non-collapsed ranges
+     * derive each end's affinity from its movement direction internally.
+     */
+    affinity?: ICaretAffinity;
 }
 
 export enum DOC_RANGE_TYPE {

--- a/packages/core/src/sheets/util.ts
+++ b/packages/core/src/sheets/util.ts
@@ -15,15 +15,15 @@
  */
 
 import type { Nullable } from '../shared';
-import type { CellValueType, TextDirection } from '../types/enum';
-import type { IDocumentData, IPaddingData, IStyleBase, IStyleData, ITextRotation, ITextStyle } from '../types/interfaces';
+import type { CellValueType } from '../types/enum';
+import type { IDocumentData, IPaddingData, IParagraphStyle, IStyleBase, IStyleData, ITextRotation, ITextStyle } from '../types/interfaces';
 import type { ICellData, IRange, IUnitRange } from './typedef';
 import { DEFAULT_EMPTY_DOCUMENT_VALUE } from '../common/const';
 import { BuildTextUtils, DocumentDataModel } from '../docs';
 import { TextX } from '../docs/data-model/text-x/text-x';
 import { convertTextRotation } from '../docs/data-model/utils';
 import { Rectangle } from '../shared';
-import { HorizontalAlign, VerticalAlign, WrapStrategy } from '../types/enum';
+import { HorizontalAlign, TextDirection, VerticalAlign, WrapStrategy } from '../types/enum';
 import { CustomRangeType, DocumentFlavor } from '../types/interfaces';
 
 export interface IFontLocale {
@@ -77,10 +77,21 @@ export function createDocumentModelWithStyle(content: string, textStyle: ITextSt
         verticalAlign = VerticalAlign.UNSPECIFIED,
         wrapStrategy = WrapStrategy.UNSPECIFIED,
         cellValueType,
+        textDirection,
     } = config;
 
     const { t: marginTop, r: marginRight, b: marginBottom, l: marginLeft } = paddingData || DEFAULT_PADDING_DATA;
     const { vertexAngle, centerAngle } = convertTextRotation(textRotation);
+    // Only attach `direction` to the paragraph style when an explicit, non-
+    // `UNSPECIFIED` text direction is supplied. We avoid writing `direction: 0`
+    // because the integer enum value 0 (`UNSPECIFIED`) is semantically "no
+    // opinion" — serialising it would dirty every paragraph snapshot in the
+    // codebase that pre-dates RTL support.
+    const hasExplicitDirection = textDirection != null && textDirection !== TextDirection.UNSPECIFIED;
+    const paragraphStyle: IParagraphStyle = hasExplicitDirection
+        ? { horizontalAlign, direction: textDirection }
+        : { horizontalAlign };
+
     const documentData: IDocumentData = {
         id: 'd',
         body: {
@@ -95,9 +106,7 @@ export function createDocumentModelWithStyle(content: string, textStyle: ITextSt
             paragraphs: [
                 {
                     startIndex: contentLength,
-                    paragraphStyle: {
-                        horizontalAlign,
-                    },
+                    paragraphStyle,
                 },
             ],
             sectionBreaks: [{
@@ -122,6 +131,11 @@ export function createDocumentModelWithStyle(content: string, textStyle: ITextSt
                 vertexAngle,
                 wrapStrategy,
                 cellValueType,
+                // Only emit the `textDirection` key when the cell actually
+                // declared a non-`UNSPECIFIED` direction; otherwise we leave
+                // the property absent so existing snapshots (which never
+                // contained the key) stay byte-identical.
+                ...(hasExplicitDirection ? { textDirection } : {}),
                 /**
                  * TODO@weird94
                  * This config was previously used to fix the issue of cell image editing, now remove it first.

--- a/packages/core/src/sheets/worksheet.ts
+++ b/packages/core/src/sheets/worksheet.ts
@@ -17,17 +17,17 @@
 import type { IDisposable } from '@wendellhu/redi';
 import type { IInterceptor } from '../common/interceptor';
 import type { IObjectMatrixPrimitiveType, Nullable } from '../shared';
-import type { BooleanNumber, HorizontalAlign, TextDirection, VerticalAlign, WrapStrategy } from '../types/enum';
-import type { IDocumentData, IDocumentRenderConfig, IPaddingData, IStyleData, ITextRotation } from '../types/interfaces';
+import type { BooleanNumber, HorizontalAlign, VerticalAlign, WrapStrategy } from '../types/enum';
+import type { IDocumentData, IDocumentRenderConfig, IPaddingData, IParagraphStyle, IStyleData, ITextRotation } from '../types/interfaces';
 import type { Styles } from './styles';
 import type { CustomData, ICellData, ICellDataForSheetInterceptor, ICellDataWithSpanAndDisplay, IFreeze, IRange, ISelectionCell, IWorksheetData } from './typedef';
 import { BuildTextUtils, DocumentDataModel } from '../docs';
 import { convertTextRotation, getFontStyleString } from '../docs/data-model/utils';
-import { composeStyles, ObjectMatrix, toDisposable, Tools } from '../shared';
+import { composeStyles, isFirstStrongCharRTL, ObjectMatrix, toDisposable, Tools } from '../shared';
 import { createRowColIter } from '../shared/row-col-iter';
 import { generateRandomId } from '../shared/tools';
 import { DEFAULT_STYLES } from '../types/const';
-import { CellValueType } from '../types/enum';
+import { CellValueType, TextDirection } from '../types/enum';
 import { DocumentFlavor } from '../types/interfaces';
 import { cloneWorksheetData } from './clone';
 import { ColumnManager } from './column-manager';
@@ -63,6 +63,14 @@ export interface ICellDocumentModelOption {
     isDeepClone?: boolean;
     displayRawFormula?: boolean;
     ignoreTextRotation?: boolean;
+    /**
+     * Forces the document model to use this text direction even when the
+     * cell's style does not declare one. Used by the canvas sheet renderer
+     * when the cell content auto-detected as RTL (first-strong character)
+     * but the user didn't explicitly set `style.td`. The implicit direction
+     * applies only when `style.td` is missing / UNSPECIFIED.
+     */
+    implicitTextDirection?: TextDirection;
 }
 
 const DEFAULT_CELL_DOCUMENT_MODEL_OPTION = {
@@ -1157,7 +1165,7 @@ export class Worksheet {
             return;
         }
 
-        const { isDeepClone, displayRawFormula, ignoreTextRotation } = {
+        const { isDeepClone, displayRawFormula, ignoreTextRotation, implicitTextDirection } = {
             ...DEFAULT_CELL_DOCUMENT_MODEL_OPTION,
             ...options,
         };
@@ -1173,10 +1181,29 @@ export class Worksheet {
         const verticalAlign: VerticalAlign = cellOtherConfig.verticalAlign || DEFAULT_STYLES.vt;
         const wrapStrategy: WrapStrategy = cellOtherConfig.wrapStrategy || DEFAULT_STYLES.tb;
         const paddingData: IPaddingData = cellOtherConfig.paddingData || DEFAULT_PADDING_DATA;
+        // `style.td` (text direction) is unwrapped by `extractOtherStyle`.
+        // Capture it here so every branch below can forward it down to the
+        // generated Doc model — both for the paragraph style (renderer baseline)
+        // and the document-level renderConfig (decides default alignment when
+        // `horizontalAlign === UNSPECIFIED`).
+        //
+        // Fallback order:
+        //   1. explicit `style.td`,
+        //   2. `options.implicitTextDirection` (auto-detected from content by
+        //      the caller, e.g. canvas renderer / editor bridge),
+        //   3. undefined (LTR baseline).
+        const explicitTextDirection = cellOtherConfig.textDirection ?? undefined;
+        const textDirection = explicitTextDirection != null && explicitTextDirection !== TextDirection.UNSPECIFIED
+            ? explicitTextDirection
+            : (implicitTextDirection != null && implicitTextDirection !== TextDirection.UNSPECIFIED
+                ? implicitTextDirection
+                : undefined);
 
         if (cell.f && displayRawFormula) {
-            // The formula does not detect horizontal alignment and rotation.
-            documentModel = createDocumentModelWithStyle(cell.f.toString(), {}, { verticalAlign });
+            // The formula does not detect horizontal alignment and rotation,
+            // but it should still respect the cell's text direction so that
+            // the default alignment (`_horizontalHandler`) flips for RTL cells.
+            documentModel = createDocumentModelWithStyle(cell.f.toString(), {}, { verticalAlign, textDirection });
             horizontalAlign = DEFAULT_STYLES.ht;
         } else if (cell.p) {
             const { centerAngle, vertexAngle } = convertTextRotation(textRotation);
@@ -1190,8 +1217,10 @@ export class Worksheet {
                     centerAngle,
                     vertexAngle,
                     wrapStrategy,
+                    textDirection,
                     zeroWidthParagraphBreak: 1,
-                }
+                },
+                textDirection
             );
         } else if (cell.v != null) {
             const textStyle = getFontFormat(style);
@@ -1209,6 +1238,11 @@ export class Worksheet {
                 ...cellOtherConfig,
                 textRotation,
                 cellValueType: cell.t!,
+                // Override with the resolved direction (explicit > implicit
+                // > none). When no explicit `style.td` exists but the
+                // content auto-detected as RTL, `textDirection` falls back
+                // to the implicit RTL direction supplied by the caller.
+                textDirection,
             });
         }
 
@@ -1242,19 +1276,26 @@ export class Worksheet {
         };
     }
 
+    // eslint-disable-next-line max-lines-per-function
     private _updateConfigAndGetDocumentModel(
-        documentData: IDocumentData,
+        sourceDocumentData: IDocumentData,
         horizontalAlign: HorizontalAlign,
         paddingData: IPaddingData,
-        renderConfig?: IDocumentRenderConfig
+        renderConfig?: IDocumentRenderConfig,
+        textDirection?: TextDirection
     ): Nullable<DocumentDataModel> {
         if (!renderConfig) {
             return;
         }
 
-        if (!documentData.body?.dataStream) {
+        if (!sourceDocumentData.body?.dataStream) {
             return;
         }
+
+        // Working copy alias so we can swap in a fresh body / documentStyle
+        // wrapper without mutating the original `cell.p` snapshot under
+        // the no-deep-clone path (see the paragraphs detach further below).
+        let documentData = sourceDocumentData;
 
         if (!documentData.documentStyle) {
             documentData.documentStyle = {};
@@ -1278,14 +1319,130 @@ export class Worksheet {
             ...renderConfig,
         };
 
-        const paragraphs = documentData.body.paragraphs || [];
+        // Shallow-copy the paragraphs array so that the per-paragraph
+        // mutations below don't leak back into the original `cell.p`
+        // snapshot when `isDeepClone === false`. The individual entries
+        // are also shallow-cloned inside the loop before we touch their
+        // `paragraphStyle`.
+        const body = documentData.body;
+        const originalParagraphs = body?.paragraphs ?? [];
+        const paragraphs = originalParagraphs.slice();
+        const dataStream = body?.dataStream || '';
 
-        for (const paragraph of paragraphs) {
-            if (!paragraph.paragraphStyle) {
-                paragraph.paragraphStyle = {};
+        // Resolve direction *per paragraph* so multi-line / list cells
+        // can mix LTR and RTL rows in one cell (e.g. an Arabic bullet
+        // followed by an English bullet, each right- or left-aligned by
+        // its own first-strong character).
+        //
+        // Priority for each paragraph:
+        //  1. `paragraphStyle.direction` already declared on the model
+        //     (e.g. via `RichTextBuilder.setDirection` or pasted content) —
+        //     takes precedence over everything; we never overwrite it.
+        //  2. Cell-level `style.td` (the `textDirection` argument): if the
+        //     user explicitly set a direction on the cell, every paragraph
+        //     inherits it. This matches Excel / Sheets where the cell
+        //     direction wins for all rows.
+        //  3. First-strong character within *that paragraph's* text slice:
+        //     mirrors the auto-detection used for simple-string cells, but
+        //     scoped to each paragraph independently so a list whose first
+        //     item is Arabic and second item is English picks the right
+        //     direction for each row.
+        //  4. Otherwise leave `direction` undefined (LTR baseline) so
+        //     clipboard / serialisation snapshots stay stable for pure
+        //     LTR rich-text content.
+        //
+        // Important: `documentData` (and therefore each `paragraph`) may
+        // alias the original `cell.p` snapshot — when the caller passes
+        // `isDeepClone: false` (the hot path for renderer cache lookups)
+        // we share references. Mutating `paragraph.paragraphStyle` in
+        // place would persist the auto-detected direction back into the
+        // cell snapshot and "stick" forever, breaking subsequent
+        // first-strong detection if the user clears the cell and types
+        // in the other direction. We therefore replace the paragraph
+        // entry with a shallow clone whenever we need to write into its
+        // style. Existing `direction` values are still respected, so
+        // explicit author/clipboard direction never gets clobbered.
+        let prevParagraphEnd = 0;
+        // Carry the previously-resolved direction so that a brand-new
+        // empty paragraph (e.g. one just inserted by Enter in the cell
+        // editor) inherits the writing direction of the line it was
+        // split from. Without this, an empty paragraph between two
+        // RTL paragraphs would silently fall back to LTR and flicker
+        // the cell's alignment.
+        let inheritedDir: TextDirection | undefined;
+        for (let i = 0; i < paragraphs.length; i++) {
+            const original = paragraphs[i];
+            const existingStyle = original.paragraphStyle ?? {};
+
+            const explicitParagraphDir = existingStyle.direction;
+            let resolvedDirection: TextDirection | undefined = explicitParagraphDir;
+            let detectedFromContent = false;
+            if (resolvedDirection == null) {
+                if (textDirection != null && textDirection !== TextDirection.UNSPECIFIED) {
+                    resolvedDirection = textDirection;
+                } else {
+                    const sliceStart = prevParagraphEnd;
+                    const sliceEnd = original.startIndex;
+                    const paragraphText = sliceEnd > sliceStart
+                        ? dataStream.slice(sliceStart, sliceEnd)
+                        : '';
+                    if (paragraphText.length === 0) {
+                        // Empty paragraph: inherit from the previous
+                        // paragraph we just resolved (this is the freshly
+                        // split-off line case). Leave `resolvedDirection`
+                        // undefined when there is no predecessor so the
+                        // overall LTR fallback elsewhere still applies.
+                        resolvedDirection = inheritedDir;
+                    } else if (isFirstStrongCharRTL(paragraphText)) {
+                        resolvedDirection = TextDirection.RIGHT_TO_LEFT;
+                        detectedFromContent = true;
+                    } else {
+                        // Treat any non-empty paragraph that doesn't start
+                        // with a strong RTL char as explicit LTR. Stamping
+                        // a value (rather than leaving `undefined`) gives
+                        // the docs engine an unambiguous baseline so a
+                        // previously RTL row that the user converted to
+                        // English flips back to LTR instead of inheriting
+                        // a stale level from the skeleton cache.
+                        resolvedDirection = TextDirection.LEFT_TO_RIGHT;
+                        detectedFromContent = true;
+                    }
+                }
             }
 
-            paragraph.paragraphStyle.horizontalAlign = horizontalAlign;
+            const nextStyle: IParagraphStyle = { ...existingStyle, horizontalAlign };
+            if (resolvedDirection != null) {
+                nextStyle.direction = resolvedDirection;
+            }
+            paragraphs[i] = { ...original, paragraphStyle: nextStyle };
+            inheritedDir = resolvedDirection ?? inheritedDir;
+
+            // Suppress unused-variable noise; the flag exists to document
+            // *why* we shallow-clone the paragraph above when our detector
+            // (rather than the author) supplied the direction. Mutating
+            // the original style in place would persist auto-detected
+            // direction back into `cell.p`, defeating future re-detection.
+            void detectedFromContent;
+
+            prevParagraphEnd = original.startIndex + 1;
+        }
+
+        // Build a fresh `documentData` for the DocumentDataModel so the
+        // mutated paragraphs array (and any direction we just stamped)
+        // never leaks back into the shared `cell.p` snapshot under the
+        // no-deep-clone path. We only need to detach `body.paragraphs`
+        // here because the rest of `documentData` (documentStyle,
+        // dataStream, textRuns) is reused as-is downstream and any
+        // already-existing pollution of `documentStyle` was there before
+        // this refactor — keeping that change out of scope.
+        if (body) {
+            documentData = {
+                ...documentData,
+                body: {
+                    ...body,
+                    paragraphs,
+                },
+            };
         }
 
         return new DocumentDataModel(documentData);
@@ -1297,11 +1454,17 @@ export class Worksheet {
     getBlankCellDocumentModel(cell: Nullable<ICellData>, row: number, column: number): IDocumentLayoutObject {
         const style = this.getComposedCellStyleByCellData(row, column, cell);
         const textStyle = getFontFormat(style);
-        const documentModelObject = this.getCellDocumentModel(cell, style, { ignoreTextRotation: true });
+        const implicitTextDirection = this._detectImplicitTextDirection(cell, style);
+        const documentModelObject = this.getCellDocumentModel(cell, style, {
+            ignoreTextRotation: true,
+            implicitTextDirection,
+        });
 
         if (documentModelObject != null) {
             if (documentModelObject.documentModel == null) {
-                documentModelObject.documentModel = createDocumentModelWithStyle('', textStyle);
+                documentModelObject.documentModel = createDocumentModelWithStyle('', textStyle, {
+                    textDirection: implicitTextDirection,
+                });
             }
             return documentModelObject;
         }
@@ -1318,7 +1481,9 @@ export class Worksheet {
 
         fontString = getFontStyleString({}).fontCache;
 
-        const documentModel = createDocumentModelWithStyle(content, textStyle);
+        const documentModel = createDocumentModelWithStyle(content, textStyle, {
+            textDirection: implicitTextDirection,
+        });
 
         return {
             documentModel,
@@ -1338,7 +1503,30 @@ export class Worksheet {
             isDeepClone: true,
             displayRawFormula: true,
             ignoreTextRotation: true,
+            implicitTextDirection: this._detectImplicitTextDirection(cell, style),
         });
+    }
+
+    /**
+     * Auto-detect text direction from the cell's content when the user has
+     * not explicitly set `style.td`. Matches Excel/Google Sheets behaviour:
+     * a cell that starts with Arabic / Hebrew is treated as RTL.
+     *
+     * Returns `undefined` when:
+     *  - `style.td` is already explicit (caller will use that), or
+     *  - the content does not start with a strong RTL character.
+     */
+    private _detectImplicitTextDirection(
+        cell: Nullable<ICellData>,
+        style: Nullable<IStyleData>
+    ): TextDirection | undefined {
+        const explicit = style?.td;
+        if (explicit != null && explicit !== TextDirection.UNSPECIFIED) {
+            return undefined;
+        }
+        if (cell == null) return undefined;
+        const text = extractPureTextFromCell(cell);
+        return isFirstStrongCharRTL(text) ? TextDirection.RIGHT_TO_LEFT : undefined;
     }
 
     /**

--- a/packages/core/src/types/interfaces/i-document-data.ts
+++ b/packages/core/src/types/interfaces/i-document-data.ts
@@ -499,6 +499,13 @@ export interface IDocumentRenderConfig {
     cellValueType?: CellValueType; // sheet cell type, In a spreadsheet cell, without any alignment settings applied, text should be left-aligned, numbers should be right-aligned, and Boolean values should be center-aligned.
     isRenderStyle?: BooleanNumber; // Whether to render the style(textRuns), used in formula bar editor. the default value is TRUE.
     zeroWidthParagraphBreak?: BooleanNumber; // Whether to render the paragraph \r to zero width. the default value is false.
+    /**
+     * Cell-level text direction. Carries the value of `style.td` through the
+     * cell → document model conversion so that the docs render pipeline
+     * (e.g. `_horizontalHandler`) can take it into account when deciding the
+     * default horizontal alignment for cells whose alignment is `UNSPECIFIED`.
+     */
+    textDirection?: TextDirection;
 }
 
 export interface ISectionBreakBase {

--- a/packages/docs-ui/src/commands/commands/doc-delete.command.ts
+++ b/packages/docs-ui/src/commands/commands/doc-delete.command.ts
@@ -44,6 +44,15 @@ import { CutContentCommand } from './clipboard.inner.command';
 import { DeleteCommand, UpdateCommand } from './core-editing.command';
 import { getCurrentParagraph } from './util';
 
+/**
+ * Logical characters removed by one BACKSPACE/DELETE on a skeleton glyph.
+ * Arabic word clusters (`charAdvances`) delete one code unit at a time;
+ * other multi-char glyphs (emoji, Tibetan) delete the whole glyph.
+ */
+function getGlyphDeleteStep(glyph: { count: number; charAdvances?: number[] }): number {
+    return glyph.charAdvances != null ? 1 : glyph.count;
+}
+
 export interface IDeleteCustomBlockParams {
     direction: DeleteDirection;
     range: ITextRangeWithStyle;
@@ -634,13 +643,14 @@ export const DeleteLeftCommand: ICommand = {
                         });
                     }
                 } else {
-                    cursor -= preGlyph.count;
+                    const deleteLen = getGlyphDeleteStep(preGlyph);
+                    cursor -= deleteLen;
                     result = await commandService.executeCommand(DeleteCommand.id, {
                         unitId: docDataModel.getUnitId(),
                         range: actualRange,
                         segmentId,
                         direction: DeleteDirection.LEFT,
-                        len: preGlyph.count,
+                        len: deleteLen,
                     });
                 }
             } else {
@@ -799,7 +809,7 @@ export const DeleteRightCommand: ICommand = {
                     segmentId,
                     direction: DeleteDirection.RIGHT,
                     textRanges,
-                    len: needDeleteGlyph.count,
+                    len: getGlyphDeleteStep(needDeleteGlyph),
                 });
             }
         } else {

--- a/packages/docs-ui/src/controllers/doc-move-cursor.controller.ts
+++ b/packages/docs-ui/src/controllers/doc-move-cursor.controller.ts
@@ -159,9 +159,11 @@ export class DocMoveCursorController extends Disposable {
         if (direction === Direction.LEFT || direction === Direction.RIGHT) {
             const preGlyph = skeleton.findNodeByCharIndex(focusOffset - 1, segmentId, segmentPage);
             const curGlyph = skeleton.findNodeByCharIndex(focusOffset, segmentId, segmentPage)!;
+            const preStep = preGlyph?.charAdvances != null ? 1 : (preGlyph?.count ?? 0);
+            const curStep = curGlyph?.charAdvances != null ? 1 : curGlyph.count;
 
             focusOffset =
-                direction === Direction.RIGHT ? focusOffset + curGlyph.count : focusOffset - (preGlyph?.count ?? 0);
+                direction === Direction.RIGHT ? focusOffset + curStep : focusOffset - preStep;
 
             focusOffset = Math.min(dataStreamLength - 2, Math.max(0, focusOffset));
 
@@ -263,11 +265,23 @@ export class DocMoveCursorController extends Disposable {
                 const curSpan = skeleton.findNodeByCharIndex(startOffset, segmentId, segmentPage)!;
                 const nextGlyph = skeleton.findNodeByCharIndex(startOffset + 1, segmentId, segmentPage);
 
+                // Cluster step rule: for caret-divisible cluster glyphs
+                // (e.g. the merged Arabic word that carries `charAdvances`),
+                // step by **one logical character** instead of jumping over
+                // the whole cluster. Non-divisible multi-char glyphs (emoji
+                // grapheme clusters, Tibetan phrases, etc.) keep the legacy
+                // "step the whole glyph" behaviour so a single ArrowRight
+                // moves past one emoji as a unit. We discriminate on the
+                // presence of `charAdvances`, which `ArabicHandler` is the
+                // sole producer of today.
+                const preStep = preSpan?.charAdvances != null ? 1 : (preSpan?.count ?? 1);
+                const curStep = curSpan?.charAdvances != null ? 1 : curSpan.count;
+
                 if (direction === Direction.LEFT) {
-                    cursor = Math.max(0, startOffset - (preSpan?.count ?? 1));
+                    cursor = Math.max(0, startOffset - preStep);
                 } else {
                     // -1 because the length of the string will be 1 larger than the index, and the reason for subtracting another 1 is because it ends in \n
-                    cursor = Math.min(dataStreamLength - 2, endOffset + curSpan.count + (nextGlyph?.streamType === DataStreamTreeTokenType.SECTION_BREAK ? 1 : 0));
+                    cursor = Math.min(dataStreamLength - 2, endOffset + curStep + (nextGlyph?.streamType === DataStreamTreeTokenType.SECTION_BREAK ? 1 : 0));
                 }
             }
             const skipTokens: string[] = [

--- a/packages/docs-ui/src/services/clipboard/udm-to-html/convertor.ts
+++ b/packages/docs-ui/src/services/clipboard/udm-to-html/convertor.ts
@@ -17,7 +17,7 @@
 import type { IDocumentBody, IDocumentData, IParagraph, ITable, ITableCell, ITextRun, ITextStyle } from '@univerjs/core';
 import type { IDocImage } from '@univerjs/docs-drawing';
 import type { DataStreamTreeNode } from '@univerjs/engine-render';
-import { BaselineOffset, BooleanNumber, CustomRangeType, DataStreamTreeNodeType, DrawingTypeEnum, HorizontalAlign, NamedStyleType, PresetListType, Tools } from '@univerjs/core';
+import { BaselineOffset, BooleanNumber, CustomRangeType, DataStreamTreeNodeType, DrawingTypeEnum, HorizontalAlign, NamedStyleType, PresetListType, TextDirection, Tools } from '@univerjs/core';
 import { ImageSourceType } from '@univerjs/drawing';
 import { parseDataStreamToTree } from '@univerjs/engine-render';
 
@@ -273,8 +273,17 @@ function processNode(node: DataStreamTreeNode, doc: IDocumentData, result: IHtml
             const { children, startIndex, endIndex } = node;
             const paragraph = doc.body?.paragraphs?.find((p) => p.startIndex === endIndex) ?? {} as IParagraph;
             const { paragraphStyle = {} } = paragraph;
-            const { horizontalAlign, spaceAbove, spaceBelow, lineSpacing } = paragraphStyle;
+            const { horizontalAlign, direction, spaceAbove, spaceBelow, lineSpacing } = paragraphStyle;
             const style = [];
+            const dir = direction === TextDirection.RIGHT_TO_LEFT
+                ? 'rtl'
+                : direction === TextDirection.LEFT_TO_RIGHT
+                    ? 'ltr'
+                    : undefined;
+
+            if (dir) {
+                style.push(`direction: ${dir}`);
+            }
 
             if (horizontalAlign != null) {
                 const align = getTextAlign(horizontalAlign);

--- a/packages/docs-ui/src/services/selection/convert-text-range.ts
+++ b/packages/docs-ui/src/services/selection/convert-text-range.ts
@@ -28,7 +28,8 @@ import type {
     INodePosition,
     IPoint,
 } from '@univerjs/engine-render';
-import { DocumentSkeletonPageType, getDocsTableRenderViewport, getPageFromPath, getTableIdAndSliceIndex, GlyphType, Liquid } from '@univerjs/engine-render';
+import { TextDirection } from '@univerjs/core';
+import { computeDocumentPageAlignOffset, DocumentSkeletonPageType, getDocsTableRenderViewport, getPageFromPath, getTableIdAndSliceIndex, GlyphType, Liquid } from '@univerjs/engine-render';
 
 export enum NodePositionStateType {
     NORMAL,
@@ -282,12 +283,6 @@ export class NodePositionConvertToCursor {
             const lastGlyph = glyphGroup[end_sp];
             const preGlyph = glyphGroup[start_sp - 1];
 
-            const firstGlyphLeft = firstGlyph?.left || 0;
-            const firstGlyphWidth = firstGlyph?.width || 0;
-
-            const lastGlyphLeft = lastGlyph?.left || 0;
-            const lastGlyphWidth = lastGlyph?.width || 0;
-
             const isCurrentList = firstGlyph?.glyphType === GlyphType.LIST;
 
             const { startOffset, endOffset } = getOffsetInDivide(glyphGroup, start_sp, end_sp, st);
@@ -303,34 +298,198 @@ export class NodePositionConvertToCursor {
                 ? startY + lineHeight - marginTop - marginBottom
                 : startY + paddingTop + contentHeight + paddingBottom;
 
+            // Caret position anchor for the start edge.
+            //
+            // `(firstGlyph, isStartBack=true)` ("caret *before* firstGlyph")
+            // and `(preGlyph, isStartBack=false)` ("caret *after* preGlyph")
+            // describe the same *logical* offset. For homogeneous-direction
+            // runs they render at identical X coords because
+            // `preGlyph.left + preGlyph.width === firstGlyph.left`.
+            //
+            // At a direction boundary they describe **two different visual
+            // positions** — this is the classic UAX#9 "caret affinity"
+            // problem (W3C css-text §8). The Univer text-range model has no
+            // affinity field yet (see docs/rtl/12-implementation-actual.md
+            // for the planned model), so we apply a deterministic
+            // tiebreaker: prefer the `preGlyph` anchor whenever it exists.
+            // `preGlyph` is the glyph the user just interacted with (the
+            // freshly inserted character, the one to the left of an arrow
+            // press, etc.), so anchoring "after preGlyph" matches the
+            // user's mental model in the common cases:
+            //
+            //   * just typed an Arabic char on an LTR line → caret stays
+            //     next to that char (its left edge, since it's RTL), not
+            //     at the trailing `\r`'s visual position.
+            //   * arrow-leftward from the start of an embedded LTR run
+            //     into RTL → caret sits on the RTL boundary glyph's "after"
+            //     edge, visually adjacent to where it came from.
+            //
+            // Fall back to `firstGlyph` when there's no preGlyph (caret at
+            // the divide head) or we're inside a list bullet (the bullet
+            // glyph itself anchors the caret).
+            const isInsideCurrentCluster = isFirst
+                && start.glyph === start_sp
+                && start.subOffset != null
+                && start.subOffset > 0;
+            const useStartFromPre = isStartBack && preGlyph != null && !isCurrentList && !isInsideCurrentCluster;
+            const startAnchor = useStartFromPre ? preGlyph : firstGlyph;
+            const startAnchorBack = useStartFromPre ? false : isStartBack;
+
+            const firstGlyphLeft = startAnchor?.left || 0;
+            const firstGlyphWidth = startAnchor?.width || 0;
+
+            const lastGlyphLeft = lastGlyph?.left || 0;
+            const lastGlyphWidth = lastGlyph?.width || 0;
+
+            // In RTL paragraphs the bidi-reorder step assigned visual `left`
+            // values so that logical-first glyphs render at the visual right
+            // (see `applyBidiReorderToLine`). Caret math must therefore
+            // *invert* the standard "isBack → left edge / !isBack → right
+            // edge" rule for the affected glyphs: visually, the right edge of
+            // an RTL glyph is its `left + width` *minus the inversion* — i.e.
+            // for a logical glyph that has been "visually reversed", "before"
+            // and "after" swap.
+            //
+            // Concretely, for an RTL glyph:
+            //   isBack === true  (caret *before* the logical char) → right edge
+            //                                                         = left + width
+            //   isBack === false (caret *after* the logical char)  → left edge
+            //                                                         = left
+            // For LTR glyphs the original rule (`isBack → left`, `!isBack → right`)
+            // still holds.
+            // Per-glyph bidi direction takes precedence over the line's
+            // baseline direction so mixed runs work correctly:
+            //   "Hello كتاب" on an LTR baseline → the Arabic glyphs carry
+            //                                       odd bidiLevel and flip on
+            //                                       their own.
+            //   "كتاب Hello" on an RTL baseline → the English glyphs carry
+            //                                       even level (≥2) and keep
+            //                                       their LTR caret rule.
+            // Fall back to the line baseline when `bidiLevel` is undefined
+            // (bidi pass skipped or not yet run).
+            const lineBaselineLevel = line.direction === TextDirection.RIGHT_TO_LEFT ? 1 : 0;
+            const isRtlAtLevel = (level: number | undefined) =>
+                (level ?? lineBaselineLevel) % 2 === 1;
+
+            const isStartGlyphRTL = isRtlAtLevel(startAnchor?.bidiLevel);
+            const isEndGlyphRTL = isRtlAtLevel(lastGlyph?.bidiLevel);
+
+            // Caret-edge X offset relative to `glyph.left`.
+            // LTR glyph:  `isBack` → left edge (0),         `!isBack` → right edge (width).
+            // RTL glyph:  `isBack` → right edge (width),    `!isBack` → left edge (0).
+            // After bidi-reorder, RTL glyphs have `left` pointing at their visual *left*
+            // edge with `width` extending to the visual *right* — but logical "before"
+            // (isBack=true) sits on the visual right, hence the inversion.
+            const edgeOffset = (back: boolean, width: number, rtl: boolean) =>
+                rtl ? (back ? width : 0) : (back ? 0 : width);
+
+            // Sub-glyph caret placement for cluster glyphs (multi-char
+            // glyphs such as the merged Arabic word). When the position
+            // carries a `subOffset`, place the caret at the char boundary
+            // inside the cluster using its `charAdvances` (cumulative
+            // logical-order widths). For RTL clusters we mirror because
+            // visual x grows leftwards through logical indices.
+            //
+            // Returns the in-glyph x offset (relative to `glyph.left`) or
+            // `undefined` if the cluster path doesn't apply, in which
+            // case callers fall back to `edgeOffset`.
+            const subOffsetWithin = (
+                glyph: typeof firstGlyph | undefined,
+                subOff: number | undefined,
+                rtl: boolean
+            ): number | undefined => {
+                if (glyph == null || subOff == null || glyph.count <= 1 || glyph.charAdvances == null) {
+                    return undefined;
+                }
+                const adv = glyph.charAdvances;
+                // logical prefix advance: 0 at sub=0, adv[i-1] otherwise.
+                const logicalX = subOff <= 0 ? 0 : adv[Math.min(subOff, adv.length) - 1];
+                return rtl ? glyph.width - logicalX : logicalX;
+            };
+
+            // Cluster sub-glyph offsets only apply when this is the
+            // single-divide partial path; `start_sp` and `end_sp` here
+            // are glyph indices, so we read `subOffset` off the
+            // corresponding original position. `start === end` for
+            // collapsed cursors so reusing `start.subOffset` /
+            // `end.subOffset` works for both anchor and focus edges.
+            const startSubX = isFirst && start.glyph === start_sp
+                ? subOffsetWithin(firstGlyph, start.subOffset, isStartGlyphRTL)
+                : undefined;
+            const endSubX = isLast && end.glyph === end_sp
+                ? subOffsetWithin(lastGlyph, end.subOffset, isEndGlyphRTL)
+                : undefined;
+
             if (start_sp === 0 && end_sp === glyphGroup.length - 1) {
+                // Full-divide selection: start at the divide's logical
+                // beginning, end at its logical end. Use each end's own
+                // glyph direction (in a homogeneous-direction line they
+                // both match `isRTLLine`; in mixed lines the boundary
+                // glyph governs).
+                const fullStartX = startX + firstGlyphLeft + (
+                    isCurrentList
+                        ? firstGlyphWidth // bullet stays on the start side
+                        : startSubX != null
+                            ? startSubX
+                            : isStartGlyphRTL ? firstGlyphWidth : 0
+                );
+                const fullEndX = startX + lastGlyphLeft
+                    + (endSubX != null ? endSubX : edgeOffset(isEndBack, lastGlyphWidth, isEndGlyphRTL));
+
                 borderBoxPosition = {
-                    startX: startX + firstGlyphLeft + (isCurrentList ? firstGlyphWidth : 0),
+                    startX: fullStartX,
                     startY: borderBoxStartY,
-                    endX: startX + lastGlyphLeft + (isEndBack ? 0 : lastGlyphWidth),
+                    endX: fullEndX,
                     endY: borderBoxEndY,
                 };
 
                 contentBoxPosition = {
-                    startX: startX + firstGlyphLeft + (isCurrentList ? firstGlyphWidth : 0),
+                    startX: fullStartX,
                     startY: startY + paddingTop + asc - anchorGlyph.bBox.ba,
-                    endX: startX + lastGlyphLeft + (isEndBack ? 0 : lastGlyphWidth),
+                    endX: fullEndX,
                     endY: startY + paddingTop + asc + anchorGlyph.bBox.bd,
                 };
             } else {
-                const isStartBackFin = isStartBack && !isCurrentList;
+                const isStartBackFin = startAnchorBack && !isCurrentList;
+
+                // Sub-glyph offset takes precedence over `isStartBackFin`
+                // when the caret position points *inside* a cluster
+                // glyph. `startSubX` was computed using `firstGlyph` and
+                // `start.subOffset`, but the actual paint anchor may be
+                // `preGlyph` (the start ambiguity resolution above). The
+                // sub-glyph caret only matters when we're rendering on
+                // `firstGlyph`, so guard on `startAnchor === firstGlyph`.
+                const startSubXForAnchor =
+                    startAnchor === firstGlyph ? startSubX : undefined;
+
+                // Use per-glyph direction here so the caret sits on the
+                // correct visual side at script boundaries (the partial
+                // selection branch is what fires during typing / arrow-key
+                // navigation, so mixed-direction caret accuracy lives here).
+                // `startAnchor` may point at the *previous* glyph (see the
+                // ambiguity-resolution comment above), in which case
+                // `startAnchorBack` is `false` and we correctly land on its
+                // "after" edge.
+                const partialStartX = startX + firstGlyphLeft
+                    + (startSubXForAnchor != null
+                        ? startSubXForAnchor
+                        : edgeOffset(isStartBackFin, firstGlyphWidth, isStartGlyphRTL));
+                const partialEndX = startX + lastGlyphLeft
+                    + (endSubX != null
+                        ? endSubX
+                        : edgeOffset(isEndBack, lastGlyphWidth, isEndGlyphRTL));
 
                 borderBoxPosition = {
-                    startX: startX + firstGlyphLeft + (isStartBackFin ? 0 : firstGlyphWidth),
+                    startX: partialStartX,
                     startY: borderBoxStartY,
-                    endX: startX + lastGlyphLeft + (isEndBack ? 0 : lastGlyphWidth),
+                    endX: partialEndX,
                     endY: borderBoxEndY,
                 };
 
                 contentBoxPosition = {
-                    startX: startX + firstGlyphLeft + (isStartBackFin ? 0 : firstGlyphWidth),
+                    startX: partialStartX,
                     startY: startY + paddingTop + asc - anchorGlyph.bBox.ba,
-                    endX: startX + lastGlyphLeft + (isEndBack ? 0 : lastGlyphWidth),
+                    endX: partialEndX,
                     endY: startY + paddingTop + asc + anchorGlyph.bBox.bd,
                 };
             }
@@ -345,9 +504,26 @@ export class NodePositionConvertToCursor {
                 contentBoxPointGroup.push(pushToPoints(clippedContentBoxPosition));
             }
 
+            // Cluster-aware logical offsets: when the caret position
+            // refers to a char inside a cluster glyph (e.g. between two
+            // Arabic letters of a merged word) the offset is
+            // `startOffset + subOffset` rather than the legacy
+            // glyph-coarse `startOffset` / `startOffset + count`. This
+            // keeps `cursorList` consistent with what
+            // `findCharIndexByPosition` returns for the same position.
+            const startSubInCluster = isFirst && start.glyph === start_sp ? start.subOffset : undefined;
+            const endSubInCluster = isLast && end.glyph === end_sp ? end.subOffset : undefined;
+
+            const finalStartOffset = (startSubInCluster != null && firstGlyph && firstGlyph.count > 1)
+                ? startOffset + startSubInCluster
+                : (isStartBack ? startOffset : startOffset + firstGlyph.count);
+            const finalEndOffset = (endSubInCluster != null && lastGlyph && lastGlyph.count > 1)
+                ? endOffset + endSubInCluster
+                : (isEndBack ? endOffset : endOffset + lastGlyph.count);
+
             cursorList.push({
-                startOffset: isStartBack ? startOffset : startOffset + firstGlyph.count,
-                endOffset: isEndBack ? endOffset : endOffset + lastGlyph.count,
+                startOffset: finalStartOffset,
+                endOffset: finalEndOffset,
                 collapsed,
             });
         });
@@ -523,7 +699,7 @@ export class NodePositionConvertToCursor {
             return [];
         }
 
-        const { pageLayoutType, pageMarginLeft, pageMarginTop } = this._documentOffsetConfig;
+        const { pageLayoutType, pageMarginLeft, pageMarginTop, docsWidth, docsHeight } = this._documentOffsetConfig;
 
         const skipPageIndex = (pageType === DocumentSkeletonPageType.BODY || pageType === DocumentSkeletonPageType.CELL) ? pageIndex : segmentPage;
         for (let p = 0; p < skipPageIndex; p++) {
@@ -603,6 +779,19 @@ export class NodePositionConvertToCursor {
                 default:
                     this._liquid.translatePagePadding(page);
                     break;
+            }
+
+            if (docsWidth > 0 && docsHeight > 0) {
+                const alignPage = pageType === DocumentSkeletonPageType.CELL ? segmentPage : page;
+                const { x: alignX, y: alignY } = computeDocumentPageAlignOffset(docsWidth, docsHeight, alignPage);
+                // `translatePagePadding` already applied marginLeft/marginTop; for LEFT
+                // `_horizontalHandler` only repeats those — apply the extra center/right
+                // offset so the caret matches painted glyphs.
+                const extraX = alignX - (alignPage.marginLeft ?? 0);
+                const extraY = alignY - (alignPage.marginTop ?? 0);
+                if (extraX !== 0 || extraY !== 0) {
+                    this._liquid.translate(extraX, extraY);
+                }
             }
 
             for (let s = start_s; s <= end_s; s++) {

--- a/packages/docs-ui/src/services/selection/doc-selection-render.service.ts
+++ b/packages/docs-ui/src/services/selection/doc-selection-render.service.ts
@@ -745,6 +745,11 @@ export class DocSelectionRenderService extends RxDisposable implements IRenderMo
         `;
 
         this._input.contentEditable = 'true';
+        // Default to `auto` so the browser picks RTL/LTR based on the typed
+        // characters even before the host (e.g. EditorContainer) has had a
+        // chance to set the direction explicitly. This keeps IME behaviour
+        // stable on Windows / macOS for both LTR and RTL inputs.
+        this._input.dir = 'auto';
 
         // TODO: to be removed
         this._input.dataset.uComp = 'editor';
@@ -761,6 +766,17 @@ export class DocSelectionRenderService extends RxDisposable implements IRenderMo
             white-space: pre-wrap;
             user-select: text;
         `;
+    }
+
+    /**
+     * Force the hidden contenteditable input to a specific writing direction.
+     * Called by the cell editor container when entering a cell with a known
+     * `style.td`. Pass `'auto'` to let the browser decide based on content.
+     */
+    setInputDirection(direction: 'ltr' | 'rtl' | 'auto'): void {
+        if (this._input) {
+            this._input.dir = direction;
+        }
     }
 
     private _ensureHostContainer(): void {
@@ -783,10 +799,10 @@ export class DocSelectionRenderService extends RxDisposable implements IRenderMo
             return;
         }
 
-        const { node: glyph, ratioX, segmentPage } = node;
+        const { node: glyph, ratioX, segmentPage, subOffset } = node;
 
         const skeleton = this._docSkeletonManagerService.getSkeleton();
-        const position = skeleton.findPositionByGlyph(glyph, segmentPage);
+        const position = skeleton.findPositionByGlyph(glyph, segmentPage, subOffset);
 
         if (position == null) {
             return;
@@ -799,9 +815,21 @@ export class DocSelectionRenderService extends RxDisposable implements IRenderMo
             isBack = true;
         }
 
+        // For cluster glyphs (multi-char glyphs such as the merged
+        // Arabic word) `subOffset` is the authoritative caret position:
+        // `isBack === true` is interpreted by `findCharIndexByPosition`
+        // as the leading edge of the glyph, which is wrong when the
+        // caret should sit *between* two chars inside the cluster. When
+        // `subOffset` is in `(0, count)` we force `isBack = true` so
+        // the index path uses `index + subOffset` (not `index + count`)
+        // — see `findCharIndexByPosition`.
+        const effectiveIsBack = subOffset != null && glyph.count > 1
+            ? subOffset < glyph.count
+            : isBack;
+
         return {
             ...position,
-            isBack,
+            isBack: effectiveIsBack,
         };
     }
 

--- a/packages/docs-ui/src/views/rich-text-editor/hooks/use-left-and-right-arrow.ts
+++ b/packages/docs-ui/src/views/rich-text-editor/hooks/use-left-and-right-arrow.ts
@@ -15,20 +15,52 @@
  */
 
 import type { Editor } from '../../../services/editor/editor';
-import { CommandType, Direction, DisposableCollection, ICommandService } from '@univerjs/core';
+import { CommandType, Direction, DisposableCollection, ICommandService, TextDirection } from '@univerjs/core';
 import { DeviceInputEventType } from '@univerjs/engine-render';
 import { IShortcutService, KeyCode, MetaKeys, useDependency } from '@univerjs/ui';
 import { useEffect, useRef } from 'react';
 import { MoveCursorOperation, MoveSelectionOperation } from '../../../commands/operations/doc-cursor.operation';
 
+export interface IUseLeftAndRightArrowOptions {
+    /**
+     * Force a writing direction for arrow-key mapping regardless of the
+     * editor's paragraph direction. Used e.g. by the formula bar to lock
+     * LTR behaviour even when the surrounding sheet / cell is RTL.
+     */
+    forceDirection?: 'ltr' | 'rtl';
+}
+
+function readEditorTextDirection(editor: Editor | undefined): TextDirection {
+    if (!editor) return TextDirection.UNSPECIFIED;
+    try {
+        // For cell / formula editors the document typically contains a single
+        // paragraph, and that paragraph carries `direction` populated by
+        // `createDocumentModelWithStyle`. Reading the first paragraph is a good
+        // heuristic and avoids resolving the cursor against the skeleton.
+        const data = editor.getDocumentData();
+        const direction = data.body?.paragraphs?.[0]?.paragraphStyle?.direction;
+        return direction ?? TextDirection.UNSPECIFIED;
+    } catch {
+        return TextDirection.UNSPECIFIED;
+    }
+}
+
 // eslint-disable-next-line max-lines-per-function
-export const useLeftAndRightArrow = (isNeed: boolean, selectingMode: boolean, editor?: Editor, onMoveInEditor?: (keyCode: KeyCode, metaKey?: MetaKeys) => void) => {
+export const useLeftAndRightArrow = (
+    isNeed: boolean,
+    selectingMode: boolean,
+    editor?: Editor,
+    onMoveInEditor?: (keyCode: KeyCode, metaKey?: MetaKeys) => void,
+    options?: IUseLeftAndRightArrowOptions
+) => {
     const commandService = useDependency(ICommandService);
     const shortcutService = useDependency(IShortcutService);
     const selectingModeRef = useRef(selectingMode);
     selectingModeRef.current = selectingMode;
     const onMoveInEditorRef = useRef(onMoveInEditor);
     onMoveInEditorRef.current = onMoveInEditor;
+    const forceDirectionRef = useRef(options?.forceDirection);
+    forceDirectionRef.current = options?.forceDirection;
 
     useEffect(() => {
         if (!editor || !isNeed) {
@@ -43,13 +75,28 @@ export const useLeftAndRightArrow = (isNeed: boolean, selectingMode: boolean, ed
                 return;
             }
 
+            // Decide effective direction:
+            //  - explicit `forceDirection` always wins (formula bar pins LTR).
+            //  - otherwise read the current editor's paragraph direction.
+            const forced = forceDirectionRef.current;
+            const effectiveDir = forced === 'rtl'
+                ? TextDirection.RIGHT_TO_LEFT
+                : forced === 'ltr'
+                    ? TextDirection.LEFT_TO_RIGHT
+                    : readEditorTextDirection(editor);
+            const isRTL = effectiveDir === TextDirection.RIGHT_TO_LEFT;
+
             let direction = Direction.LEFT;
             if (keycode === KeyCode.ARROW_DOWN) {
                 direction = Direction.DOWN;
             } else if (keycode === KeyCode.ARROW_UP) {
                 direction = Direction.UP;
+            } else if (keycode === KeyCode.ARROW_LEFT) {
+                // In RTL paragraphs the physical left arrow advances the
+                // logical cursor (matches macOS / Excel / Google Sheets).
+                direction = isRTL ? Direction.RIGHT : Direction.LEFT;
             } else if (keycode === KeyCode.ARROW_RIGHT) {
-                direction = Direction.RIGHT;
+                direction = isRTL ? Direction.LEFT : Direction.RIGHT;
             }
 
             if (metaKey === MetaKeys.SHIFT) {

--- a/packages/docs-ui/src/views/rich-text-editor/index.tsx
+++ b/packages/docs-ui/src/views/rich-text-editor/index.tsx
@@ -49,6 +49,13 @@ export interface IRichTextEditorProps {
     icon?: ReactNode;
     editorRef?: RefObject<Editor | null> | ((editor: Editor | null) => void);
     noStyle?: boolean;
+    /**
+     * Writing direction for the wrapper element. Defaults to `'auto'` so the
+     * browser inherits from the surrounding ConfigProvider / cell editor.
+     * The formula bar pins this to `'ltr'` so formula syntax is never mirrored.
+     * Also forwarded to the arrow-key hook to lock visual<->logical mapping.
+     */
+    direction?: 'ltr' | 'rtl' | 'auto';
 }
 
 export const RichTextEditor = (props: IRichTextEditorProps) => {
@@ -71,6 +78,7 @@ export const RichTextEditor = (props: IRichTextEditorProps) => {
         editorRef,
         placeholder,
         noStyle,
+        direction = 'auto',
     } = props;
     const editorService = useDependency(IEditorService);
     const onFocusChange = useEvent(_onFocusChange);
@@ -132,12 +140,18 @@ export const RichTextEditor = (props: IRichTextEditorProps) => {
 
     useEditorClickOutside(editorId, sheetEmbeddingRef, onClickOutside);
 
-    useLeftAndRightArrow(isFocusing && moveCursor, false, editor);
+    useLeftAndRightArrow(
+        isFocusing && moveCursor,
+        false,
+        editor,
+        undefined,
+        direction === 'auto' ? undefined : { forceDirection: direction }
+    );
     useKeyboardEvent(isFocusing, keyboardEventConfig, editor);
     useOnChange(editor, onChange);
 
     return (
-        <div className={className} style={style}>
+        <div className={className} style={style} dir={direction}>
             <div
                 className={clsx(
                     {

--- a/packages/engine-render/package.json
+++ b/packages/engine-render/package.json
@@ -71,6 +71,7 @@
         "@floating-ui/dom": "^1.7.4",
         "@floating-ui/utils": "^0.2.10",
         "@univerjs/core": "workspace:*",
+        "bidi-js": "^1.0.3",
         "cjk-regex": "^3.4.0",
         "franc-min": "^6.2.0",
         "opentype.js": "^2.0.0"

--- a/packages/engine-render/src/basics/i-document-skeleton-cached.ts
+++ b/packages/engine-render/src/basics/i-document-skeleton-cached.ts
@@ -28,6 +28,7 @@ import type {
     ITableRow,
     ITextStyle,
     PageOrientType,
+    TextDirection,
 } from '@univerjs/core';
 import type { BreakPointType } from '../components/docs/layout/line-breaker/break';
 
@@ -186,6 +187,14 @@ export interface IDocumentSkeletonLine {
     isBehindTable: boolean; // In DataStream, if paragraph contains table, the first line isBehindTable is true and tableId is not empty, mainly used to calculate st\ed.
     tableId: string; // tableId if paragraph contains table, tableId is not empty, mainly used to calculate st\ed.
 
+    /**
+     * Paragraph-level writing direction propagated from `IParagraphStyle.direction`.
+     * `undefined` (or `UNSPECIFIED`) means LTR baseline. Consumed by
+     * `horizontalAlignHandler` and the document render to flip default alignment
+     * and `isBack` semantics in selection.
+     */
+    direction?: TextDirection;
+
     borderBottom?: IParagraphBorder; // borderBottom
     bullet?: IDocumentSkeletonBullet; // unordered and ordered list bullet
     width?: number; // the actual width of a line
@@ -200,6 +209,14 @@ export interface IDocumentSkeletonDivide {
     width: number; // width: Total width after division
     left: number; // left: Offset position after division by objects | d1 | | d2 |
     paddingLeft: number; // paddingLeft: Alignment offset calculated based on horizonAlign and width
+    /**
+     * paddingRight: only used for RTL paragraphs. In LTR paragraphs the
+     * available space is consumed via `paddingLeft`; in RTL paragraphs we
+     * need to push glyphs from the right edge, so this field carries the
+     * remaining-space offset that downstream renderers add to `left`.
+     * Defaults to `0` so LTR code paths see no behavioural change.
+     */
+    paddingRight?: number;
     isFull: boolean; // isFull: Whether content is full
     st: number; // startIndex
     ed: number; // endIndex
@@ -235,6 +252,44 @@ export interface IDocumentSkeletonGlyph {
     url?: string; // image url
     featureId?: string; // support interaction for feature ,eg. hyperLine person
     drawingId?: string; // drawing.drawingId
+    /**
+     * Unicode bidi embedding level assigned by `applyBidiReorderToLine`.
+     * Even levels (0, 2, ...) are LTR; odd levels (1, 3, ...) are RTL.
+     * Used by caret / selection rendering to invert the "isBack → left edge"
+     * rule per-glyph, so mixed runs (e.g. English + Arabic in one line)
+     * position the caret on the correct visual side at each segment border.
+     *
+     * `undefined` means the bidi pass hasn't run or the glyph has no
+     * resolved level (callers should treat it as 0 / LTR).
+     */
+    bidiLevel?: number;
+    /**
+     * For "cluster" glyphs that hold more than one logical character — e.g.
+     * the single glyph the Arabic shaper produces for a whole word so the
+     * browser can apply cursive joining (initial / medial / final / isolated
+     * forms) — this is the per-character cumulative advance in **logical
+     * order**, measured by `ctx.measureText(content.slice(0, i + 1))` at
+     * shape time.
+     *
+     * - `charAdvances.length === content.length` when present.
+     * - `charAdvances[i]` is the x-advance from the glyph's left edge to the
+     *   trailing edge of the i-th character; so `charAdvances[count - 1]`
+     *   equals `width` modulo rounding.
+     * - Absent for single-character glyphs and for clusters whose shaping
+     *   path doesn't measure prefixes — callers must fall back to "treat the
+     *   whole glyph as one caret cell" (the legacy behaviour).
+     *
+     * Used by:
+     *  - `_collectNearestNode` to refine a hit into a `subOffset` inside the
+     *    cluster, so clicking the middle of an Arabic word lands the caret
+     *    on the right character.
+     *  - The caret painter (`_getNodePosition` + caret-translate) to draw the
+     *    caret at the actual char boundary instead of at the cluster edge.
+     *  - The keyboard step-by-char path (`getGlyphCharIndex` style lookups)
+     *    so `ArrowLeft` / `ArrowRight` advance one logical character at a
+     *    time inside a cluster.
+     */
+    charAdvances?: number[];
 }
 
 export interface IDocumentSkeletonBullet {

--- a/packages/engine-render/src/basics/interfaces.ts
+++ b/packages/engine-render/src/basics/interfaces.ts
@@ -167,6 +167,21 @@ export interface INodeInfo {
     ratioY: number;
     segmentId: string;
     segmentPage: number; // The index of the page where node is located.
+    /**
+     * For cluster glyphs (multi-character glyphs such as the merged
+     * Arabic word produced by `ArabicHandler` to support cursive
+     * joining), this is the character index *inside* the glyph that the
+     * hit-test resolved to. Range: `[0, node.count]`. A value of `0`
+     * means the hit is at the visual leading edge of the cluster (caret
+     * should sit before the first char); `node.count` means it's at the
+     * trailing edge (after the last char).
+     *
+     * Absent for single-char glyphs and for hit-tests that didn't refine
+     * into a cluster. Callers that need exact in-cluster placement (e.g.
+     * `_getNodePosition`) consume this; callers that still operate at
+     * glyph granularity ignore it and fall back to `ratioX < 0.5`.
+     */
+    subOffset?: number;
 }
 
 export interface INodeSearch {
@@ -179,6 +194,14 @@ export interface INodeSearch {
     segmentPage: number; // The index of the page where the header and footer reside.
     pageType: DocumentSkeletonPageType;
     path: (string | number)[];
+    /**
+     * Sub-glyph character offset for cluster glyphs (see
+     * `INodeInfo.subOffset`). Range: `[0, glyph.count]`. Propagated
+     * through `findPositionByGlyph` so consumers like the caret painter
+     * and the keyboard step path can render / step at the correct
+     * intra-cluster char boundary. Absent for non-cluster hits.
+     */
+    subOffset?: number;
 }
 
 export interface INodePosition extends INodeSearch {

--- a/packages/engine-render/src/components/docs/document.ts
+++ b/packages/engine-render/src/components/docs/document.ts
@@ -25,7 +25,7 @@ import type { ComponentExtension, IDrawInfo, IExtensionConfig } from '../extensi
 import type { IDocumentsConfig, IPageMarginLayout } from './doc-component';
 import type { DocumentSkeleton } from './layout/doc-skeleton';
 import type { IDocsTableRenderViewport } from './table-render-viewport';
-import { CellValueType, DashStyleType, HorizontalAlign, VerticalAlign, WrapStrategy } from '@univerjs/core';
+import { CellValueType, DashStyleType, HorizontalAlign, TextDirection, VerticalAlign, WrapStrategy } from '@univerjs/core';
 import { Subject } from 'rxjs';
 import { BORDER_TYPE as BORDER_LTRB, drawLineByBorderType } from '../../basics';
 import { calculateRectRotate, getRotateOffsetAndFarthestHypotenuse } from '../../basics/draw';
@@ -58,7 +58,105 @@ export interface IPageRenderConfig {
 export interface IDocumentOffsetConfig extends IPageMarginLayout {
     docsLeft: number;
     docsTop: number;
+    docsWidth: number;
+    docsHeight: number;
     documentTransform: Transform;
+}
+
+/**
+ * Page-level horizontal offset used by `Documents._horizontalHandler` when
+ * painting. Selection/caret code must apply the same offset so the cursor
+ * lines up with centered (and right-aligned) cell text.
+ */
+export function computeDocumentPageHorizontalAlignOffset(
+    componentWidth: number,
+    pageContentWidth: number,
+    pagePaddingLeft: number,
+    pagePaddingRight: number,
+    renderConfig: IDocumentRenderConfig = {}
+): number {
+    let {
+        horizontalAlign = HorizontalAlign.LEFT,
+        centerAngle: centerAngleDeg = 0,
+        vertexAngle: vertexAngleDeg = 0,
+        cellValueType,
+        textDirection,
+    } = renderConfig;
+
+    if (horizontalAlign === HorizontalAlign.UNSPECIFIED) {
+        if (centerAngleDeg === VERTICAL_ROTATE_ANGLE && vertexAngleDeg === VERTICAL_ROTATE_ANGLE) {
+            horizontalAlign = HorizontalAlign.CENTER;
+        } else if ((vertexAngleDeg > 0 && vertexAngleDeg !== VERTICAL_ROTATE_ANGLE) || vertexAngleDeg === -VERTICAL_ROTATE_ANGLE) {
+            horizontalAlign = HorizontalAlign.RIGHT;
+        } else {
+            const isRTL = textDirection === TextDirection.RIGHT_TO_LEFT;
+            if (cellValueType === CellValueType.NUMBER) {
+                horizontalAlign = HorizontalAlign.RIGHT;
+            } else if (cellValueType === CellValueType.BOOLEAN) {
+                horizontalAlign = HorizontalAlign.CENTER;
+            } else {
+                horizontalAlign = isRTL ? HorizontalAlign.RIGHT : HorizontalAlign.LEFT;
+            }
+        }
+    }
+
+    if (horizontalAlign === HorizontalAlign.CENTER) {
+        return (componentWidth - pageContentWidth) / 2;
+    }
+    if (horizontalAlign === HorizontalAlign.RIGHT) {
+        return componentWidth - pageContentWidth - pagePaddingRight;
+    }
+    return pagePaddingLeft;
+}
+
+export function computeDocumentPageVerticalAlignOffset(
+    componentHeight: number,
+    pageContentHeight: number,
+    pagePaddingTop: number,
+    pagePaddingBottom: number,
+    verticalAlign: VerticalAlign = VerticalAlign.TOP
+): number {
+    if (verticalAlign === VerticalAlign.MIDDLE) {
+        return (componentHeight - pageContentHeight) / 2;
+    }
+    if (verticalAlign === VerticalAlign.TOP) {
+        return pagePaddingTop;
+    }
+    return componentHeight - pageContentHeight - pagePaddingBottom;
+}
+
+export function computeDocumentPageAlignOffset(
+    componentWidth: number,
+    componentHeight: number,
+    page: IDocumentSkeletonPage
+): { x: number; y: number } {
+    const {
+        marginTop: pagePaddingTop = 0,
+        marginBottom: pagePaddingBottom = 0,
+        marginLeft: pagePaddingLeft = 0,
+        marginRight: pagePaddingRight = 0,
+        width: pageContentWidth = 0,
+        height: pageContentHeight = 0,
+        renderConfig = {},
+    } = page;
+    const { verticalAlign = VerticalAlign.TOP } = renderConfig;
+
+    return {
+        x: computeDocumentPageHorizontalAlignOffset(
+            componentWidth,
+            pageContentWidth,
+            pagePaddingLeft,
+            pagePaddingRight,
+            renderConfig
+        ),
+        y: computeDocumentPageVerticalAlignOffset(
+            componentHeight,
+            pageContentHeight,
+            pagePaddingTop,
+            pagePaddingBottom,
+            verticalAlign
+        ),
+    };
 }
 
 export class Documents extends DocComponent {
@@ -104,6 +202,8 @@ export class Documents extends DocComponent {
             pageMarginTop,
             docsLeft,
             docsTop,
+            docsWidth: this.width,
+            docsHeight: this.height,
         };
     }
 
@@ -170,6 +270,7 @@ export class Documents extends DocComponent {
                 vertexAngle: vertexAngleDeg = 0,
                 wrapStrategy = WrapStrategy.UNSPECIFIED,
                 cellValueType,
+                textDirection,
                 // isRotateNonEastAsian = BooleanNumber.FALSE,
             } = renderConfig;
             const isVertical = vertexAngleDeg === VERTICAL_ROTATE_ANGLE && centerAngleDeg === VERTICAL_ROTATE_ANGLE;
@@ -180,7 +281,8 @@ export class Documents extends DocComponent {
                 horizontalAlign,
                 vertexAngleDeg,
                 centerAngleDeg,
-                cellValueType
+                cellValueType,
+                textDirection
             );
             const verticalOffsetNoAngle = this._verticalHandler(
                 actualHeight,
@@ -292,7 +394,9 @@ export class Documents extends DocComponent {
                             pagePaddingRight,
                             horizontalAlign,
                             vertexAngleDeg,
-                            centerAngleDeg
+                            centerAngleDeg,
+                            cellValueType,
+                            textDirection
                         );
 
                         const verticalOffset = this._verticalHandler(
@@ -1146,47 +1250,22 @@ export class Documents extends DocComponent {
         horizontalAlign: HorizontalAlign,
         vertexAngleDeg: number = 0,
         centerAngleDeg: number = 0,
-        cellValueType: Nullable<CellValueType>
+        cellValueType: Nullable<CellValueType>,
+        textDirection?: TextDirection
     ) {
-        /**
-         * In Excel, if horizontal alignment is not specified,
-         * rotated text aligns to the right when rotated downwards and aligns to the left when rotated upwards.
-         */
-        if (horizontalAlign === HorizontalAlign.UNSPECIFIED) {
-            if (centerAngleDeg === VERTICAL_ROTATE_ANGLE && vertexAngleDeg === VERTICAL_ROTATE_ANGLE) {
-                horizontalAlign = HorizontalAlign.CENTER;
-            } else if ((vertexAngleDeg > 0 && vertexAngleDeg !== VERTICAL_ROTATE_ANGLE) || vertexAngleDeg === -VERTICAL_ROTATE_ANGLE) {
-                /**
-                 * https://github.com/dream-num/univer-pro/issues/334
-                 */
-                horizontalAlign = HorizontalAlign.RIGHT;
-            } else {
-                /**
-                 * sheet cell type, In a spreadsheet cell, without any alignment settings applied,
-                 * text should be left-aligned,
-                 * numbers should be right-aligned,
-                 * and Boolean values should be center-aligned.
-                 */
-                if (cellValueType === CellValueType.NUMBER) {
-                    horizontalAlign = HorizontalAlign.RIGHT;
-                } else if (cellValueType === CellValueType.BOOLEAN) {
-                    horizontalAlign = HorizontalAlign.CENTER;
-                } else {
-                    horizontalAlign = HorizontalAlign.LEFT;
-                }
+        return computeDocumentPageHorizontalAlignOffset(
+            this.width,
+            pageWidth,
+            pagePaddingLeft,
+            pagePaddingRight,
+            {
+                horizontalAlign,
+                vertexAngle: vertexAngleDeg,
+                centerAngle: centerAngleDeg,
+                cellValueType: cellValueType ?? undefined,
+                textDirection,
             }
-        }
-
-        let offsetLeft = 0;
-        if (horizontalAlign === HorizontalAlign.CENTER) {
-            offsetLeft = (this.width - pageWidth) / 2;
-        } else if (horizontalAlign === HorizontalAlign.RIGHT) {
-            offsetLeft = this.width - pageWidth - pagePaddingRight;
-        } else {
-            offsetLeft = pagePaddingLeft;
-        }
-
-        return offsetLeft;
+        );
     }
 
     private _verticalHandler(
@@ -1195,16 +1274,13 @@ export class Documents extends DocComponent {
         pagePaddingBottom: number,
         verticalAlign: VerticalAlign
     ) {
-        let offsetTop = 0;
-        if (verticalAlign === VerticalAlign.MIDDLE) {
-            offsetTop = (this.height - pageHeight) / 2;
-        } else if (verticalAlign === VerticalAlign.TOP) {
-            offsetTop = pagePaddingTop;
-        } else { // VerticalAlign.UNSPECIFIED follow the same rule as HorizontalAlign.BOTTOM.
-            offsetTop = this.height - pageHeight - pagePaddingBottom;
-        }
-
-        return offsetTop;
+        return computeDocumentPageVerticalAlignOffset(
+            this.height,
+            pageHeight,
+            pagePaddingTop,
+            pagePaddingBottom,
+            verticalAlign
+        );
     }
 
     private _startRotation(ctx: UniverRenderingContext, textAngle: number) {

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/bidi-reorder.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/bidi-reorder.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IDocumentSkeletonDivide, IDocumentSkeletonGlyph, IDocumentSkeletonLine } from '../../../../../../basics/i-document-skeleton-cached';
+import { TextDirection } from '@univerjs/core';
+import { describe, expect, it } from 'vitest';
+
+import { applyBidiReorderToLine } from '../bidi-reorder';
+
+function glyph(content: string, width = 10): IDocumentSkeletonGlyph {
+    return {
+        content,
+        raw: content,
+        width,
+        left: 0,
+        xOffset: 0,
+        count: 1,
+    } as unknown as IDocumentSkeletonGlyph;
+}
+
+function makeLine(contents: string[], width = 10): IDocumentSkeletonLine {
+    const glyphs = contents.map((c) => glyph(c, width));
+    let cursor = 0;
+    for (const g of glyphs) {
+        g.left = cursor;
+        cursor += g.width;
+    }
+    const divide: IDocumentSkeletonDivide = {
+        glyphGroup: glyphs,
+        width: 1000,
+        left: 0,
+        paddingLeft: 0,
+        isFull: false,
+        st: 0,
+        ed: glyphs.length - 1,
+        glyphGroupWidth: cursor,
+    } as unknown as IDocumentSkeletonDivide;
+    return {
+        divides: [divide],
+    } as unknown as IDocumentSkeletonLine;
+}
+
+describe('applyBidiReorderToLine', () => {
+    it('leaves pure-LTR text untouched', () => {
+        const line = makeLine(['h', 'e', 'l', 'l', 'o']);
+        applyBidiReorderToLine(line, TextDirection.LEFT_TO_RIGHT);
+        expect(line.divides[0].glyphGroup.map((g) => g.content).join('')).toBe('hello');
+        expect(line.divides[0].glyphGroup.map((g) => g.left)).toEqual([0, 10, 20, 30, 40]);
+    });
+
+    it('places RTL glyphs visually reversed while preserving logical array order', () => {
+        // Logical order in the array must stay ש ל ו ם so that the caret /
+        // hit-test code (which walks the array logically and accumulates
+        // `glyph.count`) keeps working. Visual order is encoded purely in
+        // each glyph's `left` value.
+        const line = makeLine(['ש', 'ל', 'ו', 'ם']);
+        applyBidiReorderToLine(line, TextDirection.RIGHT_TO_LEFT);
+
+        // Array order: unchanged (logical).
+        expect(line.divides[0].glyphGroup.map((g) => g.content).join('')).toBe('שלום');
+
+        // Visual positions: logical-first glyph (ש) sits at the right edge,
+        // logical-last glyph (ם) sits at the left edge. So when the renderer
+        // walks the array and uses each `glyph.left`, the on-screen sequence
+        // (sorted by `left`) reads ם ו ל ש.
+        const glyphs = line.divides[0].glyphGroup;
+        expect(glyphs[0].left).toBe(30); // ש → right
+        expect(glyphs[1].left).toBe(20);
+        expect(glyphs[2].left).toBe(10);
+        expect(glyphs[3].left).toBe(0); // ם → left
+
+        // Sorting by `left` yields visual reading order.
+        const visual = [...glyphs].sort((a, b) => a.left - b.left).map((g) => g.content).join('');
+        expect(visual).toBe('םולש');
+    });
+
+    it('reverses only the embedded Hebrew run inside an LTR baseline', () => {
+        // Logical: H i   ש ל ו ם   !  → bidi should reverse only the Hebrew.
+        const line = makeLine(['H', 'i', ' ', 'ש', 'ל', 'ו', 'ם', ' ', '!']);
+        applyBidiReorderToLine(line);
+
+        // Logical array order preserved.
+        const arrayOrder = line.divides[0].glyphGroup.map((g) => g.content).join('');
+        expect(arrayOrder).toBe('Hi שלום !');
+
+        // Visual reading order (sorted by left) reverses the Hebrew run.
+        const visual = [...line.divides[0].glyphGroup]
+            .sort((a, b) => a.left - b.left)
+            .map((g) => g.content)
+            .join('');
+        expect(visual).toBe('Hi םולש !');
+    });
+
+    it('handles a line with a single glyph as a no-op', () => {
+        const line = makeLine(['א']);
+        applyBidiReorderToLine(line, TextDirection.RIGHT_TO_LEFT);
+        expect(line.divides[0].glyphGroup.length).toBe(1);
+        expect(line.divides[0].glyphGroup[0].content).toBe('א');
+        expect(line.divides[0].glyphGroup[0].left).toBe(0);
+    });
+
+    it('stamps per-glyph bidi level so caret code can detect direction at script boundaries', () => {
+        // "Hello كتاب" on an LTR baseline. The Latin glyphs should resolve
+        // to level 0 (LTR), the Arabic glyphs to level 1 (RTL). Spaces
+        // between them are neutrals that inherit from the surrounding run.
+        const line = makeLine(['H', 'e', 'l', 'l', 'o', ' ', 'ك', 'ت', 'ا', 'ب']);
+        applyBidiReorderToLine(line);
+
+        const glyphs = line.divides[0].glyphGroup;
+        // Latin run → even levels.
+        expect((glyphs[0].bidiLevel ?? 0) % 2).toBe(0);
+        expect((glyphs[4].bidiLevel ?? 0) % 2).toBe(0);
+        // Arabic run → odd levels.
+        expect((glyphs[6].bidiLevel ?? 0) % 2).toBe(1);
+        expect((glyphs[9].bidiLevel ?? 0) % 2).toBe(1);
+    });
+
+    it('stamps baseline level on every glyph when no bidi candidates are present', () => {
+        const line = makeLine(['a', 'b', 'c']);
+        applyBidiReorderToLine(line, TextDirection.LEFT_TO_RIGHT);
+        for (const g of line.divides[0].glyphGroup) {
+            expect(g.bidiLevel).toBe(0);
+        }
+    });
+
+    it('keeps total glyph extent invariant after reordering', () => {
+        const line = makeLine(['ש', 'ל', 'ו', 'ם'], 12);
+        const totalWidth = line.divides[0].glyphGroup.reduce((s, g) => s + g.width, 0);
+        applyBidiReorderToLine(line, TextDirection.RIGHT_TO_LEFT);
+        // The visual span [min left, max left + width] still covers the
+        // original extent.
+        const lefts = line.divides[0].glyphGroup.map((g) => g.left);
+        const maxRight = Math.max(...line.divides[0].glyphGroup.map((g) => g.left + g.width));
+        expect(Math.min(...lefts)).toBe(0);
+        expect(maxRight).toBe(totalWidth);
+    });
+
+    it('places every glyph visually adjacent in mixed runs (no holes)', () => {
+        // Regression: previously only the glyphs inside a `getReorderSegments`
+        // range were re-flowed. Neutrals/whitespace/`\r` outside any segment
+        // kept their original LTR-cursor `left`, leaving a hole in the middle
+        // of the line. After switching to the L2 visual permutation
+        // (`getReorderedIndices`) every glyph must end up with a `left` that
+        // exactly equals its left neighbour's `left + width`.
+        const contents = ['H', 'e', 'l', 'l', 'o', ' ', 'ك', 'ت', 'ا', 'ب', ' ', 'H', 'i', '\r'];
+        const line = makeLine(contents);
+        applyBidiReorderToLine(line);
+
+        const sorted = [...line.divides[0].glyphGroup].sort((a, b) => a.left - b.left);
+        for (let i = 1; i < sorted.length; i++) {
+            expect(sorted[i].left).toBe(sorted[i - 1].left + sorted[i - 1].width);
+        }
+        // First glyph (visually leftmost) starts at the divide's left edge.
+        expect(sorted[0].left).toBe(0);
+    });
+
+    it('produces a visual order that matches the W3C UAX#9 sample (Hebrew embedded in English)', () => {
+        // "car means CAR." with CAR being Hebrew (here using actual Hebrew
+        // letters so bidi-js does the work). The W3C bidi sample says the
+        // visual reading order is "car means RAC." — i.e. the Hebrew run
+        // reverses while the English text stays put.
+        const contents = ['c', 'a', 'r', ' ', 'm', 'e', 'a', 'n', 's', ' ', 'ק', 'ר', 'מ', '.'];
+        const line = makeLine(contents);
+        applyBidiReorderToLine(line);
+
+        const visual = [...line.divides[0].glyphGroup]
+            .sort((a, b) => a.left - b.left)
+            .map((g) => g.content)
+            .join('');
+        // Hebrew chars reverse, the trailing "." (neutral after RTL) flows
+        // back onto the LTR baseline at the visual end.
+        expect(visual).toBe('car means מרק.');
+    });
+});

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/language-ruler-arabic.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/language-ruler-arabic.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ArabicHandler } from '../language-ruler';
+
+vi.mock('../../../model/glyph', () => ({
+    createSkeletonLetterGlyph: (content: string) => ({
+        content,
+        // Provide a non-null `fontStyle` so the charAdvances path in
+        // ArabicHandler runs; the FontCache mock below produces stub
+        // widths from the `fontStyle` reference identity, not its
+        // contents.
+        fontStyle: { fontSize: 14 },
+        // `width` is expected by ArabicHandler when it pins the last
+        // advance; use a deterministic value derived from `content` so
+        // tests can assert on it.
+        width: content.length * 10,
+    }),
+    createSkeletonWordGlyph: (content: string) => ({ content }),
+}));
+
+vi.mock('../../../tools', () => ({
+    getFontCreateConfig: () => ({}),
+}));
+
+// Stub FontCache: for each prefix `slice(0, i)`, return width = i * 10
+// (linear growth). Matches the `content.length * 10` value the mock
+// `createSkeletonLetterGlyph` reports, so `charAdvances[last] === width`
+// holds without an extra clamp.
+vi.mock('../../../shaping-engine/font-cache', () => ({
+    FontCache: {
+        getTextSize: (text: string) => ({ width: text.length * 10, height: 14 }),
+    },
+}));
+
+describe('ArabicHandler', () => {
+    it('preserves logical character order when bundling Arabic chars into a glyph', () => {
+        // Logical: ك ت ا ب  (Arabic for "book")
+        const result = ArabicHandler(
+            0,
+            'كتاب',
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any
+        );
+
+        expect(result.step).toBe(4);
+        expect(result.glyphGroup).toHaveLength(1);
+        // The glyph content MUST be in logical order so that the renderer's
+        // shaping engine produces correct initial/medial/final forms.
+        expect(result.glyphGroup[0].content).toBe('كتاب');
+    });
+
+    it('stops at the first non-Arabic character', () => {
+        const result = ArabicHandler(
+            0,
+            'كتابXY',
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any
+        );
+
+        expect(result.step).toBe(4);
+        expect(result.glyphGroup[0].content).toBe('كتاب');
+    });
+
+    it('handles a single Arabic letter', () => {
+        const result = ArabicHandler(
+            0,
+            'ا',
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any
+        );
+
+        expect(result.step).toBe(1);
+        expect(result.glyphGroup[0].content).toBe('ا');
+    });
+
+    it('does not reverse - regression for shaping bug', () => {
+        // Hebrew is handled by the default path, so use only Arabic here.
+        // Specifically guards against the historical bug where chars were
+        // unshifted (reversed), making the renderer compute wrong joining
+        // forms.
+        const input = 'مرحبا';
+        const result = ArabicHandler(
+            0,
+            input,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any
+        );
+
+        expect(result.glyphGroup[0].content).toBe(input);
+        // Explicitly assert it is NOT reversed.
+        expect(result.glyphGroup[0].content).not.toBe(input.split('').reverse().join(''));
+    });
+
+    it('attaches per-char prefix advances on multi-char clusters for sub-glyph caret', () => {
+        // Caret-aware cluster contract: an Arabic word is shaped as a
+        // single glyph (so cursive joining works) but the editor still
+        // needs to land the caret between two letters of the word.
+        // ArabicHandler is the sole producer of `charAdvances` today;
+        // the hit-test / caret / step-by-char paths all key off this
+        // array. With the mock FontCache returning width = i*10 per
+        // prefix, a 4-char cluster must have advances [10, 20, 30, 40]
+        // and the last entry must equal `glyph.width` exactly.
+        const result = ArabicHandler(0, 'كتاب', {} as any, {} as any, {} as any, {} as any);
+        const g = result.glyphGroup[0];
+
+        expect(g.charAdvances).toEqual([10, 20, 30, 40]);
+        // Last advance is pinned to the painted width — see the comment
+        // in `ArabicHandler` about sub-pixel drift.
+        expect(g.charAdvances![g.charAdvances!.length - 1]).toBe(g.width);
+    });
+
+    it('does not attach charAdvances on single-char clusters', () => {
+        // No sub-cluster geometry exists for a one-char glyph: the
+        // legacy "caret before / caret after the glyph" path is
+        // sufficient. Attaching `charAdvances` here would force the
+        // sub-offset path with no measurable benefit and risk
+        // confusing downstream consumers that probe its presence.
+        const result = ArabicHandler(0, 'ا', {} as any, {} as any, {} as any, {} as any);
+        expect(result.glyphGroup[0].charAdvances).toBeUndefined();
+    });
+
+    it('produces non-decreasing advances (clamped, monotonic)', () => {
+        // Defensive contract for hit-test binary search: even if a
+        // shaper's prefix width were to dip due to a contextual
+        // ligature reshuffle, our clamp keeps `charAdvances` weakly
+        // monotonic so `resolveSubOffset`'s midpoint walk stays
+        // well-defined. The mock here is monotonic by construction;
+        // this test pins the invariant against future regressions.
+        const result = ArabicHandler(0, 'كتاب', {} as any, {} as any, {} as any, {} as any);
+        const adv = result.glyphGroup[0].charAdvances!;
+        for (let i = 1; i < adv.length; i++) {
+            expect(adv[i]).toBeGreaterThanOrEqual(adv[i - 1]);
+        }
+    });
+});

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/language-ruler.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/language-ruler.spec.ts
@@ -18,7 +18,7 @@ import type { ISectionBreakConfig } from '../../../../../../basics/interfaces';
 import { DocumentDataModel } from '@univerjs/core';
 import { describe, expect, it } from 'vitest';
 import { DocumentViewModel } from '../../../../view-model/document-view-model';
-import { ArabicHandler, emojiHandler, otherHandler, ThaiHandler, TibetanHandler } from '../language-ruler';
+import { emojiHandler, otherHandler, ThaiHandler, TibetanHandler } from '../language-ruler';
 
 function createViewModel(content: string) {
     const dataStream = `${content}\r\n`;
@@ -99,34 +99,6 @@ describe('language-ruler', () => {
             const result = otherHandler(0, 'Hi\uD83D\uDE00', viewModel, paragraphNode, sectionBreakConfig, paragraph);
             expect(result.step).toBe(2);
             expect(result.glyphGroup.length).toBe(2);
-        });
-    });
-
-    describe('ArabicHandler', () => {
-        it('combines Arabic characters into one glyph in reverse order', () => {
-            const arabicText = '\u0645\u0631\u062D\u0628\u0627'; // 'مرحبا'
-            const { viewModel } = createViewModel(arabicText);
-            const paragraphNode = getParagraphNode(viewModel);
-            const paragraph = getParagraph(viewModel);
-            const sectionBreakConfig = createSectionBreakConfig();
-
-            const result = ArabicHandler(0, arabicText, viewModel, paragraphNode, sectionBreakConfig, paragraph);
-            expect(result.step).toBe(5);
-            expect(result.glyphGroup.length).toBe(1);
-            // Arabic characters are unshifted, so they should be in reverse order
-            expect(result.glyphGroup[0].content).toBe('\u0627\u0628\u062D\u0631\u0645'); // 'ابحرم'
-        });
-
-        it('stops at non-Arabic characters', () => {
-            const arabicText = '\u0645\u0631\u062D\u0628\u0627'; // 'مرحبا'
-            const { viewModel } = createViewModel(`${arabicText}X`);
-            const paragraphNode = getParagraphNode(viewModel);
-            const paragraph = getParagraph(viewModel);
-            const sectionBreakConfig = createSectionBreakConfig();
-
-            const result = ArabicHandler(0, `${arabicText}X`, viewModel, paragraphNode, sectionBreakConfig, paragraph);
-            expect(result.step).toBe(5);
-            expect(result.glyphGroup.length).toBe(1);
         });
     });
 

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/line-adjustment-rtl.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/line-adjustment-rtl.spec.ts
@@ -1,0 +1,361 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HorizontalAlign, TextDirection } from '@univerjs/core';
+import { describe, expect, it, vi } from 'vitest';
+import { BreakPointType } from '../../../line-breaker/break';
+
+import { lineAdjustment } from '../line-adjustment';
+
+const createHyphenDashGlyphMock = vi.fn();
+const glyphShrinkLeftMock = vi.fn();
+const glyphShrinkRightMock = vi.fn();
+const setGlyphGroupLeftMock = vi.fn();
+const getFontConfigFromLastGlyphMock = vi.fn();
+
+vi.mock('../../../model/glyph', () => ({
+    createHyphenDashGlyph: (...args: unknown[]) => createHyphenDashGlyphMock(...args),
+    glyphShrinkLeft: (...args: unknown[]) => glyphShrinkLeftMock(...args),
+    glyphShrinkRight: (...args: unknown[]) => glyphShrinkRightMock(...args),
+    setGlyphGroupLeft: (...args: unknown[]) => setGlyphGroupLeftMock(...args),
+}));
+
+vi.mock('../../../tools', () => ({
+    getFontConfigFromLastGlyph: (...args: unknown[]) => getFontConfigFromLastGlyphMock(...args),
+    getGlyphGroupWidth: (divide: any) => divide.glyphGroup.reduce((sum: number, glyph: any) => sum + glyph.width, 0),
+    lineIterator: (pages: any[], cb: (line: any) => void) => {
+        pages.forEach((page) => {
+            page.sections.forEach((section: any) => {
+                section.columns.forEach((column: any) => {
+                    column.lines.forEach((line: any) => cb(line));
+                });
+            });
+        });
+    },
+}));
+
+function createGlyph(content: string, width: number, isJustifiable = false) {
+    return {
+        content,
+        width,
+        xOffset: 0,
+        count: 1,
+        isJustifiable,
+        bBox: {
+            width: Math.max(1, width - 1),
+            ba: 7,
+            bd: 3,
+        },
+        adjustability: {
+            shrinkability: [1, 1],
+            stretchability: [1, 1],
+        },
+    } as any;
+}
+
+function createPages() {
+    const divide1 = {
+        width: 40,
+        isFull: true,
+        breakType: BreakPointType.Normal,
+        paddingLeft: 0,
+        glyphGroup: [
+            createGlyph('（', 8, false),
+            createGlyph('A', 10, true),
+            createGlyph('。', 8, false),
+        ],
+    } as any;
+
+    const divide2 = {
+        width: 24,
+        isFull: true,
+        breakType: BreakPointType.Normal,
+        paddingLeft: 0,
+        glyphGroup: [
+            createGlyph('中', 14, false),
+        ],
+    } as any;
+    divide2.glyphGroup[0].xOffset = 2;
+    divide2.glyphGroup[0].bBox.width = 8;
+
+    const divide3 = {
+        width: 30,
+        isFull: true,
+        breakType: BreakPointType.Hyphen,
+        paddingLeft: 0,
+        glyphGroup: [
+            createGlyph('w', 10, true),
+            createGlyph('o', 8, true),
+            createGlyph('r', 7, true),
+            createGlyph('d', 7, true),
+        ],
+    } as any;
+    divide3.glyphGroup[divide3.glyphGroup.length - 1].content = 'a';
+
+    const line = {
+        paragraphIndex: 0,
+        divides: [divide1, divide2, divide3],
+    } as any;
+
+    [divide1, divide2, divide3].forEach((divide) => {
+        divide.glyphGroup.forEach((glyph: any, idx: number) => {
+            glyph.left = divide.glyphGroup.slice(0, idx).reduce((sum: number, g: any) => sum + g.width, 0);
+            glyph.parent = divide;
+        });
+    });
+
+    return [
+        {
+            sections: [
+                {
+                    columns: [
+                        {
+                            lines: [line],
+                        },
+                    ],
+                },
+            ],
+        },
+    ] as any[];
+}
+
+describe('line adjustment', () => {
+    it('adjusts punctuation/hyphen/alignment for paragraph lines', () => {
+        createHyphenDashGlyphMock.mockReturnValue({
+            content: '-',
+            width: 3,
+            count: 1,
+            left: 0,
+            bBox: { width: 3, ba: 7, bd: 3 },
+            adjustability: { shrinkability: [0, 0], stretchability: [0, 0] },
+        });
+        getFontConfigFromLastGlyphMock.mockReturnValue({ fs: 12 });
+
+        const viewModel = {
+            getParagraph: () => ({
+                startIndex: 0,
+                paragraphStyle: {
+                    horizontalAlign: HorizontalAlign.JUSTIFIED,
+                },
+            }),
+        } as any;
+        const paragraphNode = { endIndex: 1 } as any;
+        const pages = createPages();
+
+        lineAdjustment(pages as any, viewModel, paragraphNode, {} as any);
+
+        const line = pages[0].sections[0].columns[0].lines[0];
+        expect(glyphShrinkLeftMock).toHaveBeenCalled();
+        expect(glyphShrinkRightMock).toHaveBeenCalled();
+        expect(setGlyphGroupLeftMock).toHaveBeenCalled();
+        expect(getFontConfigFromLastGlyphMock).toHaveBeenCalled();
+
+        const hyphenDivide = line.divides[2];
+        expect(hyphenDivide.glyphGroup[hyphenDivide.glyphGroup.length - 1].content).toBe('-');
+        expect(hyphenDivide.width).toBe(27);
+
+        expect(line.divides[0].paddingLeft).toBeGreaterThanOrEqual(0);
+    });
+
+    // Regression: each RTL line must compute paddingRight independently
+    // from *its own* glyphGroupWidth so a short Arabic line above a long
+    // one still pins to the divide's right edge instead of inheriting the
+    // long line's offset. See `_horizontalHandler` for the page-level
+    // counterpart of this fix.
+    it('pins every RTL line to its own divide right edge for UNSPECIFIED align', () => {
+        // Two divides on the same line representing two paragraphs of
+        // different glyph-group widths but the same divide.width (cell
+        // column width). Without the per-line paddingRight, the shorter
+        // run would render with paddingRight=0 and visually drift to the
+        // divide's left edge under page-level right alignment.
+        const shortRun = {
+            width: 100,
+            isFull: false,
+            breakType: BreakPointType.Normal,
+            paddingLeft: 0,
+            glyphGroup: [createGlyph('ك', 10, false), createGlyph('ت', 10, false)],
+        } as any;
+        const longRun = {
+            width: 100,
+            isFull: false,
+            breakType: BreakPointType.Normal,
+            paddingLeft: 0,
+            glyphGroup: [
+                createGlyph('ا', 10, false),
+                createGlyph('ل', 10, false),
+                createGlyph('ع', 10, false),
+                createGlyph('ر', 10, false),
+                createGlyph('ب', 10, false),
+                createGlyph('ي', 10, false),
+            ],
+        } as any;
+        const line = {
+            paragraphIndex: 0,
+            divides: [shortRun, longRun],
+        } as any;
+        const pages = [
+            { sections: [{ columns: [{ lines: [line] }] }] },
+        ] as any[];
+
+        const viewModel = {
+            getParagraph: () => ({
+                startIndex: 0,
+                paragraphStyle: {
+                    horizontalAlign: HorizontalAlign.UNSPECIFIED,
+                    direction: TextDirection.RIGHT_TO_LEFT,
+                },
+            }),
+        } as any;
+        lineAdjustment(pages, viewModel, { endIndex: 1 } as any, {} as any);
+
+        expect(shortRun.paddingRight).toBe(100 - 20);
+        expect(longRun.paddingRight).toBe(100 - 60);
+        // paddingLeft must stay 0 — we don't want to double-shift the run.
+        expect(shortRun.paddingLeft).toBe(0);
+        expect(longRun.paddingLeft).toBe(0);
+    });
+
+    // Regression: in the static sheet-render path `divide.width === Infinity`
+    // (page-size is unclamped so OVERFLOW into neighbouring cells still
+    // works). Without compensation, RTL multi-line cells would skip the
+    // per-line padding step and every line would visually collapse to the
+    // page's left edge, undoing the right-alignment. The fix substitutes
+    // `pageMaxLineWidth` (longest natural line width on the page) for the
+    // infinite `divide.width`, so each line gets a finite reference and
+    // short lines get the correct paddingRight to match the longest line.
+    it('uses pageMaxLineWidth for RTL paddingRight when divide.width is Infinity', () => {
+        // Two paragraphs on the same page, each a single line. Page is
+        // unclamped (divide.width = Infinity for both). The short line
+        // should get paddingRight = (longLineWidth) - (shortLineWidth);
+        // the long line gets paddingRight = 0.
+        const makeRtlLine = (paragraphIndex: number, charWidth: number, charCount: number) => {
+            const glyphs: any[] = [];
+            for (let i = 0; i < charCount; i++) {
+                glyphs.push(createGlyph('ك', charWidth, false));
+            }
+            glyphs.forEach((g, idx) => {
+                g.left = idx * charWidth;
+            });
+            const divide = {
+                width: Number.POSITIVE_INFINITY,
+                isFull: false,
+                breakType: BreakPointType.Normal,
+                paddingLeft: 0,
+                glyphGroup: glyphs,
+            } as any;
+            glyphs.forEach((g: any) => {
+                g.parent = divide;
+            });
+            return {
+                paragraphIndex,
+                divides: [divide],
+            } as any;
+        };
+        const shortLine = makeRtlLine(0, 10, 2);
+        const longLine = makeRtlLine(0, 10, 6);
+        const pages = [
+            { sections: [{ columns: [{ lines: [shortLine, longLine] }] }] },
+        ] as any[];
+
+        const viewModel = {
+            getParagraph: () => ({
+                startIndex: 0,
+                paragraphStyle: {
+                    horizontalAlign: HorizontalAlign.UNSPECIFIED,
+                    direction: TextDirection.RIGHT_TO_LEFT,
+                },
+            }),
+        } as any;
+        lineAdjustment(pages, viewModel, { endIndex: 0 } as any, {} as any);
+
+        // Long line is its own anchor for the page-level RIGHT push.
+        expect(longLine.divides[0].paddingRight).toBe(0);
+        // Short line pads by the difference so it lines up with the long
+        // line's right edge.
+        expect(shortLine.divides[0].paddingRight).toBe(60 - 20);
+        // paddingLeft must remain 0 — page-level offset does the cell-
+        // right anchoring; we only adjust within the line.
+        expect(shortLine.divides[0].paddingLeft).toBe(0);
+        expect(longLine.divides[0].paddingLeft).toBe(0);
+    });
+
+    // LTR multi-line with Infinity divide.width keeps legacy behaviour
+    // (skip on infinity) — we don't want to accidentally start padding
+    // LTR lines that were happy as-is.
+    it('does not pad LTR Infinity divides', () => {
+        const makeLine = (charWidth: number, charCount: number) => {
+            const glyphs: any[] = [];
+            for (let i = 0; i < charCount; i++) {
+                glyphs.push(createGlyph('a', charWidth, false));
+            }
+            glyphs.forEach((g, idx) => {
+                g.left = idx * charWidth;
+            });
+            const divide = {
+                width: Number.POSITIVE_INFINITY,
+                isFull: false,
+                breakType: BreakPointType.Normal,
+                paddingLeft: 0,
+                glyphGroup: glyphs,
+            } as any;
+            glyphs.forEach((g: any) => {
+                g.parent = divide;
+            });
+            return { paragraphIndex: 0, divides: [divide] } as any;
+        };
+        const a = makeLine(10, 2);
+        const b = makeLine(10, 6);
+        const pages = [
+            { sections: [{ columns: [{ lines: [a, b] }] }] },
+        ] as any[];
+        const viewModel = {
+            getParagraph: () => ({
+                startIndex: 0,
+                paragraphStyle: {
+                    horizontalAlign: HorizontalAlign.UNSPECIFIED,
+                    // No direction = LTR baseline.
+                },
+            }),
+        } as any;
+        lineAdjustment(pages, viewModel, { endIndex: 0 } as any, {} as any);
+
+        expect(a.divides[0].paddingRight ?? 0).toBe(0);
+        expect(b.divides[0].paddingRight ?? 0).toBe(0);
+    });
+
+    it('supports center and right align branches', () => {
+        const pages = createPages();
+        const paragraphNode = { endIndex: 1 } as any;
+
+        const viewModelCenter = {
+            getParagraph: () => ({
+                startIndex: 0,
+                paragraphStyle: { horizontalAlign: HorizontalAlign.CENTER },
+            }),
+        } as any;
+        lineAdjustment(pages as any, viewModelCenter, paragraphNode, {} as any);
+        expect(pages[0].sections[0].columns[0].lines[0].divides[0].paddingLeft).toBeGreaterThan(0);
+
+        const viewModelRight = {
+            getParagraph: () => ({
+                startIndex: 0,
+                paragraphStyle: { horizontalAlign: HorizontalAlign.RIGHT },
+            }),
+        } as any;
+        lineAdjustment(pages as any, viewModelRight, paragraphNode, {} as any);
+        expect(pages[0].sections[0].columns[0].lines[0].divides[0].paddingLeft).toBeGreaterThan(0);
+    });
+});

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/bidi-reorder.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/bidi-reorder.ts
@@ -1,0 +1,230 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IDocumentSkeletonDivide, IDocumentSkeletonGlyph, IDocumentSkeletonLine } from '../../../../../basics/i-document-skeleton-cached';
+import { TextDirection } from '@univerjs/core';
+// `bidi-js` ships without bundled `.d.ts` typings, so we declare a minimal
+// surface inline. This keeps every consumer of `engine-render` (which still
+// imports the source path through `package.json#main`) typecheck-clean
+// without forcing a workspace-wide `@types/bidi-js` install.
+
+// @ts-ignore -- no types shipped with bidi-js
+import bidiFactory from 'bidi-js';
+
+// Lazily create the bidi runtime once per process. `bidiFactory()` returns a
+// self-contained object with `getEmbeddingLevels`, `getReorderedIndices`,
+// `getReorderSegments`, `getMirroredCharactersMap`, etc.
+let _bidi: ReturnType<typeof bidiFactory> | null = null;
+function getBidi() {
+    if (_bidi == null) {
+        _bidi = bidiFactory();
+    }
+    return _bidi;
+}
+
+/**
+ * Re-layout every glyph in the divide by walking them in **visual order**
+ * (as resolved by UAX#9 L2) and assigning cumulative `left` values, while
+ * keeping the underlying `glyphGroup` array in **logical order**.
+ *
+ * Why this is the right shape:
+ *  - **W3C / UAX#9 L1+L2 fidelity.** Once `bidi-js` resolves embedding
+ *    levels, the spec says "reorder the line by applying the reverse
+ *    operation, from the highest level down to level 0+1". The net result
+ *    is a single visual permutation of the line. Re-flowing positions for
+ *    `every` glyph in that permutation (not just the ones inside a reorder
+ *    segment) is the only way to keep neighbours visually adjacent across
+ *    LTR↔RTL boundaries — otherwise the trailing/middle whitespace, the
+ *    paragraph break, and any other "neutral" glyph that bidi didn't put
+ *    into a segment keeps its original LTR cursor position and looks like
+ *    a hole in the middle of the line.
+ *  - **Logical array order stays put.** Renderers walk `glyphGroup` and
+ *    use each `glyph.left` to position — they don't depend on array order.
+ *    Caret / selection / hit-test code (`_findNodeByIndex` in
+ *    `DocumentSkeleton`) walks `glyphGroup` in array order and
+ *    accumulates `glyph.count` to map a *logical* char offset → glyph.
+ *    Physically reversing the array would break that mapping for any RTL
+ *    run, so the caret would snap to the wrong end and inserts would
+ *    appear on the wrong side.
+ *
+ * @param glyphGroup The glyphs in logical order (mutated in place).
+ * @param visualOrder Array of glyph indices in visual (left-to-right)
+ *                    order. Every glyph in `[0, glyphGroup.length)` must
+ *                    appear exactly once.
+ */
+function relayoutGlyphsByVisualOrder(
+    glyphGroup: IDocumentSkeletonGlyph[],
+    visualOrder: number[]
+): void {
+    if (visualOrder.length === 0) return;
+
+    // Use the original divide-relative cursor (smallest `left`) as the
+    // anchor so we don't drift the divide's outer rect. `glyph.left` is
+    // already in divide-local coordinates; the smallest of them is the
+    // divide's left edge for this run of glyphs.
+    let cursor = Infinity;
+    for (let i = 0; i < glyphGroup.length; i++) {
+        if (glyphGroup[i].left < cursor) cursor = glyphGroup[i].left;
+    }
+    if (!Number.isFinite(cursor)) cursor = 0;
+
+    for (const gi of visualOrder) {
+        const glyph = glyphGroup[gi];
+        if (!glyph) continue;
+        glyph.left = cursor;
+        cursor += glyph.width;
+    }
+}
+
+/**
+ * Build the text content of a divide by concatenating each glyph's raw/content
+ * string. The mapping is index-to-glyph: `glyphIndexAt[i]` gives the glyph
+ * index in `divide.glyphGroup` that contributes the character at string offset
+ * `i`. This is needed because bidi-js operates on UTF-16 code units while we
+ * operate on glyphs.
+ */
+function buildDivideText(divide: IDocumentSkeletonDivide): {
+    text: string;
+    glyphIndexAt: number[];
+} {
+    let text = '';
+    const glyphIndexAt: number[] = [];
+    for (let i = 0; i < divide.glyphGroup.length; i++) {
+        const glyph = divide.glyphGroup[i];
+        const piece = glyph.content || glyph.raw || '';
+        for (let c = 0; c < piece.length; c++) {
+            text += piece[c];
+            glyphIndexAt.push(i);
+        }
+    }
+    return { text, glyphIndexAt };
+}
+
+/**
+ * Apply Unicode bidirectional reordering to every divide in `line`, mutating
+ * the glyph order and their `left` offsets so the divide renders correctly
+ * when the renderer simply walks `glyphGroup` left-to-right.
+ *
+ * - For LTR paragraphs we still run bidi: an embedded Hebrew/Arabic run inside
+ *   English text must visually reverse, even though the paragraph baseline is
+ *   LTR. (Bidi-js auto-detects per paragraph when no explicit direction is
+ *   passed.)
+ * - For RTL paragraphs we pass `'rtl'` so an all-LTR run still resolves at
+ *   level 1 and gets reversed correctly.
+ */
+export function applyBidiReorderToLine(
+    line: IDocumentSkeletonLine,
+    direction?: TextDirection
+): void {
+    if (line.divides.length === 0) return;
+
+    const explicitDir =
+        direction === TextDirection.RIGHT_TO_LEFT
+            ? 'rtl'
+            : direction === TextDirection.LEFT_TO_RIGHT
+                ? 'ltr'
+                : undefined;
+
+    const bidi = getBidi();
+
+    for (const divide of line.divides) {
+        if (divide.glyphGroup.length === 0) {
+            continue;
+        }
+
+        const { text, glyphIndexAt } = buildDivideText(divide);
+
+        // Default every glyph's bidi level to the line's baseline so callers
+        // (caret / selection) don't see stale `undefined` for glyphs that
+        // weren't part of any reorder segment. `explicitDir==='rtl' ⇒ 1`,
+        // everything else defaults to 0 (LTR).
+        const baselineLevel = explicitDir === 'rtl' ? 1 : 0;
+        for (const glyph of divide.glyphGroup) {
+            glyph.bidiLevel = baselineLevel;
+        }
+
+        if (text.length < 2) {
+            continue;
+        }
+
+        // Fast path: pure LTR ASCII/CJK runs never need reordering. We still
+        // assign the baseline level above so caret code can rely on it.
+        if (explicitDir !== 'rtl' && !hasBidiCandidate(text)) {
+            continue;
+        }
+
+        const embeddingLevels = bidi.getEmbeddingLevels(text, explicitDir);
+
+        // Stamp the resolved bidi level onto each glyph. We take the level
+        // of the *first* code unit that maps to this glyph; mixed-direction
+        // single glyphs are rare (the renderer keeps a glyph per code point
+        // for bidi-relevant scripts), and the first code unit is what
+        // bidi-js uses for its own segment boundaries anyway.
+        const levels = embeddingLevels.levels;
+        const seenForLevel = new Set<number>();
+        for (let i = 0; i < glyphIndexAt.length; i++) {
+            const gi = glyphIndexAt[i];
+            if (seenForLevel.has(gi)) continue;
+            seenForLevel.add(gi);
+            const glyph = divide.glyphGroup[gi];
+            if (glyph) glyph.bidiLevel = levels[i];
+        }
+
+        // Ask bidi-js for the full L2 visual permutation (character-level).
+        // It returns an array of *character indices* in visual left-to-right
+        // order. We then translate to glyph indices, dedup (multi-codepoint
+        // glyphs map several chars to one glyph), and re-flow every glyph
+        // — see `relayoutGlyphsByVisualOrder` for why "every" matters.
+        const visualCharOrder = bidi.getReorderedIndices(text, embeddingLevels);
+        const visualGlyphOrder: number[] = [];
+        const seenGlyph = new Set<number>();
+        for (let i = 0; i < visualCharOrder.length; i++) {
+            const ci = visualCharOrder[i];
+            if (ci < 0 || ci >= glyphIndexAt.length) continue;
+            const gi = glyphIndexAt[ci];
+            if (gi == null || seenGlyph.has(gi)) continue;
+            seenGlyph.add(gi);
+            visualGlyphOrder.push(gi);
+        }
+
+        // Defensive: if some glyphs weren't covered by `glyphIndexAt`
+        // (shouldn't happen but be robust to future content shapes),
+        // append them in logical order so they aren't dropped.
+        if (visualGlyphOrder.length < divide.glyphGroup.length) {
+            for (let i = 0; i < divide.glyphGroup.length; i++) {
+                if (!seenGlyph.has(i)) {
+                    seenGlyph.add(i);
+                    visualGlyphOrder.push(i);
+                }
+            }
+        }
+
+        relayoutGlyphsByVisualOrder(divide.glyphGroup, visualGlyphOrder);
+    }
+}
+
+// Cheap heuristic: any character above U+0590 might be a bidi-relevant
+// character (Hebrew starts at U+0590, Arabic at U+0600, etc.). Avoids running
+// the bidi algorithm on the common case of pure Latin/CJK text.
+function hasBidiCandidate(text: string): boolean {
+    for (let i = 0; i < text.length; i++) {
+        const code = text.charCodeAt(i);
+        if (code >= 0x0590 && code <= 0x08FF) return true; // Hebrew/Arabic/Syriac
+        if (code >= 0xFB1D && code <= 0xFDFF) return true; // Hebrew/Arabic presentation forms A
+        if (code >= 0xFE70 && code <= 0xFEFF) return true; // Arabic presentation forms B
+    }
+    return false;
+}

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/language-ruler.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/language-ruler.ts
@@ -21,6 +21,7 @@ import type { DataStreamTreeNode } from '../../../view-model/data-stream-tree-no
 import type { DocumentViewModel } from '../../../view-model/document-view-model';
 import { getFirstGrapheme, hasArabic, hasSpace, hasThai, hasTibetan, startWithEmoji } from '../../../../../basics/tools';
 import { createSkeletonLetterGlyph, createSkeletonWordGlyph } from '../../model/glyph';
+import { FontCache } from '../../shaping-engine/font-cache';
 import { getFontCreateConfig } from '../../tools';
 
 // Handle English word, English punctuation, number characters.
@@ -72,24 +73,72 @@ export function ArabicHandler(
     sectionBreakConfig: ISectionBreakConfig,
     paragraph: IParagraph
 ) {
-    // Combine Arabic phrases
+    // Combine consecutive Arabic characters into a single glyph so the
+    // browser's text-shaping engine (used by `ctx.fillText` /
+    // `ctx.measureText`) can apply Arabic cursive joining
+    // (initial / medial / final / isolated forms) correctly.
+    //
+    // IMPORTANT: characters MUST be kept in their original (logical) order.
+    // An earlier implementation reversed the characters here as a poor-man's
+    // RTL "trick" (so that LTR Canvas painting produced visually right-aligned
+    // text). That reversal corrupted shaping because the renderer recomputed
+    // joining forms on the reversed string, producing the wrong contextual
+    // glyphs. RTL visual reordering is now handled at the glyph-sequence level
+    // by `applyBidiReorderToLine`, so we only need to keep the logical order
+    // intact here.
     const config = getFontCreateConfig(index, viewModel, paragraphNode, sectionBreakConfig, paragraph);
-    const glyph = [];
+    const chars: string[] = [];
     let step = 0;
 
     for (let i = 0; i < charArray.length; i++) {
         const newChar = charArray[i];
         if (hasArabic(newChar)) {
-            glyph.unshift(newChar);
+            chars.push(newChar);
             step++;
         } else {
             break;
         }
     }
 
+    const content = chars.join('');
+    const glyph = createSkeletonLetterGlyph(content, config);
+
+    // Caret-aware cluster: an Arabic word is rendered as a single
+    // shaped glyph (so the browser can apply cursive joining), but the
+    // editor must still let the caret land *inside* the cluster. We
+    // measure prefix advances now and attach them; the hit-test, caret
+    // painter and keyboard step-by-char path all key off
+    // `glyph.charAdvances` to operate sub-cluster. Only attach when the
+    // cluster has more than one logical character — a one-char "word"
+    // has trivial geometry and the legacy path is sufficient.
+    //
+    // We deliberately scope this to `ArabicHandler` (instead of the
+    // generic `_createSkeletonWordOrLetter`) because other multi-char
+    // glyphs (e.g. the emoji handler's grapheme-cluster glyph, the
+    // Tibetan phrase glyph) should *not* be sub-divisible by the
+    // caret: a user dragging through an emoji or a Tibetan syllable
+    // expects to step over it as one visual unit. Arabic is the
+    // outlier where the shaper joins what users perceive as multiple
+    // characters.
+    if (content.length > 1 && glyph.fontStyle) {
+        const advances = new Array<number>(content.length);
+        let prev = 0;
+        for (let i = 1; i <= content.length; i++) {
+            const box = FontCache.getTextSize(content.slice(0, i), glyph.fontStyle);
+            advances[i - 1] = Math.max(box.width, prev);
+            prev = advances[i - 1];
+        }
+        // Pin the last advance to the glyph's painted `width` so
+        // downstream consumers can use `charAdvances[count-1]` and
+        // `glyph.width` interchangeably (the per-prefix measurement
+        // would otherwise drift by sub-pixel rounding).
+        advances[content.length - 1] = glyph.width;
+        glyph.charAdvances = advances;
+    }
+
     return {
         step,
-        glyphGroup: [createSkeletonLetterGlyph(glyph.join(''), config)],
+        glyphGroup: [glyph],
     };
 }
 

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/layout-ruler.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/layout-ruler.ts
@@ -30,7 +30,7 @@ import type {
     IFloatObject,
     ILayoutContext,
 } from '../../tools';
-import { BooleanNumber, DataStreamTreeTokenType, GridType, NAMED_STYLE_SPACE_MAP, ObjectRelativeFromV, PositionedObjectLayoutType, SpacingRule, TableTextWrapType } from '@univerjs/core';
+import { BooleanNumber, DataStreamTreeTokenType, GridType, NAMED_STYLE_SPACE_MAP, ObjectRelativeFromV, PositionedObjectLayoutType, SpacingRule, TableTextWrapType, TextDirection } from '@univerjs/core';
 import { GlyphType, LineType } from '../../../../../basics/i-document-skeleton-cached';
 import { BreakPointType } from '../../line-breaker/break';
 import { addGlyphToDivide, createSkeletonBulletGlyph } from '../../model/glyph';
@@ -82,7 +82,16 @@ export function layoutParagraph(
             const { snapToGrid = BooleanNumber.TRUE } = paragraphStyle;
 
             const charSpaceApply = getCharSpaceApply(charSpace, defaultTabStop, gridType, snapToGrid);
-            const bulletGlyph = createSkeletonBulletGlyph(glyphGroup[0], bulletSkeleton, charSpaceApply);
+            // Pass the paragraph direction so the bullet builder can
+            // pin the symbol to the glyph's logical-start (visual-right
+            // in RTL). See createSkeletonBulletGlyph for the rationale
+            // and the page-width carve-out in tools.ts.
+            const bulletGlyph = createSkeletonBulletGlyph(
+                glyphGroup[0],
+                bulletSkeleton,
+                charSpaceApply,
+                paragraphStyle.direction
+            );
             const paragraphProperties = bulletSkeleton.paragraphProperties || {};
 
             paragraphConfig.paragraphStyle = mergeByV<IParagraphStyle>(paragraphConfig.paragraphStyle, { ...paragraphProperties, hanging: { v: bulletGlyph.width } } as IParagraphProperties, 'max');
@@ -459,7 +468,7 @@ function _lineOperator(
     };
 
     const {
-        // direction,
+        direction,
         spaceAbove,
         spaceBelow,
         indentFirstLine,
@@ -593,7 +602,8 @@ function _lineOperator(
         indentStart,
         indentEnd,
         charSpaceApply,
-        isParagraphFirstShapedText
+        isParagraphFirstShapedText,
+        direction
     );
 
     // If the width is insufficient to accommodate the margin, leave 1px width for placeholder.
@@ -626,6 +636,12 @@ function _lineOperator(
         footerPage
     );
 
+    // Stamp the paragraph-level writing direction onto the skeleton line so
+    // that downstream consumers (`horizontalAlignHandler`, selection rendering,
+    // arrow-key visual<->logical mapping) can look it up without re-resolving
+    // the paragraph each time. Lines inherit the direction of their owning
+    // paragraph.
+    newLine.direction = direction;
     column.lines.push(newLine);
     newLine.parent = column;
     createAndUpdateBlockAnchor(paragraphIndex, newLine, lineTop, pDrawingAnchor);
@@ -1060,6 +1076,24 @@ function _pageOperator(
 
 /**
  * 17.3.1.12 ind (Paragraph Indentation)
+ *
+ * RTL paragraphs interpret the indent values in **logical** terms
+ * (CSS Writing Modes Level 3 §3.6 / OOXML §17.3.1.12):
+ *   - `indentStart` is the start-side margin → logical start → visual *right*
+ *     edge of an RTL line.
+ *   - `indentEnd` is the end-side margin → logical end → visual *left*
+ *     edge of an RTL line.
+ *   - `indentFirstLine` and `hanging` both reduce/extend the **start**
+ *     edge → visual right for RTL.
+ *
+ * The CSS / OOXML model maps cleanly to "paddingLeft = start" for LTR and
+ * "paddingRight = start" for RTL. Skipping this swap (the way the layout
+ * ruler used to) keeps list bullets and hanging indents on the visual
+ * left even in RTL paragraphs — so an Arabic bulleted list ends up
+ * with the bullet rendered glyph-right (correct, courtesy of bidi
+ * reorder) but the hanging-indent gutter sitting on the visual left
+ * (wrong), making the bullet appear glued to the text and a phantom
+ * whitespace block float at the line's left edge.
  */
 function __getIndentPadding(
     indentFirstLine: Nullable<INumberUnit>,
@@ -1067,27 +1101,32 @@ function __getIndentPadding(
     indentStart: Nullable<INumberUnit>,
     indentEnd: Nullable<INumberUnit>,
     charSpaceApply: number,
-    isParagraphFirstShapedText = false
+    isParagraphFirstShapedText = false,
+    direction?: TextDirection
 ) {
     const indentFirstLineNumber = getNumberUnitValue(indentFirstLine, charSpaceApply);
     const hangingNumber = getNumberUnitValue(hanging, charSpaceApply);
     const indentStartNumber = getNumberUnitValue(indentStart, charSpaceApply);
     const indentEndNumber = getNumberUnitValue(indentEnd, charSpaceApply);
 
-    let paddingLeft = indentStartNumber;
-    const paddingRight = indentEndNumber;
+    let startPadding = indentStartNumber;
+    const endPadding = indentEndNumber;
 
     if (indentFirstLineNumber > 0 && isParagraphFirstShapedText) {
-        paddingLeft += indentFirstLineNumber;
+        startPadding += indentFirstLineNumber;
     }
 
     if (hangingNumber > 0 && !isParagraphFirstShapedText) {
-        paddingLeft += hangingNumber;
+        startPadding += hangingNumber;
     }
 
+    const isRTL = direction === TextDirection.RIGHT_TO_LEFT;
     return {
-        paddingLeft,
-        paddingRight,
+        // For LTR: paddingLeft = start, paddingRight = end (legacy).
+        // For RTL: swap, so the bullet/hanging gutter sits at the
+        // line's visual right edge instead of phantom-padding the left.
+        paddingLeft: isRTL ? endPadding : startPadding,
+        paddingRight: isRTL ? startPadding : endPadding,
     };
 }
 

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/line-adjustment.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/line-adjustment.ts
@@ -19,12 +19,13 @@ import type { ISectionBreakConfig } from '../../../../../basics';
 import type { IDocumentSkeletonDivide, IDocumentSkeletonLine, IDocumentSkeletonPage } from '../../../../../basics/i-document-skeleton-cached';
 import type { DataStreamTreeNode } from '../../../view-model/data-stream-tree-node';
 import type { DocumentViewModel } from '../../../view-model/document-view-model';
-import { HorizontalAlign } from '@univerjs/core';
+import { HorizontalAlign, TextDirection } from '@univerjs/core';
 import { hasCJK, hasCJKText, isCjkLeftAlignedPunctuation, isCjkRightAlignedPunctuation } from '../../../../../basics/tools';
 import { BreakPointType } from '../../line-breaker/break';
 import { isLetter } from '../../line-breaker/enhancers/utils';
 import { createHyphenDashGlyph, glyphShrinkLeft, glyphShrinkRight, setGlyphGroupLeft } from '../../model/glyph';
 import { getFontConfigFromLastGlyph, getGlyphGroupWidth, lineIterator } from '../../tools';
+import { applyBidiReorderToLine } from './bidi-reorder';
 
 // How much a character should hang into the end margin.
 // For more discussion, see:
@@ -119,33 +120,85 @@ function adjustGlyphsInDivide(divide: IDocumentSkeletonDivide, justificationRati
 }
 
 /**
+ * Sum the natural widths of all glyphs across every divide of a line.
+ * Used to derive a "line natural width" when `divide.width` is Infinity
+ * (the common static-render path in sheet cells where the docs page size
+ * hasn't been clamped). Multi-line RTL alignment needs this so short
+ * lines can compute the right amount of `paddingRight` to pin to the
+ * same right edge as the longest line.
+ */
+function getLineNaturalWidth(line: IDocumentSkeletonLine): number {
+    let w = 0;
+    for (const divide of line.divides) {
+        for (const glyph of divide.glyphGroup) {
+            w += glyph.width;
+        }
+    }
+    return w;
+}
+
+/**
  * When aligning text horizontally within a document,
  * it may be ineffective if the total line width is not initially calculated.
  * Therefore, multiple calculations are performed, which may impact performance.
  * Needs optimization for efficiency.
+ *
+ * `pageMaxLineWidth` is the natural width of the widest line on the page
+ * the line belongs to. It is only consulted on the **infinite divide**
+ * path (static sheet render with `divide.width === Infinity`) to give
+ * RTL lines a finite reference width — short lines on a multi-line cell
+ * use `paddingRight = pageMaxLineWidth - thisLineWidth` to pin to the
+ * same right edge as the longest line, while the page-level
+ * `_horizontalHandler` does the outer "push the whole page to the cell's
+ * right edge" anchor. When `pageMaxLineWidth` is undefined (single-page
+ * docs use-cases that haven't computed it) we fall back to the finite
+ * `divide.width` branch and skip on infinity, preserving legacy behavior.
  */
-function horizontalAlignHandler(line: IDocumentSkeletonLine, horizontalAlign: HorizontalAlign) {
+function horizontalAlignHandler(
+    line: IDocumentSkeletonLine,
+    horizontalAlign: HorizontalAlign,
+    direction?: TextDirection,
+    pageMaxLineWidth?: number
+) {
+    const isRTL = direction === TextDirection.RIGHT_TO_LEFT;
     const { divides } = line;
 
     for (let i = 0; i < divides.length; i++) {
         const divide = divides[i];
-        const { width } = divide;
+        let { width } = divide;
         let glyphGroupWidth = getGlyphGroupWidth(divide);
 
         divide.glyphGroupWidth = glyphGroupWidth;
 
         if (width === Number.POSITIVE_INFINITY) {
-            continue;
+            // Static sheet-render path: divide.width is Infinity because
+            // the docs pageSize was left at INFINITY (so OVERFLOW into the
+            // neighbouring cells still works). The justification / LEFT /
+            // CENTER / RIGHT branches below all need a finite reference
+            // width to compute padding, so for RTL only we substitute
+            // `pageMaxLineWidth` (the natural width of the widest line on
+            // this page). With that substitution, short RTL lines get
+            // `paddingRight = pageMaxLineWidth - glyphGroupWidth` and pin
+            // to the same right anchor as the longest line. LTR keeps the
+            // legacy "skip on infinity" behaviour.
+            if (!isRTL || pageMaxLineWidth == null || !Number.isFinite(pageMaxLineWidth)) {
+                continue;
+            }
+            width = pageMaxLineWidth;
         }
 
         if (divide.isFull) {
             let remaining = width - glyphGroupWidth;
 
-            // Handle hanging punctuation to the right.
-            // TODO: @jocs Handle hanging punctuation to the left if text dir is RTL.
+            // Handle hanging punctuation. In LTR text the overhanging glyph
+            // sits at the right edge of the line (last glyph); in RTL we mirror
+            // it to the left edge (first glyph). Both budgets feed back into
+            // `remaining` so justification math stays the same.
             if (divide.glyphGroup.length > 1) {
-                const lastGlyph = divide.glyphGroup[divide.glyphGroup.length - 1];
-                const amount = overhang(lastGlyph.content) * lastGlyph.width;
+                const edgeGlyph = isRTL
+                    ? divide.glyphGroup[0]
+                    : divide.glyphGroup[divide.glyphGroup.length - 1];
+                const amount = overhang(edgeGlyph.content) * edgeGlyph.width;
 
                 remaining += amount;
             }
@@ -184,14 +237,73 @@ function horizontalAlignHandler(line: IDocumentSkeletonLine, horizontalAlign: Ho
             }
         }
 
-        if (horizontalAlign === HorizontalAlign.CENTER) {
-            divide.paddingLeft = (width - glyphGroupWidth) / 2;
-        } else if (horizontalAlign === HorizontalAlign.RIGHT) {
-            divide.paddingLeft = width - glyphGroupWidth;
+        if (isRTL) {
+            // In RTL paragraphs the "natural" side is the right; we push
+            // remaining whitespace to the right when the alignment asks for it.
+            //   - LEFT                  → glyphs visually pinned to the left
+            //                             edge (logical end).
+            //   - RIGHT / UNSPECIFIED   → glyphs pinned to the right edge
+            //                             (logical start). This is the default
+            //                             for RTL, including the very common
+            //                             "no horizontalAlign set on the cell"
+            //                             case where `_horizontalHandler`
+            //                             implicitly resolves to RIGHT for
+            //                             string-valued RTL content.
+            //   - CENTER                → halve the leftover space.
+            // JUSTIFIED is handled by the justification math above and falls
+            // back to the right-pinned default visually.
+            //
+            // IMPORTANT (multi-line cells): each line's `paddingRight` is
+            // computed independently from *its own* `glyphGroupWidth`, so a
+            // short Arabic line above a long one still pins to the divide's
+            // right edge instead of sharing the long line's left anchor.
+            // The page-level `_horizontalHandler` then pushes the whole page
+            // to the cell's right side, giving "every short line right-flush"
+            // instead of "all lines left-flush to the longest line".
+            if (horizontalAlign === HorizontalAlign.CENTER) {
+                divide.paddingLeft = (width - glyphGroupWidth) / 2;
+                divide.paddingRight = 0;
+            } else if (horizontalAlign === HorizontalAlign.LEFT) {
+                // RTL paragraphs interpret HorizontalAlign.LEFT as "logical
+                // start side" — which is the *visual* right edge in RTL
+                // text. This matches W3C css-logical and Excel behaviour:
+                // setting "left" on an Arabic paragraph pins it to the
+                // start of the line (= visual right).
+                divide.paddingLeft = 0;
+                divide.paddingRight = Math.max(0, width - glyphGroupWidth);
+            } else {
+                // RIGHT or UNSPECIFIED — also pin glyphs to the visual
+                // right edge of their divide. RIGHT is the "natural" RTL
+                // alignment; UNSPECIFIED falls here too because RTL text
+                // without an explicit `ht` should hug the right edge by
+                // default. `translateDivide` adds paddingRight on top of
+                // the layout-ruler's `glyph.left` (which is always left-
+                // anchored from 0), so we route the leftover whitespace
+                // into paddingRight to shift the whole glyph run flush
+                // with the divide's right edge.
+                //
+                // Computing this per-line independently is what fixes the
+                // "短行跟着长行左对齐" bug in multi-line Arabic cells: each
+                // line's `paddingRight = divide.width - glyphGroupWidth`
+                // varies with the line's own width, so short Arabic lines
+                // sit at their own right edge regardless of how wide the
+                // longest line is.
+                divide.paddingLeft = 0;
+                divide.paddingRight = Math.max(0, width - glyphGroupWidth);
+            }
+        } else {
+            if (horizontalAlign === HorizontalAlign.CENTER) {
+                divide.paddingLeft = (width - glyphGroupWidth) / 2;
+            } else if (horizontalAlign === HorizontalAlign.RIGHT) {
+                divide.paddingLeft = width - glyphGroupWidth;
+            }
         }
 
         // To fix https://github.com/dream-num/univer-pro/issues/2930
         divide.paddingLeft = Math.max(divide.paddingLeft, 0);
+        if (divide.paddingRight != null) {
+            divide.paddingRight = Math.max(divide.paddingRight, 0);
+        }
     }
 }
 
@@ -272,6 +384,47 @@ function addHyphenDash(
     }
 }
 
+/** Widest natural line on a page (sum of glyph widths per line). */
+function getPageMaxLineWidth(page: IDocumentSkeletonPage): number {
+    let max = 0;
+    for (const section of page.sections) {
+        for (const column of section.columns) {
+            for (const line of column.lines) {
+                const w = getLineNaturalWidth(line);
+                if (w > max) max = w;
+            }
+        }
+    }
+    return max;
+}
+
+/**
+ * Re-apply RTL horizontal alignment for every line on the page using a fresh
+ * max line width. `lineAdjustment` runs once per paragraph; caching the max on
+ * the first paragraph left shorter earlier lines pinned to a stale anchor when
+ * a later paragraph grew wider (multi-line Arabic in the cell editor).
+ */
+function reapplyRtlHorizontalAlignmentOnPage(
+    page: IDocumentSkeletonPage,
+    viewModel: DocumentViewModel
+) {
+    const pageMaxLineWidth = getPageMaxLineWidth(page);
+    for (const section of page.sections) {
+        for (const column of section.columns) {
+            for (const line of column.lines) {
+                const para = viewModel.getParagraph(line.paragraphIndex);
+                const { paragraphStyle = {} } = para || {};
+                const { horizontalAlign = HorizontalAlign.UNSPECIFIED, direction } = paragraphStyle;
+                if (direction !== TextDirection.RIGHT_TO_LEFT) {
+                    continue;
+                }
+                horizontalAlignHandler(line, horizontalAlign, direction, pageMaxLineWidth);
+                applyBidiReorderToLine(line, direction);
+            }
+        }
+    }
+}
+
 export function lineAdjustment(
     pages: IDocumentSkeletonPage[],
     viewModel: DocumentViewModel,
@@ -281,21 +434,34 @@ export function lineAdjustment(
     const { endIndex } = paragraphNode;
     const paragraph = viewModel.getParagraph(endIndex) || { startIndex: 0 };
 
-    lineIterator(pages, (line) => {
-        // Only need to adjust the current paragraph.
-        if (line.paragraphIndex !== paragraph.startIndex) {
-            return;
-        }
+    // Walk the pages so we can pass each line its page's max natural line
+    // width to `horizontalAlignHandler`. We keep the per-line work (CJK
+    // shrinking, hyphenation, bidi reorder) right next to where it was so
+    // sub-functions don't need extra plumbing.
+    const { paragraphStyle = {} } = paragraph;
+    const { horizontalAlign = HorizontalAlign.UNSPECIFIED, direction } = paragraphStyle;
+    const isRtlParagraph = direction === TextDirection.RIGHT_TO_LEFT;
 
-        const { paragraphStyle = {} } = paragraph;
-        const { horizontalAlign = HorizontalAlign.UNSPECIFIED } = paragraphStyle;
-        // If the last glyph is a CJK punctuation, we want to shrink it.
-        shrinkStartAndEndCJKPunctuation(line);
-        // restore the original glyph width.
-        restoreLastCJKGlyphWidth(line);
-        // Add dash to the end of divide when divide is break by Hyphen.
-        addHyphenDash(line, viewModel, paragraphNode, sectionBreakConfig, paragraphStyle);
-        // Handle horizontal align: left\center\right\justified.
-        horizontalAlignHandler(line, horizontalAlign);
-    });
+    for (const page of pages) {
+        for (const section of page.sections) {
+            for (const column of section.columns) {
+                for (const line of column.lines) {
+                    if (line.paragraphIndex !== paragraph.startIndex) {
+                        continue;
+                    }
+
+                    shrinkStartAndEndCJKPunctuation(line);
+                    restoreLastCJKGlyphWidth(line);
+                    addHyphenDash(line, viewModel, paragraphNode, sectionBreakConfig, paragraphStyle);
+                    // RTL horizontal align runs once per page below so every line
+                    // shares the same fresh `pageMaxLineWidth` anchor.
+                    if (!isRtlParagraph) {
+                        horizontalAlignHandler(line, horizontalAlign, direction);
+                        applyBidiReorderToLine(line, direction);
+                    }
+                }
+            }
+        }
+        reapplyRtlHorizontalAlignmentOnPage(page, viewModel);
+    }
 }

--- a/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
+++ b/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
@@ -74,6 +74,59 @@ export interface IFindNodeRestrictions {
     segmentPage: number;
 }
 
+/**
+ * For cluster glyphs (multi-character glyphs that hold an entire
+ * Arabic word so the browser can apply cursive joining), refine a
+ * hit-test x-coordinate into a `subOffset` — the character index inside
+ * the cluster, in `[0, glyph.count]`, where the caret should sit.
+ *
+ * The cluster glyph carries `charAdvances[i] = cumulative width up to
+ * (and including) the i-th character in **logical** order`. We binary-
+ * search for the half-way point of each character so a click on the
+ * **leading** half of char `i` snaps the caret *before* char `i`, and a
+ * click on the **trailing** half snaps it *after* char `i`. This mirrors
+ * the standard browser caret hit-test heuristic.
+ *
+ * Bidi note: `charAdvances` is laid out in logical order, but the
+ * cluster is rendered in visual order. For an RTL cluster (resolved
+ * bidiLevel === 1) the *visual* x grows leftwards through the logical
+ * indices, so we mirror `xInGlyph` before searching.
+ *
+ * Returns `undefined` when the glyph isn't a refinable cluster
+ * (no `charAdvances` available, or `count <= 1`), so callers transparently
+ * fall back to the legacy `ratioX < 0.5` heuristic.
+ */
+function resolveSubOffset(glyph: IDocumentSkeletonGlyph, xInGlyph: number): number | undefined {
+    const advances = glyph.charAdvances;
+    if (advances == null || advances.length <= 1 || glyph.count <= 1) {
+        return undefined;
+    }
+
+    // Mirror visual x for RTL clusters so the search runs in logical
+    // order regardless of paint direction.
+    const isRTL = (glyph.bidiLevel ?? 0) % 2 === 1;
+    const effectiveX = isRTL ? glyph.width - xInGlyph : xInGlyph;
+
+    const lastIndex = advances.length - 1;
+    // Clamp out-of-range to the cluster ends.
+    if (effectiveX <= 0) return 0;
+    if (effectiveX >= advances[lastIndex]) return advances.length;
+
+    // Walk forward picking the half-way midpoint of each char. We
+    // intentionally do this linearly — Arabic words are short and the
+    // overhead of `Array.prototype.findIndex` here is negligible
+    // compared to the surrounding hit-test cost.
+    let prevAdvance = 0;
+    for (let i = 0; i < advances.length; i++) {
+        const midpoint = (prevAdvance + advances[i]) / 2;
+        if (effectiveX < midpoint) {
+            return i;
+        }
+        prevAdvance = advances[i];
+    }
+    return advances.length;
+}
+
 function getPagePath(page: IDocumentSkeletonPage) {
     const path: (string | number)[] = [];
 
@@ -217,7 +270,7 @@ export class DocumentSkeleton extends Skeleton {
         return this.getViewModel().getDataModel().documentStyle.pageSize;
     }
 
-    findPositionByGlyph(glyph: IDocumentSkeletonGlyph, segmentPage: number): Nullable<INodeSearch> {
+    findPositionByGlyph(glyph: IDocumentSkeletonGlyph, segmentPage: number, subOffset?: number): Nullable<INodeSearch> {
         const divide = glyph.parent;
         const line = divide?.parent;
         const column = line?.parent;
@@ -277,6 +330,7 @@ export class DocumentSkeleton extends Skeleton {
             segmentPage,
             pageType,
             path,
+            subOffset,
         };
     }
 
@@ -300,6 +354,17 @@ export class DocumentSkeleton extends Skeleton {
             index += g.count;
         }
 
+        // Cluster-glyph refinement: when the position carries a
+        // `subOffset` (the character index inside a multi-char glyph
+        // such as the merged Arabic word), honour it instead of the
+        // glyph-coarse `isBack` fallback. `subOffset === 0` means
+        // "caret before first char of this glyph"; `subOffset ===
+        // glyph.count` means "after last char"; intermediate values
+        // place the caret between chars inside the cluster.
+        if (position.subOffset != null && glyph && glyph.count > 1) {
+            return index + position.subOffset;
+        }
+
         return position.isBack ? index : (index + glyph!.count);
     }
 
@@ -318,7 +383,7 @@ export class DocumentSkeleton extends Skeleton {
 
         const pages = skeletonData.pages;
 
-        const { glyph, divide, line, column, section, page, segmentPageIndex, pageType } = nodes;
+        const { glyph, divide, line, column, section, page, segmentPageIndex, pageType, subOffset } = nodes;
 
         const path = getPagePath(page);
 
@@ -357,6 +422,7 @@ export class DocumentSkeleton extends Skeleton {
             segmentPage: segmentPageIndex,
             isBack,
             path,
+            subOffset,
         };
     }
 
@@ -825,6 +891,7 @@ export class DocumentSkeleton extends Skeleton {
                                                 segmentId,
                                                 ratioX: x / (startX_fin + endX_fin),
                                                 ratioY: y / (startY_fin + endY_fin),
+                                                subOffset: resolveSubOffset(glyph, x - startX_fin),
                                             };
                                         }
 
@@ -1342,9 +1409,18 @@ export class DocumentSkeleton extends Skeleton {
                             let delta = charIndex - st;
 
                             for (const glyph of glyphGroup) {
+                                const beforeGlyph = delta;
                                 delta -= glyph.count;
 
                                 if (delta < 0) {
+                                    // `beforeGlyph` is the in-glyph
+                                    // character index for the requested
+                                    // `charIndex` — exactly the
+                                    // `subOffset` consumers need to
+                                    // place the caret inside a cluster
+                                    // glyph. For single-char glyphs it
+                                    // is always 0 and harmlessly
+                                    // ignored downstream.
                                     return {
                                         page: segmentPage,
                                         pageType: segmentPage.type,
@@ -1354,6 +1430,7 @@ export class DocumentSkeleton extends Skeleton {
                                         divide,
                                         glyph,
                                         segmentPageIndex,
+                                        subOffset: glyph.count > 1 ? beforeGlyph : undefined,
                                     };
                                 }
                             }

--- a/packages/engine-render/src/components/docs/layout/model/glyph.ts
+++ b/packages/engine-render/src/components/docs/layout/model/glyph.ts
@@ -24,7 +24,7 @@ import type {
 
 import type { IFontCreateConfig } from '../../../../basics/interfaces';
 import type { IOpenTypeGlyphInfo } from '../shaping-engine/text-shaping';
-import { BooleanNumber, BulletAlignment, DataStreamTreeTokenType as DT, GridType } from '@univerjs/core';
+import { BooleanNumber, BulletAlignment, DataStreamTreeTokenType as DT, GridType, TextDirection } from '@univerjs/core';
 import { GlyphType } from '../../../../basics/i-document-skeleton-cached';
 import { hasCJK, hasCJKText, isCjkCenterAlignedPunctuation, isCjkLeftAlignedPunctuation, isCjkRightAlignedPunctuation, ptToPixel } from '../../../../basics/tools';
 import { FontCache } from '../shaping-engine/font-cache';
@@ -249,7 +249,8 @@ export function _createSkeletonWordOrLetter(
 export function createSkeletonBulletGlyph(
     glyph: IDocumentSkeletonGlyph,
     bulletSkeleton: IDocumentSkeletonBullet,
-    charSpaceApply: number
+    charSpaceApply: number,
+    direction?: TextDirection
 ): IDocumentSkeletonGlyph {
     const {
         // bBox: boundingBox,
@@ -270,9 +271,35 @@ export function createSkeletonBulletGlyph(
     let width = (multiple < 2 ? 2 : multiple) * charSpaceApply; // Default bullet has 2 tabs
 
     let left = 0;
+    // `xOffset` is the in-glyph paint offset used by the renderer:
+    // `paintX = glyph.left + glyph.xOffset` (see `document.ts`). It does
+    // not change the laid-out box (`glyph.left` is reassigned by the
+    // layout pipeline anyway), only where the symbol is painted inside
+    // that box.
+    let xOffset = 0;
+    const isRTL = direction === TextDirection.RIGHT_TO_LEFT;
 
-    if (bulletType) {
-        // Ordered list processing, left=0 when left-aligned, otherwise adjusted based on contentWidth
+    if (isRTL) {
+        // RTL paragraphs: after bidi-reorder places this bullet glyph at
+        // the visual right of the line, the **bullet symbol** also needs
+        // to sit at the glyph's local-right so the wide bullet-glyph
+        // padding becomes the gap between the symbol and the RTL text.
+        // Without this push, the symbol stays at the glyph's local-left,
+        // glued to the text, while the bullet's natural padding floats
+        // unused at the line's far-right.
+        //
+        // `xOffset` is the right knob because `glyph.left` is reassigned
+        // by `setGlyphGroupLeft` during layout (any pre-set value is
+        // wiped). The page-width accumulator in `tools.ts` is taught to
+        // skip this `xOffset` for `GlyphType.LIST` so we don't shrink
+        // the line and accidentally wrap narrow cells.
+        xOffset = width - contentWidth;
+    } else if (bulletType) {
+        // Ordered list processing (LTR), left=0 when left-aligned,
+        // otherwise adjusted based on contentWidth. The `width -= left`
+        // here grows the glyph rect leftwards so the symbol can extend
+        // past the glyph's local origin — preserved for legacy
+        // CENTER/END alignment.
         if (bulletAlign === BulletAlignment.CENTER) {
             left = -contentWidth / 2;
             width -= left;
@@ -295,7 +322,7 @@ export function createSkeletonBulletGlyph(
         },
         fontStyle,
         width,
-        xOffset: 0,
+        xOffset,
         bBox,
         left,
         isJustifiable: isJustifiable(content),

--- a/packages/engine-render/src/components/docs/layout/model/line.ts
+++ b/packages/engine-render/src/components/docs/layout/model/line.ts
@@ -589,6 +589,7 @@ function __getDivideSKe(left: number, width: number): IDocumentSkeletonDivide {
         width, // Total width after division
         left, // Offset position after division by objects | d1 | | d2 |
         paddingLeft: 0, // paddingLeft alignment offset calculated based on horizonAlign and width
+        paddingRight: 0, // paddingRight (only used for RTL alignment, see horizontalAlignHandler)
         isFull: false, // isFull, // whether content is full
         st: 0, // startIndex
         ed: 0, // endIndex

--- a/packages/engine-render/src/components/docs/layout/tools.ts
+++ b/packages/engine-render/src/components/docs/layout/tools.ts
@@ -405,7 +405,21 @@ export function updateBlockIndex(pages: IDocumentSkeletonPage[], start: number =
 
                         lineHasGlyph = true;
 
-                        if (glyphGroup[0].xOffset !== 0 && i === divideLength - 1) {
+                        if (
+                            glyphGroup[0].xOffset !== 0
+                            && i === divideLength - 1
+                            // Exclude list bullets: their `xOffset` is
+                            // used in RTL paragraphs to push the bullet
+                            // symbol from the glyph's local-left to its
+                            // local-right (so the symbol ends up flush
+                            // with the visual-right edge after bidi
+                            // reorder). It is *not* compensation for
+                            // shrunk CJK punctuation, so subtracting it
+                            // from `actualWidth` would shrink the page
+                            // width by ~13px and force unintended line
+                            // wraps in narrow cells.
+                            && glyphGroup[0].glyphType !== GlyphType.LIST
+                        ) {
                             actualWidth -= glyphGroup[0].xOffset;
                         }
 

--- a/packages/engine-render/src/components/docs/liquid.ts
+++ b/packages/engine-render/src/components/docs/liquid.ts
@@ -173,10 +173,15 @@ export class Liquid {
     }
 
     translateDivide(divide: IDocumentSkeletonDivide, isVerticalAndWrap = false, verticalAlign = VerticalAlign.UNSPECIFIED, rotatedHeight = 0) {
-        const { left: divideLeft, paddingLeft: dividePaddingLeft, glyphGroupWidth = 0 } = divide;
+        const { left: divideLeft, paddingLeft: dividePaddingLeft, paddingRight: dividePaddingRight = 0, glyphGroupWidth = 0 } = divide;
         let left = divideLeft;
         if (!isVerticalAndWrap) {
-            left += dividePaddingLeft;
+            // For LTR `paddingRight` is always 0 and the math collapses to the
+            // historical `left += paddingLeft` behaviour. For RTL paragraphs
+            // `horizontalAlignHandler` writes the remaining whitespace into
+            // `paddingRight`, which we add here so glyphs are pushed away from
+            // the right edge of their divide.
+            left += dividePaddingLeft + dividePaddingRight;
         } else {
             if (verticalAlign === VerticalAlign.MIDDLE) {
                 left += (rotatedHeight - glyphGroupWidth) / 2;

--- a/packages/engine-render/src/components/sheets/extensions/font.ts
+++ b/packages/engine-render/src/components/sheets/extensions/font.ts
@@ -25,7 +25,7 @@ import type { IDrawInfo } from '../../extension';
 import type { IFontCacheItem } from '../interfaces';
 import type { SheetComponent } from '../sheet-component';
 import type { SpreadsheetSkeleton } from '../sheet.render-skeleton';
-import { CellValueType, getDisplayValueFromCell, HorizontalAlign, Range, Tools, VerticalAlign, WrapStrategy } from '@univerjs/core';
+import { CellValueType, getDisplayValueFromCell, HorizontalAlign, isFirstStrongCharRTL, Range, TextDirection, Tools, VerticalAlign, WrapStrategy } from '@univerjs/core';
 import { FIX_ONE_PIXEL_BLUR_OFFSET } from '../../../basics';
 import { VERTICAL_ROTATE_ANGLE } from '../../../basics/text-rotation';
 import { clampRange, inViewRanges } from '../../../basics/tools';
@@ -539,6 +539,23 @@ export class Font extends SheetExtension {
             } else if (cellData.t === CellValueType.BOOLEAN) {
                 // If the cell value is a boolean, default to center alignment.
                 hAlign = HorizontalAlign.CENTER;
+            } else if (
+                fontCache.style?.td === TextDirection.RIGHT_TO_LEFT
+                // Auto-detect RTL when the text starts with a strong RTL char
+                // (Excel / Sheets style) even if `style.td` was never set.
+                //
+                // Note: under the current `_setFontStylesCache` policy, any
+                // cell whose content contains an RTL codepoint at all is
+                // routed through the docs pipeline (`_renderDocuments`), so
+                // this branch is only reached by truly pure-LTR /
+                // pure-numeric cells. Keeping the auto-detect here as a
+                // belt-and-braces fallback in case the upstream policy ever
+                // narrows again.
+                || isFirstStrongCharRTL(text)
+            ) {
+                // RTL strings default to right alignment (mirrors LTR's default-left behaviour).
+                // This is the fallback when the cell escapes the docs pipeline (e.g. legacy paths).
+                hAlign = HorizontalAlign.RIGHT;
             }
         }
 

--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -49,11 +49,13 @@ import {
     extractPureTextFromCell,
     getColorStyle,
     getDisplayValueFromCell,
+    hasRTLCharacter,
     HorizontalAlign,
     IConfigService,
     IContextService,
     Inject,
     Injector,
+    isFirstStrongCharRTL,
     isNullCell,
     isWhiteColor,
     LocaleService,
@@ -61,6 +63,7 @@ import {
     Range,
     searchArray,
     SheetSkeleton,
+    TextDirection,
     Tools,
     VerticalAlign,
     WrapStrategy,
@@ -542,7 +545,8 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
         const sideGap = (cell?.fontRenderExtension?.leftOffset ?? 0) + (cell?.fontRenderExtension?.rightOffset ?? 0);
 
         const { vertexAngle, centerAngle } = convertTextRotation(style?.tr ?? { a: 0 });
-        const isRichText = cell?.p || vertexAngle || centerAngle;
+        const hasExplicitTextDirection = style?.td != null && style.td !== TextDirection.UNSPECIFIED;
+        const isRichText = cell?.p || vertexAngle || centerAngle || hasExplicitTextDirection;
 
         let colWidth = columnData[col]?.w ?? defaultColumnWidth;
         if (cellMergeInfo.isMergedMainCell) {
@@ -1049,10 +1053,13 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
         const verticalAlign: VerticalAlign = cellOtherConfig.verticalAlign || DEFAULT_STYLES.vt;
         const wrapStrategy: WrapStrategy = cellOtherConfig.wrapStrategy || DEFAULT_STYLES.tb;
         const paddingData: IPaddingData = cellOtherConfig.paddingData || DEFAULT_PADDING_DATA;
+        // Forward the cell-level text direction (`style.td`) so the docs render
+        // pipeline can pick correct defaults for `UNSPECIFIED` alignment and
+        // apply bidi reordering / RTL padding at layout time.
+        const textDirection = cellOtherConfig.textDirection ?? undefined;
 
         if (cell.f && displayRawFormula) {
-            // The formula does not detect horizontal alignment and rotation.
-            documentModel = createDocumentModelWithStyle(cell.f.toString(), {}, { verticalAlign });
+            documentModel = createDocumentModelWithStyle(cell.f.toString(), {}, { verticalAlign, textDirection });
             horizontalAlign = DEFAULT_STYLES.ht;
         } else if (cell.p) {
             const { centerAngle, vertexAngle } = convertTextRotation(textRotation);
@@ -1066,8 +1073,10 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
                     centerAngle,
                     vertexAngle,
                     wrapStrategy,
+                    textDirection,
                     zeroWidthParagraphBreak: 1,
-                }
+                },
+                textDirection
             );
         } else if (cell.v != null) {
             const textStyle = getFontFormat(style);
@@ -1422,10 +1431,44 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
             return;
         }
         const { vertexAngle, centerAngle } = convertTextRotation(style?.tr ?? { a: 0 });
-        const isRichText = cellData?.p || vertexAngle || centerAngle;
+        // Cells whose `style.td` requests an explicit text direction need to go
+        // through the docs render pipeline (which honours `renderConfig.textDirection`
+        // and per-paragraph bidi), otherwise they would fall back to the simple
+        // `Text.drawWith` branch that has no awareness of RTL.
+        const hasExplicitTextDirection = style?.td != null && style.td !== TextDirection.UNSPECIFIED;
+        // Auto-detection. Two related but distinct signals:
+        //
+        //  * `contentLooksRTL` (first-strong char is RTL) — used to decide
+        //    the cell's *implicit* paragraph direction. Mirrors Excel /
+        //    Google Sheets: a cell that starts with Arabic right-aligns by
+        //    default even without `style.td`.
+        //  * `contentHasBidi` (text contains *any* RTL codepoint) — used to
+        //    decide whether the cell must go through the docs pipeline at
+        //    all. This is the wider net: LTR-baseline mixed text like
+        //    "Hello كتاب" doesn't look RTL but **must not** be rendered by
+        //    the simple `Text.drawWith` fallback, because that fallback
+        //    delegates bidi/shaping to the browser's `ctx.fillText`, which
+        //    disagrees with our docs-engine bidi in edit mode and would
+        //    show different visual ordering when the editor closes.
+        const pureText = cellData != null ? extractPureTextFromCell(cellData) : '';
+        const contentLooksRTL = !hasExplicitTextDirection && isFirstStrongCharRTL(pureText);
+        const contentHasBidi = !hasExplicitTextDirection && hasRTLCharacter(pureText);
+        const isRichText = cellData?.p
+            || vertexAngle
+            || centerAngle
+            || hasExplicitTextDirection
+            || contentHasBidi;
 
         const modelObject = isRichText ?
-            this.worksheet.getCellDocumentModel(cellData, style, { displayRawFormula: this._renderRawFormula })
+            this.worksheet.getCellDocumentModel(cellData, style, {
+                displayRawFormula: this._renderRawFormula,
+                // Inject an implicit RTL direction when the cell didn't ask
+                // for one but the content itself is RTL. The override flows
+                // into `paragraphStyle.direction` and
+                // `documentStyle.renderConfig.textDirection`, driving the
+                // alignment defaults and bidi reorder downstream.
+                implicitTextDirection: contentLooksRTL ? TextDirection.RIGHT_TO_LEFT : undefined,
+            })
             : null;
 
         if (modelObject) {

--- a/packages/engine-render/src/components/sheets/util.ts
+++ b/packages/engine-render/src/components/sheets/util.ts
@@ -14,118 +14,14 @@
  * limitations under the License.
  */
 
-import type { CellValueType, IDocumentData, IPaddingData, IStyleBase, IStyleData, ITextRotation, ITextStyle, Nullable, TextDirection } from '@univerjs/core';
-import { DEFAULT_EMPTY_DOCUMENT_VALUE, DocumentDataModel, DocumentFlavor, HorizontalAlign, VerticalAlign, WrapStrategy } from '@univerjs/core';
-import { convertTextRotation } from '../../basics/text-rotation';
-import { DEFAULT_PADDING_DATA } from './sheet.render-skeleton';
-
-export interface ICellStyle {
-    textRotation?: ITextRotation;
-    textDirection?: Nullable<TextDirection>;
-    horizontalAlign?: HorizontalAlign;
-    verticalAlign?: VerticalAlign;
-    wrapStrategy?: WrapStrategy;
-    paddingData?: IPaddingData;
-    cellValueType?: CellValueType;
-}
-
-export function createDocumentModelWithStyle(content: string, textStyle: ITextStyle, config: ICellStyle = {}) {
-    const contentLength = content.length;
-    const {
-        textRotation,
-        paddingData,
-        horizontalAlign = HorizontalAlign.UNSPECIFIED,
-        verticalAlign = VerticalAlign.UNSPECIFIED,
-        wrapStrategy = WrapStrategy.UNSPECIFIED,
-        cellValueType,
-    } = config;
-
-    const { t: marginTop, r: marginRight, b: marginBottom, l: marginLeft } = paddingData || DEFAULT_PADDING_DATA;
-    const { vertexAngle, centerAngle } = convertTextRotation(textRotation);
-    const documentData: IDocumentData = {
-        id: 'd',
-        body: {
-            dataStream: `${content}${DEFAULT_EMPTY_DOCUMENT_VALUE}`,
-            textRuns: [
-                {
-                    ts: textStyle,
-                    st: 0,
-                    ed: contentLength,
-                },
-            ],
-            paragraphs: [
-                {
-                    startIndex: contentLength,
-                    paragraphStyle: {
-                        horizontalAlign,
-                    },
-                },
-            ],
-            sectionBreaks: [{
-                startIndex: contentLength + 1,
-            }],
-        },
-        documentStyle: {
-            pageSize: {
-                width: Number.POSITIVE_INFINITY,
-                height: Number.POSITIVE_INFINITY,
-            },
-            documentFlavor: DocumentFlavor.UNSPECIFIED,
-            marginTop,
-            marginBottom,
-            marginRight,
-            marginLeft,
-            paragraphLineGapDefault: 0,
-            renderConfig: {
-                horizontalAlign,
-                verticalAlign,
-                centerAngle,
-                vertexAngle,
-                wrapStrategy,
-                cellValueType,
-            },
-        },
-        drawings: {},
-        drawingsOrder: [],
-    };
-
-    return new DocumentDataModel(documentData);
-}
-
-export function extractOtherStyle(style?: Nullable<IStyleData>): ICellStyle {
-    if (!style) return {};
-    const {
-        tr: textRotation,
-        td: textDirection,
-        ht: horizontalAlign,
-        vt: verticalAlign,
-        tb: wrapStrategy,
-        pd: paddingData,
-    } = style;
-
-    return {
-        textRotation,
-        textDirection,
-        horizontalAlign,
-        verticalAlign,
-        wrapStrategy,
-        paddingData,
-    } as ICellStyle;
-}
-
-export function getFontFormat(format?: Nullable<IStyleData>): IStyleBase {
-    if (!format) {
-        return {};
-    }
-    const { ff, fs, it, bl, ul, st, ol, cl } = format;
-    const style: IStyleBase = {};
-    ff && (style.ff = ff);
-    fs && (style.fs = fs);
-    it && (style.it = it);
-    bl && (style.bl = bl);
-    ul && (style.ul = ul);
-    st && (style.st = st);
-    ol && (style.ol = ol);
-    cl && (style.cl = cl);
-    return style;
-}
+/**
+ * @deprecated The implementations here have been merged into `@univerjs/core`.
+ *             This file re-exports them for backward compatibility and will be
+ *             removed in a future release. Import from `@univerjs/core` instead.
+ */
+export {
+    createDocumentModelWithStyle,
+    extractOtherStyle,
+    getFontFormat,
+    type ICellStyle,
+} from '@univerjs/core';

--- a/packages/engine-render/src/index.ts
+++ b/packages/engine-render/src/index.ts
@@ -20,7 +20,12 @@ export { getOffsetRectForDom } from './basics/position';
 export * from './canvas';
 export * from './components';
 export { DocBackground } from './components/docs/doc-background';
-export { Documents } from './components/docs/document';
+export {
+    computeDocumentPageAlignOffset,
+    computeDocumentPageHorizontalAlignOffset,
+    computeDocumentPageVerticalAlignOffset,
+    Documents,
+} from './components/docs/document';
 export type { IPageRenderConfig } from './components/docs/document';
 export type { IDocumentOffsetConfig } from './components/docs/document';
 export { getTableIdAndSliceIndex } from './components/docs/layout/block/table';

--- a/packages/sheets-formula-ui/src/views/formula-editor/hooks/use-left-and-right-arrow.ts
+++ b/packages/sheets-formula-ui/src/views/formula-editor/hooks/use-left-and-right-arrow.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Editor } from '@univerjs/docs-ui';
-import { CommandType, Direction, DisposableCollection, ICommandService } from '@univerjs/core';
+import { CommandType, Direction, DisposableCollection, ICommandService, TextDirection } from '@univerjs/core';
 import { MoveCursorOperation, MoveSelectionOperation } from '@univerjs/docs-ui';
 import { DeviceInputEventType } from '@univerjs/engine-render';
 import { ExpandSelectionCommand, JumpOver, MoveSelectionCommand } from '@univerjs/sheets-ui';
@@ -23,14 +23,37 @@ import { IShortcutService, KeyCode, MetaKeys, useDependency } from '@univerjs/ui
 import { useEffect, useRef } from 'react';
 import { FormulaSelectingType } from './use-formula-selection';
 
+export interface IUseFormulaArrowOptions {
+    /** Force LTR/RTL arrow-key semantics regardless of paragraph direction. */
+    forceDirection?: 'ltr' | 'rtl';
+}
+
+function readEditorTextDirection(editor: Editor | undefined): TextDirection {
+    if (!editor) return TextDirection.UNSPECIFIED;
+    try {
+        const data = editor.getDocumentData();
+        return data.body?.paragraphs?.[0]?.paragraphStyle?.direction ?? TextDirection.UNSPECIFIED;
+    } catch {
+        return TextDirection.UNSPECIFIED;
+    }
+}
+
 // eslint-disable-next-line max-lines-per-function
-export const useLeftAndRightArrow = (isNeed: boolean, shouldMoveSelection: FormulaSelectingType, editor?: Editor, onMoveInEditor?: (keyCode: KeyCode, metaKey?: MetaKeys) => void) => {
+export const useLeftAndRightArrow = (
+    isNeed: boolean,
+    shouldMoveSelection: FormulaSelectingType,
+    editor?: Editor,
+    onMoveInEditor?: (keyCode: KeyCode, metaKey?: MetaKeys) => void,
+    options?: IUseFormulaArrowOptions
+) => {
     const commandService = useDependency(ICommandService);
     const shortcutService = useDependency(IShortcutService);
     const shouldMoveSelectionRef = useRef(shouldMoveSelection);
     shouldMoveSelectionRef.current = shouldMoveSelection;
     const onMoveInEditorRef = useRef(onMoveInEditor);
     onMoveInEditorRef.current = onMoveInEditor;
+    const forceDirectionRef = useRef(options?.forceDirection);
+    forceDirectionRef.current = options?.forceDirection;
 
     // eslint-disable-next-line max-lines-per-function
     useEffect(() => {
@@ -46,13 +69,23 @@ export const useLeftAndRightArrow = (isNeed: boolean, shouldMoveSelection: Formu
                 return;
             }
 
+            const forced = forceDirectionRef.current;
+            const effectiveDir = forced === 'rtl'
+                ? TextDirection.RIGHT_TO_LEFT
+                : forced === 'ltr'
+                    ? TextDirection.LEFT_TO_RIGHT
+                    : readEditorTextDirection(editor);
+            const isRTL = effectiveDir === TextDirection.RIGHT_TO_LEFT;
+
             let direction = Direction.LEFT;
             if (keycode === KeyCode.ARROW_DOWN) {
                 direction = Direction.DOWN;
             } else if (keycode === KeyCode.ARROW_UP) {
                 direction = Direction.UP;
+            } else if (keycode === KeyCode.ARROW_LEFT) {
+                direction = isRTL ? Direction.RIGHT : Direction.LEFT;
             } else if (keycode === KeyCode.ARROW_RIGHT) {
-                direction = Direction.RIGHT;
+                direction = isRTL ? Direction.LEFT : Direction.RIGHT;
             }
 
             if (metaKey === MetaKeys.SHIFT) {

--- a/packages/sheets-formula-ui/src/views/formula-editor/index.tsx
+++ b/packages/sheets-formula-ui/src/views/formula-editor/index.tsx
@@ -88,6 +88,13 @@ export interface IFormulaEditorProps {
         backgroundColor?: string;
         fontSize?: number;
     };
+    /**
+     * Force the arrow-key visual<->logical mapping to a specific direction
+     * regardless of the editor's paragraph direction. The formula bar passes
+     * `'ltr'` so formula syntax navigation stays consistent even when the
+     * surrounding workbook is set to RTL.
+     */
+    forceDirection?: 'ltr' | 'rtl';
 }
 
 export interface IFormulaEditorRef {
@@ -121,6 +128,7 @@ export const FormulaEditor = forwardRef((props: IFormulaEditorProps, ref: Ref<IF
         style,
         borderless = false,
         canvasStyle,
+        forceDirection,
     } = props;
 
     const editorService = useDependency(IEditorService);
@@ -312,7 +320,13 @@ export const FormulaEditor = forwardRef((props: IFormulaEditorProps, ref: Ref<IF
 
     const { checkScrollBar } = useResize(editor, isSingle, autoScrollbar);
     useRefactorEffect(isFocus, Boolean(isSelecting && docFocusing), unitId, editorId, disableContextMenu);
-    useLeftAndRightArrow(Boolean(isFocus && isFocusing && moveCursor), selectingMode, editor, onMoveInEditor);
+    useLeftAndRightArrow(
+        Boolean(isFocus && isFocusing && moveCursor),
+        selectingMode,
+        editor,
+        onMoveInEditor,
+        forceDirection ? { forceDirection } : undefined
+    );
 
     const handleSelectionChange = useEvent((refString: string, offset: number, isEnd: boolean) => {
         if (!isFocusing) {

--- a/packages/sheets-ui/src/controllers/clipboard/clipboard.controller.ts
+++ b/packages/sheets-ui/src/controllers/clipboard/clipboard.controller.ts
@@ -22,6 +22,7 @@ import type {
     IObjectArrayPrimitiveType,
     IObjectMatrixPrimitiveType,
     IRange,
+    Nullable,
     Workbook,
     Worksheet,
 } from '@univerjs/core';
@@ -52,11 +53,13 @@ import {
     IContextService,
     Inject,
     Injector,
+    isFirstStrongCharRTL,
     isFormulaString,
     IUniverInstanceService,
     LocaleService,
     ObjectMatrix,
     RxDisposable,
+    TextDirection,
     Tools,
     UniverInstanceType,
 } from '@univerjs/core';
@@ -121,6 +124,19 @@ const shouldRemoveShapeIds = [
     MoveRowsMutation.id,
     MoveColsMutation.id,
 ];
+
+function resolveClipboardDirection(cell: Nullable<ICellData>, textDirection?: Nullable<TextDirection>) {
+    if (textDirection === TextDirection.LEFT_TO_RIGHT) {
+        return { dir: 'ltr' as const, implicit: false };
+    }
+    if (textDirection === TextDirection.RIGHT_TO_LEFT) {
+        return { dir: 'rtl' as const, implicit: false };
+    }
+
+    return isFirstStrongCharRTL(extractPureTextFromCell(cell))
+        ? { dir: 'rtl' as const, implicit: true }
+        : { dir: undefined, implicit: false };
+}
 
 export class SheetClipboardController extends RxDisposable {
     private _refreshOptionalPaste$ = new Subject();
@@ -281,6 +297,11 @@ export class SheetClipboardController extends RxDisposable {
                     style = handleStyleToString(textStyle);
                 }
 
+                const { dir, implicit } = resolveClipboardDirection(currentSheet!.getCell(row, col), textStyle?.td);
+                if (implicit) {
+                    style += `${style ? ';' : ''}direction: rtl; `;
+                }
+
                 if (mergedCellByRowCol) {
                     const endRow = mergedCellByRowCol.endRow;
                     const endColumn = mergedCellByRowCol.endColumn;
@@ -298,6 +319,9 @@ export class SheetClipboardController extends RxDisposable {
 
                 if (style) {
                     properties.style = style;
+                }
+                if (dir) {
+                    properties.dir = dir;
                 }
 
                 return Object.keys(properties).length ? properties : null;

--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -48,6 +48,7 @@ import {
     FOCUSING_EDITOR_STANDALONE,
     FOCUSING_FX_BAR_EDITOR,
     generateRandomId,
+    HorizontalAlign,
     ICommandService,
     IConfigService,
     IContextService,
@@ -57,6 +58,7 @@ import {
     IUndoRedoService,
     IUniverInstanceService,
     LocaleService,
+    TextDirection,
     toDisposable,
     Tools,
     UniverInstanceType,
@@ -370,6 +372,11 @@ export class EditingRenderController extends Disposable {
                 }
 
                 if (commandUnitId === DOCS_NORMAL_EDITOR_UNIT_ID_KEY) {
+                    // Re-evaluate the live text direction first: typing
+                    // Arabic into an empty cell needs to flip the editor to
+                    // RTL *before* we recompute layout, so `fitTextSize`
+                    // picks up the updated `effectiveHorizontalAlign`.
+                    this._editorBridgeService.syncEditorTextDirection();
                     this._sheetCellEditorResizeService?.fitTextSize();
                 }
             }
@@ -445,11 +452,26 @@ export class EditingRenderController extends Disposable {
             return;
         }
 
+        this._editorBridgeService.syncEditorTextDirection();
         this._sheetCellEditorResizeService?.fitTextSize(() => {
             const viewMain = scene.getViewport(DOC_VIEWPORT_KEY.VIEW_MAIN);
+            const cellAlign = editCellState.documentLayoutObject.horizontalAlign;
+            const isRTL = this._editorBridgeService.getEffectiveTextDirection() === TextDirection.RIGHT_TO_LEFT;
+            let effectiveAlign = cellAlign;
+            if (cellAlign === HorizontalAlign.UNSPECIFIED && isRTL) {
+                effectiveAlign = HorizontalAlign.RIGHT;
+            }
+            const scrollContentToFarRight = effectiveAlign === HorizontalAlign.LEFT
+                || (cellAlign === HorizontalAlign.UNSPECIFIED && !isRTL);
             viewMain?.scrollToViewportPos({
-                viewportScrollX: Number.POSITIVE_INFINITY,
+                // Only LTR-left overflow editing scrolls to +Infinity; center/right/RTL
+                // use pageSize=Infinity + `_horizontalHandler` anchored at scroll 0.
+                viewportScrollX: scrollContentToFarRight ? Number.POSITIVE_INFINITY : 0,
                 viewportScrollY: Number.POSITIVE_INFINITY,
+            });
+            this._textSelectionManagerService.refreshSelection({
+                unitId: DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
+                subUnitId: DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
             });
         });
 
@@ -786,13 +808,16 @@ export class EditingRenderController extends Disposable {
 
     // TODO: @JOCS, is it necessary to move these commands MoveSelectionOperation\MoveCursorOperation to shortcut? and use multi-commands?
     private _moveInEditor(keycode: KeyCode, isShift: boolean) {
+        const isRTL = this._editorBridgeService.getEffectiveTextDirection() === TextDirection.RIGHT_TO_LEFT;
         let direction = Direction.LEFT;
         if (keycode === KeyCode.ARROW_DOWN) {
             direction = Direction.DOWN;
         } else if (keycode === KeyCode.ARROW_UP) {
             direction = Direction.UP;
+        } else if (keycode === KeyCode.ARROW_LEFT) {
+            direction = isRTL ? Direction.RIGHT : Direction.LEFT;
         } else if (keycode === KeyCode.ARROW_RIGHT) {
-            direction = Direction.RIGHT;
+            direction = isRTL ? Direction.LEFT : Direction.RIGHT;
         }
 
         if (isShift) {

--- a/packages/sheets-ui/src/services/__tests__/editor-bridge.service.spec.ts
+++ b/packages/sheets-ui/src/services/__tests__/editor-bridge.service.spec.ts
@@ -14,20 +14,47 @@
  * limitations under the License.
  */
 
-import { DOCS_NORMAL_EDITOR_UNIT_ID_KEY } from '@univerjs/core';
+import { DOCS_NORMAL_EDITOR_UNIT_ID_KEY, TextDirection } from '@univerjs/core';
 import { DeviceInputEventType } from '@univerjs/engine-render';
 import { Subject } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 import { EditorBridgeService } from '../editor-bridge.service';
 
-function createService(options?: { hasFocusEditor?: boolean }) {
+interface IServiceOptions {
+    hasFocusEditor?: boolean;
+    editorBodyText?: string;
+    explicitCellTd?: TextDirection;
+}
+
+function createService(options?: IServiceOptions) {
     const unitDisposed$ = new Subject<any>();
     const workbook = {
         getUnitId: () => 'unit-1',
+        getSheetBySheetId: vi.fn(() => ({
+            getComposedCellStyle: vi.fn(() => (options?.explicitCellTd != null ? { td: options.explicitCellTd } : {})),
+        })),
+    };
+
+    // The editor docs unit. Its body is mutable so tests can simulate typing
+    // between calls to `syncEditorTextDirection`. The default `getBody` mock
+    // places the paragraph break right after the body text so the per-
+    // paragraph direction detector sees the actual content.
+    const seedText = options?.editorBodyText ?? '';
+    const editorDoc = {
+        documentStyle: {
+            renderConfig: {
+                textDirection: undefined as TextDirection | undefined,
+            },
+        },
+        getBody: vi.fn(() => ({
+            dataStream: `${seedText}\r\n`,
+            paragraphs: [{ startIndex: seedText.length, paragraphStyle: {} }],
+        })),
     };
 
     const mocks = {
         unitDisposed$,
+        editorDoc,
         sheetInterceptorService: {
             writeCellInterceptor: {
                 fetchThroughInterceptors: vi.fn(() => (cell: unknown) => cell),
@@ -45,6 +72,10 @@ function createService(options?: { hasFocusEditor?: boolean }) {
         univerInstanceService: {
             getTypeOfUnitDisposed$: vi.fn(() => unitDisposed$.asObservable()),
             getCurrentUnitOfType: vi.fn(() => workbook),
+            getUnit: vi.fn((unitId: string) => {
+                if (unitId === DOCS_NORMAL_EDITOR_UNIT_ID_KEY) return editorDoc;
+                return workbook;
+            }),
         },
         editorService: {
             getFocusEditor: vi.fn(() => (options?.hasFocusEditor ? { id: 'existing' } : null)),
@@ -203,5 +234,201 @@ describe('EditorBridgeService', () => {
         service.refreshEditCellPosition();
         expect(getLatestSpy).toHaveBeenCalled();
         expect(mocks.editorService.focus).not.toHaveBeenCalled();
+    });
+
+    describe('syncEditorTextDirection', () => {
+        function seedEditingState(service: EditorBridgeService) {
+            const latest = createLatestState();
+            vi.spyOn(service, 'getLatestEditCellState').mockReturnValue(latest as any);
+            service.setEditCell(createEditCellParam());
+        }
+
+        it('flips effective direction to RTL when the live body becomes Arabic', () => {
+            const { service, mocks } = createService({ editorBodyText: '' });
+            seedEditingState(service);
+            expect(service.getEffectiveTextDirection()).toBe(TextDirection.LEFT_TO_RIGHT);
+
+            // Simulate the user typing Arabic into a previously empty cell.
+            const arabic = 'كتاب';
+            mocks.editorDoc.getBody.mockReturnValue({
+                dataStream: `${arabic}\r\n`,
+                paragraphs: [{ startIndex: arabic.length, paragraphStyle: {} }],
+            });
+            service.syncEditorTextDirection();
+
+            expect(service.getEffectiveTextDirection()).toBe(TextDirection.RIGHT_TO_LEFT);
+            // Implicit (auto-detected) direction is written per-paragraph,
+            // not to the document-level renderConfig, so multi-line cells
+            // can mix LTR and RTL rows. RenderConfig only carries cell-level
+            // explicit `style.td`.
+            const liveBody = mocks.editorDoc.getBody.mock.results.at(-1)?.value;
+            expect(liveBody.paragraphs[0].paragraphStyle.direction)
+                .toBe(TextDirection.RIGHT_TO_LEFT);
+        });
+
+        it('flips back to LTR after the user deletes the Arabic and types Latin', () => {
+            const { service, mocks } = createService({ editorBodyText: 'كتاب' });
+            seedEditingState(service);
+            service.syncEditorTextDirection();
+            expect(service.getEffectiveTextDirection()).toBe(TextDirection.RIGHT_TO_LEFT);
+
+            // Backspace, then type "Hello".
+            mocks.editorDoc.getBody.mockReturnValue({
+                dataStream: 'Hello\r\n',
+                paragraphs: [{ startIndex: 5, paragraphStyle: { direction: TextDirection.RIGHT_TO_LEFT } }],
+            });
+            service.syncEditorTextDirection();
+
+            expect(service.getEffectiveTextDirection()).toBe(TextDirection.LEFT_TO_RIGHT);
+            const liveBody = mocks.editorDoc.getBody.mock.results.at(-1)?.value;
+            expect(liveBody.paragraphs[0].paragraphStyle.direction)
+                .toBe(TextDirection.LEFT_TO_RIGHT);
+        });
+
+        it('honours explicit cell-level style.td regardless of typed content', () => {
+            // Cell has `td=RTL` set explicitly; even if the user types only
+            // Latin, the direction must stay RTL because the author chose it.
+            const { service, mocks } = createService({
+                editorBodyText: 'Hello',
+                explicitCellTd: TextDirection.RIGHT_TO_LEFT,
+            });
+            seedEditingState(service);
+            service.syncEditorTextDirection();
+
+            expect(service.getEffectiveTextDirection()).toBe(TextDirection.RIGHT_TO_LEFT);
+            // Explicit `style.td` is propagated to renderConfig so the
+            // document-level `_horizontalHandler` fallback also picks it up.
+            expect(mocks.editorDoc.documentStyle.renderConfig.textDirection)
+                .toBe(TextDirection.RIGHT_TO_LEFT);
+        });
+
+        it('emits a single value per actual direction change', () => {
+            const { service, mocks } = createService({ editorBodyText: '' });
+            seedEditingState(service);
+
+            const emissions: TextDirection[] = [];
+            service.effectiveTextDirection$.subscribe((d) => emissions.push(d));
+
+            service.syncEditorTextDirection(); // still empty → LTR
+            service.syncEditorTextDirection(); // still empty → LTR (no emit)
+
+            const arabic = 'مرحبا';
+            mocks.editorDoc.getBody.mockReturnValue({
+                dataStream: `${arabic}\r\n`,
+                paragraphs: [{ startIndex: arabic.length, paragraphStyle: {} }],
+            });
+            service.syncEditorTextDirection(); // flip → RTL
+
+            // BehaviorSubject replays the seed value (LTR) on subscription,
+            // then we expect exactly one additional RTL emission.
+            const ltrCount = emissions.filter((d) => d === TextDirection.LEFT_TO_RIGHT).length;
+            const rtlCount = emissions.filter((d) => d === TextDirection.RIGHT_TO_LEFT).length;
+            expect(ltrCount).toBeGreaterThanOrEqual(1);
+            expect(rtlCount).toBe(1);
+        });
+
+        it('assigns each paragraph an independent direction based on its own first-strong character', () => {
+            // Simulate a list cell containing three bullets:
+            //   * Arabic
+            //   * Arabic
+            //   * Latin
+            // Each line must flip individually so the canvas /
+            // `horizontalAlignHandler` aligns each row to its own side.
+            const { service, mocks } = createService({ editorBodyText: '' });
+            seedEditingState(service);
+
+            const lines = ['كتاب', 'مرحبا', 'Hello'];
+            const stream = `${lines.join('\r')}\r\n`;
+            // Build paragraph startIndex list pointing at each `\r`.
+            const paragraphs: any[] = [];
+            let cursor = 0;
+            for (const line of lines) {
+                cursor += line.length;
+                paragraphs.push({ startIndex: cursor, paragraphStyle: {} });
+                cursor += 1; // skip the `\r`
+            }
+
+            mocks.editorDoc.getBody.mockReturnValue({
+                dataStream: stream,
+                paragraphs,
+            });
+            service.syncEditorTextDirection();
+
+            const liveBody = mocks.editorDoc.getBody.mock.results.at(-1)?.value;
+            expect(liveBody.paragraphs[0].paragraphStyle.direction)
+                .toBe(TextDirection.RIGHT_TO_LEFT);
+            expect(liveBody.paragraphs[1].paragraphStyle.direction)
+                .toBe(TextDirection.RIGHT_TO_LEFT);
+            expect(liveBody.paragraphs[2].paragraphStyle.direction)
+                .toBe(TextDirection.LEFT_TO_RIGHT);
+        });
+
+        it('makes an empty paragraph created by Enter inherit the previous direction', () => {
+            // Simulate the user pressing Enter at the end of an Arabic
+            // paragraph: the live body now has two paragraphs, where the
+            // second one is empty (no strong char yet) but should still
+            // be treated as RTL so the caret stays on the visual right
+            // and the next keystroke continues the Arabic flow.
+            const { service, mocks } = createService({ editorBodyText: '' });
+            seedEditingState(service);
+
+            // Build dataStream = "كتاب\r\r\n":
+            //   - paragraph 0: "كتاب" (RTL)
+            //   - paragraph 1: empty (just inserted by Enter)
+            //   - trailing \r\n is the sentinel terminator
+            const arabic = 'كتاب';
+            const stream = `${arabic}\r\r\n`;
+            const paragraphs = [
+                { startIndex: arabic.length, paragraphStyle: {} },
+                { startIndex: arabic.length + 1, paragraphStyle: {} },
+            ];
+
+            mocks.editorDoc.getBody.mockReturnValue({
+                dataStream: stream,
+                paragraphs,
+            });
+            service.syncEditorTextDirection();
+
+            const liveBody = mocks.editorDoc.getBody.mock.results.at(-1)?.value;
+            expect(liveBody.paragraphs[0].paragraphStyle.direction)
+                .toBe(TextDirection.RIGHT_TO_LEFT);
+            expect(liveBody.paragraphs[1].paragraphStyle.direction)
+                .toBe(TextDirection.RIGHT_TO_LEFT);
+            // Outer baseline tracks the first paragraph for the cell.
+            expect(service.getEffectiveTextDirection()).toBe(TextDirection.RIGHT_TO_LEFT);
+        });
+
+        it('forces every paragraph to the explicit cell-level direction', () => {
+            // When the cell author explicitly set `style.td=RTL`, even a
+            // paragraph whose own content is Latin must inherit RTL — the
+            // author's choice trumps content auto-detection.
+            const { service, mocks } = createService({
+                editorBodyText: '',
+                explicitCellTd: TextDirection.RIGHT_TO_LEFT,
+            });
+            seedEditingState(service);
+
+            const lines = ['Hello', 'World'];
+            const stream = `${lines.join('\r')}\r\n`;
+            const paragraphs: any[] = [];
+            let cursor = 0;
+            for (const line of lines) {
+                cursor += line.length;
+                paragraphs.push({ startIndex: cursor, paragraphStyle: {} });
+                cursor += 1;
+            }
+
+            mocks.editorDoc.getBody.mockReturnValue({
+                dataStream: stream,
+                paragraphs,
+            });
+            service.syncEditorTextDirection();
+
+            const liveBody = mocks.editorDoc.getBody.mock.results.at(-1)?.value;
+            expect(liveBody.paragraphs[0].paragraphStyle.direction)
+                .toBe(TextDirection.RIGHT_TO_LEFT);
+            expect(liveBody.paragraphs[1].paragraphStyle.direction)
+                .toBe(TextDirection.RIGHT_TO_LEFT);
+        });
     });
 });

--- a/packages/sheets-ui/src/services/clipboard/__tests__/__snapshots__/sheet-paste.spec.ts.snap
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/__snapshots__/sheet-paste.spec.ts.snap
@@ -2943,6 +2943,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "bl": 1,
+        "td": 1,
         "vt": 3,
       },
       "v": " bold ",
@@ -2954,6 +2955,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         "bg": {
           "rgb": "rgb(201,218,248)",
         },
+        "td": 1,
         "vt": 3,
       },
       "v": " background color ",
@@ -2962,6 +2964,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -2970,6 +2973,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "merge cell",
@@ -2978,6 +2982,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -2986,6 +2991,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -2994,6 +3000,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": " merge cell with border & style ",
@@ -3002,6 +3009,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3010,6 +3018,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3018,6 +3027,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "numfmt",
@@ -3029,6 +3039,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "it": 1,
+        "td": 1,
         "vt": 3,
       },
       "v": " italic ",
@@ -3045,6 +3056,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3053,6 +3065,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3061,6 +3074,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3069,6 +3083,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3077,6 +3092,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3093,6 +3109,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3109,6 +3126,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3117,6 +3135,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3125,6 +3144,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3135,6 +3155,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "rich text",
@@ -3144,6 +3165,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "ht": 3,
+        "td": 1,
         "vt": 3,
       },
       "v": " horizontal Aligment ",
@@ -3152,6 +3174,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3160,6 +3183,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": undefined,
       "rowSpan": undefined,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": undefined,
@@ -3168,6 +3192,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": undefined,
       "rowSpan": undefined,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": undefined,
@@ -3184,6 +3209,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3219,6 +3245,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         "st": {
           "s": 1,
         },
+        "td": 1,
         "vt": 2,
       },
       "v": undefined,
@@ -3254,6 +3281,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         "st": {
           "s": 1,
         },
+        "td": 1,
         "vt": 2,
       },
       "v": undefined,
@@ -3262,6 +3290,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3271,6 +3300,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "ht": 3,
+        "td": 1,
         "vt": 3,
       },
       "v": " 1.11E+09 ",
@@ -3397,6 +3427,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       },
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": " UNIVER UP UP UP ",
@@ -3405,6 +3436,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3413,6 +3445,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3421,6 +3454,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3429,6 +3463,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3437,6 +3472,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3445,6 +3481,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3453,6 +3490,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3461,6 +3499,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3469,6 +3508,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3479,6 +3519,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3488,6 +3529,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "tb": 3,
+        "td": 1,
         "vt": 3,
       },
       "v": " text wrap wrap wrap wrap wrap wrap wrap wrap wrap ",
@@ -3496,6 +3538,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3504,6 +3547,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3512,6 +3556,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3520,6 +3565,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3528,6 +3574,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3536,6 +3583,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3544,6 +3592,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3552,6 +3601,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3562,6 +3612,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3613,6 +3664,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "  text wrap wrap wrap wrap wrap wrap wrap wrap wrap  ",
@@ -3621,6 +3673,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3629,6 +3682,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3637,6 +3691,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3645,6 +3700,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3653,6 +3709,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3661,6 +3718,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3669,6 +3727,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3677,6 +3736,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3687,6 +3747,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3696,6 +3757,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "tb": 2,
+        "td": 1,
         "vt": 3,
       },
       "v": " text wrap wrap wrap wrap wrap wrap wrap wrap wrap ",
@@ -3704,6 +3766,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3712,6 +3775,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3720,6 +3784,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3728,6 +3793,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3736,6 +3802,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3744,6 +3811,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3752,6 +3820,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3760,6 +3829,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3770,6 +3840,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3778,6 +3849,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3786,6 +3858,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3794,6 +3867,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3802,6 +3876,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3810,6 +3885,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3818,6 +3894,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3826,6 +3903,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3834,6 +3912,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3842,6 +3921,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3860,6 +3940,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "ul": {
           "s": 1,
         },
@@ -3885,6 +3966,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": " border line ",
@@ -3893,6 +3975,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3901,6 +3984,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 2,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3909,6 +3993,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": undefined,
       "rowSpan": undefined,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": undefined,
@@ -3925,6 +4010,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -3956,6 +4042,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         },
         "ht": 2,
         "it": 1,
+        "td": 1,
         "vt": 2,
       },
       "v": " univer ",
@@ -3987,6 +4074,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         },
         "ht": 2,
         "it": 1,
+        "td": 1,
         "vt": 2,
       },
       "v": undefined,
@@ -3995,6 +4083,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4004,6 +4093,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "ht": 3,
+        "td": 1,
         "vt": 3,
       },
       "v": " 2024/1/1 ",
@@ -4017,6 +4107,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         "st": {
           "s": 1,
         },
+        "td": 1,
         "vt": 3,
       },
       "v": " strike through ",
@@ -4025,6 +4116,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4033,6 +4125,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4041,6 +4134,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4049,6 +4143,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4057,6 +4152,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4073,6 +4169,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4081,6 +4178,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4089,6 +4187,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4097,6 +4196,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4108,6 +4208,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "fs": 17,
+        "td": 1,
         "vt": 3,
       },
       "v": " font size ",
@@ -4116,6 +4217,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 1,
       },
       "v": "vertical Alignment",
@@ -4124,6 +4226,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4167,6 +4270,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       },
       "rowSpan": 3,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "    ",
@@ -4175,6 +4279,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4191,6 +4296,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4291,6 +4397,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         },
         "ht": 2,
         "it": 1,
+        "td": 1,
         "vt": 2,
       },
       "v": "  univer  ",
@@ -4299,6 +4406,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4307,6 +4415,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4316,6 +4425,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "ht": 3,
+        "td": 1,
         "vt": 3,
       },
       "v": " $1.00 ",
@@ -4329,6 +4439,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         "cl": {
           "rgb": "rgb(0,0,255)",
         },
+        "td": 1,
         "vt": 3,
       },
       "v": " font color ",
@@ -4337,6 +4448,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 2,
       },
       "v": "vertical Alignment",
@@ -4345,6 +4457,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4353,6 +4466,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": undefined,
       "rowSpan": undefined,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": undefined,
@@ -4361,6 +4475,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4377,6 +4492,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4408,6 +4524,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         },
         "ht": 2,
         "it": 1,
+        "td": 1,
         "vt": 2,
       },
       "v": undefined,
@@ -4416,6 +4533,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4424,6 +4542,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4432,6 +4551,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4444,6 +4564,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "s": {
         "bl": 0,
         "ff": "Impact",
+        "td": 1,
         "vt": 3,
       },
       "v": " font family ",
@@ -4452,6 +4573,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "vertical Alignment",
@@ -4460,6 +4582,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4468,6 +4591,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": undefined,
       "rowSpan": undefined,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": undefined,
@@ -4476,6 +4600,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4492,6 +4617,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4523,6 +4649,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         },
         "ht": 2,
         "it": 1,
+        "td": 1,
         "vt": 2,
       },
       "v": undefined,
@@ -4531,6 +4658,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4539,6 +4667,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4548,6 +4677,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "ht": 3,
+        "td": 1,
         "vt": 3,
       },
       "v": " 5% ",
@@ -4558,6 +4688,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4566,6 +4697,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4574,6 +4706,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4582,6 +4715,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4590,6 +4724,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4598,6 +4733,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4614,6 +4750,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4630,6 +4767,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4638,6 +4776,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4646,6 +4785,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4656,6 +4796,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4664,6 +4805,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "horizontal Aligment",
@@ -4672,6 +4814,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4715,6 +4858,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       },
       "rowSpan": 3,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "    ",
@@ -4723,6 +4867,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": undefined,
       "rowSpan": undefined,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": undefined,
@@ -4739,6 +4884,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4846,6 +4992,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         "st": {
           "s": 1,
         },
+        "td": 1,
         "vt": 2,
       },
       "v": "  univer  ",
@@ -4881,6 +5028,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         "st": {
           "s": 1,
         },
+        "td": 1,
         "vt": 2,
       },
       "v": undefined,
@@ -4889,6 +5037,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4898,6 +5047,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "ht": 3,
+        "td": 1,
         "vt": 3,
       },
       "v": " 32.32 ",
@@ -4908,6 +5058,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4917,6 +5068,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "rowSpan": 1,
       "s": {
         "ht": 2,
+        "td": 1,
         "vt": 3,
       },
       "v": " horizontal Aligment ",
@@ -4925,6 +5077,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4933,6 +5086,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": undefined,
       "rowSpan": undefined,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": undefined,
@@ -4941,6 +5095,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": undefined,
       "rowSpan": undefined,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": undefined,
@@ -4957,6 +5112,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
             "s": 1,
           },
         },
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -4992,6 +5148,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         "st": {
           "s": 1,
         },
+        "td": 1,
         "vt": 2,
       },
       "v": undefined,
@@ -5027,6 +5184,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
         "st": {
           "s": 1,
         },
+        "td": 1,
         "vt": 2,
       },
       "v": undefined,
@@ -5035,6 +5193,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",
@@ -5043,6 +5202,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
       "colSpan": 1,
       "rowSpan": 1,
       "s": {
+        "td": 1,
         "vt": 3,
       },
       "v": "",

--- a/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-paste-form-excel.spec.ts
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-paste-form-excel.spec.ts
@@ -219,9 +219,13 @@ describe('Test clipboard', () => {
             expect(richTextStyle?.body?.dataStream).toBe('Univer\r\n');
             expect(richTextStyle?.body?.paragraphs).toStrictEqual([
                 {
-                    paragraphStyle: {
-                        horizontalAlign: 0,
-                    },
+                    // Previously this captured the `paragraphStyle:
+                    // { horizontalAlign: 0 }` that `_updateConfigAndGetDocumentModel`
+                    // used to write back into the shared `cell.p` snapshot.
+                    // The per-paragraph RTL refactor no longer mutates the
+                    // original cell — alignment / direction now live only
+                    // on the renderer-local document copy — so the pasted
+                    // snapshot stays clean here.
                     startIndex: 6,
                 },
             ]);

--- a/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-paste-from-google.spec.ts
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-paste-from-google.spec.ts
@@ -175,7 +175,10 @@ describe('Test clipboard', () => {
                     s: 0,
                 },
                 tb: 0,
-                td: 0,
+                // Google Sheets exports cells with an explicit `dir="ltr"`.
+                // RTL paste support now preserves that direction as
+                // `td: TextDirection.LEFT_TO_RIGHT (1)` instead of dropping it.
+                td: 1,
                 tr: {
                     a: 0,
                     v: 0,
@@ -203,9 +206,12 @@ describe('Test clipboard', () => {
             expect(richTextStyle?.body?.dataStream).toBe('univer\r\n');
             expect(richTextStyle?.body?.paragraphs).toStrictEqual([
                 {
-                    paragraphStyle: {
-                        horizontalAlign: 0,
-                    },
+                    // See clipboard-paste-form-excel.spec for context: the
+                    // pasted `cell.p` snapshot used to pick up
+                    // `paragraphStyle: { horizontalAlign: 0 }` written
+                    // back by `_updateConfigAndGetDocumentModel`. After
+                    // the per-paragraph RTL refactor the renderer mutates
+                    // a local clone instead, so the snapshot stays clean.
                     startIndex: 6,
                 },
             ]);

--- a/packages/sheets-ui/src/services/clipboard/__tests__/clipboard.service.spec.ts
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/clipboard.service.spec.ts
@@ -190,7 +190,7 @@ describe('Test clipboard', () => {
                     s: 0,
                 },
                 tb: 0,
-                td: 0,
+                td: 1,
                 tr: {
                     a: 0,
                     v: 0,
@@ -263,7 +263,7 @@ describe('Test clipboard', () => {
                     s: 0,
                 },
                 tb: 0,
-                td: 0,
+                td: 1,
                 tr: {
                     a: 0,
                     v: 0,
@@ -336,7 +336,7 @@ describe('Test clipboard', () => {
                     s: 0,
                 },
                 tb: 0,
-                td: 0,
+                td: 1,
                 tr: {
                     a: 0,
                     v: 0,
@@ -413,7 +413,7 @@ describe('Test clipboard', () => {
                     s: 0,
                 },
                 tb: 0,
-                td: 0,
+                td: 1,
                 tr: {
                     a: 0,
                     v: 0,
@@ -457,7 +457,7 @@ describe('Test clipboard', () => {
                     s: 0,
                 },
                 tb: 0,
-                td: 0,
+                td: 1,
                 tr: {
                     a: 0,
                     v: 0,
@@ -541,7 +541,7 @@ describe('Test clipboard', () => {
                         s: 0,
                     },
                     tb: 0,
-                    td: 0,
+                    td: 1,
                     tr: {
                         a: 0,
                         v: 0,
@@ -585,7 +585,7 @@ describe('Test clipboard', () => {
                         s: 0,
                     },
                     tb: 0,
-                    td: 0,
+                    td: 1,
                     tr: {
                         a: 0,
                         v: 0,
@@ -707,7 +707,7 @@ describe('Test clipboard', () => {
                     s: 0,
                 },
                 tb: 0,
-                td: 0,
+                td: 1,
                 tr: {
                     a: 0,
                     v: 0,
@@ -845,7 +845,7 @@ describe('Test clipboard', () => {
                     s: 0,
                 },
                 tb: 0,
-                td: 0,
+                td: 1,
                 tr: {
                     a: 0,
                     v: 0,
@@ -972,7 +972,7 @@ describe('Test clipboard', () => {
                     s: 0,
                 },
                 tb: 0,
-                td: 0,
+                td: 1,
                 tr: {
                     a: 0,
                     v: 0,

--- a/packages/sheets-ui/src/services/clipboard/html-to-usm/converter.ts
+++ b/packages/sheets-ui/src/services/clipboard/html-to-usm/converter.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable complexity */
 
-import type { ICustomRange, IDocumentBody, IDocumentData, IStyleData, ITextRun, ITextStyle, Nullable } from '@univerjs/core';
+import type { ICustomRange, IDocumentBody, IDocumentData, IParagraph, IStyleData, ITextRun, ITextStyle, Nullable } from '@univerjs/core';
 import type { SpreadsheetSkeleton } from '@univerjs/engine-render';
 import type { ISheetSkeletonManagerParam } from '@univerjs/sheets';
 import type {
@@ -29,7 +29,7 @@ import type { IAfterProcessRule, IPastePlugin } from './paste-plugins/type';
 import { CustomRangeType, DEFAULT_WORKSHEET_ROW_HEIGHT, generateRandomId, getNumfmtParseValueFilter, isSafeUrl, numfmt, ObjectMatrix, skipParseTagNames } from '@univerjs/core';
 import { handleStringToStyle, textTrim } from '@univerjs/ui';
 import { extractNodeStyle } from './parse-node-style';
-import parseToDom, { convertToCellStyle, generateParagraphs } from './utils';
+import parseToDom, { convertToCellStyle, generateParagraphs, getParagraphStyle } from './utils';
 
 export interface IStyleRule {
     filter: string | string[] | ((node: HTMLElement) => boolean);
@@ -45,6 +45,7 @@ const sheetStyleRules: string[] =
         // Rich Text Style Rules,
         'color',
         'background',
+        'direction',
         'font-size',
         'text-align',
         'vertical-align',
@@ -190,7 +191,7 @@ export class HtmlToUSMService {
                     body: {
                         dataStream: cellDataStream,
                         textRuns: cellTextRuns,
-                        paragraphs: generateParagraphs(cellDataStream),
+                        paragraphs: generateParagraphs(cellDataStream, paragraphs[i]),
                         customRanges: cellCustomRanges,
                     },
                 });
@@ -327,6 +328,11 @@ export class HtmlToUSMService {
                     this._getStyleBySelectorText(`#${node.id}`, 'text-decoration-line') || this._getStyleBySelectorText(`#${node.id}`, key) ||
                     this._getStyleBySelectorText(node.nodeName.toLowerCase(), key) || this._getStyleBySelectorText(node.nodeName, 'text-decoration-line') || recordStyle['text-decoration-line'] || '';
                 textDecoration && (newStyleStr += `text-decoration:${textDecoration};`);
+                continue;
+            }
+            if (key === 'direction') {
+                const direction = style.getPropertyValue(key) || node.getAttribute('dir') || recordStyle[key] || '';
+                direction && (newStyleStr += `${key}:${direction};`);
                 continue;
             }
 
@@ -554,6 +560,29 @@ export class HtmlToUSMService {
                 doc.paragraphs.push({ startIndex: doc.dataStream.length });
                 doc.dataStream += '\r';
             } else if (node.nodeType === Node.ELEMENT_NODE) {
+                if (node.nodeName.toLowerCase() === 'p') {
+                    const currentNodeStyle = this._getStyle(node as HTMLElement, styleStr);
+                    const parentStyles = parent ? styleCache.get(parent) : {};
+                    const predefinedStyles = turnToStyleObject(currentNodeStyle);
+                    const nodeStyles = extractNodeStyle(node as HTMLElement, predefinedStyles);
+                    const paragraphStyle = getParagraphStyle(node as HTMLElement);
+                    styleCache.set(node, { ...parentStyles, ...nodeStyles });
+                    this._parseCellHtml(node, node.childNodes, doc, styleCache, currentNodeStyle);
+
+                    const paragraph: IParagraph = {
+                        startIndex: doc.dataStream.length,
+                    };
+                    if (paragraphStyle) {
+                        paragraph.paragraphStyle = paragraphStyle;
+                    }
+                    if (!doc.paragraphs) {
+                        doc.paragraphs = [];
+                    }
+                    doc.paragraphs.push(paragraph);
+                    doc.dataStream += '\r';
+                    continue;
+                }
+
                 const currentNodeStyle = this._getStyle(node as HTMLElement, styleStr);
                 const parentStyles = parent ? styleCache.get(parent) : {};
                 const predefinedStyles = turnToStyleObject(currentNodeStyle);
@@ -597,14 +626,18 @@ export class HtmlToUSMService {
             this._parseCellHtml(null, cell.childNodes, newDocBody, undefined, styleStr);
             const documentModel = skeleton.getBlankCellDocumentModel()?.documentModel;
             const p = documentModel?.getSnapshot();
-            const singleDataStream = `${newDocBody.dataStream}\r\n`;
+            const singleDataStream = newDocBody.dataStream.endsWith('\r')
+                ? `${newDocBody.dataStream}\n`
+                : `${newDocBody.dataStream}\r\n`;
             const documentData = {
                 ...p,
                 ...{
                     body: {
                         dataStream: singleDataStream,
                         textRuns: newDocBody.textRuns,
-                        paragraphs: generateParagraphs(singleDataStream),
+                        paragraphs: newDocBody.paragraphs?.length
+                            ? newDocBody.paragraphs
+                            : generateParagraphs(singleDataStream),
                     },
                 },
             };

--- a/packages/sheets-ui/src/services/clipboard/html-to-usm/utils.ts
+++ b/packages/sheets-ui/src/services/clipboard/html-to-usm/utils.ts
@@ -16,7 +16,7 @@
 
 import type { IParagraph, IParagraphStyle, ITextRun, Nullable } from '@univerjs/core';
 import type { ICellDataWithSpanInfo } from '../type';
-import { DataStreamTreeTokenType, Tools } from '@univerjs/core';
+import { DataStreamTreeTokenType, TextDirection, Tools } from '@univerjs/core';
 import { ptToPixel } from '@univerjs/engine-render';
 import { sanitizeParsedHtml } from '@univerjs/ui';
 
@@ -58,12 +58,22 @@ export function getParagraphStyle(el: HTMLElement): Nullable<IParagraphStyle> {
     const styles = el.style;
 
     const paragraphStyle: IParagraphStyle = {};
+    const direction = styles.getPropertyValue('direction') || el.getAttribute('dir');
+    if (direction === 'rtl') {
+        paragraphStyle.direction = TextDirection.RIGHT_TO_LEFT;
+    } else if (direction === 'ltr') {
+        paragraphStyle.direction = TextDirection.LEFT_TO_RIGHT;
+    }
 
     for (let i = 0; i < styles.length; i++) {
         const cssRule = styles[i];
         const cssValue = styles.getPropertyValue(cssRule);
 
         switch (cssRule) {
+            case 'direction': {
+                break;
+            }
+
             case 'margin-top': {
                 const marginTopValue = Number.parseInt(cssValue);
                 paragraphStyle.spaceAbove = { v: /pt/.test(cssValue) ? ptToPixel(marginTopValue) : marginTopValue };

--- a/packages/sheets-ui/src/services/editor-bridge.service.ts
+++ b/packages/sheets-ui/src/services/editor-bridge.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IDisposable, IPosition, ISelectionCell, Nullable, Workbook } from '@univerjs/core';
+import type { DocumentDataModel, IDisposable, IPosition, ISelectionCell, Nullable, Workbook } from '@univerjs/core';
 import type { Engine, IDocumentLayoutObject, Scene } from '@univerjs/engine-render';
 import type { KeyCode } from '@univerjs/ui';
 import type { Observable } from 'rxjs';
@@ -28,7 +28,9 @@ import {
     FOCUSING_EDITOR_STANDALONE,
     IContextService,
     Inject,
+    isFirstStrongCharRTL,
     IUniverInstanceService,
+    TextDirection,
     ThemeService,
     toDisposable,
     UniverInstanceType,
@@ -81,6 +83,19 @@ export interface IEditorBridgeService {
     currentEditCell$: Observable<Nullable<IEditorBridgeServiceParam>>;
     visible$: Observable<IEditorBridgeServiceVisibleParam>;
     forceKeepVisible$: Observable<boolean>;
+    /**
+     * Stream of the *effective* text direction for the active cell editor.
+     * Re-evaluates whenever the editor's body content changes (typing, paste,
+     * delete) so the wrapper `<div dir>`, the hidden contenteditable, the
+     * cell-editor resize math, and the canvas paragraph alignment can all
+     * react in real time.
+     *
+     * Resolution order:
+     *  1. The cell's explicit `style.td`.
+     *  2. First-strong character in the live editor body.
+     *  3. LTR fallback.
+     */
+    effectiveTextDirection$: Observable<TextDirection>;
 
     dispose(): void;
     refreshEditCellState(): void;
@@ -104,6 +119,18 @@ export interface IEditorBridgeService {
     isForceKeepVisible(): boolean;
     getCurrentEditorId(): string;
     helpFunctionVisible$: BehaviorSubject<boolean>;
+    /**
+     * Recompute the cell editor's effective text direction based on the
+     * **live** content in the editor docs unit, write it back into the
+     * editor's `documentStyle.renderConfig.textDirection` and per-paragraph
+     * `paragraphStyle.direction`, and emit on `effectiveTextDirection$`.
+     *
+     * Call this on every keystroke / RichTextEditingMutation so the
+     * direction tracks reality (e.g. empty → Arabic flips to RTL, deleting
+     * back to ASCII flips to LTR).
+     */
+    syncEditorTextDirection(): void;
+    getEffectiveTextDirection(): TextDirection;
 }
 
 export class EditorBridgeService extends Disposable implements IEditorBridgeService, IDisposable {
@@ -142,6 +169,12 @@ export class EditorBridgeService extends Disposable implements IEditorBridgeServ
     private readonly _forceKeepVisible$ = new BehaviorSubject(false);
     readonly forceKeepVisible$ = this._forceKeepVisible$.asObservable();
 
+    // Live effective direction for the cell editor. Distinct so subscribers
+    // re-render exactly when it flips (e.g. user types Arabic into an empty
+    // English-leaning cell). Starts LTR; reset on each editor open.
+    private readonly _effectiveTextDirection$ = new BehaviorSubject<TextDirection>(TextDirection.LEFT_TO_RIGHT);
+    readonly effectiveTextDirection$ = this._effectiveTextDirection$.asObservable();
+
     constructor(
         @Inject(SheetInterceptorService) private readonly _sheetInterceptorService: SheetInterceptorService,
         @Inject(SheetSkeletonService) private readonly _sheetSkeletonService: SheetSkeletonService,
@@ -172,6 +205,11 @@ export class EditorBridgeService extends Disposable implements IEditorBridgeServ
             this._currentEditCellLayout = null;
             this._currentEditCellState$.next(null);
             this._currentEditCellLayout$.next(null);
+            // Editor closing → reset live direction so the next open starts
+            // with a clean LTR baseline (cell may have no content yet).
+            if (this._effectiveTextDirection$.getValue() !== TextDirection.LEFT_TO_RIGHT) {
+                this._effectiveTextDirection$.next(TextDirection.LEFT_TO_RIGHT);
+            }
             return;
         }
         const { position, scaleX, scaleY, canvasOffset, ...rest } = editCellState;
@@ -179,6 +217,20 @@ export class EditorBridgeService extends Disposable implements IEditorBridgeServ
         this._currentEditCellLayout = { position, scaleX, scaleY, canvasOffset };
         this._currentEditCellState$.next(this._currentEditCellState);
         this._currentEditCellLayout$.next(this._currentEditCellLayout);
+
+        // Seed the live direction stream with the snapshot value so the
+        // editor's `<div dir>` is correct *before* the user starts typing.
+        const seedDir = rest.documentLayoutObject
+            ?.documentModel
+            ?.documentStyle
+            ?.renderConfig
+            ?.textDirection;
+        const initial = seedDir === TextDirection.RIGHT_TO_LEFT
+            ? TextDirection.RIGHT_TO_LEFT
+            : TextDirection.LEFT_TO_RIGHT;
+        if (this._effectiveTextDirection$.getValue() !== initial) {
+            this._effectiveTextDirection$.next(initial);
+        }
     }
 
     refreshEditCellPosition(resetSizeOnly?: boolean) {
@@ -347,10 +399,17 @@ export class EditorBridgeService extends Disposable implements IEditorBridgeServ
 
         documentLayoutObject = cell && worksheet.getCellDocumentModelWithFormula(cell, location.row, location.col);
 
-        // Rewrite the cellValueType to STRING to avoid render the value on the right side when number type.
+        // Rewrite the cellValueType to STRING so the document doesn't right-align
+        // numeric cells while we're editing them. For RTL cells we keep the
+        // original cellValueType because `_horizontalHandler` already decides
+        // the default alignment based on `renderConfig.textDirection` and we
+        // don't want to override the natural RTL right-alignment.
         const renderConfig = documentLayoutObject?.documentModel?.documentStyle.renderConfig;
         if (renderConfig != null) {
-            renderConfig.cellValueType = CellValueType.STRING;
+            const isRTL = renderConfig.textDirection === TextDirection.RIGHT_TO_LEFT;
+            if (!isRTL) {
+                renderConfig.cellValueType = CellValueType.STRING;
+            }
         }
 
         if (!documentLayoutObject || documentLayoutObject.documentModel == null) {
@@ -450,6 +509,164 @@ export class EditorBridgeService extends Disposable implements IEditorBridgeServ
 
     getEditorDirty() {
         return this._editorIsDirty;
+    }
+
+    getEffectiveTextDirection(): TextDirection {
+        return this._effectiveTextDirection$.getValue();
+    }
+
+    syncEditorTextDirection(): void {
+        // Only the cell author's *explicit* `style.td` is treated as a hard
+        // override. Snapshot renderConfig values that came from content
+        // auto-detection should not be sticky once the user starts editing,
+        // because the content is now in flux.
+        const explicitTd = this._getEditCellExplicitTextDirection();
+
+        // Push per-paragraph directions into the live editor model so each
+        // line (e.g. each bullet in a list) flips independently when its
+        // first-strong character is RTL / LTR. `explicitTd != null` makes
+        // the whole cell honour the author's choice regardless of content.
+        // The returned `baselineDir` is the single cell-level direction
+        // that outer UI surfaces (container `<div dir>`, resize math)
+        // should follow.
+        const baselineDir = this._applyEditorDirection(explicitTd);
+
+        if (this._effectiveTextDirection$.getValue() !== baselineDir) {
+            this._effectiveTextDirection$.next(baselineDir);
+        }
+    }
+
+    /**
+     * Returns the cell's explicit `style.td` (LTR / RTL) when set, or
+     * `undefined` when the cell has no direction set / is `UNSPECIFIED`.
+     * Reads from the actual workbook so it can't be fooled by the renderConfig
+     * value that was previously auto-derived from the seed content.
+     */
+    private _getEditCellExplicitTextDirection(): TextDirection | undefined {
+        const state = this._currentEditCellState;
+        if (!state) return undefined;
+        const workbook = this._univerInstanceService.getUnit<Workbook>(state.unitId, UniverInstanceType.UNIVER_SHEET);
+        const worksheet = workbook?.getSheetBySheetId(state.sheetId);
+        const style = worksheet?.getComposedCellStyle(state.row, state.column);
+        const td = style?.td;
+        return td != null && td !== TextDirection.UNSPECIFIED ? td : undefined;
+    }
+
+    /**
+     * Concatenate the editor body's dataStream. We strip the trailing
+     * sentinel paragraph break + chapter break that Univer always appends.
+     */
+    private _readEditorBodyText(): string {
+        const editorDoc = this._univerInstanceService.getUnit<DocumentDataModel>(
+            DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
+            UniverInstanceType.UNIVER_DOC
+        );
+        const body = editorDoc?.getBody();
+        const stream = body?.dataStream ?? '';
+        // The dataStream ends with `\r\n` (paragraph break + section end).
+        // Slicing it off avoids false-positives on neutral terminators.
+        return stream.replace(/[\r\n]+$/, '');
+    }
+
+    /**
+     * Push paragraph-level directions into the live editor docs unit so the
+     * canvas pipeline (`_horizontalHandler`, `applyBidiReorderToLine`) and
+     * `cell-editor-resize.service` `effectiveHorizontalAlign` math see the
+     * same source of truth. Callers (`fitTextSize` / the React container)
+     * handle the DOM-side `<div dir>` + contenteditable updates.
+     *
+     * @param explicitOverride When set, every paragraph and the document
+     *   renderConfig get this single direction (cell-level explicit
+     *   `style.td`). When `undefined`, each paragraph independently picks
+     *   a direction from its own first-strong character — this is what
+     *   makes mixed-direction list cells (Arabic bullet → English bullet)
+     *   align each row correctly.
+     * @returns The single "baseline" direction representing the whole
+     *   cell, used by outer UI signals (`<div dir>`, resize math, the
+     *   `effectiveTextDirection$` observable). Equals `explicitOverride`
+     *   when set, otherwise the first paragraph's resolved direction
+     *   (LTR fallback when the cell has no paragraphs / content).
+     */
+    private _applyEditorDirection(explicitOverride: TextDirection | undefined): TextDirection {
+        const editorDoc = this._univerInstanceService.getUnit<DocumentDataModel>(
+            DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
+            UniverInstanceType.UNIVER_DOC
+        );
+        if (!editorDoc) return explicitOverride ?? TextDirection.LEFT_TO_RIGHT;
+
+        const body = editorDoc.getBody();
+        if (!body?.paragraphs) {
+            return explicitOverride ?? TextDirection.LEFT_TO_RIGHT;
+        }
+
+        const dataStream = body.dataStream ?? '';
+        let prevParagraphEnd = 0;
+        let firstParagraphDir: TextDirection | undefined;
+        // Carry the previously resolved direction forward so that a brand-
+        // new empty paragraph created by Enter (no strong char yet) keeps
+        // pointing in the same direction as the line the user just left.
+        // Without this, an empty RTL paragraph silently falls back to LTR
+        // and the caret jumps to the visual left edge — even though the
+        // user expects to keep typing Arabic on the right.
+        let inheritedDir: TextDirection | undefined;
+
+        for (const paragraph of body.paragraphs) {
+            if (!paragraph.paragraphStyle) {
+                paragraph.paragraphStyle = {};
+            }
+
+            let nextDir: TextDirection;
+            if (explicitOverride != null) {
+                nextDir = explicitOverride;
+            } else {
+                const sliceStart = prevParagraphEnd;
+                const sliceEnd = paragraph.startIndex;
+                const paragraphText = sliceEnd > sliceStart
+                    ? dataStream.slice(sliceStart, sliceEnd)
+                    : '';
+                if (paragraphText.length === 0) {
+                    // Empty paragraph: keep whatever the previous
+                    // paragraph resolved to (or the paragraph's own
+                    // previously-declared direction, if any). Falling
+                    // back to LTR here is what made Enter-in-RTL pop
+                    // the caret to the wrong side.
+                    nextDir = inheritedDir
+                        ?? paragraph.paragraphStyle.direction
+                        ?? TextDirection.LEFT_TO_RIGHT;
+                } else if (isFirstStrongCharRTL(paragraphText)) {
+                    nextDir = TextDirection.RIGHT_TO_LEFT;
+                } else {
+                    nextDir = TextDirection.LEFT_TO_RIGHT;
+                }
+            }
+
+            if (paragraph.paragraphStyle.direction !== nextDir) {
+                paragraph.paragraphStyle.direction = nextDir;
+            }
+            if (firstParagraphDir === undefined) {
+                firstParagraphDir = nextDir;
+            }
+            inheritedDir = nextDir;
+
+            prevParagraphEnd = paragraph.startIndex + 1;
+        }
+
+        // Document-level renderConfig.textDirection drives the page-level
+        // `_horizontalHandler` default-alignment fallback (used when the
+        // cell has no explicit `horizontalAlign`). In multi-line cells
+        // the page can carry only one baseline, so we use:
+        //   - the explicit cell-level direction when set, or
+        //   - the first paragraph's auto-detected direction as the visual
+        //     baseline of the cell box.
+        // Per-paragraph alignment of the actual glyph rows is handled
+        // independently in `horizontalAlignHandler` from each paragraph's
+        // own `direction` written above.
+        const renderConfig = editorDoc.documentStyle.renderConfig;
+        const baselineDir = explicitOverride ?? firstParagraphDir ?? TextDirection.LEFT_TO_RIGHT;
+        if (renderConfig && renderConfig.textDirection !== baselineDir) {
+            renderConfig.textDirection = baselineDir;
+        }
+        return baselineDir;
     }
 }
 

--- a/packages/sheets-ui/src/services/editor/cell-editor-resize.service.ts
+++ b/packages/sheets-ui/src/services/editor/cell-editor-resize.service.ts
@@ -16,7 +16,7 @@
 
 import type { DocumentDataModel, IPosition, Nullable } from '@univerjs/core';
 import type { DocumentSkeleton, IDocumentLayoutObject, Scene } from '@univerjs/engine-render';
-import { Disposable, DOCS_NORMAL_EDITOR_UNIT_ID_KEY, HorizontalAlign, IConfigService, IUniverInstanceService, UniverInstanceType, VerticalAlign, WrapStrategy } from '@univerjs/core';
+import { Disposable, DOCS_NORMAL_EDITOR_UNIT_ID_KEY, HorizontalAlign, IConfigService, IUniverInstanceService, TextDirection, UniverInstanceType, VerticalAlign, WrapStrategy } from '@univerjs/core';
 import { DocSkeletonManagerService } from '@univerjs/docs';
 import { DOCS_COMPONENT_MAIN_LAYER_INDEX, VIEWPORT_KEY } from '@univerjs/docs-ui';
 import { convertTextRotation, fixLineWidthByScale, getCurrentTypeOfRenderer, IRenderManagerService, Rect, ScrollBar } from '@univerjs/engine-render';
@@ -72,6 +72,14 @@ export class SheetCellEditorResizeService extends Disposable {
         return this._renderer?.engine;
     }
 
+    private _getEffectiveHorizontalAlign(horizontalAlign: HorizontalAlign): HorizontalAlign {
+        if (horizontalAlign === HorizontalAlign.UNSPECIFIED
+            && this._editorBridgeService.getEffectiveTextDirection() === TextDirection.RIGHT_TO_LEFT) {
+            return HorizontalAlign.RIGHT;
+        }
+        return horizontalAlign;
+    }
+
     fitTextSize(callback?: () => void) {
         const param = this._editorBridgeService.getEditCellState();
         if (!param) return;
@@ -98,6 +106,14 @@ export class SheetCellEditorResizeService extends Disposable {
         if (!info || info.actualWidth <= 0) return;
         let { actualWidth, actualHeight } = info;
         const { verticalAlign, horizontalAlign, paddingData, fill } = documentLayoutObject;
+        // For RTL cells whose horizontal alignment isn't explicitly set we
+        // mirror the LTR default: behave as if the cell were RIGHT-aligned so
+        // overflow (when content is wider than the cell) extends towards the
+        // left. We consult the **live** effective direction (re-emitted by
+        // the editor bridge on every keystroke) so the editor flips its
+        // overflow side mid-edit when the user types Arabic into a previously
+        // empty/LTR cell.
+        const effectiveHorizontalAlign = this._getEffectiveHorizontalAlign(horizontalAlign);
         actualWidth = actualWidth + (paddingData.l ?? 0) * scaleX + (paddingData.r ?? 0) * scaleX;
         actualHeight = actualHeight + (paddingData.t ?? 0) * scaleY + (paddingData.b ?? 0) * scaleY;
         let editorWidth = endX - startX;
@@ -123,10 +139,12 @@ export class SheetCellEditorResizeService extends Disposable {
         }
 
         let offsetLeft = 0;
-        if (horizontalAlign === HorizontalAlign.CENTER) {
-            // offsetLeft = ((editorWidth - actualWidth) / 2 / scaleX);
-        } else if (horizontalAlign === HorizontalAlign.RIGHT) {
-            offsetLeft = (editorWidth - actualWidth) / scaleX;
+        if (effectiveHorizontalAlign === HorizontalAlign.CENTER
+            || effectiveHorizontalAlign === HorizontalAlign.RIGHT) {
+            // Match static cell render: page-level align via `_horizontalHandler`
+            // (+ selection `computeDocumentPageAlignOffset`). Margin-based
+            // center/right offsets stack and break LTR center / RTL / right (#6039).
+            offsetLeft = paddingData.l || 0;
         } else {
             offsetLeft = paddingData.l || 0;
         }
@@ -146,7 +164,7 @@ export class SheetCellEditorResizeService extends Disposable {
             fill,
             scaleX,
             scaleY,
-            horizontalAlign,
+            effectiveHorizontalAlign,
             callback
         );
     }
@@ -184,6 +202,22 @@ export class SheetCellEditorResizeService extends Disposable {
             };
         }
 
+        const effectiveHorizontalAlign = this._getEffectiveHorizontalAlign(documentLayoutObject.horizontalAlign);
+        if ((effectiveHorizontalAlign === HorizontalAlign.CENTER
+            || effectiveHorizontalAlign === HorizontalAlign.RIGHT) && angle === 0) {
+            return this._predictingSizeForSheetCellAlign(
+                actualRangeWithCoord,
+                documentSkeleton,
+                documentDataModel,
+                scaleX,
+                scaleY,
+                paddingData,
+                effectiveHorizontalAlign
+            );
+        }
+
+        const cellHorizontalAlign = documentLayoutObject.horizontalAlign;
+
         const maxSize = this._getEditorMaxSize(actualRangeWithCoord, canvasOffset, documentLayoutObject.horizontalAlign);
         if (!maxSize) return;
         documentDataModel?.updateDocumentDataPageSize(maxSize.width / scaleX);
@@ -198,18 +232,64 @@ export class SheetCellEditorResizeService extends Disposable {
 
         // Scaling is handled by the renderer, so the skeleton only accepts the original width and height, which need to be divided by the magnification factor.
         documentDataModel?.updateDocumentDataPageSize(editorWidth / scaleX);
+        documentSkeleton.calculate();
+        const finalSize = documentSkeleton.getActualSize();
 
-        /**
-         * Do not rely on cell layout logic, depend on the document's internal alignment logic.
-         */
         documentDataModel?.updateDocumentRenderConfig({
-            horizontalAlign: HorizontalAlign.UNSPECIFIED,
+            horizontalAlign: cellHorizontalAlign !== HorizontalAlign.UNSPECIFIED
+                ? cellHorizontalAlign
+                : HorizontalAlign.UNSPECIFIED,
             cellValueType: undefined,
         });
 
         return {
-            actualWidth: size.actualWidth * scaleX,
-            actualHeight: size.actualHeight * scaleY,
+            actualWidth: finalSize.actualWidth * scaleX,
+            actualHeight: finalSize.actualHeight * scaleY,
+        };
+    }
+
+    /**
+     * Center / right + overflow (default): mirror static sheet cells —
+     * pageSize stays infinite so line-level align uses `_horizontalHandler`
+     * (and RTL per-line flush). Never use `cellWidth + 2*min(gaps)` as pageSize.
+     */
+    private _predictingSizeForSheetCellAlign(
+        actualRangeWithCoord: IPosition,
+        documentSkeleton: DocumentSkeleton,
+        documentDataModel: Nullable<DocumentDataModel>,
+        scaleX: number,
+        scaleY: number,
+        paddingData: IDocumentLayoutObject['paddingData'],
+        horizontalAlign: HorizontalAlign.CENTER | HorizontalAlign.RIGHT
+    ) {
+        const { startX, endX } = actualRangeWithCoord;
+        const cellWidthCanvas = endX - startX;
+
+        documentDataModel?.updateDocumentDataPageSize(Number.POSITIVE_INFINITY);
+        documentDataModel?.updateDocumentDataMargin({
+            l: paddingData.l,
+            r: paddingData.r,
+            t: paddingData.t,
+            b: paddingData.b,
+        });
+        const renderConfig = documentDataModel?.getSnapshot().documentStyle?.renderConfig ?? {};
+        documentDataModel?.updateDocumentRenderConfig({
+            ...renderConfig,
+            horizontalAlign,
+            cellValueType: undefined,
+        });
+        documentSkeleton.calculate();
+
+        const { actualWidth, actualHeight } = documentSkeleton.getActualSize();
+        let editorWidthCanvas = cellWidthCanvas;
+
+        if (editorWidthCanvas < actualWidth * scaleX + EDITOR_INPUT_SELF_EXTEND_GAP * scaleX) {
+            editorWidthCanvas = actualWidth * scaleX + EDITOR_INPUT_SELF_EXTEND_GAP * scaleX;
+        }
+
+        return {
+            actualWidth: actualWidth * scaleX,
+            actualHeight: actualHeight * scaleY,
         };
     }
 
@@ -309,6 +389,13 @@ export class SheetCellEditorResizeService extends Disposable {
             viewportMain?.getScrollBar()?.dispose();
         }
 
+        if ((horizontalAlign === HorizontalAlign.CENTER || horizontalAlign === HorizontalAlign.RIGHT) && viewportMain) {
+            viewportMain.scrollToViewportPos({
+                viewportScrollX: 0,
+                viewportScrollY: viewportMain.viewportScrollY ?? 0,
+            });
+        }
+
         editorWidth += scrollBar?.barSize || 0;
 
         if (editorWidth > clientWidth) {
@@ -348,10 +435,10 @@ export class SheetCellEditorResizeService extends Disposable {
         startY = startY * scaleAdjust + (canvasBoundingRect.top - contentBoundingRect.top);
 
         const cellWidth = actualRangeWithCoord.endX - actualRangeWithCoord.startX;
-        if (horizontalAlign === HorizontalAlign.RIGHT) {
+        if (horizontalAlign === HorizontalAlign.RIGHT && editorWidth > cellWidth) {
             startX += (cellWidth - editorWidth) * scaleAdjust;
-        } else if (horizontalAlign === HorizontalAlign.CENTER) {
-            startX += (cellWidth - editorWidth * scaleAdjust) / 2;
+        } else if (horizontalAlign === HorizontalAlign.CENTER && editorWidth > cellWidth) {
+            startX += ((cellWidth - editorWidth) * scaleAdjust) / 2;
         }
 
         // Update cell editor container position and size.
@@ -414,7 +501,8 @@ export class SheetCellEditorResizeService extends Disposable {
         if (!skeleton) return;
         const { row, column, scaleX, scaleY, position, canvasOffset, documentLayoutObject } = editCellState;
         const { horizontalAlign } = documentLayoutObject;
-        const maxSize = this._getEditorMaxSize(position, canvasOffset, horizontalAlign);
+        const effectiveHorizontalAlign = this._getEffectiveHorizontalAlign(horizontalAlign);
+        const maxSize = this._getEditorMaxSize(position, canvasOffset, effectiveHorizontalAlign);
         if (!maxSize) return;
         const { height: clientHeight, width: clientWidth, scaleAdjust } = maxSize;
 

--- a/packages/sheets-ui/src/views/editor-container/EditorContainer.tsx
+++ b/packages/sheets-ui/src/views/editor-container/EditorContainer.tsx
@@ -15,7 +15,7 @@
  */
 
 import type { KeyCode } from '@univerjs/ui';
-import { DOCS_NORMAL_EDITOR_UNIT_ID_KEY, ICommandService, IContextService } from '@univerjs/core';
+import { DOCS_NORMAL_EDITOR_UNIT_ID_KEY, ICommandService, IContextService, TextDirection } from '@univerjs/core';
 import { DocSelectionRenderService, IEditorService } from '@univerjs/docs-ui';
 import { DeviceInputEventType } from '@univerjs/engine-render';
 import { ComponentManager, DISABLE_AUTO_FOCUS_KEY, MetaKeys, useDependency, useEvent, useObservable, useSidebarClick } from '@univerjs/ui';
@@ -62,6 +62,23 @@ export const EditorContainer: React.FC<ICellIEditorProps> = () => {
     );
     const FormulaEditor = componentManager.get(EMBEDDING_FORMULA_EDITOR_COMPONENT_KEY);
     const editState = editorBridgeService.getEditLocation();
+    // Live effective direction, re-emitted from the bridge service whenever
+    // the editor body changes. Subscribing here keeps `<div dir>` and the
+    // hidden contenteditable's `dir` attribute in sync with what the user is
+    // actually typing - so flipping ASCII → Arabic flips the wrapper to RTL
+    // on the same keystroke, and deleting all Arabic flips back to LTR.
+    const effectiveTextDirection = useObservable(
+        editorBridgeService.effectiveTextDirection$,
+        editorBridgeService.getEffectiveTextDirection()
+    );
+    const dir = effectiveTextDirection === TextDirection.RIGHT_TO_LEFT ? 'rtl' : 'ltr';
+
+    useEffect(() => {
+        if (!visible?.visible) return;
+        const editor = editorService.getEditor(DOCS_NORMAL_EDITOR_UNIT_ID_KEY);
+        const docSelectionRenderService = editor?.render.with(DocSelectionRenderService);
+        docSelectionRenderService?.setInputDirection(dir);
+    }, [dir, editorService, visible?.visible]);
 
     useEffect(() => {
         const sub = cellEditorManagerService.state$.subscribe((param) => {
@@ -167,6 +184,7 @@ export const EditorContainer: React.FC<ICellIEditorProps> = () => {
     return (
         <div
             className="univer-absolute univer-z-10 univer-flex"
+            dir={dir}
             style={{
                 left: state.left,
                 top: state.top,

--- a/packages/sheets-ui/src/views/formula-bar/FormulaBar.tsx
+++ b/packages/sheets-ui/src/views/formula-bar/FormulaBar.tsx
@@ -360,6 +360,10 @@ export function FormulaBar(props: IProps) {
                 <div className="univer-flex univer-w-full univer-flex-1 univer-overflow-hidden univer-pl-3">
                     <div
                         ref={ref}
+                        // Formula syntax (e.g. `=SUM(A1:B2)`) must never be
+                        // mirrored. Pin the formula bar editor to LTR even
+                        // when the surrounding workbench / sheet is RTL.
+                        dir="ltr"
                         className="
                           univer-relative univer-flex-1 univer-bg-white
                           dark:!univer-bg-gray-900
@@ -374,6 +378,7 @@ export function FormulaBar(props: IProps) {
                                 borderless
                                 disableSelectionOnClick
                                 editorId={DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY}
+                                forceDirection="ltr"
                                 initValue=""
                                 onChange={() => { }}
                                 isFocus={isFocusFxBar}

--- a/packages/sheets/src/facade/f-range.ts
+++ b/packages/sheets/src/facade/f-range.ts
@@ -31,7 +31,7 @@ import type {
     SplitDelimiterEnum,
 } from '@univerjs/sheets';
 import type { IFacadeClearOptions } from './f-worksheet';
-import type { FHorizontalAlignment, FVerticalAlignment } from './utils';
+import type { FHorizontalAlignment, FTextDirection, FVerticalAlignment } from './utils';
 import { BooleanNumber, covertCellValue, covertCellValues, DEFAULT_STYLES, Dimension, ICommandService, Inject, Injector, isNullCell, Rectangle, RichTextValue, TextStyleValue, WrapStrategy } from '@univerjs/core';
 import { FBaseInitialable } from '@univerjs/core/facade';
 import { FormulaDataModel, serializeRange, serializeRangeWithSheet } from '@univerjs/engine-formula';
@@ -65,7 +65,7 @@ import {
 import { FWorkbook } from './f-workbook';
 import { FWorksheet } from './f-worksheet';
 import { FRangePermission } from './permission/f-range-permission';
-import { transformCoreHorizontalAlignment, transformCoreVerticalAlignment, transformFacadeHorizontalAlignment, transformFacadeVerticalAlignment } from './utils';
+import { transformCoreHorizontalAlignment, transformCoreTextDirection, transformCoreVerticalAlignment, transformFacadeHorizontalAlignment, transformFacadeTextDirection, transformFacadeVerticalAlignment } from './utils';
 
 export type FontLine = 'none' | 'underline' | 'line-through';
 export type FontStyle = 'normal' | 'italic';
@@ -1479,6 +1479,53 @@ export class FRange extends FBaseInitialable {
             value: transformFacadeHorizontalAlignment(alignment),
         } as ISetHorizontalTextAlignCommandParams);
 
+        return this;
+    }
+
+    /**
+     * Get the text direction of the top-left cell in the range.
+     * @returns {FTextDirection} `'ltr' | 'rtl' | 'auto'`.
+     * @example
+     * ```ts
+     * const fWorkbook = univerAPI.getActiveWorkbook();
+     * const fWorksheet = fWorkbook.getActiveSheet();
+     * const fRange = fWorksheet.getRange('A1');
+     * console.log(fRange.getTextDirection()); // 'auto' by default
+     * ```
+     */
+    getTextDirection(): FTextDirection {
+        const value = this._worksheet.getRange(this._range).getTextDirection();
+        return transformCoreTextDirection(value);
+    }
+
+    /**
+     * Set the text direction for every cell in the range. Equivalent to setting
+     * `style.td` on those cells.
+     *
+     * - `'ltr'` forces a left-to-right baseline (Latin, CJK).
+     * - `'rtl'` forces a right-to-left baseline (Arabic, Hebrew).
+     * - `'auto'` clears the override and lets the renderer pick.
+     *
+     * @param {FTextDirection} direction The desired text direction.
+     * @returns {FRange} This range, for chaining.
+     * @example
+     * ```ts
+     * const fWorkbook = univerAPI.getActiveWorkbook();
+     * const fWorksheet = fWorkbook.getActiveSheet();
+     * const fRange = fWorksheet.getRange('A1:B2');
+     * fRange.setTextDirection('rtl');
+     * ```
+     */
+    setTextDirection(direction: FTextDirection): FRange {
+        this._commandService.syncExecuteCommand(SetStyleCommand.id, {
+            unitId: this._workbook.getUnitId(),
+            subUnitId: this._worksheet.getSheetId(),
+            range: this._range,
+            style: {
+                type: 'td',
+                value: transformFacadeTextDirection(direction),
+            },
+        } as ISetStyleCommandParams<number>);
         return this;
     }
 

--- a/packages/sheets/src/facade/utils.ts
+++ b/packages/sheets/src/facade/utils.ts
@@ -18,12 +18,53 @@ import type { IRange, IRangeWithCoord, Worksheet } from '@univerjs/core';
 import {
     HorizontalAlign,
     RANGE_TYPE,
+    TextDirection,
     VerticalAlign,
 } from '@univerjs/core';
 
 export type FDefaultAlignment = 'general';
 export type FHorizontalAlignment = 'left' | 'center' | 'normal';
 export type FVerticalAlignment = 'top' | 'middle' | 'bottom';
+
+/**
+ * Facade-friendly text direction value.
+ *
+ * - `'ltr'` — left-to-right (e.g. Latin, CJK).
+ * - `'rtl'` — right-to-left (e.g. Arabic, Hebrew).
+ * - `'auto'` — let the renderer pick based on content / global locale
+ *   (maps to `TextDirection.UNSPECIFIED` internally).
+ */
+export type FTextDirection = 'auto' | 'ltr' | 'rtl';
+
+/**
+ * Translate the public Facade text-direction value into the internal
+ * `TextDirection` enum.
+ */
+export function transformFacadeTextDirection(value: FTextDirection): TextDirection {
+    switch (value) {
+        case 'ltr':
+            return TextDirection.LEFT_TO_RIGHT;
+        case 'rtl':
+            return TextDirection.RIGHT_TO_LEFT;
+        case 'auto':
+        default:
+            return TextDirection.UNSPECIFIED;
+    }
+}
+
+/**
+ * Translate the internal `TextDirection` enum into the public Facade value.
+ */
+export function transformCoreTextDirection(value: TextDirection | number | undefined | null): FTextDirection {
+    switch (value) {
+        case TextDirection.LEFT_TO_RIGHT:
+            return 'ltr';
+        case TextDirection.RIGHT_TO_LEFT:
+            return 'rtl';
+        default:
+            return 'auto';
+    }
+}
 
 /**
  * Transform the Facade API horizontal alignment to the Univer Core horizontal alignment.

--- a/packages/ui/src/utils/cell.ts
+++ b/packages/ui/src/utils/cell.ts
@@ -23,7 +23,7 @@ import type {
     ITextDecoration,
     ITextRun,
 } from '@univerjs/core';
-import { BaselineOffset, BorderStyleTypes, ColorKit, generateRandomId, getBorderStyleType, Tools } from '@univerjs/core';
+import { BaselineOffset, BorderStyleTypes, ColorKit, generateRandomId, getBorderStyleType, TextDirection, Tools } from '@univerjs/core';
 import { ptToPx } from '@univerjs/engine-render';
 
 import { parseHtmlDocument, parseHtmlFragment } from './html';
@@ -373,6 +373,14 @@ export function handleStringToStyle($dom?: HTMLElement, cssStyle: string = '') {
                 styleList.ht = 4;
             } else {
                 styleList.ht = 0;
+            }
+        }
+
+        if (key === 'direction') {
+            if (value === 'rtl') {
+                styleList.td = TextDirection.RIGHT_TO_LEFT;
+            } else if (value === 'ltr') {
+                styleList.td = TextDirection.LEFT_TO_RIGHT;
             }
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1401,6 +1401,9 @@ importers:
       '@univerjs/core':
         specifier: workspace:*
         version: link:../core
+      bidi-js:
+        specifier: ^1.0.3
+        version: 1.0.3
       cjk-regex:
         specifier: ^3.4.0
         version: 3.4.0


### PR DESCRIPTION
## Summary

Adds right-to-left (RTL) and bidirectional (bidi) text support across the document and spreadsheet rendering stack.

- **core**: text-direction helpers, worksheet implicit/explicit direction resolution, and centralized `createDocumentModelWithStyle` / `extractOtherStyle` cell-style utilities.
- **engine-render**: bidi reordering (via `bidi-js`), Arabic/Thai/Tibetan language rulers, sub-glyph caret metrics (`charAdvances`), and per-line right-flush line adjustment.
- **docs-ui / sheets-ui**: RTL-aware caret and selection geometry, arrow-key visual↔logical mapping, clipboard text-direction preservation on copy/paste, cell-edit alignment, and formula bar/editor pinned to LTR.
- **ui**: default font fallback adjustments.

Adds the `bidi-js` dependency to `@univerjs/engine-render`.

## Test plan

- [x] `pnpm typecheck` passes for all touched packages (core, engine-render, docs-ui, sheets-ui, sheets-formula-ui, sheets, ui).
- [x] `pnpm test` passes for the touched packages.
- [x] `eslint` reports 0 errors on changed files.
- [x] New unit tests: bidi reordering, Arabic language ruler, RTL line adjustment.
- [ ] Reviewer: verify visual RTL behavior in the editor / spreadsheet.

> Note: this branch is currently based on the `v0.25.0` release tag; happy to rebase onto the latest `dev` if preferred.