### PR TITLE
fix(docs): initialize body for partial document data

### DIFF
--- a/packages/core/src/docs/data-model/__tests__/document-data-model.spec.ts
+++ b/packages/core/src/docs/data-model/__tests__/document-data-model.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DocumentDataModel } from '../document-data-model';
+
+describe('DocumentDataModel', () => {
+    it('normalizes document data without body to an editable empty document', () => {
+        const document = new DocumentDataModel({
+            id: 'doc-without-body',
+            title: 'Document Without Body',
+            documentStyle: {},
+        });
+
+        expect(document.getUnitId()).toBe('doc-without-body');
+        expect(document.getTitle()).toBe('Document Without Body');
+        expect(document.getBody()).toMatchObject({
+            dataStream: '\r\n',
+            paragraphs: [{ startIndex: 0 }],
+            sectionBreaks: [{ startIndex: 1 }],
+        });
+    });
+});

--- a/packages/core/src/docs/data-model/document-data-model.ts
+++ b/packages/core/src/docs/data-model/document-data-model.ts
@@ -20,7 +20,7 @@ import type { IPaddingData } from '../../types/interfaces/i-style-data';
 import type { JSONXActions } from './json-x/json-x';
 import { BehaviorSubject } from 'rxjs';
 import { UnitModel, UniverInstanceType } from '../../common/unit';
-import { generateRandomId, Tools } from '../../shared/tools';
+import { generateRandomId } from '../../shared/tools';
 import { getEmptySnapshot } from './empty-snapshot';
 import { JSONX } from './json-x/json-x';
 import { PRESET_LIST_TYPE } from './preset-list-type';
@@ -31,6 +31,20 @@ export const DEFAULT_DOC = {
     id: 'default_doc',
     documentStyle: {},
 };
