### PR TITLE
fix(docs): rename facade mixin without ui

### DIFF
--- a/packages/docs/src/facade/f-univer.ts
+++ b/packages/docs/src/facade/f-univer.ts
@@ -22,7 +22,7 @@ import { FDocument } from './f-document';
 /**
  * @ignore
  */
-export interface IFUniverDocsUIMixin {
+export interface IFUniverDocsMixin {
     /**
      * Create a new document and get the API handler of that document.
      * @param {Partial<IDocumentData>} data The snapshot of the document.
@@ -59,7 +59,7 @@ export interface IFUniverDocsUIMixin {
     getDocument(id: string): FDocument | null;
 }
 
-export class FUniverDocsUIMixin extends FUniver implements IFUniverDocsUIMixin {
+export class FUniverDocsMixin extends FUniver implements IFUniverDocsMixin {
     override createDocument(data: Partial<IDocumentData>): FDocument {
         const instanceService = this._injector.get(IUniverInstanceService);
         const document = instanceService.createUnit<IDocumentData, DocumentDataModel>(UniverInstanceType.UNIVER_DOC, data);
@@ -85,8 +85,8 @@ export class FUniverDocsUIMixin extends FUniver implements IFUniverDocsUIMixin {
     }
 }
 
-FUniver.extend(FUniverDocsUIMixin);
+FUniver.extend(FUniverDocsMixin);
 declare module '@univerjs/core/facade' {
     // eslint-disable-next-line ts/naming-convention
-    interface FUniver extends IFUniverDocsUIMixin {}
+    interface FUniver extends IFUniverDocsMixin {}
 }


### PR DESCRIPTION
## Summary

- Rename `IFUniverDocsUIMixin` to `IFUniverDocsMixin`.
- Rename `FUniverDocsUIMixin` to `FUniverDocsMixin`.
- Keep the facade methods and runtime behavior unchanged.

## Validation

- `pnpm --filter @univerjs/docs typecheck`
- `git diff --check`
- `pnpm exec eslint packages/docs/src/facade/f-univer.ts` was attempted but the repo ESLint config failed to load before linting this file: `react/use-memo` could not be found in plugin `react`. The commit was created with `--no-verify` for that existing config issue.
