### PR TITLE
feat(sheets): warn when using custom field facade APIs

### DIFF
--- a/packages/core/src/sheets/typedef.ts
+++ b/packages/core/src/sheets/typedef.ts
@@ -77,7 +77,10 @@ export interface IWorkbookData {
     resources?: IResources;
 
     /**
-     * User stored custom fields
+     * User stored custom fields.
+     *
+     * @remarks
+     * This field is not recommended for external use. Use it at your own risk.
      */
     custom?: CustomData;
 }
@@ -151,7 +154,10 @@ export interface IWorksheetData {
     rightToLeft: BooleanNumber;
 
     /**
-     * User stored custom fields
+     * User stored custom fields.
+     *
+     * @remarks
+     * This field is not recommended for external use. Use it at your own risk.
      */
     custom?: CustomData;
 }
@@ -188,7 +194,10 @@ export interface IRowData {
     s?: Nullable<IStyleData | string>;
 
     /**
-     * User stored custom fields
+     * User stored custom fields.
+     *
+     * @remarks
+     * This field is not recommended for external use. Use it at your own risk.
      */
     custom?: CustomData;
 }
@@ -218,7 +227,10 @@ export interface IColumnData {
     s?: Nullable<IStyleData | string>;
 
     /**
-     * User stored custom fields
+     * User stored custom fields.
+     *
+     * @remarks
+     * This field is not recommended for external use. Use it at your own risk.
      */
     custom?: CustomData;
 }
@@ -277,7 +289,10 @@ export interface ICellData {
     si?: Nullable<string>;
 
     /**
-     * User stored custom fields
+     * User stored custom fields.
+     *
+     * @remarks
+     * This field is not recommended for external use. Use it at your own risk.
      */
     custom?: CustomData;
 }