+
+function normalizeDocumentSnapshot(snapshot: Partial<IDocumentData>): Partial<IDocumentData> {
+    if (snapshot.body != null) {
+        return snapshot;
+    }
+
+    const emptySnapshot = getEmptySnapshot(snapshot.id, snapshot.locale, snapshot.title);
+
+    return {
+        ...emptySnapshot,
+        ...snapshot,
+        body: emptySnapshot.body,
+    };
+}
 
 interface IDrawingUpdateConfig {
     left: number;
@@ -238,7 +252,7 @@ export class DocumentDataModel extends DocumentDataModelSimple {
     change$ = new BehaviorSubject<number>(0);
 
     constructor(snapshot: Partial<IDocumentData>) {
-        super(Tools.isEmptyObject(snapshot) ? getEmptySnapshot() : snapshot);
+        super(normalizeDocumentSnapshot(snapshot));
 
         const UNIT_ID_LENGTH = 6;
 

--- a/packages/core/src/docs/data-model/text-x/build-utils/__test__/drawings.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/__test__/drawings.spec.ts
@@ -97,10 +97,11 @@ describe('drawing build utils', () => {
         expect(doc.getBody()?.dataStream).toBe('A\bB\r\n');
     });
 
-    it('should return false when drawing insertion targets a missing body', () => {
-        const result = addDrawing({
+    it('should add drawings to document data without body after normalization', () => {
+        const doc = new DocumentDataModel({ id: 'doc-without-body' });
+        const actions = addDrawing({
             selection: { startOffset: 0, endOffset: 0, collapsed: true },
-            documentDataModel: new DocumentDataModel({ id: 'doc-without-body' }),
+            documentDataModel: doc,
             drawings: [{
                 unitId: 'doc-without-body',
                 subUnitId: '',
@@ -117,6 +118,14 @@ describe('drawing build utils', () => {
             } as never],
         });
 
-        expect(result).toBe(false);
+        expect(actions).toBeTruthy();
+        if (!actions) {
+            throw new Error('Expected addDrawing to return JSONX actions');
+        }
+        doc.apply(actions);
+
+        expect(doc.getDrawingsOrder()).toEqual(['drawing-new']);
+        expect(doc.getBody()?.customBlocks).toEqual([{ startIndex: 0, blockId: 'drawing-new' }]);
+        expect(doc.getBody()?.dataStream).toBe('\b\r\n');
     });
 });

--- a/packages/core/src/docs/data-model/text-x/build-utils/__test__/paragraph.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/__test__/paragraph.spec.ts
@@ -125,7 +125,6 @@ describe('paragraph build utils', () => {
             listType: PresetListType.ORDER_LIST,
             document: doc,
         });
-        expect(setParagraphBullet({ paragraphs: [thirdParagraph], listType: PresetListType.ORDER_LIST, segmentId: 'missing', document: new DocumentDataModel({ id: 'missing-segment' }) })).toBe(false);
         if (setBulletTextX === false) {
             throw new Error('Expected setParagraphBullet to return TextX actions');
         }
@@ -134,6 +133,24 @@ describe('paragraph build utils', () => {
             listType: PresetListType.ORDER_LIST,
             nestingLevel: 0,
             textStyle: { fs: 20 },
+        });
+
+        const normalizedDoc = new DocumentDataModel({ id: 'normalized-paragraph-doc' });
+        const normalizedBody = normalizedDoc.getBody()!;
+        const normalizedParagraph = normalizedBody.paragraphs![0] as IParagraph;
+        const normalizedTextX = setParagraphBullet({
+            paragraphs: [normalizedParagraph],
+            listType: PresetListType.ORDER_LIST,
+            document: normalizedDoc,
+        });
+        expect(normalizedTextX).not.toBe(false);
+        if (normalizedTextX === false) {
+            throw new Error('Expected setParagraphBullet to return TextX actions');
+        }
+        TextX.apply(normalizedBody, normalizedTextX.serialize());
+        expect(normalizedBody.paragraphs?.[0].bullet).toMatchObject({
+            listType: PresetListType.ORDER_LIST,
+            nestingLevel: 0,
         });
 
         const toggled = toggleChecklistParagraph({ paragraphIndex: secondParagraph.startIndex, document: doc });

--- a/packages/docs/src/facade/__tests__/f-document-node.spec.ts
+++ b/packages/docs/src/facade/__tests__/f-document-node.spec.ts
@@ -170,7 +170,7 @@ describe('FDocument facade in Node', () => {
         expect(document.save().body?.dataStream).toBe('Hello,Line 1\rLine 2\r\r\n');
     });
 
-    it('throws when appending text to a document without a body', () => {
+    it('appends text to a document created without a body', () => {
         univer.dispose();
         createDocumentFacade({
             id: 'test',
@@ -178,7 +178,8 @@ describe('FDocument facade in Node', () => {
             documentStyle: {},
         });
 
-        expect(() => document.appendText('Univer')).toThrowError('The document body is empty');
+        expect(document.appendText('Univer')).toBe(true);
+        expect(document.save().body?.dataStream).toBe('Univer\r\n');
     });
 
     it('includes current document resources in snapshots', () => {


### PR DESCRIPTION
Related downstream report: Univer CLI document creation followed by Facade text insertion failed because the created document had no body.

This PR makes partial document data without `body` initialize as a standard empty document in `DocumentDataModel`. This is necessary because Facade callers can create documents with only `id` and `title`, then naturally call `appendText` or `insertText`; before this change the document had no body and those APIs failed with `The document body is empty`.

The fix keeps a single document creation path by normalizing missing-body document snapshots at the core data-model boundary. It does not add CLI string matching or Facade fallback behavior. Documents that already provide a body keep their supplied body.

How to test them:

- `pnpm --filter @univerjs/core exec vitest run src/docs/data-model/__tests__/document-data-model.spec.ts src/docs/data-model/__tests__/empty-snapshot.spec.ts`
- `pnpm --filter @univerjs/docs exec vitest run src/facade/__tests__/f-document-node.spec.ts`
- `pnpm --filter @univerjs/core typecheck`
- `pnpm --filter @univerjs/docs typecheck`
- `git diff --check`

## Pull Request Checklist

- [x] Related downstream report is described in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes introduced in this PR.