### PR TITLE
fix(sheets-formula): add progress locale strings

### DIFF
--- a/packages/sheets-formula/src/locale/ar-SA.ts
+++ b/packages/sheets-formula/src/locale/ar-SA.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/en-US';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'جارٍ تحليل الصيغ...',
+            calculating: 'جارٍ حساب الصيغ...',
+            'array-analysis': 'جارٍ تحليل صيغ الصفائف...',
+            'array-calculation': 'جارٍ حساب صيغ الصفائف...',
+            done: 'تم',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/ca-ES.ts
+++ b/packages/sheets-formula/src/locale/ca-ES.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/ca-ES';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Analitzant fórmules...',
+            calculating: 'Calculant fórmules...',
+            'array-analysis': 'Analitzant fórmules de matriu...',
+            'array-calculation': 'Calculant fórmules de matriu...',
+            done: 'Fet',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/de-DE.ts
+++ b/packages/sheets-formula/src/locale/de-DE.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/en-US';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Formeln werden analysiert...',
+            calculating: 'Formeln werden berechnet...',
+            'array-analysis': 'Matrixformeln werden analysiert...',
+            'array-calculation': 'Matrixformeln werden berechnet...',
+            done: 'Fertig',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/en-US.ts
+++ b/packages/sheets-formula/src/locale/en-US.ts
@@ -32,6 +32,13 @@ import web from './function-list/web/en-US';
 
 const locale = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Analyzing formulas...',
+            calculating: 'Calculating formulas...',
+            'array-analysis': 'Analyzing array formulas...',
+            'array-calculation': 'Calculating array formulas...',
+            done: 'Done',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/es-ES.ts
+++ b/packages/sheets-formula/src/locale/es-ES.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/es-ES';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Analizando fórmulas...',
+            calculating: 'Calculando fórmulas...',
+            'array-analysis': 'Analizando fórmulas de matriz...',
+            'array-calculation': 'Calculando fórmulas de matriz...',
+            done: 'Listo',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/fa-IR.ts
+++ b/packages/sheets-formula/src/locale/fa-IR.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/fa-IR';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'در حال تحلیل فرمول‌ها...',
+            calculating: 'در حال محاسبه فرمول‌ها...',
+            'array-analysis': 'در حال تحلیل فرمول‌های آرایه‌ای...',
+            'array-calculation': 'در حال محاسبه فرمول‌های آرایه‌ای...',
+            done: 'انجام شد',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/fr-FR.ts
+++ b/packages/sheets-formula/src/locale/fr-FR.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/fr-FR';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Analyse des formules...',
+            calculating: 'Calcul des formules...',
+            'array-analysis': 'Analyse des formules matricielles...',
+            'array-calculation': 'Calcul des formules matricielles...',
+            done: 'Terminé',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/id-ID.ts
+++ b/packages/sheets-formula/src/locale/id-ID.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/en-US';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Menganalisis rumus...',
+            calculating: 'Menghitung rumus...',
+            'array-analysis': 'Menganalisis rumus array...',
+            'array-calculation': 'Menghitung rumus array...',
+            done: 'Selesai',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/it-IT.ts
+++ b/packages/sheets-formula/src/locale/it-IT.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/en-US';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Analisi delle formule...',
+            calculating: 'Calcolo delle formule...',
+            'array-analysis': 'Analisi delle formule matrice...',
+            'array-calculation': 'Calcolo delle formule matrice...',
+            done: 'Completato',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/ja-JP.ts
+++ b/packages/sheets-formula/src/locale/ja-JP.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/ja-JP';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: '数式を分析中...',
+            calculating: '数式を計算中...',
+            'array-analysis': '配列数式を分析中...',
+            'array-calculation': '配列数式を計算中...',
+            done: '完了',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/ko-KR.ts
+++ b/packages/sheets-formula/src/locale/ko-KR.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/ko-KR';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: '수식 분석 중...',
+            calculating: '수식 계산 중...',
+            'array-analysis': '배열 수식 분석 중...',
+            'array-calculation': '배열 수식 계산 중...',
+            done: '완료',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/pl-PL.ts
+++ b/packages/sheets-formula/src/locale/pl-PL.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/en-US';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Analizowanie formuł...',
+            calculating: 'Obliczanie formuł...',
+            'array-analysis': 'Analizowanie formuł tablicowych...',
+            'array-calculation': 'Obliczanie formuł tablicowych...',
+            done: 'Gotowe',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/pt-BR.ts
+++ b/packages/sheets-formula/src/locale/pt-BR.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/en-US';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Analisando fórmulas...',
+            calculating: 'Calculando fórmulas...',
+            'array-analysis': 'Analisando fórmulas de matriz...',
+            'array-calculation': 'Calculando fórmulas de matriz...',
+            done: 'Concluído',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/ru-RU.ts
+++ b/packages/sheets-formula/src/locale/ru-RU.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/ru-RU';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Анализ формул...',
+            calculating: 'Вычисление формул...',
+            'array-analysis': 'Анализ формул массива...',
+            'array-calculation': 'Вычисление формул массива...',
+            done: 'Готово',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/sk-SK.ts
+++ b/packages/sheets-formula/src/locale/sk-SK.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/sk-SK';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Analyzujú sa vzorce...',
+            calculating: 'Počítajú sa vzorce...',
+            'array-analysis': 'Analyzujú sa maticové vzorce...',
+            'array-calculation': 'Počítajú sa maticové vzorce...',
+            done: 'Hotovo',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/vi-VN.ts
+++ b/packages/sheets-formula/src/locale/vi-VN.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/vi-VN';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: 'Đang phân tích công thức...',
+            calculating: 'Đang tính toán công thức...',
+            'array-analysis': 'Đang phân tích công thức mảng...',
+            'array-calculation': 'Đang tính toán công thức mảng...',
+            done: 'Hoàn tất',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/zh-CN.ts
+++ b/packages/sheets-formula/src/locale/zh-CN.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/zh-CN';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: '正在分析公式...',
+            calculating: '正在计算公式...',
+            'array-analysis': '正在分析数组公式...',
+            'array-calculation': '正在计算数组公式...',
+            done: '完成',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/zh-HK.ts
+++ b/packages/sheets-formula/src/locale/zh-HK.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/en-US';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: '正在分析公式...',
+            calculating: '正在計算公式...',
+            'array-analysis': '正在分析陣列公式...',
+            'array-calculation': '正在計算陣列公式...',
+            done: '完成',
+        },
         functionList: {
             ...array,
             ...compatibility,

--- a/packages/sheets-formula/src/locale/zh-TW.ts
+++ b/packages/sheets-formula/src/locale/zh-TW.ts
@@ -34,6 +34,13 @@ import web from './function-list/web/zh-TW';
 
 const locale: typeof enUS = {
     'sheets-formula': {
+        progress: {
+            analyzing: '正在分析公式...',
+            calculating: '正在計算公式...',
+            'array-analysis': '正在分析陣列公式...',
+            'array-calculation': '正在計算陣列公式...',
+            done: '完成',
+        },
         functionList: {
             ...array,
             ...compatibility,


### PR DESCRIPTION
Add progress message translations across 19 locales for formula analysis and calculation states, covering both standard and array formulas plus a completion indicator.

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
