### PR TITLE
refactor: clean up LocaleService usage

### DIFF
--- a/packages/find-replace/src/views/dialog/FindReplaceDialog.tsx
+++ b/packages/find-replace/src/views/dialog/FindReplaceDialog.tsx
@@ -77,7 +77,6 @@ export const FindDialog = forwardRef(function FindDialogImpl(_props, ref) {
                 matchesCount={matchesCount}
                 matchesPosition={matchesPosition}
                 findReplaceService={findReplaceService}
-                localeService={localeService}
                 initialFindString={findString}
                 onChange={onFindStringChange}
             />
@@ -183,7 +182,6 @@ export const ReplaceDialog = forwardRef(function ReplaceDialogImpl(_props, ref) 
                     matchesCount={matchesCount}
                     matchesPosition={matchesPosition}
                     findReplaceService={findReplaceService}
-                    localeService={localeService}
                     initialFindString={inputtingFindString}
                     onChange={onFindStringChange}
                 />

--- a/packages/find-replace/src/views/dialog/SearchInput.tsx
+++ b/packages/find-replace/src/views/dialog/SearchInput.tsx
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import type { LocaleService } from '@univerjs/core';
 import type { IInputProps } from '@univerjs/design';
 import type { IFindReplaceService } from '../../services/find-replace.service';
+import { LocaleService } from '@univerjs/core';
 import { Input, Pager } from '@univerjs/design';
+import { useDependency } from '@univerjs/ui';
 import { useState } from 'react';
 
 export interface ISearchInputProps extends Pick<IInputProps, 'onFocus' | 'onBlur' | 'className' | 'onChange'> {
     findCompleted: boolean;
-    localeService: LocaleService;
     findReplaceService: IFindReplaceService;
     matchesPosition: number;
     matchesCount: number;
@@ -32,7 +32,6 @@ export interface ISearchInputProps extends Pick<IInputProps, 'onFocus' | 'onBlur
 export function SearchInput(props: ISearchInputProps) {
     const {
         findCompleted: findComplete,
-        localeService,
         matchesCount,
         matchesPosition,
         initialFindString,
@@ -40,6 +39,8 @@ export function SearchInput(props: ISearchInputProps) {
         onChange,
         ...rest
     } = props;
+
+    const localeService = useDependency(LocaleService);
 
     const [value, setValue] = useState(initialFindString);
     const noResult = findComplete && matchesCount === 0;

--- a/packages/sheets-numfmt-ui/src/views/components/Accounting.tsx
+++ b/packages/sheets-numfmt-ui/src/views/components/Accounting.tsx
@@ -37,7 +37,6 @@ export const AccountingPanel: FC<IBusinessComponentProps> = (props) => {
     const options = useMemo(() => userHabitCurrency.map((key) => ({ label: key, value: key })), []);
 
     const localeService = useDependency(LocaleService);
-    const t = localeService.t;
 
     action.current = () => setPatternDecimal(`_("${suffix}"* #,##0${decimal > 0 ? '.0' : ''}_)`, decimal);
 
@@ -56,7 +55,7 @@ export const AccountingPanel: FC<IBusinessComponentProps> = (props) => {
         <div>
             <div className="univer-mt-4 univer-flex univer-justify-between">
                 <div className="option">
-                    <div className="univer-text-sm univer-text-gray-400">{t('sheets-numfmt-ui.decimalLength')}</div>
+                    <div className="univer-text-sm univer-text-gray-400">{localeService.t('sheets-numfmt-ui.decimalLength')}</div>
 
                     <div className="univer-mt-2 univer-w-32">
                         <InputNumber
@@ -70,7 +69,7 @@ export const AccountingPanel: FC<IBusinessComponentProps> = (props) => {
                     </div>
                 </div>
                 <div className="option">
-                    <div className="univer-text-sm univer-text-gray-400">{t('sheets-numfmt-ui.currencyType')}</div>
+                    <div className="univer-text-sm univer-text-gray-400">{localeService.t('sheets-numfmt-ui.currencyType')}</div>
 
                     <div className="univer-mt-2 univer-w-36">
                         <Select
@@ -82,7 +81,7 @@ export const AccountingPanel: FC<IBusinessComponentProps> = (props) => {
                 </div>
             </div>
 
-            <div className="univer-mt-4 univer-text-sm univer-text-gray-400">{t('sheets-numfmt-ui.accountingDes')}</div>
+            <div className="univer-mt-4 univer-text-sm univer-text-gray-400">{localeService.t('sheets-numfmt-ui.accountingDes')}</div>
         </div>
     );
 };

--- a/packages/sheets-numfmt-ui/src/views/components/Currency.tsx
+++ b/packages/sheets-numfmt-ui/src/views/components/Currency.tsx
@@ -30,7 +30,6 @@ export const isCurrencyPanel = (pattern: string) => {
 
 export const CurrencyPanel: FC<IBusinessComponentProps> = (props) => {
     const localeService = useDependency(LocaleService);
-    const t = localeService.t;
     const userHabitCurrency = useContext(UserHabitCurrencyContext);
     const [suffix, setSuffix] = useState(() => getCurrencyType(props.defaultPattern) || userHabitCurrency[0]);
     const [decimal, setDecimal] = useState(() => getDecimalFromPattern(props.defaultPattern || '', 2));
@@ -74,7 +73,7 @@ export const CurrencyPanel: FC<IBusinessComponentProps> = (props) => {
         <div>
             <div className="univer-mt-4 univer-flex univer-justify-between">
                 <div className="option">
-                    <div className="univer-text-sm univer-text-gray-400">{t('sheets-numfmt-ui.decimalLength')}</div>
+                    <div className="univer-text-sm univer-text-gray-400">{localeService.t('sheets-numfmt-ui.decimalLength')}</div>
                     <div className="univer-mt-2 univer-w-32">
                         <InputNumber
                             value={decimal}
@@ -85,7 +84,7 @@ export const CurrencyPanel: FC<IBusinessComponentProps> = (props) => {
                     </div>
                 </div>
                 <div className="option">
-                    <div className="univer-text-sm univer-text-gray-400">{t('sheets-numfmt-ui.currencyType')}</div>
+                    <div className="univer-text-sm univer-text-gray-400">{localeService.t('sheets-numfmt-ui.currencyType')}</div>
                     <div className="univer-mt-2 univer-w-36">
                         <Select
                             value={suffix}
@@ -96,14 +95,14 @@ export const CurrencyPanel: FC<IBusinessComponentProps> = (props) => {
                 </div>
             </div>
             <div className="label univer-mt-4">
-                {t('sheets-numfmt-ui.negType')}
+                {localeService.t('sheets-numfmt-ui.negType')}
             </div>
 
             <div className="univer-mt-2">
                 <SelectList value={pattern} options={negativeOptions} onChange={onChange} />
             </div>
 
-            <div className="univer-mt-4 univer-text-sm univer-text-gray-400">{t('sheets-numfmt-ui.currencyDes')}</div>
+            <div className="univer-mt-4 univer-text-sm univer-text-gray-400">{localeService.t('sheets-numfmt-ui.currencyDes')}</div>
         </div>
     );
 };

--- a/packages/sheets-numfmt-ui/src/views/components/General.tsx
+++ b/packages/sheets-numfmt-ui/src/views/components/General.tsx
@@ -23,7 +23,6 @@ export const isGeneralPanel = (pattern: string) => !pattern;
 
 export const GeneralPanel: FC<IBusinessComponentProps> = (props) => {
     const localeService = useDependency(LocaleService);
-    const t = localeService.t;
 
     // FIXME: WTF
     props.action.current = () => '';
@@ -36,7 +35,7 @@ export const GeneralPanel: FC<IBusinessComponentProps> = (props) => {
                   dark:!univer-text-gray-200
                 `}
             >
-                {t('sheets-numfmt-ui.generalDes')}
+                {localeService.t('sheets-numfmt-ui.generalDes')}
             </div>
         </div>
     );

--- a/packages/sheets-numfmt-ui/src/views/components/index.tsx
+++ b/packages/sheets-numfmt-ui/src/views/components/index.tsx
@@ -41,7 +41,6 @@ export const SheetNumfmtPanel: FC<ISheetNumfmtPanelProps> = (props) => {
     const { defaultValue, defaultPattern, row, col } = props.value;
     const localeService = useDependency(LocaleService);
     const getCurrentPattern = useRef<() => string | null>(() => '');
-    const t = localeService.t;
     const nextTick = useNextTick();
     const typeOptions = useMemo(
         () =>
@@ -52,8 +51,8 @@ export const SheetNumfmtPanel: FC<ISheetNumfmtPanelProps> = (props) => {
                 { label: 'sheets-numfmt-ui.date', component: DatePanel },
                 { label: 'sheets-numfmt-ui.thousandthPercentile', component: ThousandthPercentilePanel },
                 { label: 'sheets-numfmt-ui.customFormat', component: CustomFormat },
-            ].map((item) => ({ ...item, label: t(item.label) })),
-        []
+            ].map((item) => ({ ...item, label: localeService.t(item.label) })),
+        [localeService]
     );
     const [type, setType] = useState(findDefaultType);
     const [key, setKey] = useState(() => `${row}_${col}`);
@@ -116,7 +115,7 @@ export const SheetNumfmtPanel: FC<ISheetNumfmtPanelProps> = (props) => {
             `, scrollbarClassName)}
         >
             <div>
-                <div className="univer-mt-3.5 univer-text-sm univer-text-gray-400">{t('sheets-numfmt-ui.numfmtType')}</div>
+                <div className="univer-mt-3.5 univer-text-sm univer-text-gray-400">{localeService.t('sheets-numfmt-ui.numfmtType')}</div>
                 <div className="univer-mt-2">
                     <Select className="univer-w-full" value={type} options={selectOptions} onChange={handleSelect} />
                 </div>
@@ -131,10 +130,10 @@ export const SheetNumfmtPanel: FC<ISheetNumfmtPanelProps> = (props) => {
 
             <div className="univer-mb-5 univer-mt-3.5 univer-flex univer-justify-end">
                 <Button onClick={handleCancel} className="univer-mr-3">
-                    {t('sheets-numfmt-ui.cancel')}
+                    {localeService.t('sheets-numfmt-ui.cancel')}
                 </Button>
                 <Button variant="primary" onClick={handleConfirm}>
-                    {t('sheets-numfmt-ui.confirm')}
+                    {localeService.t('sheets-numfmt-ui.confirm')}
                 </Button>
             </div>
         </div>

--- a/packages/sheets-table-ui/src/views/components/util.ts
+++ b/packages/sheets-table-ui/src/views/components/util.ts
@@ -25,179 +25,178 @@ import { ConditionSubComponentEnum } from './type';
 
 export function getCascaderListOptions(injector: Injector) {
     const localeService = injector.get(LocaleService);
-    const t = localeService.t;
     return [
         {
             value: TableConditionTypeEnum.String,
-            label: t(`sheets-table-ui.condition.${TableConditionTypeEnum.String}`),
+            label: localeService.t(`sheets-table-ui.condition.${TableConditionTypeEnum.String}`),
             children: [
                 {
                     value: TableStringCompareTypeEnum.Equal,
-                    label: t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.Equal}`),
+                    label: localeService.t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.Equal}`),
                 },
                 {
                     value: TableStringCompareTypeEnum.NotEqual,
-                    label: t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.NotEqual}`),
+                    label: localeService.t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.NotEqual}`),
                 },
                 {
                     value: TableStringCompareTypeEnum.Contains,
-                    label: t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.Contains}`),
+                    label: localeService.t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.Contains}`),
                 },
                 {
                     value: TableStringCompareTypeEnum.NotContains,
-                    label: t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.NotContains}`),
+                    label: localeService.t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.NotContains}`),
                 },
                 {
                     value: TableStringCompareTypeEnum.StartsWith,
-                    label: t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.StartsWith}`),
+                    label: localeService.t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.StartsWith}`),
                 },
                 {
                     value: TableStringCompareTypeEnum.EndsWith,
-                    label: t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.EndsWith}`),
+                    label: localeService.t(`sheets-table-ui.string.compare.${TableStringCompareTypeEnum.EndsWith}`),
                 },
             ],
         },
         {
             value: TableConditionTypeEnum.Number,
-            label: t(`sheets-table-ui.condition.${TableConditionTypeEnum.Number}`),
+            label: localeService.t(`sheets-table-ui.condition.${TableConditionTypeEnum.Number}`),
             children: [
                 {
                     value: TableNumberCompareTypeEnum.Equal,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.Equal}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.Equal}`),
                 },
                 {
                     value: TableNumberCompareTypeEnum.NotEqual,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.NotEqual}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.NotEqual}`),
                 },
                 {
                     value: TableNumberCompareTypeEnum.GreaterThan,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.GreaterThan}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.GreaterThan}`),
                 },
                 {
                     value: TableNumberCompareTypeEnum.GreaterThanOrEqual,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.GreaterThanOrEqual}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.GreaterThanOrEqual}`),
                 },
                 {
                     value: TableNumberCompareTypeEnum.LessThan,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.LessThan}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.LessThan}`),
                 },
                 {
                     value: TableNumberCompareTypeEnum.LessThanOrEqual,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.LessThanOrEqual}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.LessThanOrEqual}`),
                 },
                 {
                     value: TableNumberCompareTypeEnum.Between,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.Between}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.Between}`),
                 },
                 {
                     value: TableNumberCompareTypeEnum.NotBetween,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.NotBetween}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.NotBetween}`),
                 },
                 {
                     value: TableNumberCompareTypeEnum.Above,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.Above}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.Above}`),
                 },
                 {
                     value: TableNumberCompareTypeEnum.Below,
-                    label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.Below}`),
+                    label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.Below}`),
                 },
                 // {
                 //     value: TableNumberCompareTypeEnum.TopN,