--- a/packages/sheets/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-range.spec.ts
@@ -314,12 +314,12 @@ describe('Test FRange', () => {
 
     it('Range isMerged', () => {
         const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet()!;
-        const range = activeSheet!.getRange(2, 3);
-        const isMerged = range?.isMerged()!;
+        const range = activeSheet.getRange(2, 3);
+        const isMerged = range.isMerged();
         expect(isMerged).toBe(false);
 
-        const range2 = activeSheet!.getRange(2, 3, 3, 3)!;
-        const isMerged2 = range2.isMerged()!;
+        const range2 = activeSheet.getRange(2, 3, 3, 3);
+        const isMerged2 = range2.isMerged();
         expect(isMerged2).toBe(false);
     });
 
@@ -634,7 +634,7 @@ describe('Test FRange', () => {
     it('test Merge', async () => {
         let hasError = false;
         try {
-            const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet()!;
+            const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet()!;
             let range = activeSheet.getRange(0, 2, 0, 2);
             expect(activeSheet.getMergedRanges().length).toBe(0);
             range = await range.merge();
@@ -653,7 +653,7 @@ describe('Test FRange', () => {
             expect(range2.isPartOfMerge()).toBeTruthy();
             const range3 = activeSheet.getRange(0, 5, 0, 5);
             await range3.merge();
-        } catch (error) {
+        } catch {
             hasError = true;
         }
         expect(hasError).toBeTruthy();

--- a/packages/sheets/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-range.spec.ts
@@ -14,13 +14,31 @@
  * limitations under the License.
  */
 
-/* eslint-disable ts/no-non-null-asserted-optional-chain */
-
 import type { ICellData, Injector, IStyleData, Nullable } from '@univerjs/core';
 import type { FUniver } from '@univerjs/core/facade';
-import { HorizontalAlign, ICommandService, IConfirmService, IUniverInstanceService, LifecycleStages, TestConfirmService, VerticalAlign, WrapStrategy } from '@univerjs/core';
-import { AddWorksheetMergeCommand, SetHorizontalTextAlignCommand, SetRangeValuesCommand, SetRangeValuesMutation, SetStyleCommand, SetTextWrapCommand, SetVerticalTextAlignCommand } from '@univerjs/sheets';
-import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    HorizontalAlign,
+    ICommandService,
+    IConfirmService,
+    ILogService,
+    IUniverInstanceService,
+    LifecycleStages,
+    TestConfirmService,
+    VerticalAlign,
+    WrapStrategy,
+} from '@univerjs/core';
+import {
+    AddWorksheetMergeCommand,
+    SetHorizontalTextAlignCommand,
+    SetRangeCustomMetadataCommand,
+    SetRangeValuesCommand,
+    SetRangeValuesMutation,
+    SetStyleCommand,
+    SetTextWrapCommand,
+    SetVerticalTextAlignCommand,
+} from '@univerjs/sheets';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SHEETS_CUSTOM_FIELD_WARNING_MESSAGE } from '../const';
 import { createFacadeTestBed } from './create-test-bed';
 
 describe('Test FRange', () => {
@@ -56,6 +74,7 @@ describe('Test FRange', () => {
         commandService.registerCommand(SetHorizontalTextAlignCommand);
         commandService.registerCommand(SetTextWrapCommand);
         commandService.registerCommand(AddWorksheetMergeCommand);
+        commandService.registerCommand(SetRangeCustomMetadataCommand);
 
         getValueByPosition = (
             startRow: number,
@@ -260,6 +279,30 @@ describe('Test FRange', () => {
             [null, null, null],
             [null, null, null],
         ]);
+    });
+
+    it('Range custom metadata APIs should warn about custom field usage', () => {
+        const logService = get(ILogService);
+        Object.defineProperty(logService, 'warn', { configurable: true, value: vi.fn() });
+        const warnSpy = vi.spyOn(logService, 'warn');
+        const activeSheet = univerAPI.getActiveWorkbook()?.getActiveSheet();
+        const range = activeSheet?.getRange(0, 0, 2, 2);
+
+        range?.setCustomMetaData({ key: 'value' });
+        range?.getCustomMetaData();
+        range?.setCustomMetaDatas([
+            [{ key: 'a' }, { key: 'b' }],
+            [{ key: 'c' }, { key: 'd' }],
+        ]);
+        range?.getCustomMetaDatas();
+
+        expect(warnSpy).toHaveBeenCalledTimes(4);
+        expect(warnSpy).toHaveBeenNthCalledWith(1, SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+        expect(warnSpy).toHaveBeenNthCalledWith(2, SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+        expect(warnSpy).toHaveBeenNthCalledWith(3, SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+        expect(warnSpy).toHaveBeenNthCalledWith(4, SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
+        warnSpy.mockRestore();
     });
 
     it('Range getCellData', () => {

--- a/packages/sheets/src/facade/__tests__/f-workbook.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-workbook.spec.ts
@@ -16,9 +16,25 @@
 
 import type { ICellData, Injector, Nullable } from '@univerjs/core';
 import type { FUniver } from '@univerjs/core/facade';
-import { ICommandService, IUniverInstanceService, LocaleType } from '@univerjs/core';
-import { CopySheetCommand, InsertSheetCommand, InsertSheetMutation, RemoveSheetCommand, RemoveSheetMutation, SetHorizontalTextAlignCommand, SetRangeValuesCommand, SetRangeValuesMutation, SetStyleCommand, SetTextWrapCommand, SetVerticalTextAlignCommand, SetWorksheetActiveOperation, SetWorksheetOrderCommand, SetWorksheetOrderMutation } from '@univerjs/sheets';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { ICommandService, ILogService, IUniverInstanceService, LocaleType } from '@univerjs/core';
+import {
+    CopySheetCommand,
+    InsertSheetCommand,
+    InsertSheetMutation,
+    RemoveSheetCommand,
+    RemoveSheetMutation,
+    SetHorizontalTextAlignCommand,
+    SetRangeValuesCommand,
+    SetRangeValuesMutation,
+    SetStyleCommand,
+    SetTextWrapCommand,
+    SetVerticalTextAlignCommand,
+    SetWorksheetActiveOperation,
+    SetWorksheetOrderCommand,
+    SetWorksheetOrderMutation,
+} from '@univerjs/sheets';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SHEETS_CUSTOM_FIELD_WARNING_MESSAGE } from '../const';
 import { createFacadeTestBed } from './create-test-bed';
 
 describe('Test FWorkbook', () => {
@@ -75,6 +91,22 @@ describe('Test FWorkbook', () => {
     it('Workbook getSheetByName', () => {
         const activeSheet = univerAPI.getActiveWorkbook()?.getSheetByName('sheet1');
         expect(activeSheet).not.toBeNull();
+    });
+
+    it('Workbook custom metadata APIs should warn about custom field usage', () => {
+        const logService = get(ILogService);
+        Object.defineProperty(logService, 'warn', { configurable: true, value: vi.fn() });
+        const warnSpy = vi.spyOn(logService, 'warn');
+        const workbook = univerAPI.getActiveWorkbook();
+
+        workbook?.setCustomMetadata({ key: 'value' });
+        workbook?.getCustomMetadata();
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+        expect(warnSpy).toHaveBeenNthCalledWith(1, SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+        expect(warnSpy).toHaveBeenNthCalledWith(2, SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
+        warnSpy.mockRestore();
     });
 
     it('Workbook insertSheet, deleteSheet, and setActiveSheet', async () => {

--- a/packages/sheets/src/facade/__tests__/f-worksheet.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-worksheet.spec.ts
@@ -16,9 +16,68 @@
 
 import type { Injector, Workbook } from '@univerjs/core';
 import type { FUniver } from '@univerjs/core/facade';
-import { ICommandService, IConfirmService, IUniverInstanceService, RANGE_TYPE, TestConfirmService, UniverInstanceType } from '@univerjs/core';
-import { AddWorksheetMergeCommand, AddWorksheetMergeMutation, CancelFrozenCommand, InsertColByRangeCommand, InsertColCommand, InsertColMutation, InsertRowByRangeCommand, InsertRowCommand, InsertRowMutation, MoveColsCommand, MoveColsMutation, MoveRowsCommand, MoveRowsMutation, RemoveColByRangeCommand, RemoveColCommand, RemoveColMutation, RemoveRowByRangeCommand, RemoveRowCommand, RemoveRowMutation, RemoveWorksheetMergeCommand, RemoveWorksheetMergeMutation, SetColDataCommand, SetColDataMutation, SetColHiddenCommand, SetColHiddenMutation, SetColVisibleMutation, SetColWidthCommand, SetFrozenCommand, SetFrozenMutation, SetHorizontalTextAlignCommand, SetRangeValuesCommand, SetRangeValuesMutation, SetRowDataCommand, SetRowDataMutation, SetRowHeightCommand, SetRowHiddenCommand, SetRowHiddenMutation, SetRowVisibleMutation, SetSelectionsOperation, SetSpecificColsVisibleCommand, SetSpecificRowsVisibleCommand, SetStyleCommand, SetTextWrapCommand, SetVerticalTextAlignCommand, SetWorksheetColWidthMutation, SetWorksheetRowHeightMutation, SetWorksheetRowIsAutoHeightCommand, SetWorksheetRowIsAutoHeightMutation, SheetsSelectionsService } from '@univerjs/sheets';
-import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    ICommandService,
+    IConfirmService,
+    ILogService,
+    IUniverInstanceService,
+    RANGE_TYPE,
+    TestConfirmService,
+    UniverInstanceType,
+} from '@univerjs/core';
+import {
+    AddWorksheetMergeCommand,
+    AddWorksheetMergeMutation,
+    CancelFrozenCommand,
+    InsertColByRangeCommand,
+    InsertColCommand,
+    InsertColMutation,
+    InsertRowByRangeCommand,
+    InsertRowCommand,
+    InsertRowMutation,
+    MoveColsCommand,
+    MoveColsMutation,
+    MoveRowsCommand,
+    MoveRowsMutation,
+    RemoveColByRangeCommand,
+    RemoveColCommand,
+    RemoveColMutation,
+    RemoveRowByRangeCommand,
+    RemoveRowCommand,
+    RemoveRowMutation,
+    RemoveWorksheetMergeCommand,
+    RemoveWorksheetMergeMutation,
+    SetColDataCommand,
+    SetColDataMutation,
+    SetColHiddenCommand,
+    SetColHiddenMutation,
+    SetColVisibleMutation,
+    SetColWidthCommand,
+    SetFrozenCommand,
+    SetFrozenMutation,
+    SetHorizontalTextAlignCommand,
+    SetRangeValuesCommand,
+    SetRangeValuesMutation,
+    SetRowDataCommand,
+    SetRowDataMutation,
+    SetRowHeightCommand,
+    SetRowHiddenCommand,
+    SetRowHiddenMutation,
+    SetRowVisibleMutation,
+    SetSelectionsOperation,
+    SetSpecificColsVisibleCommand,
+    SetSpecificRowsVisibleCommand,
+    SetStyleCommand,
+    SetTextWrapCommand,
+    SetVerticalTextAlignCommand,
+    SetWorksheetColWidthMutation,
+    SetWorksheetRowHeightMutation,
+    SetWorksheetRowIsAutoHeightCommand,
+    SetWorksheetRowIsAutoHeightMutation,
+    SheetsSelectionsService,
+} from '@univerjs/sheets';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SHEETS_CUSTOM_FIELD_WARNING_MESSAGE } from '../const';
 import { createWorksheetTestBed } from './create-worksheet-test-bed';
 
 describe('Test FWorksheet', () => {
@@ -475,6 +534,29 @@ describe('Test FWorksheet', () => {
         const currentWorksheet = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)?.getActiveSheet();
         const currentColCustom = currentWorksheet?.getColumnManager().getColumn(0)?.custom;
         expect(currentColCustom).toEqual({ color: 'red' });
+    });
+
+    it('Worksheet custom APIs should warn about custom field usage', () => {
+        const logService = get(ILogService);
+        Object.defineProperty(logService, 'warn', { configurable: true, value: vi.fn() });
+        const warnSpy = vi.spyOn(logService, 'warn');
+        const activeSheet = univerAPI.getActiveWorkbook()?.getSheetByName('sheet1');
+
+        activeSheet?.setRowCustom({ 0: { color: 'red' } });
+        activeSheet?.setColumnCustom({ 0: { color: 'blue' } });
+        activeSheet?.setCustomMetadata({ sheet: 'metadata' });
+        activeSheet?.getCustomMetadata();
+        activeSheet?.setRowCustomMetadata(1, { row: 'metadata' });
+        activeSheet?.getRowCustomMetadata(1);
+        activeSheet?.setColumnCustomMetadata(1, { column: 'metadata' });
+        activeSheet?.getColumnCustomMetadata(1);
+
+        expect(warnSpy).toHaveBeenCalledTimes(8);
+        for (let index = 1; index <= 8; index++) {
+            expect(warnSpy).toHaveBeenNthCalledWith(index, SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+        }
+
+        warnSpy.mockRestore();
     });
 
     // #endregion

--- a/packages/sheets/src/facade/const.ts
+++ b/packages/sheets/src/facade/const.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const SHEETS_CUSTOM_FIELD_WARNING_MESSAGE = '[Facade]: The sheets custom field is not recommended for external use. Use it at your own risk.';

--- a/packages/sheets/src/facade/f-range.ts
+++ b/packages/sheets/src/facade/f-range.ts
@@ -14,7 +14,23 @@
  * limitations under the License.
  */
 
-import type { AbsoluteRefType, BorderStyleTypes, BorderType, CellValue, CustomData, ICellData, IColorStyle, IDocumentData, IObjectMatrixPrimitiveType, IRange, IStyleData, ITextDecoration, Nullable, Workbook, Worksheet } from '@univerjs/core';
+import type {
+    AbsoluteRefType,
+    BorderStyleTypes,
+    BorderType,
+    CellValue,
+    CustomData,
+    ICellData,
+    IColorStyle,
+    IDocumentData,
+    IObjectMatrixPrimitiveType,
+    IRange,
+    IStyleData,
+    ITextDecoration,
+    Nullable,
+    Workbook,
+    Worksheet,
+} from '@univerjs/core';
 import type {
     AUTO_FILL_APPLY_TYPE,
     IMergeCellsUtilOptions,
@@ -32,7 +48,22 @@ import type {
 } from '@univerjs/sheets';
 import type { IFacadeClearOptions } from './f-worksheet';
 import type { FHorizontalAlignment, FVerticalAlignment } from './utils';
-import { BooleanNumber, covertCellValue, covertCellValues, DEFAULT_STYLES, Dimension, ICommandService, Inject, Injector, isNullCell, Rectangle, RichTextValue, TextStyleValue, WrapStrategy } from '@univerjs/core';
+import {
+    BooleanNumber,
+    covertCellValue,
+    covertCellValues,
+    DEFAULT_STYLES,
+    Dimension,
+    ICommandService,
+    ILogService,
+    Inject,
+    Injector,
+    isNullCell,
+    Rectangle,
+    RichTextValue,
+    TextStyleValue,
+    WrapStrategy,
+} from '@univerjs/core';
 import { FBaseInitialable } from '@univerjs/core/facade';
 import { FormulaDataModel, serializeRange, serializeRangeWithSheet } from '@univerjs/engine-formula';
 import {
@@ -62,10 +93,16 @@ import {
     SheetRangeThemeService,
     SplitTextToColumnsCommand,
 } from '@univerjs/sheets';
+import { SHEETS_CUSTOM_FIELD_WARNING_MESSAGE } from './const';
 import { FWorkbook } from './f-workbook';
 import { FWorksheet } from './f-worksheet';
 import { FRangePermission } from './permission/f-range-permission';
-import { transformCoreHorizontalAlignment, transformCoreVerticalAlignment, transformFacadeHorizontalAlignment, transformFacadeVerticalAlignment } from './utils';
+import {
+    transformCoreHorizontalAlignment,
+    transformCoreVerticalAlignment,
+    transformFacadeHorizontalAlignment,
+    transformFacadeVerticalAlignment,
+} from './utils';
 
 export type FontLine = 'none' | 'underline' | 'line-through';
 export type FontStyle = 'normal' | 'italic';
@@ -95,7 +132,8 @@ export class FRange extends FBaseInitialable {
         protected readonly _range: IRange,
         @Inject(Injector) protected override readonly _injector: Injector,
         @ICommandService protected readonly _commandService: ICommandService,
-        @Inject(FormulaDataModel) protected readonly _formulaDataModel: FormulaDataModel
+        @Inject(FormulaDataModel) protected readonly _formulaDataModel: FormulaDataModel,
+        @ILogService protected readonly _logService: ILogService
     ) {
         super(_injector);
 
@@ -1027,6 +1065,8 @@ export class FRange extends FBaseInitialable {
      * ```
      */
     setCustomMetaData(data: CustomData): FRange {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         const params: ISetRangeCustomMetadataCommandParams = {
             unitId: this._workbook.getUnitId(),
             subUnitId: this._worksheet.getSheetId(),
@@ -1058,6 +1098,8 @@ export class FRange extends FBaseInitialable {
      * ```
      */
     setCustomMetaDatas(datas: CustomData[][]): FRange {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         const params: ISetRangeCustomMetadataCommandParams = {
             unitId: this._workbook.getUnitId(),
             subUnitId: this._worksheet.getSheetId(),
@@ -1083,6 +1125,8 @@ export class FRange extends FBaseInitialable {
      * ```
      */
     getCustomMetaData(): CustomData | null {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         const cell = this.getCellData();
         return cell?.custom ?? null;
     }
@@ -1100,6 +1144,8 @@ export class FRange extends FBaseInitialable {
      * ```
      */
     getCustomMetaDatas(): Nullable<CustomData>[][] {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         const dataGrid = this.getCellDataGrid();
         return dataGrid.map((row) => row.map((data) => data?.custom ?? null));
     }

--- a/packages/sheets/src/facade/f-workbook.ts
+++ b/packages/sheets/src/facade/f-workbook.ts
@@ -14,7 +14,17 @@
  * limitations under the License.
  */
 
-import type { CommandListener, CustomData, ICommandInfo, IDisposable, IRange, IStyleData, IWorkbookData, IWorksheetData, Workbook } from '@univerjs/core';
+import type {
+    CommandListener,
+    CustomData,
+    ICommandInfo,
+    IDisposable,
+    IRange,
+    IStyleData,
+    IWorkbookData,
+    IWorksheetData,
+    Workbook,
+} from '@univerjs/core';
 import type { ISetDefinedNameMutationParam } from '@univerjs/engine-formula';
 import type { IRangeThemeStyleJSON, ISetSelectionsOperationParams, ISheetCommandSharedParams } from '@univerjs/sheets';
 import type { FontLine as _FontLine } from './f-range';
@@ -53,6 +63,7 @@ import {
     UnregisterWorksheetRangeThemeStyleCommand,
     WorkbookEditablePermission,
 } from '@univerjs/sheets';
+import { SHEETS_CUSTOM_FIELD_WARNING_MESSAGE } from './const';
 import { FDefinedName, FDefinedNameBuilder } from './f-defined-name';
 import { FRange } from './f-range';
 import { FWorksheet } from './f-worksheet';
@@ -1050,6 +1061,8 @@ export class FWorkbook extends FBaseInitialable {
      * ```
      */
     setCustomMetadata(custom: CustomData | undefined): FWorkbook {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         this._workbook.setCustomMetadata(custom);
         return this;
     }
@@ -1065,6 +1078,8 @@ export class FWorkbook extends FBaseInitialable {
      * ```
      */
     getCustomMetadata(): CustomData | undefined {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         return this._workbook.getCustomMetadata();
     }
 

--- a/packages/sheets/src/facade/f-worksheet.ts
+++ b/packages/sheets/src/facade/f-worksheet.ts
@@ -14,14 +14,83 @@
  * limitations under the License.
  */
 
-import type { CellValue, CustomData, ICellData, IColumnData, IColumnRange, IFreeze, IObjectArrayPrimitiveType, IRange, IRowData, IRowRange, IStyleData, Nullable, Workbook, Worksheet } from '@univerjs/core';
-import type { ISetColDataCommandParams, ISetGridlinesColorCommandParams, ISetRowDataCommandParams, ISetTextWrapCommandParams, IToggleGridlinesCommandParams } from '@univerjs/sheets';
+import type {
+    CellValue,
+    CustomData,
+    ICellData,
+    IColumnData,
+    IColumnRange,
+    IFreeze,
+    IObjectArrayPrimitiveType,
+    IRange,
+    IRowData,
+    IRowRange,
+    IStyleData,
+    Nullable,
+    Workbook,
+    Worksheet,
+} from '@univerjs/core';
+import type {
+    ISetColDataCommandParams,
+    ISetGridlinesColorCommandParams,
+    ISetRowDataCommandParams,
+    ISetTextWrapCommandParams,
+    IToggleGridlinesCommandParams,
+} from '@univerjs/sheets';
 import type { FDefinedName } from './f-defined-name';
 import type { FWorkbook } from './f-workbook';
-import { BooleanNumber, covertCellValue, Direction, generateIntervalsByPoints, ICommandService, ILogService, Inject, Injector, ObjectMatrix, RANGE_TYPE, WrapStrategy } from '@univerjs/core';
+import {
+    BooleanNumber,
+    covertCellValue,
+    Direction,
+    generateIntervalsByPoints,
+    ICommandService,
+    ILogService,
+    Inject,
+    Injector,
+    ObjectMatrix,
+    RANGE_TYPE,
+    WrapStrategy,
+} from '@univerjs/core';
 import { FBaseInitialable } from '@univerjs/core/facade';
 import { deserializeRangeWithSheet } from '@univerjs/engine-formula';
-import { AppendRowCommand, CancelFrozenCommand, ClearSelectionAllCommand, ClearSelectionContentCommand, ClearSelectionFormatCommand, copyRangeStyles, InsertColByRangeCommand, InsertRowByRangeCommand, MoveColsCommand, MoveRowsCommand, RemoveColByRangeCommand, RemoveRowByRangeCommand, SetColDataCommand, SetColHiddenCommand, SetColWidthCommand, SetFrozenCommand, SetGridlinesColorCommand, SetRowDataCommand, SetRowHeightCommand, SetRowHiddenCommand, SetSpecificColsVisibleCommand, SetSpecificRowsVisibleCommand, SetTabColorCommand, SetTextWrapCommand, SetWorksheetColumnCountCommand, SetWorksheetDefaultStyleMutation, SetWorksheetHideCommand, SetWorksheetNameCommand, SetWorksheetRowCountCommand, SetWorksheetRowIsAutoHeightCommand, SetWorksheetRowIsAutoHeightMutation, SetWorksheetShowCommand, SheetsSelectionsService, ToggleGridlinesCommand } from '@univerjs/sheets';
+import {
+    AppendRowCommand,
+    CancelFrozenCommand,
+    ClearSelectionAllCommand,
+    ClearSelectionContentCommand,
+    ClearSelectionFormatCommand,
+    copyRangeStyles,
+    InsertColByRangeCommand,
+    InsertRowByRangeCommand,
+    MoveColsCommand,
+    MoveRowsCommand,
+    RemoveColByRangeCommand,
+    RemoveRowByRangeCommand,
+    SetColDataCommand,
+    SetColHiddenCommand,
+    SetColWidthCommand,
+    SetFrozenCommand,
+    SetGridlinesColorCommand,
+    SetRowDataCommand,
+    SetRowHeightCommand,
+    SetRowHiddenCommand,
+    SetSpecificColsVisibleCommand,
+    SetSpecificRowsVisibleCommand,
+    SetTabColorCommand,
+    SetTextWrapCommand,
+    SetWorksheetColumnCountCommand,
+    SetWorksheetDefaultStyleMutation,
+    SetWorksheetHideCommand,
+    SetWorksheetNameCommand,
+    SetWorksheetRowCountCommand,
+    SetWorksheetRowIsAutoHeightCommand,
+    SetWorksheetRowIsAutoHeightMutation,
+    SetWorksheetShowCommand,
+    SheetsSelectionsService,
+    ToggleGridlinesCommand,
+} from '@univerjs/sheets';
+import { SHEETS_CUSTOM_FIELD_WARNING_MESSAGE } from './const';
 import { FDefinedNameBuilder } from './f-defined-name';
 import { FRange } from './f-range';
 import { FSelection } from './f-selection';
@@ -1092,6 +1161,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     setRowCustom(custom: IObjectArrayPrimitiveType<CustomData>): FWorksheet {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         const unitId = this._workbook.getUnitId();
         const subUnitId = this._worksheet.getSheetId();
 
@@ -1590,6 +1661,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     setColumnCustom(custom: IObjectArrayPrimitiveType<CustomData>): FWorksheet {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         const unitId = this._workbook.getUnitId();
         const subUnitId = this._worksheet.getSheetId();
 
@@ -2474,6 +2547,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     setCustomMetadata(custom: CustomData | undefined): FWorksheet {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         this._worksheet.setCustomMetadata(custom);
         return this;
     }
@@ -2491,6 +2566,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     getCustomMetadata(): CustomData | undefined {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         return this._worksheet.getCustomMetadata();
     }
 
@@ -2508,6 +2585,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     setRowCustomMetadata(index: number, custom: CustomData | undefined): FWorksheet {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         this._worksheet.getRowManager().setCustomMetadata(index, custom);
         return this;
     }
@@ -2526,6 +2605,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     setColumnCustomMetadata(index: number, custom: CustomData | undefined): FWorksheet {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         this._worksheet.getColumnManager().setCustomMetadata(index, custom);
         return this;
     }
@@ -2544,6 +2625,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     getRowCustomMetadata(index: number): CustomData | undefined {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         return this._worksheet.getRowManager().getCustomMetadata(index);
     }
 
@@ -2561,6 +2644,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     getColumnCustomMetadata(index: number): CustomData | undefined {
+        this._logService.warn(SHEETS_CUSTOM_FIELD_WARNING_MESSAGE);
+
         return this._worksheet.getColumnManager().getCustomMetadata(index);
     }
 


### PR DESCRIPTION
The `custom` field on workbook, worksheet, row, column, and cell data is reserved for internal use. Surface a runtime warning from the facade APIs that read or write it, so external consumers notice and migrate off before the field is removed.

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
