### PR TITLE
feat(core): add shape text optical align render config

### DIFF
--- a/packages/core/src/types/interfaces/i-document-data.ts
+++ b/packages/core/src/types/interfaces/i-document-data.ts
@@ -507,6 +507,7 @@ export interface IDocumentRenderConfig {
     cellValueType?: CellValueType; // sheet cell type, In a spreadsheet cell, without any alignment settings applied, text should be left-aligned, numbers should be right-aligned, and Boolean values should be center-aligned.
     isRenderStyle?: BooleanNumber; // Whether to render the style(textRuns), used in formula bar editor. the default value is TRUE.
     zeroWidthParagraphBreak?: BooleanNumber; // Whether to render the paragraph \r to zero width. the default value is false.
+    shapeTextOpticalVerticalAlign?: BooleanNumber; // Align shape text by visible glyph bounds instead of the font line box.
 }
 
 export interface ISectionBreakBase {


### PR DESCRIPTION
## Summary
- add a document render config flag for shape text optical vertical alignment

## Validation
- pnpm --filter @univerjs/core typecheck

## Notes
- supports the Univer Pro shape text visible-bounds alignment change.