### PR TITLE
fix(sheets-note): accept range-local note input

### DIFF
--- a/packages/sheets-note/src/facade/__tests__/sheets-note.facade.spec.ts
+++ b/packages/sheets-note/src/facade/__tests__/sheets-note.facade.spec.ts
@@ -16,7 +16,6 @@
 
 import type { Dependency, IWorkbookData, UnitModel } from '@univerjs/core';
 import type { FUniver } from '@univerjs/core/facade';
-import type { ISheetNote } from '../../models/sheets-note.model';
 import {
     ILogService,
     Inject,
@@ -166,10 +165,16 @@ describe('sheets-note facade mixins', () => {
         const range = sheet.getRange(1, 1, 1, 1);
         expect(range.getNote()).toBeUndefined();
 
-        const note: ISheetNote = { id: 'ignored-id', row: 1, col: 1, width: 160, height: 72, note: 'hello', show: true };
-        range.createOrUpdateNote(note);
+        range.createOrUpdateNote({ width: 160, height: 72, note: 'hello', show: true });
 
-        expect(range.getNote()?.note).toBe('hello');
+        expect(range.getNote()).toMatchObject({
+            col: 1,
+            height: 72,
+            note: 'hello',
+            row: 1,
+            show: true,
+            width: 160,
+        });
         expect(sheet.getNotes()).toHaveLength(1);
 
         range.deleteNote();

--- a/packages/sheets-note/src/facade/f-range.ts
+++ b/packages/sheets-note/src/facade/f-range.ts
@@ -19,6 +19,14 @@ import type { ISheetNote } from '@univerjs/sheets-note';
 import { RemoveNoteMutation, SheetsNoteModel, UpdateNoteMutation } from '@univerjs/sheets-note';
 import { FRange } from '@univerjs/sheets/facade';
 
+export interface ICreateOrUpdateNoteOptions {
+    id?: string;
+    width: number;
+    height: number;
+    note: string;
+    show?: boolean;
+}
+
 /**
  * @ignore
  */
@@ -39,7 +47,7 @@ export interface IFRangeSheetsNoteMixin {
     getNote(): Nullable<ISheetNote>;
     /**
      * Create or update the annotation of the top-left cell in the range
-     * @param {ISheetNote} note The annotation to create or update
+     * @param {ICreateOrUpdateNoteOptions} note The annotation to create or update
      * @returns {FRange} This range for method chaining
      * @example
      * ```ts
@@ -55,7 +63,7 @@ export interface IFRangeSheetsNoteMixin {
      * });
      * ```
      */
-    createOrUpdateNote(note: ISheetNote): FRange;
+    createOrUpdateNote(note: ICreateOrUpdateNoteOptions): FRange;
     /**
      * Delete the annotation of the top-left cell in the range
      * @returns {FRange} This range for method chaining
@@ -78,7 +86,7 @@ export interface IFRangeSheetsNoteMixin {
 }
 
 export class FRangeSheetsNoteMixin extends FRange implements IFRangeSheetsNoteMixin {
-    override createOrUpdateNote(note: ISheetNote): FRange {
+    override createOrUpdateNote(note: ICreateOrUpdateNoteOptions): FRange {
         this._commandService.syncExecuteCommand(
             UpdateNoteMutation.id,
             {


### PR DESCRIPTION
## Summary

- Introduce `IRangeLocalSheetNote` for `FRange.createOrUpdateNote` so range-local calls can omit `id`, `row`, and `col`.
- Keep `note`, `width`, and `height` required, matching the note payload shape while letting the range/model fill position and generated id.
- Update the facade test to cover the range-local payload and read back the filled row/col values.

## Validation

- `pnpm --filter @univerjs/sheets-note test -- src/facade/__tests__/sheets-note.facade.spec.ts`
- `pnpm --filter @univerjs/sheets-note typecheck`
- `pnpm exec eslint packages/sheets-note/src/facade/f-range.ts packages/sheets-note/src/facade/__tests__/sheets-note.facade.spec.ts` (passes with one pre-existing warning in the test file: `react/no-unnecessary-use-prefix` at line 107)