-                //     label: t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.TopN}`),
+                //     label: localeService.t(`sheets-table-ui.number.compare.${TableNumberCompareTypeEnum.TopN}`),
                 // },
             ],
         },
         {
             value: TableConditionTypeEnum.Date,
-            label: t(`sheets-table-ui.condition.${TableConditionTypeEnum.Date}`),
+            label: localeService.t(`sheets-table-ui.condition.${TableConditionTypeEnum.Date}`),
             children: [
                 {
                     value: TableDateCompareTypeEnum.Equal,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Equal}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Equal}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.NotEqual,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NotEqual}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NotEqual}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.After,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.After}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.After}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.AfterOrEqual,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.AfterOrEqual}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.AfterOrEqual}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Before,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Before}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Before}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.BeforeOrEqual,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.BeforeOrEqual}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.BeforeOrEqual}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Between,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Between}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Between}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.NotBetween,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NotBetween}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NotBetween}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Today,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Today}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Today}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Yesterday,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Yesterday}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Yesterday}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Tomorrow,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Tomorrow}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Tomorrow}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.ThisWeek,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.ThisWeek}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.ThisWeek}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.LastWeek,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.LastWeek}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.LastWeek}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.NextWeek,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NextWeek}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NextWeek}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.ThisMonth,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.ThisMonth}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.ThisMonth}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.LastMonth,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.LastMonth}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.LastMonth}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.NextMonth,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NextMonth}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NextMonth}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.ThisYear,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.ThisYear}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.ThisYear}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.LastYear,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.LastYear}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.LastYear}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.NextYear,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NextYear}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.NextYear}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Quarter,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Quarter}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Quarter}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Month,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Month}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Month}`),
                 },
             ],
         },
@@ -209,76 +208,75 @@ export function getConditionDateSelect(injector: Injector, dateType?: TableDateC
         return [];
     }
     const localeService = injector.get(LocaleService);
-    const t = localeService.t;
     switch (dateType) {
         case TableDateCompareTypeEnum.Quarter:
             return [
                 {
                     value: TableDateCompareTypeEnum.Q1,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Q1}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Q1}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Q2,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Q2}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Q2}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Q3,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Q3}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Q3}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.Q4,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Q4}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.Q4}`),
                 },
             ];
         case TableDateCompareTypeEnum.Month:
             return [
                 {
                     value: TableDateCompareTypeEnum.M1,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M1}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M1}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M2,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M2}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M2}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M3,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M3}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M3}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M4,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M4}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M4}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M5,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M5}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M5}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M6,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M6}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M6}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M7,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M7}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M7}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M8,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M8}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M8}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M9,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M9}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M9}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M10,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M10}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M10}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M11,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M11}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M11}`),
                 },
                 {
                     value: TableDateCompareTypeEnum.M12,
-                    label: t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M12}`),
+                    label: localeService.t(`sheets-table-ui.date.compare.${TableDateCompareTypeEnum.M12}`),
                 },
             ];
         default:


### PR DESCRIPTION
- find-replace: drop the localeService prop on SearchInput and resolve LocaleService via useDependency instead of prop drilling
- sheets-numfmt-ui, sheets-table-ui: remove the const t = localeService.t alias and call localeService.t(...) inline at use sites

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
