### PR TITLE
feat(docs): add persisted paragraph identity

### DIFF
--- a/common/debugger/src/controllers/e2e/data/default-doc.ts
+++ b/common/debugger/src/controllers/e2e/data/default-doc.ts
@@ -86,6 +86,7 @@ export function getDefaultDocData(): IDocumentData {
             ],
             paragraphs: [
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_1',
                     startIndex: 4,
                     paragraphStyle: {
                         spaceAbove: { v: 0 },
@@ -94,6 +95,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_2',
                     startIndex: 5,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -102,6 +104,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_3',
                     startIndex: 12,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -110,6 +113,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_4',
                     startIndex: 13,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -118,6 +122,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_5',
                     startIndex: 127,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -130,6 +135,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_6',
                     startIndex: 128,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -138,6 +144,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_7',
                     startIndex: 244,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -146,6 +153,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_8',
                     startIndex: 245,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -154,6 +162,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_9',
                     startIndex: 398,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -162,6 +171,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_10',
                     startIndex: 399,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -170,6 +180,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_11',
                     startIndex: 618,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -178,6 +189,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_12',
                     startIndex: 619,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -186,6 +198,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_13',
                     startIndex: 824,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -194,6 +207,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_14',
                     startIndex: 825,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -202,6 +216,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_15',
                     startIndex: 1007,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -210,6 +225,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_16',
                     startIndex: 1008,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -218,6 +234,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_17',
                     startIndex: 1130,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -226,6 +243,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_18',
                     startIndex: 1131,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -234,6 +252,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_19',
                     startIndex: 1203,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -242,6 +261,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_20',
                     startIndex: 1204,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -250,6 +270,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_21',
                     startIndex: 1238,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -258,6 +279,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_22',
                     startIndex: 1239,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -266,6 +288,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_23',
                     startIndex: 1256,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -274,6 +297,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_24',
                     startIndex: 1257,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -282,6 +306,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_25',
                     startIndex: 1282,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -290,6 +315,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_26',
                     startIndex: 1283,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -298,6 +324,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_27',
                     startIndex: 1380,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -306,6 +333,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_28',
                     startIndex: 1381,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -314,6 +342,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_29',
                     startIndex: 1396,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -322,6 +351,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_30',
                     startIndex: 1397,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -330,6 +360,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_31',
                     startIndex: 1398,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -338,6 +369,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_32',
                     startIndex: 1399,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -346,6 +378,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_33',
                     startIndex: 1457,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -354,6 +387,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_34',
                     startIndex: 1458,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -362,6 +396,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_35',
                     startIndex: 1559,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -370,6 +405,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_36',
                     startIndex: 1560,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -378,6 +414,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_37',
                     startIndex: 1566,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -386,6 +423,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_38',
                     startIndex: 1670,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -394,6 +432,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_39',
                     startIndex: 1671,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -402,6 +441,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_40',
                     startIndex: 1728,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -410,6 +450,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_41',
                     startIndex: 1729,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -418,6 +459,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_42',
                     startIndex: 1811,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -426,6 +468,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_43',
                     startIndex: 1812,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -434,6 +477,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_44',
                     startIndex: 1912,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -442,6 +486,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_45',
                     startIndex: 1913,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -450,6 +495,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_46',
                     startIndex: 2053,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -458,6 +504,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_47',
                     startIndex: 2054,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -466,6 +513,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_48',
                     startIndex: 2190,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -474,6 +522,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_49',
                     startIndex: 2191,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -482,6 +531,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_50',
                     startIndex: 2341,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -490,6 +540,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_51',
                     startIndex: 2342,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -498,6 +549,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_52',
                     startIndex: 2481,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -506,6 +558,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_53',
                     startIndex: 2482,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -514,6 +567,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_54',
                     startIndex: 2582,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -522,6 +576,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_55',
                     startIndex: 2583,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -530,6 +585,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_56',
                     startIndex: 2750,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -538,6 +594,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_57',
                     startIndex: 2751,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -546,6 +603,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_58',
                     startIndex: 2853,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -554,6 +612,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_59',
                     startIndex: 2854,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -562,6 +621,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_60',
                     startIndex: 2948,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -570,6 +630,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_61',
                     startIndex: 2949,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
@@ -578,6 +639,7 @@ export function getDefaultDocData(): IDocumentData {
                     },
                 },
                 {
+                    paragraphId: 'para_common_debugger_src_controllers_e2e_data_default_doc_62',
                     startIndex: 3065,
                     paragraphStyle: {
                         spaceAbove: { v: 10 },

--- a/common/mockdata/src/docs/default-document-data-cn.ts
+++ b/common/mockdata/src/docs/default-document-data-cn.ts
@@ -102,6 +102,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_1',
                 startIndex: 4,
                 paragraphStyle: {
                     spaceAbove: { v: 0 },
@@ -110,6 +111,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_2',
                 startIndex: 5,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -118,6 +120,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_3',
                 startIndex: 12,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -134,6 +137,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_4',
                 startIndex: 13,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -142,6 +146,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_5',
                 startIndex: 127,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -154,6 +159,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_6',
                 startIndex: 128,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -162,6 +168,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_7',
                 startIndex: 244,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -170,6 +177,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_8',
                 startIndex: 245,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -178,6 +186,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_9',
                 startIndex: 398,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -186,6 +195,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_10',
                 startIndex: 399,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -194,6 +204,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_11',
                 startIndex: 618,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -202,6 +213,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_12',
                 startIndex: 619,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -210,6 +222,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_13',
                 startIndex: 824,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -218,6 +231,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_14',
                 startIndex: 825,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -226,6 +240,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_15',
                 startIndex: 1007,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -234,6 +249,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_16',
                 startIndex: 1008,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -242,6 +258,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_17',
                 startIndex: 1130,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -250,6 +267,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_18',
                 startIndex: 1131,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -258,6 +276,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_19',
                 startIndex: 1203,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -266,6 +285,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_20',
                 startIndex: 1204,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -274,6 +294,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_21',
                 startIndex: 1238,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -282,6 +303,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_22',
                 startIndex: 1239,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -290,6 +312,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_23',
                 startIndex: 1256,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -298,6 +321,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_24',
                 startIndex: 1257,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -306,6 +330,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_25',
                 startIndex: 1282,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -314,6 +339,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_26',
                 startIndex: 1283,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -322,6 +348,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_27',
                 startIndex: 1380,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -330,6 +357,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_28',
                 startIndex: 1381,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -338,6 +366,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_29',
                 startIndex: 1396,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -346,6 +375,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_30',
                 startIndex: 1397,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -354,6 +384,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_31',
                 startIndex: 1398,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -362,6 +393,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_32',
                 startIndex: 1399,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -370,6 +402,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_33',
                 startIndex: 1457,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -378,6 +411,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_34',
                 startIndex: 1458,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -386,6 +420,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_35',
                 startIndex: 1559,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -394,6 +429,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_36',
                 startIndex: 1560,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -402,6 +438,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_37',
                 startIndex: 1566,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -410,6 +447,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_38',
                 startIndex: 1670,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -418,6 +456,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_39',
                 startIndex: 1671,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -426,6 +465,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_40',
                 startIndex: 1728,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -434,6 +474,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_41',
                 startIndex: 1729,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -442,6 +483,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_42',
                 startIndex: 1811,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -450,6 +492,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_43',
                 startIndex: 1812,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -458,6 +501,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_44',
                 startIndex: 1912,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -466,6 +510,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_45',
                 startIndex: 1913,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -474,6 +519,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_46',
                 startIndex: 2053,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -482,6 +528,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_47',
                 startIndex: 2054,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -490,6 +537,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_48',
                 startIndex: 2190,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -498,6 +546,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_49',
                 startIndex: 2191,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -506,6 +555,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_50',
                 startIndex: 2341,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -514,6 +564,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_51',
                 startIndex: 2342,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -522,6 +573,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_52',
                 startIndex: 2481,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -530,6 +582,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_53',
                 startIndex: 2482,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -538,6 +591,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_54',
                 startIndex: 2582,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -546,6 +600,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_55',
                 startIndex: 2583,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -554,6 +609,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_56',
                 startIndex: 2750,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -562,6 +618,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_57',
                 startIndex: 2751,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -570,6 +627,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_58',
                 startIndex: 2853,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -578,6 +636,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_59',
                 startIndex: 2854,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -586,6 +645,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_60',
                 startIndex: 2948,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -594,6 +654,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_61',
                 startIndex: 2949,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -602,6 +663,7 @@ export const DEFAULT_DOCUMENT_DATA_CN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_cn_62',
                 startIndex: 3065,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },

--- a/common/mockdata/src/docs/default-document-data-dreamer.ts
+++ b/common/mockdata/src/docs/default-document-data-dreamer.ts
@@ -113,6 +113,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_1',
                 startIndex: 11,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -121,6 +122,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_2',
                 startIndex: 12,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -129,6 +131,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_3',
                 startIndex: 100,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -137,6 +140,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_4',
                 startIndex: 101,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -145,6 +149,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_5',
                 startIndex: 1040,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -153,6 +158,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_6',
                 startIndex: 1041,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -161,6 +167,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_7',
                 startIndex: 1409,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -169,6 +176,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_8',
                 startIndex: 1410,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -177,6 +185,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_9',
                 startIndex: 1830,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -185,6 +194,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_10',
                 startIndex: 1831,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -193,6 +203,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_11',
                 startIndex: 2103,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -201,6 +212,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_12',
                 startIndex: 2104,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -209,6 +221,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_13',
                 startIndex: 2255,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -217,6 +230,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_14',
                 startIndex: 2256,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -225,6 +239,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_15',
                 startIndex: 2774,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -233,6 +248,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_16',
                 startIndex: 2775,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -241,6 +257,7 @@ export const DEFAULT_DOCUMENT_DATA_DREAMER: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_dreamer_17',
                 startIndex: 3318,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },

--- a/common/mockdata/src/docs/default-document-data-en.ts
+++ b/common/mockdata/src/docs/default-document-data-en.ts
@@ -197,10 +197,12 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_1',
                 startIndex: 67,
             },
             // Keep the English default demo aligned with the current docs default spacing.
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_2',
                 startIndex: 253,
                 paragraphStyle: {
                     spaceAbove: { v: 30 },
@@ -209,6 +211,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_3',
                 startIndex: 404,
                 paragraphStyle: {
                     spaceAbove: { v: 20 },
@@ -217,6 +220,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_4',
                 startIndex: 433,
                 bullet: {
                     listType: PresetListType.ORDER_LIST,
@@ -235,6 +239,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_5',
                 startIndex: 484,
                 bullet: {
                     listType: PresetListType.ORDER_LIST,
@@ -250,6 +255,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_6',
                 startIndex: 516,
                 bullet: {
                     listType: PresetListType.ORDER_LIST,
@@ -265,6 +271,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_7',
                 startIndex: 713,
                 paragraphStyle: {
                     spaceAbove: { v: 20 },
@@ -273,6 +280,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_8',
                 startIndex: 771,
                 paragraphStyle: {
                     spaceAbove: { v: 20 },
@@ -280,6 +288,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_9',
                 startIndex: 1244,
                 paragraphStyle: {
                     spaceAbove: { v: 20 },
@@ -288,6 +297,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_10',
                 startIndex: 1589,
                 paragraphStyle: {
                     indentFirstLine: { v: 20 },
@@ -295,6 +305,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_11',
                 startIndex: 1986,
                 paragraphStyle: {
                     indentFirstLine: { v: 20 },
@@ -302,6 +313,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_12',
                 startIndex: 2062,
                 paragraphStyle: {
                     indentFirstLine: { v: 20 },
@@ -309,6 +321,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_13',
                 startIndex: 2294,
                 paragraphStyle: {
                     indentFirstLine: { v: 20 },
@@ -324,6 +337,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_14',
                 startIndex: 2438,
                 paragraphStyle: {
                     indentFirstLine: { v: 20 },
@@ -339,6 +353,7 @@ export const DEFAULT_DOCUMENT_DATA_EN: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_en_15',
                 startIndex: 2628,
                 paragraphStyle: {
                     indentFirstLine: { v: 20 },

--- a/common/mockdata/src/docs/default-document-data.ts
+++ b/common/mockdata/src/docs/default-document-data.ts
@@ -128,6 +128,7 @@ export const DEFAULT_DOCUMENT_DATA: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_1',
                 startIndex: 60,
                 bullet: {
                     listType: PresetListType.ORDER_LIST,
@@ -139,6 +140,7 @@ export const DEFAULT_DOCUMENT_DATA: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_2',
                 startIndex: 91,
                 bullet: {
                     listType: PresetListType.ORDER_LIST,
@@ -150,6 +152,7 @@ export const DEFAULT_DOCUMENT_DATA: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_3',
                 startIndex: 234,
                 bullet: {
                     listType: PresetListType.ORDER_LIST,
@@ -161,6 +164,7 @@ export const DEFAULT_DOCUMENT_DATA: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_4',
                 startIndex: 327,
                 bullet: {
                     listType: PresetListType.ORDER_LIST,
@@ -172,6 +176,7 @@ export const DEFAULT_DOCUMENT_DATA: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_docs_default_document_data_5',
                 startIndex: 406,
                 bullet: {
                     listType: PresetListType.ORDER_LIST,

--- a/common/mockdata/src/docs/default-document.data-simple.ts
+++ b/common/mockdata/src/docs/default-document.data-simple.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IDocumentData, IParagraph, ISectionBreak, ITable, ITableCell, ITableColumn, ITableRow } from '@univerjs/core';
-import { BooleanNumber, DocumentFlavor, HorizontalAlign, ObjectRelativeFromH, ObjectRelativeFromV, TableAlignmentType, TableRowHeightRule, TableSizeType, TableTextWrapType, Tools, VerticalAlignmentType } from '@univerjs/core';
+import { BooleanNumber, createParagraphId, DocumentFlavor, HorizontalAlign, ObjectRelativeFromH, ObjectRelativeFromV, TableAlignmentType, TableRowHeightRule, TableSizeType, TableTextWrapType, Tools, VerticalAlignmentType } from '@univerjs/core';
 import { ptToPixel } from '@univerjs/engine-render';
 
 const TABLE_START = '\x1A'; // 表格开始
@@ -66,11 +66,13 @@ const endIndex = tableStream.length + startIndex;
 function createParagraphAndSectionBreaks(dataStream: string) {
     const paragraphs: IParagraph[] = [];
     const sectionBreaks: ISectionBreak[] = [];
+    const existingParagraphIds = new Set<string>();
     for (let i = 0; i < dataStream.length; i++) {
         const char = dataStream[i];
         if (char === '\r') {
             paragraphs.push({
                 startIndex: i,
+                paragraphId: createParagraphId(existingParagraphIds),
                 paragraphStyle: {
                     spaceAbove: { v: 5 },
                     lineSpacing: 2,

--- a/common/mockdata/src/sheets/default-workbook-data.ts
+++ b/common/mockdata/src/sheets/default-workbook-data.ts
@@ -113,6 +113,7 @@ const richTextTestFloat: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_sheets_default_workbook_data_1',
                 startIndex: 60,
                 bullet: {
                     listId: 'orderList',
@@ -200,6 +201,7 @@ const richTextTest: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_sheets_default_workbook_data_2',
                 startIndex: 60,
                 bullet: {
                     listId: 'orderList',

--- a/common/mockdata/src/sheets/demo/default-workbook-data-default-style.ts
+++ b/common/mockdata/src/sheets/demo/default-workbook-data-default-style.ts
@@ -33577,6 +33577,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO_DEFAULT_STYLE = {
                                 ],
                                 paragraphs: [
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_default_style_1',
                                         startIndex: 10,
                                     },
                                 ],
@@ -34145,9 +34146,11 @@ export const DEFAULT_WORKBOOK_DATA_DEMO_DEFAULT_STYLE = {
                                 ],
                                 paragraphs: [
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_default_style_2',
                                         startIndex: 67,
                                     },
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_default_style_3',
                                         startIndex: 253,
                                         paragraphStyle: {
                                             spaceAbove: {
@@ -34159,6 +34162,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO_DEFAULT_STYLE = {
                                         },
                                     },
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_default_style_4',
                                         startIndex: 404,
                                         paragraphStyle: {
                                             spaceAbove: {
@@ -34170,6 +34174,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO_DEFAULT_STYLE = {
                                         },
                                     },
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_default_style_5',
                                         startIndex: 433,
                                         bullet: {
                                             listType: 'BULLET_LIST',
@@ -34184,6 +34189,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO_DEFAULT_STYLE = {
                                         },
                                     },
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_default_style_6',
                                         startIndex: 484,
                                         bullet: {
                                             listType: 'BULLET_LIST',
@@ -34198,6 +34204,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO_DEFAULT_STYLE = {
                                         },
                                     },
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_default_style_7',
                                         startIndex: 516,
                                         bullet: {
                                             listType: 'BULLET_LIST',
@@ -36042,6 +36049,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO_DEFAULT_STYLE = {
                                 ],
                                 paragraphs: [
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_default_style_8',
                                         startIndex: 489,
                                         paragraphStyle: {
                                             spaceAbove: {

--- a/common/mockdata/src/sheets/demo/default-workbook-data-demo.ts
+++ b/common/mockdata/src/sheets/demo/default-workbook-data-demo.ts
@@ -36,6 +36,7 @@ const richTextDemo: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_1',
                 startIndex: 489,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
@@ -84,6 +85,7 @@ const richTextDemo1: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_2',
                 startIndex: 10,
             },
         ],
@@ -14197,6 +14199,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                                 textRuns: [],
                                 paragraphs: [
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_3',
                                         startIndex: 1,
                                         paragraphStyle: {
                                             horizontalAlign: 0,
@@ -14289,18 +14292,21 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                                 textRuns: [],
                                 paragraphs: [
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_4',
                                         startIndex: 43,
                                         paragraphStyle: {
                                             horizontalAlign: 0,
                                         },
                                     },
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_5',
                                         startIndex: 49,
                                         paragraphStyle: {
                                             horizontalAlign: 0,
                                         },
                                     },
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_6',
                                         startIndex: 93,
                                         paragraphStyle: {
                                             horizontalAlign: 0,
@@ -14434,6 +14440,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                                 textRuns: [],
                                 paragraphs: [
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_7',
                                         startIndex: 1,
                                         paragraphStyle: {
                                             horizontalAlign: 2,
@@ -14487,6 +14494,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                                 textRuns: [],
                                 paragraphs: [
                                     {
+                                        paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_8',
                                         startIndex: 1,
                                         paragraphStyle: {
                                             horizontalAlign: 2,
@@ -24357,12 +24365,12 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
         {
             name: 'SHEET_UNIVER_THREAD_COMMENT_PLUGIN',
             data: JSON.stringify({
-                'sheet-0011': [{ text: { textRuns: [], paragraphs: [{ startIndex: 3, paragraphStyle: {} }], sectionBreaks: [{ startIndex: 4 }], dataStream: '123\r\n', customRanges: [] }, dT: '2024/05/17 21:16', id: 'jwV0QtHwUbhG3o--iy1qa', ref: 'H9', personId: 'Owner_qxVnhPbQ', unitId: 'workbook-01', subUnitId: 'sheet-0011' }],
+                'sheet-0011': [{ text: { textRuns: [], paragraphs: [{ paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_9', startIndex: 3, paragraphStyle: {} }], sectionBreaks: [{ startIndex: 4 }], dataStream: '123\r\n', customRanges: [] }, dT: '2024/05/17 21:16', id: 'jwV0QtHwUbhG3o--iy1qa', ref: 'H9', personId: 'Owner_qxVnhPbQ', unitId: 'workbook-01', subUnitId: 'sheet-0011' }],
                 'dv-test': [
                     {
                         text: {
                             textRuns: [],
-                            paragraphs: [{ startIndex: 3, paragraphStyle: {} }],
+                            paragraphs: [{ paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_10', startIndex: 3, paragraphStyle: {} }],
                             sectionBreaks: [{ startIndex: 4 }],
                             dataStream: '1\r\n',
                             customRanges: [],
@@ -24377,7 +24385,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                     {
                         text: {
                             textRuns: [],
-                            paragraphs: [{ startIndex: 3, paragraphStyle: {} }],
+                            paragraphs: [{ paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_11', startIndex: 3, paragraphStyle: {} }],
                             sectionBreaks: [{ startIndex: 4 }],
                             dataStream: '1\r\n',
                             customRanges: [],
@@ -24392,7 +24400,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                     {
                         text: {
                             textRuns: [],
-                            paragraphs: [{ startIndex: 3, paragraphStyle: {} }],
+                            paragraphs: [{ paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_12', startIndex: 3, paragraphStyle: {} }],
                             sectionBreaks: [{ startIndex: 4 }],
                             dataStream: '2\r\n',
                             customRanges: [],
@@ -24407,7 +24415,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                     {
                         text: {
                             textRuns: [],
-                            paragraphs: [{ startIndex: 3, paragraphStyle: {} }],
+                            paragraphs: [{ paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_13', startIndex: 3, paragraphStyle: {} }],
                             sectionBreaks: [{ startIndex: 4 }],
                             dataStream: '3\r\n',
                             customRanges: [],
@@ -24422,7 +24430,7 @@ export const DEFAULT_WORKBOOK_DATA_DEMO: IWorkbookData = {
                     {
                         text: {
                             textRuns: [],
-                            paragraphs: [{ startIndex: 3, paragraphStyle: {} }],
+                            paragraphs: [{ paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo_14', startIndex: 3, paragraphStyle: {} }],
                             sectionBreaks: [{ startIndex: 4 }],
                             dataStream: '4\r\n',
                             customRanges: [],

--- a/common/mockdata/src/sheets/demo/default-workbook-data-demo3.ts
+++ b/common/mockdata/src/sheets/demo/default-workbook-data-demo3.ts
@@ -34,6 +34,7 @@ const richTextDemo: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo3_1',
                 startIndex: 489,
                 paragraphStyle: {
                     spaceAbove: { v: 10 },

--- a/common/mockdata/src/sheets/demo/default-workbook-data-demo4.ts
+++ b/common/mockdata/src/sheets/demo/default-workbook-data-demo4.ts
@@ -45,6 +45,7 @@ const richTextDemo1: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_sheets_demo_default_workbook_data_demo4_1',
                 startIndex: 10,
             },
         ],

--- a/common/mockdata/src/slides/rich-text/page3-richtext1.ts
+++ b/common/mockdata/src/slides/rich-text/page3-richtext1.ts
@@ -50,6 +50,7 @@ export const PAGE3_RICHTEXT_1 = {
                 ],
                 paragraphs: [
                     {
+                        paragraphId: 'para_common_mockdata_src_slides_rich_text_page3_richtext1_1',
                         startIndex: 21,
                         bullet: {
                             listType: PresetListType.ORDER_LIST,
@@ -64,6 +65,7 @@ export const PAGE3_RICHTEXT_1 = {
                         },
                     },
                     {
+                        paragraphId: 'para_common_mockdata_src_slides_rich_text_page3_richtext1_2',
                         startIndex: 43,
                         bullet: {
                             listType: PresetListType.ORDER_LIST,

--- a/common/mockdata/src/slides/rich-text/page3-richtext2.ts
+++ b/common/mockdata/src/slides/rich-text/page3-richtext2.ts
@@ -50,6 +50,7 @@ export const PAGE3_RICHTEXT_2 = {
                 ],
                 paragraphs: [
                     {
+                        paragraphId: 'para_common_mockdata_src_slides_rich_text_page3_richtext2_1',
                         startIndex: 41,
                         bullet: {
                             listType: PresetListType.ORDER_LIST,
@@ -64,6 +65,7 @@ export const PAGE3_RICHTEXT_2 = {
                         },
                     },
                     {
+                        paragraphId: 'para_common_mockdata_src_slides_rich_text_page3_richtext2_2',
                         startIndex: 168,
                         bullet: {
                             listType: PresetListType.ORDER_LIST,

--- a/common/mockdata/src/slides/rich-text/page3-richtext3.ts
+++ b/common/mockdata/src/slides/rich-text/page3-richtext3.ts
@@ -50,6 +50,7 @@ export const PAGE3_RICHTEXT_3 = {
                 ],
                 paragraphs: [
                     {
+                        paragraphId: 'para_common_mockdata_src_slides_rich_text_page3_richtext3_1',
                         startIndex: 71,
                         bullet: {
                             listType: PresetListType.ORDER_LIST,
@@ -64,6 +65,7 @@ export const PAGE3_RICHTEXT_3 = {
                         },
                     },
                     {
+                        paragraphId: 'para_common_mockdata_src_slides_rich_text_page3_richtext3_2',
                         startIndex: 160,
                         bullet: {
                             listType: PresetListType.ORDER_LIST,

--- a/common/mockdata/src/slides/rich-text/page5-richtext1.ts
+++ b/common/mockdata/src/slides/rich-text/page5-richtext1.ts
@@ -87,9 +87,11 @@ export const PAGE5_RICHTEXT_1: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_common_mockdata_src_slides_rich_text_page5_richtext1_1',
                 startIndex: 67,
             },
             {
+                paragraphId: 'para_common_mockdata_src_slides_rich_text_page5_richtext1_2',
                 startIndex: 253,
                 paragraphStyle: {
                     spaceAbove: { v: 20 },
@@ -97,6 +99,7 @@ export const PAGE5_RICHTEXT_1: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_slides_rich_text_page5_richtext1_3',
                 startIndex: 404,
                 paragraphStyle: {
                     spaceAbove: { v: 20 },
@@ -104,6 +107,7 @@ export const PAGE5_RICHTEXT_1: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_slides_rich_text_page5_richtext1_4',
                 startIndex: 433,
                 bullet: {
                     listType: PresetListType.BULLET_LIST,
@@ -118,6 +122,7 @@ export const PAGE5_RICHTEXT_1: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_slides_rich_text_page5_richtext1_5',
                 startIndex: 484,
                 bullet: {
                     listType: PresetListType.BULLET_LIST,
@@ -132,6 +137,7 @@ export const PAGE5_RICHTEXT_1: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_common_mockdata_src_slides_rich_text_page5_richtext1_6',
                 startIndex: 516,
                 bullet: {
                     listType: PresetListType.BULLET_LIST,

--- a/packages/core/src/docs/__tests__/paragraph-id.spec.ts
+++ b/packages/core/src/docs/__tests__/paragraph-id.spec.ts
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-import type { IDocumentBody, IDocumentData } from '../../types/interfaces/i-document-data';
+import type { IDocumentBody } from '../../types/interfaces/i-document-data';
 import { describe, expect, it } from 'vitest';
 import {
     cloneBodyWithFreshParagraphIds,
     cloneParagraphWithId,
-    ensureUniqueParagraphIds,
-    normalizeBodyParagraphIds,
-    normalizeDocumentParagraphIds,
     PARAGRAPH_ID_PREFIX,
 } from '../paragraph-id';
 
@@ -29,63 +26,16 @@ function createBody(): IDocumentBody {
     return {
         dataStream: 'Alpha\rBeta\r\n',
         paragraphs: [
-            { startIndex: 5 },
+            { startIndex: 5, paragraphId: 'para_alpha' },
             { startIndex: 10, paragraphId: 'para_existing' },
         ],
         sectionBreaks: [{ startIndex: 11 }],
     };
 }
 
-describe('paragraph id normalization', () => {
-    it('adds ids to paragraphs that do not have one and preserves an existing valid id', () => {
-        const body = normalizeBodyParagraphIds(createBody(), { unitId: 'doc-1', segmentId: '' });
-
-        expect(body.paragraphs?.[0].paragraphId).toMatch(new RegExp(`^${PARAGRAPH_ID_PREFIX}`));
-        expect(body.paragraphs?.[1].paragraphId).toBe('para_existing');
-    });
-
-    it('repairs duplicate and invalid ids without changing startIndex', () => {
-        const body: IDocumentBody = {
-            dataStream: 'A\rB\rC\r\n',
-            paragraphs: [
-                { startIndex: 1, paragraphId: 'para_dup' },
-                { startIndex: 3, paragraphId: 'para_dup' },
-                { startIndex: 5, paragraphId: 1 as never },
-            ],
-            sectionBreaks: [{ startIndex: 6 }],
-        };
-
-        ensureUniqueParagraphIds(body, { unitId: 'doc-1', segmentId: '' });
-
-        expect(body.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual([1, 3, 5]);
-        expect(body.paragraphs?.[0].paragraphId).toBe('para_dup');
-        expect(new Set(body.paragraphs?.map((paragraph) => paragraph.paragraphId)).size).toBe(3);
-        expect(body.paragraphs?.every((paragraph) => typeof paragraph.paragraphId === 'string')).toBe(true);
-        expect(body.paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith(PARAGRAPH_ID_PREFIX))).toBe(true);
-    });
-
-    it('normalizes main body and header/footer bodies', () => {
-        const documentData: IDocumentData = {
-            id: 'doc-1',
-            body: createBody(),
-            headers: {
-                h1: { headerId: 'h1', body: createBody() },
-            },
-            footers: {
-                f1: { footerId: 'f1', body: createBody() },
-            },
-            documentStyle: {},
-        };
-
-        const normalized = normalizeDocumentParagraphIds(documentData);
-
-        expect(normalized.body?.paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith(PARAGRAPH_ID_PREFIX))).toBe(true);
-        expect(normalized.headers?.h1.body?.paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith(PARAGRAPH_ID_PREFIX))).toBe(true);
-        expect(normalized.footers?.f1.body?.paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith(PARAGRAPH_ID_PREFIX))).toBe(true);
-    });
-
+describe('paragraph id helpers', () => {
     it('clones paste/import fragments with fresh unique ids while preserving paragraph count and start indexes', () => {
-        const source = normalizeBodyParagraphIds(createBody(), { unitId: 'doc-1', segmentId: '' });
+        const source = createBody();
         const cloned = cloneBodyWithFreshParagraphIds(source, { unitId: 'doc-2', segmentId: '' });
 
         expect(cloned.paragraphs).toHaveLength(source.paragraphs!.length);

--- a/packages/core/src/docs/__tests__/paragraph-id.spec.ts
+++ b/packages/core/src/docs/__tests__/paragraph-id.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IDocumentBody, IDocumentData } from '../../types/interfaces/i-document-data';
+import { describe, expect, it } from 'vitest';
+import {
+    cloneBodyWithFreshParagraphIds,
+    cloneParagraphWithId,
+    ensureUniqueParagraphIds,
+    normalizeBodyParagraphIds,
+    normalizeDocumentParagraphIds,
+    PARAGRAPH_ID_PREFIX,
+} from '../paragraph-id';
+
+function createBody(): IDocumentBody {
+    return {
+        dataStream: 'Alpha\rBeta\r\n',
+        paragraphs: [
+            { startIndex: 5 },
+            { startIndex: 10, paragraphId: 'para_existing' },
+        ],
+        sectionBreaks: [{ startIndex: 11 }],
+    };
+}
+
+describe('paragraph id normalization', () => {
+    it('adds ids to paragraphs that do not have one and preserves an existing valid id', () => {
+        const body = normalizeBodyParagraphIds(createBody(), { unitId: 'doc-1', segmentId: '' });
+
+        expect(body.paragraphs?.[0].paragraphId).toMatch(new RegExp(`^${PARAGRAPH_ID_PREFIX}`));
+        expect(body.paragraphs?.[1].paragraphId).toBe('para_existing');
+    });
+
+    it('repairs duplicate and invalid ids without changing startIndex', () => {
+        const body: IDocumentBody = {
+            dataStream: 'A\rB\rC\r\n',
+            paragraphs: [
+                { startIndex: 1, paragraphId: 'para_dup' },
+                { startIndex: 3, paragraphId: 'para_dup' },
+                { startIndex: 5, paragraphId: 1 as never },
+            ],
+            sectionBreaks: [{ startIndex: 6 }],
+        };
+
+        ensureUniqueParagraphIds(body, { unitId: 'doc-1', segmentId: '' });
+
+        expect(body.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual([1, 3, 5]);
+        expect(body.paragraphs?.[0].paragraphId).toBe('para_dup');
+        expect(new Set(body.paragraphs?.map((paragraph) => paragraph.paragraphId)).size).toBe(3);
+        expect(body.paragraphs?.every((paragraph) => typeof paragraph.paragraphId === 'string')).toBe(true);
+        expect(body.paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith(PARAGRAPH_ID_PREFIX))).toBe(true);
+    });
+
+    it('normalizes main body and header/footer bodies', () => {
+        const documentData: IDocumentData = {
+            id: 'doc-1',
+            body: createBody(),
+            headers: {
+                h1: { headerId: 'h1', body: createBody() },
+            },
+            footers: {
+                f1: { footerId: 'f1', body: createBody() },
+            },
+            documentStyle: {},
+        };
+
+        const normalized = normalizeDocumentParagraphIds(documentData);
+
+        expect(normalized.body?.paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith(PARAGRAPH_ID_PREFIX))).toBe(true);
+        expect(normalized.headers?.h1.body?.paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith(PARAGRAPH_ID_PREFIX))).toBe(true);
+        expect(normalized.footers?.f1.body?.paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith(PARAGRAPH_ID_PREFIX))).toBe(true);
+    });
+
+    it('clones paste/import fragments with fresh unique ids while preserving paragraph count and start indexes', () => {
+        const source = normalizeBodyParagraphIds(createBody(), { unitId: 'doc-1', segmentId: '' });
+        const cloned = cloneBodyWithFreshParagraphIds(source, { unitId: 'doc-2', segmentId: '' });
+
+        expect(cloned.paragraphs).toHaveLength(source.paragraphs!.length);
+        expect(cloned.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual(source.paragraphs?.map((paragraph) => paragraph.startIndex));
+        expect(cloned.paragraphs?.map((paragraph) => paragraph.paragraphId)).not.toEqual(source.paragraphs?.map((paragraph) => paragraph.paragraphId));
+        expect(new Set(cloned.paragraphs?.map((paragraph) => paragraph.paragraphId)).size).toBe(cloned.paragraphs?.length);
+        expect(cloned.paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith(PARAGRAPH_ID_PREFIX))).toBe(true);
+    });
+
+    it('preserves a valid unique id when cloning a paragraph by default or when preserveId is true', () => {
+        const existingIds = new Set<string>();
+        const paragraph = { startIndex: 5, paragraphId: 'para_keep' };
+
+        const defaultClone = cloneParagraphWithId(paragraph, existingIds);
+        const explicitClone = cloneParagraphWithId({ ...paragraph, paragraphId: 'para_keep_explicit' }, existingIds, true);
+
+        expect(defaultClone).not.toBe(paragraph);
+        expect(defaultClone.paragraphId).toBe('para_keep');
+        expect(explicitClone.paragraphId).toBe('para_keep_explicit');
+        expect(existingIds.has('para_keep')).toBe(true);
+        expect(existingIds.has('para_keep_explicit')).toBe(true);
+    });
+
+    it('regenerates a paragraph id when preserving would duplicate an existing id', () => {
+        const existingIds = new Set<string>(['para_duplicate']);
+        const cloned = cloneParagraphWithId({ startIndex: 5, paragraphId: 'para_duplicate' }, existingIds);
+
+        expect(cloned.paragraphId).not.toBe('para_duplicate');
+        expect(cloned.paragraphId).toMatch(new RegExp(`^${PARAGRAPH_ID_PREFIX}`));
+        expect(existingIds.has(cloned.paragraphId!)).toBe(true);
+    });
+
+    it('regenerates invalid paragraph ids when cloning a paragraph', () => {
+        const existingIds = new Set<string>();
+        const cloned = cloneParagraphWithId({ startIndex: 5, paragraphId: 'invalid' }, existingIds);
+
+        expect(cloned.paragraphId).not.toBe('invalid');
+        expect(cloned.paragraphId).toMatch(new RegExp(`^${PARAGRAPH_ID_PREFIX}`));
+        expect(existingIds.has(cloned.paragraphId!)).toBe(true);
+    });
+
+    it('regenerates a paragraph id when preserveId is false', () => {
+        const existingIds = new Set<string>();
+        const cloned = cloneParagraphWithId({ startIndex: 5, paragraphId: 'para_replace' }, existingIds, false);
+
+        expect(cloned.paragraphId).not.toBe('para_replace');
+        expect(cloned.paragraphId).toMatch(new RegExp(`^${PARAGRAPH_ID_PREFIX}`));
+        expect(existingIds.has(cloned.paragraphId!)).toBe(true);
+    });
+});

--- a/packages/core/src/docs/data-model/__tests__/document-modeling.integration.spec.ts
+++ b/packages/core/src/docs/data-model/__tests__/document-modeling.integration.spec.ts
@@ -35,7 +35,7 @@ function createDocSnapshot(id = 'doc-main'): IDocumentData {
         },
         body: {
             dataStream: 'Hello World\r\n',
-            paragraphs: [{ startIndex: 0 }],
+            paragraphs: [{ startIndex: 0, paragraphId: 'para_fixture_1' }],
             textRuns: [{ st: 0, ed: 5, ts: { ff: 'Arial', fs: 12 } }],
             customRanges: [],
             customDecorations: [],
@@ -45,7 +45,7 @@ function createDocSnapshot(id = 'doc-main'): IDocumentData {
                 headerId: 'header1',
                 body: {
                     dataStream: 'Header\r\n',
-                    paragraphs: [{ startIndex: 0 }],
+                    paragraphs: [{ startIndex: 0, paragraphId: 'para_fixture_2' }],
                     textRuns: [],
                 },
             },
@@ -55,7 +55,7 @@ function createDocSnapshot(id = 'doc-main'): IDocumentData {
                 footerId: 'footer1',
                 body: {
                     dataStream: 'Footer\r\n',
-                    paragraphs: [{ startIndex: 0 }],
+                    paragraphs: [{ startIndex: 0, paragraphId: 'para_fixture_3' }],
                     textRuns: [],
                 },
             },
@@ -157,8 +157,8 @@ describe('DocumentDataModel + RichTextBuilder integration', () => {
             body: {
                 dataStream: 'First\rSecond\r',
                 paragraphs: [
-                    { startIndex: 5, paragraphStyle: { horizontalAlign: HorizontalAlign.CENTER } },
-                    { startIndex: 12, paragraphStyle: { textStyle: { fs: 18 } } },
+                    { startIndex: 5, paragraphId: 'para_fixture_4', paragraphStyle: { horizontalAlign: HorizontalAlign.CENTER } },
+                    { startIndex: 12, paragraphId: 'para_fixture_5', paragraphStyle: { textStyle: { fs: 18 } } },
                 ],
             },
         });
@@ -188,7 +188,7 @@ describe('DocumentDataModel + RichTextBuilder integration', () => {
             body: {
                 dataStream: tableStream,
                 tables: [{ startIndex: 0, endIndex: tableStream.length, tableId: 'table-1' }],
-                paragraphs: [{ startIndex: 7 }],
+                paragraphs: [{ startIndex: 7, paragraphId: 'para_fixture_6' }],
             },
         });
         expect(partialTableModel.sliceBody(1, tableStream.length - 1)?.tables?.[0]).toMatchObject({
@@ -224,7 +224,7 @@ describe('DocumentDataModel + RichTextBuilder integration', () => {
                 headerId: 'header2',
                 body: {
                     dataStream: 'Another Header\r\n',
-                    paragraphs: [{ startIndex: 0 }],
+                    paragraphs: [{ startIndex: 0, paragraphId: 'para_fixture_7' }],
                 },
             },
         }) as never);
@@ -239,7 +239,7 @@ describe('DocumentDataModel + RichTextBuilder integration', () => {
             title: 'Reset Title',
             body: {
                 dataStream: 'Reset\r\n',
-                paragraphs: [{ startIndex: 5 }],
+                paragraphs: [{ startIndex: 5, paragraphId: 'para_fixture_8' }],
             },
             documentStyle: {},
         });

--- a/packages/core/src/docs/data-model/__tests__/replacement.spec.ts
+++ b/packages/core/src/docs/data-model/__tests__/replacement.spec.ts
@@ -63,6 +63,7 @@ function getTestDocumentBody() {
         paragraphs: [
             {
                 startIndex: 4,
+                paragraphId: 'para_fixture_1001',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,
@@ -71,6 +72,7 @@ function getTestDocumentBody() {
             },
             {
                 startIndex: 11,
+                paragraphId: 'para_fixture_1002',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,
@@ -125,6 +127,7 @@ describe('test case in replaceInDocumentBody utils', () => {
             paragraphs: [
                 {
                     startIndex: 6,
+                    paragraphId: 'para_fixture_1001',
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
                         lineSpacing: 2,
@@ -133,6 +136,7 @@ describe('test case in replaceInDocumentBody utils', () => {
                 },
                 {
                     startIndex: 15,
+                    paragraphId: 'para_fixture_1002',
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
                         lineSpacing: 2,
@@ -184,6 +188,7 @@ describe('test case in replaceInDocumentBody utils', () => {
             paragraphs: [
                 {
                     startIndex: 2,
+                    paragraphId: 'para_fixture_1001',
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
                         lineSpacing: 2,
@@ -192,6 +197,7 @@ describe('test case in replaceInDocumentBody utils', () => {
                 },
                 {
                     startIndex: 7,
+                    paragraphId: 'para_fixture_1002',
                     paragraphStyle: {
                         spaceAbove: { v: 10 },
                         lineSpacing: 2,

--- a/packages/core/src/docs/data-model/__tests__/rich-text-builder.test.ts
+++ b/packages/core/src/docs/data-model/__tests__/rich-text-builder.test.ts
@@ -220,6 +220,7 @@ describe('RichTextValue', () => {
             textRuns: [],
             paragraphs: [{
                 startIndex: 11,
+                paragraphId: 'para_fixture_1007',
                 paragraphStyle,
             }],
         });
@@ -237,6 +238,7 @@ describe('RichTextValue', () => {
             textRuns: [],
             paragraphs: [{
                 startIndex: 11,
+                paragraphId: 'para_fixture_1008',
                 bullet,
             }],
         });
@@ -297,6 +299,7 @@ describe('RichTextValue', () => {
             }],
             paragraphs: [{
                 startIndex: 11,
+                paragraphId: 'para_fixture_1009',
                 paragraphStyle: { horizontalAlign: HorizontalAlign.CENTER },
             }],
         };
@@ -312,7 +315,13 @@ describe('RichTextBuilder', () => {
     it('should create empty rich text builder', () => {
         const builder = RichTextBuilder.create();
         const emptyData = RichTextBuilder.newEmptyData();
-        expect(builder.getData()).toEqual(emptyData);
+        expect(builder.getData()).toMatchObject({
+            ...emptyData,
+            body: {
+                ...emptyData.body,
+                paragraphs: [{ startIndex: 0, paragraphId: expect.stringMatching(/^para_/) }],
+            },
+        });
     });
 
     describe('text insertion', () => {

--- a/packages/core/src/docs/data-model/empty-snapshot.ts
+++ b/packages/core/src/docs/data-model/empty-snapshot.ts
@@ -20,6 +20,7 @@ import { DEFAULT_DOCUMENT_PARAGRAPH_LINE_SPACING, DEFAULT_DOCUMENT_PARAGRAPH_SPA
 import { BooleanNumber } from '../../types/enum';
 import { LocaleType } from '../../types/enum/locale-type';
 import { DocumentFlavor } from '../../types/interfaces';
+import { createParagraphId } from '../paragraph-id';
 
 export function getEmptySnapshot(
     unitID = generateRandomId(6),
@@ -46,6 +47,7 @@ export function getEmptySnapshot(
             paragraphs: [
                 {
                     startIndex: 0,
+                    paragraphId: createParagraphId(new Set()),
                     paragraphStyle: {
                         spaceAbove: { v: DEFAULT_DOCUMENT_PARAGRAPH_SPACE_ABOVE },
                         lineSpacing: DEFAULT_DOCUMENT_PARAGRAPH_LINE_SPACING,

--- a/packages/core/src/docs/data-model/json-x/__tests__/json-x.spec.ts
+++ b/packages/core/src/docs/data-model/json-x/__tests__/json-x.spec.ts
@@ -24,7 +24,7 @@ function createDoc(id = 'doc-json-x'): IDocumentData {
         id,
         body: {
             dataStream: 'Hello\r\n',
-            paragraphs: [{ startIndex: 5 }],
+            paragraphs: [{ startIndex: 5, paragraphId: 'para_fixture_9' }],
         },
         documentStyle: {
             pageSize: { width: 100, height: 100 },
@@ -72,7 +72,7 @@ describe('Basic use of json-x', () => {
             expect(transformed).toBeTruthy();
             expect(edited.body?.dataStream).toBe('Hello!?\r\n');
             expect(restored).toMatchObject(createDoc());
-            expect(restored.body).toMatchObject({ dataStream: 'Hello\r\n', paragraphs: [{ startIndex: 5 }] });
+            expect(restored.body).toMatchObject({ dataStream: 'Hello\r\n', paragraphs: [{ startIndex: 5, paragraphId: 'para_fixture_9' }] });
         });
     });
 });

--- a/packages/core/src/docs/data-model/rich-text-builder.ts
+++ b/packages/core/src/docs/data-model/rich-text-builder.ts
@@ -20,6 +20,7 @@ import type { IBorderData, IColorStyle, IDocumentBody, IDocumentData, INumberUni
 import { generateRandomId, Tools } from '../../shared';
 import { BooleanNumber } from '../../types/enum';
 import { CustomRangeType } from '../../types/interfaces';
+import { createParagraphId } from '../paragraph-id';
 import { DocumentDataModel } from './document-data-model';
 import { BuildTextUtils } from './text-x/build-utils';
 import { TextX } from './text-x/text-x';
@@ -32,9 +33,10 @@ export function normalizeBody(body: IDocumentBody) {
 
     if (!body.paragraphs) {
         body.paragraphs = [];
+        const existingParagraphIds = new Set<string>();
         for (let i = 0; i < body.dataStream.length; i++) {
             if (body.dataStream[i] === '\r') {
-                body.paragraphs.push({ startIndex: i });
+                body.paragraphs.push({ startIndex: i, paragraphId: createParagraphId(existingParagraphIds) });
             }
         }
     }
@@ -1698,7 +1700,7 @@ export class RichTextBuilder extends RichTextValue {
                 dataStream: '\r\n',
                 customBlocks: [],
                 customRanges: [],
-                paragraphs: [{ startIndex: 0 }],
+                paragraphs: [{ startIndex: 0, paragraphId: createParagraphId(new Set()) }],
                 textRuns: [],
                 tables: [],
                 sectionBreaks: [],
@@ -2043,6 +2045,7 @@ export class RichTextBuilder extends RichTextValue {
                 dataStream: '\r',
                 paragraphs: [{
                     startIndex: 0,
+                    paragraphId: createParagraphId(new Set()),
                     paragraphStyle: start.build(),
                 }],
             };
@@ -2053,6 +2056,7 @@ export class RichTextBuilder extends RichTextValue {
                 dataStream: '\r',
                 paragraphs: [{
                     startIndex: 0,
+                    paragraphId: createParagraphId(new Set()),
                     paragraphStyle: paragraphStyle?.build(),
                 }],
             };

--- a/packages/core/src/docs/data-model/text-x/__tests__/apply-consistency.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/apply-consistency.spec.ts
@@ -38,9 +38,11 @@ function getDefaultDocWithCustomRange() {
         paragraphs: [
             {
                 startIndex: 4,
+                paragraphId: 'para_first',
             },
             {
                 startIndex: 9,
+                paragraphId: 'para_second',
             },
         ],
         customDecorations: [],
@@ -69,6 +71,7 @@ describe('apply consistency', () => {
                     dataStream: '\r',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_first',
                     }],
                     customRanges: [],
                 },

--- a/packages/core/src/docs/data-model/text-x/__tests__/apply-utils.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/apply-utils.spec.ts
@@ -56,15 +56,19 @@ describe('test case in apply utils', () => {
             paragraphs: [
                 {
                     startIndex: 5,
+                    paragraphId: 'para_fixture_1010',
                 },
                 {
                     startIndex: 17,
+                    paragraphId: 'para_fixture_1011',
                 },
                 {
                     startIndex: 29,
+                    paragraphId: 'para_fixture_1012',
                 },
                 {
                     startIndex: 38,
+                    paragraphId: 'para_fixture_1013',
                 },
             ],
         };
@@ -177,15 +181,19 @@ describe('test case in apply utils', () => {
                 paragraphs: [
                     {
                         startIndex: 5,
+                        paragraphId: 'para_fixture_1014',
                     },
                     {
                         startIndex: 17,
+                        paragraphId: 'para_fixture_1015',
                     },
                     {
                         startIndex: 29,
+                        paragraphId: 'para_fixture_1016',
                     },
                     {
                         startIndex: 38,
+                        paragraphId: 'para_fixture_1017',
                     },
                 ],
             };

--- a/packages/core/src/docs/data-model/text-x/__tests__/apply.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/apply.spec.ts
@@ -73,6 +73,7 @@ function getDefaultDocWithParagraph() {
         paragraphs: [
             {
                 startIndex: 1,
+                paragraphId: 'para_fixture_1018',
             },
         ],
     };
@@ -104,6 +105,7 @@ function getDefaultDocWithCustomRange() {
         paragraphs: [
             {
                 startIndex: 10,
+                paragraphId: 'para_fixture_1019',
             },
         ],
     };
@@ -299,6 +301,7 @@ describe('apply method', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1020',
                         paragraphStyle: {
                             horizontalAlign: HorizontalAlign.LEFT,
                         },
@@ -319,6 +322,7 @@ describe('apply method', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1020',
                         paragraphStyle: {
                             horizontalAlign: HorizontalAlign.RIGHT,
                         },
@@ -361,6 +365,7 @@ describe('apply method', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1022',
                         paragraphStyle: {
                             horizontalAlign: HorizontalAlign.LEFT,
                         },
@@ -382,6 +387,7 @@ describe('apply method', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1022',
                         paragraphStyle: {
                             horizontalAlign: HorizontalAlign.RIGHT,
                         },
@@ -424,6 +430,7 @@ describe('apply method', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1024',
                         bullet: {
                             listId: 'J7FZTm',
                             listType: PresetListType.CHECK_LIST,
@@ -450,6 +457,7 @@ describe('apply method', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1024',
                         bullet: {
                             listId: 'uODEbf',
                             listType: PresetListType.BULLET_LIST,
@@ -555,6 +563,7 @@ describe('apply method', () => {
                     dataStream: '\r',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1026',
                         paragraphStyle: {
                             horizontalAlign: HorizontalAlign.LEFT,
                         },

--- a/packages/core/src/docs/data-model/text-x/__tests__/paragraph-id.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/paragraph-id.spec.ts
@@ -1,0 +1,379 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IDocumentBody } from '../../../../types/interfaces';
+import type { TextXAction } from '../action-types';
+import { describe, expect, it } from 'vitest';
+import { UpdateDocsAttributeType } from '../../../../shared';
+import { TextXActionType } from '../action-types';
+import { TextX } from '../text-x';
+
+const PARAGRAPH_ID_PATTERN = /^para_.+/;
+
+describe('TextX paragraph ids', () => {
+    it('preserves paragraph ids when inserting text before paragraphs', () => {
+        const body: IDocumentBody = {
+            dataStream: 'A\rB\r\n',
+            paragraphs: [
+                { startIndex: 1, paragraphId: 'para_first' },
+                { startIndex: 3, paragraphId: 'para_second' },
+            ],
+        };
+
+        TextX.apply(body, [{
+            t: TextXActionType.INSERT,
+            len: 1,
+            body: { dataStream: 'X' },
+        }]);
+
+        expect(body.paragraphs).toEqual([
+            { startIndex: 2, paragraphId: 'para_first' },
+            { startIndex: 4, paragraphId: 'para_second' },
+        ]);
+    });
+
+    it('preserves inserted paragraph ids through invert', () => {
+        const textX = new TextX();
+
+        textX.insert(2, {
+            dataStream: 'A\r',
+            paragraphs: [{ startIndex: 1, paragraphId: 'para_inserted' }],
+        });
+
+        const invertedActions = TextX.invert(textX.serialize());
+
+        expect(invertedActions).toEqual([{
+            t: TextXActionType.DELETE,
+            len: 2,
+            body: {
+                dataStream: 'A\r',
+                paragraphs: [{ startIndex: 1, paragraphId: 'para_inserted' }],
+            },
+        }]);
+    });
+
+    it('generates paragraph ids for inserted builder bodies when making them invertible', () => {
+        const textX = new TextX();
+
+        textX.insert(2, {
+            dataStream: 'A\r',
+            paragraphs: [{ startIndex: 1 }],
+        });
+
+        const actions = textX.serialize();
+        TextX.makeInvertible(actions, {
+            dataStream: '\r\n',
+            paragraphs: [{ startIndex: 0, paragraphId: 'para_existing' }],
+        });
+
+        const insertParagraphId = actions[0].body?.paragraphs?.[0].paragraphId;
+        const invertedParagraphId = TextX.invert(actions)[0].body?.paragraphs?.[0].paragraphId;
+
+        expect(insertParagraphId).toMatch(PARAGRAPH_ID_PATTERN);
+        expect(invertedParagraphId).toBe(insertParagraphId);
+    });
+
+    it('generates paragraph ids for inserted bodies that omit them', () => {
+        const body: IDocumentBody = {
+            dataStream: '\r\n',
+            paragraphs: [{ startIndex: 0, paragraphId: 'para_existing' }],
+        };
+
+        TextX.apply(body, [{
+            t: TextXActionType.INSERT,
+            len: 2,
+            body: {
+                dataStream: 'A\r',
+                paragraphs: [{ startIndex: 1 }],
+            },
+        }]);
+
+        expect(body.paragraphs?.[0]).toMatchObject({ startIndex: 1 });
+        expect(body.paragraphs?.[0].paragraphId).toMatch(PARAGRAPH_ID_PATTERN);
+        expect(body.paragraphs?.[0].paragraphId).not.toBe('para_existing');
+        expect(body.paragraphs?.[1]).toEqual({ startIndex: 2, paragraphId: 'para_existing' });
+    });
+
+    it('keeps original paragraph id and gives split paragraph a new id', () => {
+        const body: IDocumentBody = {
+            dataStream: 'AB\r\n',
+            paragraphs: [{ startIndex: 2, paragraphId: 'para_original' }],
+        };
+
+        TextX.apply(body, [{
+            t: TextXActionType.RETAIN,
+            len: 1,
+        }, {
+            t: TextXActionType.INSERT,
+            len: 1,
+            body: {
+                dataStream: '\r',
+                paragraphs: [{ startIndex: 0 }],
+            },
+        }]);
+
+        expect(body.paragraphs?.[0]).toEqual({ startIndex: 1, paragraphId: 'para_original' });
+        expect(body.paragraphs?.[1].startIndex).toBe(3);
+        expect(body.paragraphs?.[1].paragraphId).toMatch(PARAGRAPH_ID_PATTERN);
+        expect(body.paragraphs?.[1].paragraphId).not.toBe('para_original');
+    });
+
+    it('keeps original paragraph id and gives explicit inserted id to split paragraph', () => {
+        const body: IDocumentBody = {
+            dataStream: 'AB\r\n',
+            paragraphs: [{ startIndex: 2, paragraphId: 'para_original' }],
+        };
+
+        TextX.apply(body, [{
+            t: TextXActionType.RETAIN,
+            len: 1,
+        }, {
+            t: TextXActionType.INSERT,
+            len: 1,
+            body: {
+                dataStream: '\r',
+                paragraphs: [{ startIndex: 0, paragraphId: 'para_explicit' }],
+            },
+        }]);
+
+        expect(body.paragraphs).toEqual([
+            { startIndex: 1, paragraphId: 'para_original' },
+            { startIndex: 3, paragraphId: 'para_explicit' },
+        ]);
+    });
+
+    it('keeps original paragraph id when applying an invertible split action', () => {
+        const body: IDocumentBody = {
+            dataStream: 'AB\r\n',
+            paragraphs: [{ startIndex: 2, paragraphId: 'para_original' }],
+        };
+        const actions: TextXAction[] = [{
+            t: TextXActionType.RETAIN,
+            len: 1,
+        }, {
+            t: TextXActionType.INSERT,
+            len: 1,
+            body: {
+                dataStream: '\r',
+                paragraphs: [{ startIndex: 0 }],
+            },
+        }];
+
+        TextX.makeInvertible(actions, body);
+        TextX.apply(body, actions);
+
+        expect(actions[1].body?.paragraphs?.[0].paragraphId).toBe('para_original');
+        expect(body.paragraphs?.[0]).toEqual({ startIndex: 1, paragraphId: 'para_original' });
+        expect(body.paragraphs?.[1].startIndex).toBe(3);
+        expect(body.paragraphs?.[1].paragraphId).toMatch(PARAGRAPH_ID_PATTERN);
+        expect(body.paragraphs?.[1].paragraphId).not.toBe('para_original');
+    });
+
+    it('keeps explicit split paragraph id through makeInvertible and apply', () => {
+        const body: IDocumentBody = {
+            dataStream: 'AB\r\n',
+            paragraphs: [{ startIndex: 2, paragraphId: 'para_original' }],
+        };
+        const actions: TextXAction[] = [{
+            t: TextXActionType.RETAIN,
+            len: 1,
+        }, {
+            t: TextXActionType.INSERT,
+            len: 1,
+            body: {
+                dataStream: '\r',
+                paragraphs: [{ startIndex: 0, paragraphId: 'para_explicit' }],
+            },
+        }];
+
+        TextX.makeInvertible(actions, body);
+        TextX.apply(body, actions);
+
+        expect(actions[1].body?.paragraphs?.[0].paragraphId).toBe('para_explicit');
+        expect(body.paragraphs).toEqual([
+            { startIndex: 1, paragraphId: 'para_original' },
+            { startIndex: 3, paragraphId: 'para_explicit' },
+        ]);
+    });
+
+    it('repairs inserted paragraph ids that collide with the target document before invert', () => {
+        const body: IDocumentBody = {
+            dataStream: 'A\r\n',
+            paragraphs: [{ startIndex: 1, paragraphId: 'para_existing' }],
+        };
+        const actions: TextXAction[] = [{
+            t: TextXActionType.INSERT,
+            len: 2,
+            body: {
+                dataStream: 'B\r',
+                paragraphs: [{ startIndex: 1, paragraphId: 'para_existing' }],
+            },
+        }];
+
+        TextX.makeInvertible(actions, body);
+        const insertedParagraphId = actions[0].body?.paragraphs?.[0].paragraphId;
+        const invertedParagraphId = TextX.invert(actions)[0].body?.paragraphs?.[0].paragraphId;
+
+        TextX.apply(body, actions);
+
+        expect(insertedParagraphId).toMatch(PARAGRAPH_ID_PATTERN);
+        expect(insertedParagraphId).not.toBe('para_existing');
+        expect(invertedParagraphId).toBe(insertedParagraphId);
+        expect(body.paragraphs?.[0]).toEqual({ startIndex: 1, paragraphId: insertedParagraphId });
+        expect(body.paragraphs?.[1]).toEqual({ startIndex: 3, paragraphId: 'para_existing' });
+    });
+
+    it('repairs duplicate paragraph ids across multiple inserts before invert', () => {
+        const body: IDocumentBody = {
+            dataStream: 'A\r\n',
+            paragraphs: [{ startIndex: 1, paragraphId: 'para_existing' }],
+        };
+        const actions: TextXAction[] = [{
+            t: TextXActionType.INSERT,
+            len: 2,
+            body: {
+                dataStream: 'B\r',
+                paragraphs: [{ startIndex: 1, paragraphId: 'para_dup' }],
+            },
+        }, {
+            t: TextXActionType.INSERT,
+            len: 2,
+            body: {
+                dataStream: 'C\r',
+                paragraphs: [{ startIndex: 1, paragraphId: 'para_dup' }],
+            },
+        }];
+
+        TextX.makeInvertible(actions, body);
+        const firstInsertParagraphId = actions[0].body?.paragraphs?.[0].paragraphId;
+        const secondInsertParagraphId = actions[1].body?.paragraphs?.[0].paragraphId;
+        const invertedActions = TextX.invert(actions);
+
+        TextX.apply(body, actions);
+
+        expect(firstInsertParagraphId).toBe('para_dup');
+        expect(secondInsertParagraphId).toMatch(PARAGRAPH_ID_PATTERN);
+        expect(secondInsertParagraphId).not.toBe(firstInsertParagraphId);
+        expect(invertedActions[0].body?.paragraphs?.[0].paragraphId).toBe(firstInsertParagraphId);
+        expect(invertedActions[1].body?.paragraphs?.[0].paragraphId).toBe(secondInsertParagraphId);
+        expect(body.paragraphs?.[0]).toEqual({ startIndex: 1, paragraphId: firstInsertParagraphId });
+        expect(body.paragraphs?.[1]).toEqual({ startIndex: 3, paragraphId: secondInsertParagraphId });
+    });
+
+    it('keeps the following paragraph id when deleting a paragraph marker under the current merge model', () => {
+        const body: IDocumentBody = {
+            dataStream: 'A\rB\r\n',
+            paragraphs: [
+                { startIndex: 1, paragraphId: 'para_first' },
+                { startIndex: 3, paragraphId: 'para_second' },
+            ],
+        };
+
+        TextX.apply(body, [{
+            t: TextXActionType.RETAIN,
+            len: 1,
+        }, {
+            t: TextXActionType.DELETE,
+            len: 1,
+        }]);
+
+        expect(body.dataStream).toBe('AB\r\n');
+        expect(body.paragraphs).toEqual([{ startIndex: 2, paragraphId: 'para_second' }]);
+    });
+
+    it('preserves target paragraph id when retain metadata omits one', () => {
+        const body: IDocumentBody = {
+            dataStream: '\r\n',
+            paragraphs: [{ startIndex: 0, paragraphId: 'para_original' }],
+        };
+
+        TextX.apply(body, [{
+            t: TextXActionType.RETAIN,
+            len: 1,
+            coverType: UpdateDocsAttributeType.REPLACE,
+            body: {
+                dataStream: '',
+                paragraphs: [{
+                    startIndex: 0,
+                    paragraphStyle: { lineSpacing: 2 },
+                }],
+            },
+        }]);
+
+        expect(body.paragraphs).toEqual([{
+            startIndex: 0,
+            paragraphId: 'para_original',
+            paragraphStyle: { lineSpacing: 2 },
+        }]);
+    });
+
+    it('uses explicit paragraph id when retain metadata provides one', () => {
+        const body: IDocumentBody = {
+            dataStream: '\r\n',
+            paragraphs: [{ startIndex: 0, paragraphId: 'para_original' }],
+        };
+
+        TextX.apply(body, [{
+            t: TextXActionType.RETAIN,
+            len: 1,
+            coverType: UpdateDocsAttributeType.REPLACE,
+            body: {
+                dataStream: '',
+                paragraphs: [{
+                    startIndex: 0,
+                    paragraphId: 'para_replacement',
+                    paragraphStyle: { lineSpacing: 2 },
+                }],
+            },
+        }]);
+
+        expect(body.paragraphs).toEqual([{
+            startIndex: 0,
+            paragraphId: 'para_replacement',
+            paragraphStyle: { lineSpacing: 2 },
+        }]);
+    });
+
+    it('makeInvertible delete body captures original paragraph ids', () => {
+        const body: IDocumentBody = {
+            dataStream: 'A\rB\r\n',
+            paragraphs: [
+                { startIndex: 1, paragraphId: 'para_first' },
+                { startIndex: 3, paragraphId: 'para_second' },
+            ],
+        };
+        const actions: TextXAction[] = [{
+            t: TextXActionType.RETAIN,
+            len: 1,
+        }, {
+            t: TextXActionType.DELETE,
+            len: 1,
+        }];
+
+        TextX.makeInvertible(actions, body);
+
+        expect(actions[1]).toEqual({
+            t: TextXActionType.DELETE,
+            len: 1,
+            body: {
+                dataStream: '\r',
+                textRuns: undefined,
+                paragraphs: [{ startIndex: 0, paragraphId: 'para_first' }],
+                customBlocks: undefined,
+            },
+        });
+    });
+});

--- a/packages/core/src/docs/data-model/text-x/__tests__/paragraph-id.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/paragraph-id.spec.ts
@@ -70,7 +70,7 @@ describe('TextX paragraph ids', () => {
 
         textX.insert(2, {
             dataStream: 'A\r',
-            paragraphs: [{ startIndex: 1 }],
+            paragraphs: [{ startIndex: 1, paragraphId: 'para_fixture_11' }],
         });
 
         const actions = textX.serialize();
@@ -97,7 +97,7 @@ describe('TextX paragraph ids', () => {
             len: 2,
             body: {
                 dataStream: 'A\r',
-                paragraphs: [{ startIndex: 1 }],
+                paragraphs: [{ startIndex: 1, paragraphId: 'para_fixture_12' }],
             },
         }]);
 
@@ -121,7 +121,7 @@ describe('TextX paragraph ids', () => {
             len: 1,
             body: {
                 dataStream: '\r',
-                paragraphs: [{ startIndex: 0 }],
+                paragraphs: [{ startIndex: 0, paragraphId: 'para_fixture_13' }],
             },
         }]);
 
@@ -168,7 +168,7 @@ describe('TextX paragraph ids', () => {
             len: 1,
             body: {
                 dataStream: '\r',
-                paragraphs: [{ startIndex: 0 }],
+                paragraphs: [{ startIndex: 0 } as never],
             },
         }];
 
@@ -309,7 +309,7 @@ describe('TextX paragraph ids', () => {
                 paragraphs: [{
                     startIndex: 0,
                     paragraphStyle: { lineSpacing: 2 },
-                }],
+                } as never],
             },
         }]);
 

--- a/packages/core/src/docs/data-model/text-x/__tests__/transform-paragraph.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/transform-paragraph.spec.ts
@@ -22,12 +22,17 @@ import { PresetListType } from '../../preset-list-type';
 import { TextXActionType } from '../action-types';
 import { TextX } from '../text-x';
 
+function getParagraphsWithoutBullets(body: IDocumentBody) {
+    return body.paragraphs?.map(({ bullet, ...paragraph }) => paragraph);
+}
+
 function getDefaultDocWithParagraph() {
     const doc: IDocumentBody = {
         dataStream: '\r\n',
         paragraphs: [
             {
                 startIndex: 0,
+                paragraphId: 'para_fixture_1028',
             },
         ],
     };
@@ -47,6 +52,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1030',
                         paragraphStyle: {
                             lineSpacing: 1,
                         },
@@ -72,6 +78,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1030',
                         paragraphStyle: {
                             lineSpacing: 1,
                             spaceBelow: {
@@ -92,6 +99,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1030',
                         paragraphStyle: {
                             lineSpacing: 1,
                         },
@@ -117,6 +125,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1030',
                         paragraphStyle: {
                             lineSpacing: 1,
                             spaceBelow: {
@@ -146,9 +155,12 @@ describe('transform paragraph in body', () => {
         expect(TextX.transform(actionsB, actionsA, 'right')).toEqual(expectedTransformedActionFalse);
 
         expect(resultA).toEqual(resultB);
-        expect(resultC).toEqual(resultD);
-        expect(resultA).toEqual(resultC);
-        expect(composedAction1).toEqual(composedAction2);
+        expect(resultC.dataStream).toBe(resultD.dataStream);
+        expect(getParagraphsWithoutBullets(resultC)).toEqual(getParagraphsWithoutBullets(resultD));
+        expect(resultA.dataStream).toBe(resultC.dataStream);
+        expect(getParagraphsWithoutBullets(resultA)).toEqual(getParagraphsWithoutBullets(resultC));
+        expect(composedAction1[0].body?.dataStream).toBe(composedAction2[0].body?.dataStream);
+        expect(getParagraphsWithoutBullets(composedAction1[0].body!)).toEqual(getParagraphsWithoutBullets(composedAction2[0].body!));
     });
 
     it('should pass test when REPLACE + COVER', () => {
@@ -161,6 +173,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1034',
                         paragraphStyle: {
                             lineSpacing: 2,
                         },
@@ -186,6 +199,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1034',
                         paragraphStyle: {
                             lineSpacing: 1,
                             spaceBelow: {
@@ -214,6 +228,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1034',
                         paragraphStyle: {
                             lineSpacing: 1,
                             spaceBelow: {
@@ -242,6 +257,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1034',
                         paragraphStyle: {
                             lineSpacing: 2,
                             spaceBelow: {
@@ -316,6 +332,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1038',
                         paragraphStyle: {
                             lineSpacing: 2,
                         },
@@ -341,6 +358,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1038',
                         paragraphStyle: {
                             lineSpacing: 1,
                             spaceBelow: {
@@ -364,6 +382,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1038',
                         paragraphStyle: {
                             lineSpacing: 1,
                             spaceBelow: {
@@ -387,6 +406,7 @@ describe('transform paragraph in body', () => {
                     dataStream: '',
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: 'para_fixture_1038',
                         paragraphStyle: {
                             spaceBelow: {
                                 v: 20,

--- a/packages/core/src/docs/data-model/text-x/__tests__/transform.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/transform.spec.ts
@@ -563,6 +563,7 @@ describe('transform()', () => {
                     paragraphs: [
                         {
                             startIndex: 0,
+                            paragraphId: 'para_fixture_1041',
                             paragraphStyle: {
                                 lineSpacing: 1,
                             },
@@ -581,6 +582,7 @@ describe('transform()', () => {
                     paragraphs: [
                         {
                             startIndex: 0,
+                            paragraphId: 'para_fixture_1042',
                             paragraphStyle: {
                                 lineSpacing: 5,
                                 spaceBelow: { v: 6 },
@@ -601,6 +603,7 @@ describe('transform()', () => {
                     paragraphs: [
                         {
                             startIndex: 0,
+                            paragraphId: 'para_fixture_1042',
                             paragraphStyle: {
                                 spaceBelow: { v: 6 },
                             },
@@ -620,6 +623,7 @@ describe('transform()', () => {
                     paragraphs: [
                         {
                             startIndex: 0,
+                            paragraphId: 'para_fixture_1042',
                             paragraphStyle: {
                                 lineSpacing: 5,
                                 spaceBelow: { v: 6 },
@@ -645,6 +649,7 @@ describe('transform()', () => {
                     paragraphs: [
                         {
                             startIndex: 0,
+                            paragraphId: 'para_fixture_1045',
                             paragraphStyle: {
                                 lineSpacing: 1,
                             },
@@ -664,6 +669,7 @@ describe('transform()', () => {
                     paragraphs: [
                         {
                             startIndex: 0,
+                            paragraphId: 'para_fixture_1046',
                             paragraphStyle: {
                                 lineSpacing: 5,
                                 spaceBelow: { v: 6 },
@@ -684,6 +690,7 @@ describe('transform()', () => {
                     paragraphs: [
                         {
                             startIndex: 0,
+                            paragraphId: 'para_fixture_1046',
                             paragraphStyle: {
                                 lineSpacing: 1,
                             },
@@ -703,6 +710,7 @@ describe('transform()', () => {
                     paragraphs: [
                         {
                             startIndex: 0,
+                            paragraphId: 'para_fixture_1046',
                             paragraphStyle: {
                                 lineSpacing: 5,
                                 spaceBelow: { v: 6 },

--- a/packages/core/src/docs/data-model/text-x/__tests__/utils.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/utils.spec.ts
@@ -45,11 +45,12 @@ describe('test text-x utils', () => {
             ],
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1049',
             }],
         };
 
         const sliceBody = getBodySlice(body, 3, 8, false);
-        expect(sliceBody).toEqual({
+        expect(sliceBody).toMatchObject({
             dataStream: 'lo\nwo',
             textRuns: [
                 {
@@ -70,6 +71,7 @@ describe('test text-x utils', () => {
             ],
             paragraphs: [{
                 startIndex: 2,
+                paragraphId: 'para_fixture_1049',
             }],
         } as IDocumentBody);
     });
@@ -103,11 +105,12 @@ describe('test text-x utils', () => {
             ],
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1051',
             }],
         };
 
         const sliceBody = getBodySlice(body, 2, 8, false);
-        expect(sliceBody).toEqual({
+        expect(sliceBody).toMatchObject({
             dataStream: 'llo\nwo',
             textRuns: [
                 {
@@ -135,6 +138,7 @@ describe('test text-x utils', () => {
             ],
             paragraphs: [{
                 startIndex: 3,
+                paragraphId: 'para_fixture_1051',
             }],
         });
     });
@@ -161,6 +165,7 @@ describe('test text-x utils', () => {
             ],
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1053',
             }],
         };
 
@@ -186,7 +191,7 @@ describe('test text-x utils', () => {
 
         const composedBody = composeBody(thisBody, otherBody);
 
-        expect(composedBody).toEqual({
+        expect(composedBody).toMatchObject({
             dataStream: 'hello\nworld',
             textRuns: [
                 {
@@ -215,6 +220,7 @@ describe('test text-x utils', () => {
             ],
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1053',
             }],
         });
     });
@@ -239,6 +245,7 @@ describe('test text-x utils', () => {
             dataStream: 'hello\nworld',
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1055',
             }],
         };
 
@@ -246,6 +253,7 @@ describe('test text-x utils', () => {
             dataStream: '',
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1056',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,
@@ -256,10 +264,11 @@ describe('test text-x utils', () => {
 
         const composedBody = composeBody(thisBody, otherBody);
 
-        expect(composedBody).toEqual({
+        expect(composedBody).toMatchObject({
             dataStream: 'hello\nworld',
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1056',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,
@@ -274,6 +283,7 @@ describe('test text-x utils', () => {
             dataStream: '',
             paragraphs: [{
                 startIndex: 0,
+                paragraphId: 'para_fixture_1058',
                 paragraphStyle: {
                     lineSpacing: 2,
                 },
@@ -292,6 +302,7 @@ describe('test text-x utils', () => {
             dataStream: '',
             paragraphs: [{
                 startIndex: 0,
+                paragraphId: 'para_fixture_1059',
                 paragraphStyle: {
                     lineSpacing: 1,
                     spaceBelow: {
@@ -303,10 +314,11 @@ describe('test text-x utils', () => {
 
         const composedBody = composeBody(thisBody, otherBody);
 
-        expect(composedBody).toEqual({
+        expect(composedBody).toMatchObject({
             dataStream: '',
             paragraphs: [{
                 startIndex: 0,
+                paragraphId: 'para_fixture_1059',
                 paragraphStyle: {
                     lineSpacing: 1,
                     spaceBelow: {
@@ -330,6 +342,7 @@ describe('test text-x utils', () => {
             dataStream: '',
             paragraphs: [{
                 startIndex: 2,
+                paragraphId: 'para_fixture_1061',
             }],
         };
 
@@ -337,6 +350,7 @@ describe('test text-x utils', () => {
             dataStream: '',
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1062',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,
@@ -347,12 +361,14 @@ describe('test text-x utils', () => {
 
         const composedBody = composeBody(thisBody, otherBody);
 
-        expect(composedBody).toEqual({
+        expect(composedBody).toMatchObject({
             dataStream: '',
             paragraphs: [{
                 startIndex: 2,
+                paragraphId: 'para_fixture_1061',
             }, {
                 startIndex: 5,
+                paragraphId: 'para_fixture_1062',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,
@@ -367,6 +383,7 @@ describe('test text-x utils', () => {
             dataStream: '',
             paragraphs: [{
                 startIndex: 8,
+                paragraphId: 'para_fixture_1065',
             }],
         };
 
@@ -374,6 +391,7 @@ describe('test text-x utils', () => {
             dataStream: '',
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1066',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,
@@ -384,10 +402,11 @@ describe('test text-x utils', () => {
 
         const composedBody = composeBody(thisBody, otherBody);
 
-        expect(composedBody).toEqual({
+        expect(composedBody).toMatchObject({
             dataStream: '',
             paragraphs: [{
                 startIndex: 5,
+                paragraphId: 'para_fixture_1066',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,
@@ -395,6 +414,7 @@ describe('test text-x utils', () => {
                 },
             }, {
                 startIndex: 8,
+                paragraphId: 'para_fixture_1065',
             }],
         });
     });

--- a/packages/core/src/docs/data-model/text-x/apply-utils/common.ts
+++ b/packages/core/src/docs/data-model/text-x/apply-utils/common.ts
@@ -29,7 +29,11 @@ import type {
 import { shallowEqual } from '../../../../common/equal';
 import { horizontalLineSegmentsSubtraction, sortRulesFactory, Tools } from '../../../../shared';
 import { isSameStyleTextRun } from '../../../../shared/compare';
+import { cloneParagraphWithId } from '../../../paragraph-id';
 import { getBodySlice } from '../utils';
+
+// Internal TextX undo marker: restored delete bodies keep their captured paragraph ids.
+export const RESTORE_INSERTED_PARAGRAPH_IDS = '__textXRestoreParagraphIds';
 
 export function normalizeTextRuns(textRuns: ITextRun[], reserveEmptyTextRun = false): ITextRun[] {
     const results: ITextRun[] = [];
@@ -167,7 +171,8 @@ export function insertParagraphs(
     body: IDocumentBody,
     insertBody: IDocumentBody,
     textLength: number,
-    currentIndex: number
+    currentIndex: number,
+    preserveMissingParagraphIds = false
 ) {
     const { paragraphs } = body;
     if (paragraphs == null) {
@@ -175,6 +180,11 @@ export function insertParagraphs(
     }
 
     const { paragraphs: insertParagraphs } = insertBody;
+    normalizeInsertedParagraphIdsForDocument(paragraphs, insertParagraphs, currentIndex, {
+        freshenSplitParagraph: true,
+        preserveMissingParagraphIds,
+        preserveExplicitSplitParagraphIds: Boolean((insertBody as unknown as Record<string, unknown>)[RESTORE_INSERTED_PARAGRAPH_IDS]),
+    });
 
     const paragraphIndexList = [];
     let firstInsertParagraphNextIndex = -1;
@@ -211,6 +221,119 @@ export function insertParagraphs(
         paragraphs.push(...insertParagraphs);
         paragraphs.sort(sortRulesFactory('startIndex'));
     }
+}
+
+export function normalizeInsertedParagraphIdsForDocument(
+    paragraphs: IParagraph[] | undefined,
+    insertParagraphs: IParagraph[] | undefined,
+    currentIndex: number,
+    options: {
+        freshenSplitParagraph: boolean;
+        preserveExplicitSplitParagraphIds?: boolean;
+        preserveMissingParagraphIds?: boolean;
+        reservedParagraphIds?: Set<string>;
+    }
+) {
+    if (!paragraphs || !insertParagraphs?.length) {
+        return;
+    }
+
+    const splitParagraph = getParagraphSplitByInsert(paragraphs, currentIndex);
+    const firstSplitInsertIndex = splitParagraph ? getFirstInsertedParagraphIndex(insertParagraphs) : -1;
+    const splitParagraphId = splitParagraph?.paragraphId;
+    const firstInsertedParagraphId = firstSplitInsertIndex === -1 ? undefined : insertParagraphs[firstSplitInsertIndex].paragraphId;
+    const shouldPreserveExplicitSplitParagraphId = options.preserveExplicitSplitParagraphIds && firstInsertedParagraphId != null && firstInsertedParagraphId !== splitParagraphId;
+    const existingParagraphIds = collectParagraphIds(paragraphs);
+
+    if (splitParagraphId) {
+        existingParagraphIds.delete(splitParagraphId);
+    }
+
+    for (const paragraphId of options.reservedParagraphIds ?? []) {
+        existingParagraphIds.add(paragraphId);
+    }
+
+    let splitRemainderParagraph: IParagraph | undefined;
+
+    if (splitParagraphId && firstSplitInsertIndex !== -1 && !shouldPreserveExplicitSplitParagraphId) {
+        const firstInsertParagraph = insertParagraphs[firstSplitInsertIndex];
+        splitRemainderParagraph = firstInsertedParagraphId != null && firstInsertedParagraphId !== splitParagraphId
+            ? cloneInsertedParagraphWithId(firstInsertParagraph, existingParagraphIds, options.preserveMissingParagraphIds ?? false)
+            : cloneParagraphWithId(firstInsertParagraph, existingParagraphIds, false);
+
+        if (options.freshenSplitParagraph && splitRemainderParagraph.paragraphId) {
+            splitParagraph.paragraphId = splitRemainderParagraph.paragraphId;
+        }
+    }
+
+    for (let i = 0, len = insertParagraphs.length; i < len; i++) {
+        if (i !== firstSplitInsertIndex || splitParagraphId == null || shouldPreserveExplicitSplitParagraphId) {
+            insertParagraphs[i] = cloneInsertedParagraphWithId(insertParagraphs[i], existingParagraphIds, options.preserveMissingParagraphIds ?? false);
+            continue;
+        }
+
+        insertParagraphs[i] = options.freshenSplitParagraph || firstInsertedParagraphId == null || firstInsertedParagraphId === splitParagraphId
+            ? cloneParagraphWithId({
+                ...insertParagraphs[i],
+                paragraphId: splitParagraphId,
+            }, existingParagraphIds)
+            : splitRemainderParagraph!;
+    }
+
+    for (const insertParagraph of insertParagraphs) {
+        if (insertParagraph.paragraphId) {
+            options.reservedParagraphIds?.add(insertParagraph.paragraphId);
+        }
+    }
+}
+
+function collectParagraphIds(paragraphs: IParagraph[] | undefined): Set<string> {
+    const paragraphIds = new Set<string>();
+
+    for (const paragraph of paragraphs ?? []) {
+        if (paragraph.paragraphId) {
+            paragraphIds.add(paragraph.paragraphId);
+        }
+    }
+
+    return paragraphIds;
+}
+
+function cloneInsertedParagraphWithId(
+    insertParagraph: IParagraph,
+    existingParagraphIds: Set<string>,
+    preserveMissingParagraphIds: boolean
+): IParagraph {
+    if (preserveMissingParagraphIds && insertParagraph.paragraphId == null) {
+        return Tools.deepClone(insertParagraph);
+    }
+
+    return cloneParagraphWithId(insertParagraph, existingParagraphIds);
+}
+
+function getParagraphSplitByInsert(paragraphs: IParagraph[], currentIndex: number): IParagraph | undefined {
+    const sortedParagraphs = [...paragraphs].sort((left, right) => left.startIndex - right.startIndex);
+
+    for (let i = 0; i < sortedParagraphs.length; i++) {
+        const paragraph = sortedParagraphs[i];
+        const paragraphStart = i > 0 ? sortedParagraphs[i - 1].startIndex + 1 : 0;
+
+        if (currentIndex > paragraphStart && currentIndex < paragraph.startIndex) {
+            return paragraph;
+        }
+    }
+}
+
+function getFirstInsertedParagraphIndex(insertParagraphs: IParagraph[]): number {
+    let index = 0;
+
+    for (let i = 1; i < insertParagraphs.length; i++) {
+        if (insertParagraphs[i].startIndex < insertParagraphs[index].startIndex) {
+            index = i;
+        }
+    }
+
+    return index;
 }
 
 export function insertSectionBreaks(

--- a/packages/core/src/docs/data-model/text-x/apply-utils/update-apply.ts
+++ b/packages/core/src/docs/data-model/text-x/apply-utils/update-apply.ts
@@ -233,6 +233,7 @@ function updateParagraphs(
         for (const updateParagraph of updateDataParagraphs) {
             const {
                 startIndex: updateStartIndex,
+                paragraphId: updateParagraphId,
                 paragraphStyle: updateParagraphStyle,
                 bullet: updateBullet,
             } = updateParagraph;
@@ -242,6 +243,7 @@ function updateParagraphs(
             for (const removeParagraph of removeParagraphs) {
                 const {
                     startIndex: removeStartIndex,
+                    paragraphId: removeParagraphId,
                     paragraphStyle: removeParagraphStyle,
                     bullet: removeBullet,
                 } = removeParagraph;
@@ -273,6 +275,7 @@ function updateParagraphs(
                 if (updateStartIndex === removeStartIndex) {
                     splitUpdateParagraphs.push({
                         startIndex: updateStartIndex,
+                        paragraphId: updateParagraphId ?? removeParagraphId,
                         paragraphStyle: newParagraphStyle,
                         bullet: newBullet,
                     });
@@ -284,9 +287,17 @@ function updateParagraphs(
         }
 
         updateBody.paragraphs = newUpdateParagraphs;
+    } else {
+        for (const updateParagraph of updateDataParagraphs) {
+            const removeParagraph = removeParagraphs.find((paragraph) => paragraph.startIndex === updateParagraph.startIndex);
+
+            if (removeParagraph && updateParagraph.paragraphId == null) {
+                updateParagraph.paragraphId = removeParagraph.paragraphId;
+            }
+        }
     }
 
-    insertParagraphs(body, updateBody, textLength, currentIndex);
+    insertParagraphs(body, updateBody, textLength, currentIndex, true);
 
     return removeParagraphs;
 }

--- a/packages/core/src/docs/data-model/text-x/build-utils/__test__/drawings.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/__test__/drawings.spec.ts
@@ -25,7 +25,7 @@ describe('drawing build utils', () => {
             id: 'doc-drawing',
             body: {
                 dataStream: 'A\bB\r\n',
-                paragraphs: [{ startIndex: 4 }],
+                paragraphs: [{ startIndex: 4, paragraphId: 'para_fixture_15' }],
                 customBlocks: [{ startIndex: 1, blockId: 'drawing-old' }],
             },
             drawings: {

--- a/packages/core/src/docs/data-model/text-x/build-utils/__test__/paragraph.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/__test__/paragraph.spec.ts
@@ -35,6 +35,7 @@ function createParagraphBody(): IDocumentBody {
         paragraphs: [
             {
                 startIndex: 5,
+                paragraphId: 'para_fixture_1069',
                 paragraphStyle: { horizontalAlign: HorizontalAlign.LEFT },
                 bullet: {
                     listId: 'bullet-prev',
@@ -45,6 +46,7 @@ function createParagraphBody(): IDocumentBody {
             },
             {
                 startIndex: 10,
+                paragraphId: 'para_fixture_1070',
                 paragraphStyle: { horizontalAlign: HorizontalAlign.LEFT },
                 bullet: {
                     listId: 'check-1',
@@ -55,6 +57,7 @@ function createParagraphBody(): IDocumentBody {
             },
             {
                 startIndex: 16,
+                paragraphId: 'para_fixture_1071',
                 paragraphStyle: { horizontalAlign: HorizontalAlign.RIGHT },
             },
         ],

--- a/packages/core/src/docs/data-model/text-x/build-utils/__test__/parse.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/__test__/parse.spec.ts
@@ -34,7 +34,7 @@ describe('parse build utils', () => {
 
         expect(body).toMatchObject({
             dataStream: 'https://univer.ai\rSecond line',
-            paragraphs: [{ startIndex: 17 }],
+            paragraphs: [{ startIndex: 17, paragraphId: expect.stringMatching(/^para_/) }],
             customRanges: [
                 {
                     startIndex: 0,

--- a/packages/core/src/docs/data-model/text-x/build-utils/__test__/text-x.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/__test__/text-x.ts
@@ -29,6 +29,7 @@ describe('test textX function', () => {
             paragraphs: [
                 {
                     startIndex: text.length - 1,
+                    paragraphId: 'para_fixture_1072',
                 },
             ],
             customRanges: [

--- a/packages/core/src/docs/data-model/text-x/build-utils/paragraph.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/paragraph.ts
@@ -66,7 +66,7 @@ export const switchParagraphBullet = (params: ISwitchParagraphBulletParams) => {
     const textX = new TextX();
 
     for (const paragraph of currentParagraphs) {
-        const { startIndex, paragraphStyle = {}, bullet } = paragraph;
+        const { startIndex, paragraphId, paragraphStyle = {}, bullet } = paragraph;
 
         textX.push({
             t: TextXActionType.RETAIN,
@@ -81,11 +81,13 @@ export const switchParagraphBullet = (params: ISwitchParagraphBulletParams) => {
                 paragraphs: [
                     isAlreadyList
                         ? {
+                            paragraphId,
                             paragraphStyle,
                             startIndex: 0,
                         }
                         : {
                             startIndex: 0,
+                            paragraphId,
                             paragraphStyle: {
                                 ...paragraphStyle,
                             },
@@ -193,7 +195,7 @@ export const setParagraphBullet = (params: ISetParagraphBulletParams) => {
     const textX = new TextX();
 
     for (const paragraph of currentParagraphs) {
-        const { startIndex, paragraphStyle = {}, bullet } = paragraph;
+        const { startIndex, paragraphId, paragraphStyle = {}, bullet } = paragraph;
 
         textX.push({
             t: TextXActionType.RETAIN,
@@ -208,6 +210,7 @@ export const setParagraphBullet = (params: ISetParagraphBulletParams) => {
                 paragraphs: [
                     {
                         startIndex: 0,
+                        paragraphId,
                         paragraphStyle,
                         bullet: {
                             nestingLevel: bullet?.nestingLevel ?? 0,
@@ -259,7 +262,7 @@ export const changeParagraphBulletNestLevel = (params: IChangeParagraphBulletNes
     };
 
     for (const paragraph of currentParagraphs) {
-        const { startIndex, paragraphStyle = {}, bullet } = paragraph;
+        const { startIndex, paragraphId, paragraphStyle = {}, bullet } = paragraph;
         const isInTable = hasParagraphInTable(paragraph, tables);
 
         textX.push({
@@ -282,6 +285,7 @@ export const changeParagraphBulletNestLevel = (params: IChangeParagraphBulletNes
                     paragraphs: [
                         {
                             startIndex: 0,
+                            paragraphId,
                             paragraphStyle: {
                                 ...paragraphStyle,
                             },
@@ -359,7 +363,7 @@ export const setParagraphStyle = (params: ISetParagraphStyleParams) => {
     }
 
     for (const paragraph of currentParagraphs) {
-        const { startIndex, paragraphStyle = {} } = paragraph;
+        const { startIndex, paragraphId, paragraphStyle = {} } = paragraph;
         const len = startIndex - memoryCursor.cursor;
         textX.push({
             t: TextXActionType.RETAIN,
@@ -387,6 +391,7 @@ export const setParagraphStyle = (params: ISetParagraphStyleParams) => {
                 paragraphs: [
                     {
                         startIndex: 0,
+                        paragraphId,
                         paragraphStyle: {
                             ...paragraphStyle,
                             ...style,

--- a/packages/core/src/docs/data-model/text-x/build-utils/parse.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/parse.ts
@@ -17,6 +17,7 @@
 import type { ICustomRange, IDocumentBody, IParagraph } from '../../../../types/interfaces';
 import { generateRandomId, Tools } from '../../../../shared';
 import { CustomRangeType } from '../../../../types/interfaces';
+import { createParagraphId } from '../../../paragraph-id';
 import { DataStreamTreeTokenType } from '../../types';
 
 const tags = [
@@ -53,6 +54,7 @@ export const isEmptyDocument = (dataStream?: string) => {
 export const fromPlainText = (text: string): IDocumentBody => {
     const dataStream = text.replace(/\n/g, '\r');
     const paragraphs: IParagraph[] = [];
+    const existingParagraphIds = new Set<string>();
     const customRanges: ICustomRange[] = [];
     let cursor = 0;
     let newDataStream = '';
@@ -76,13 +78,13 @@ export const fromPlainText = (text: string): IDocumentBody => {
             cursor = i + 1;
             if (insertP) {
                 newDataStream += '\r';
-                paragraphs.push({ startIndex: i });
+                paragraphs.push({ startIndex: i, paragraphId: createParagraphId(existingParagraphIds) });
             }
         } else {
             newDataStream += dataStream.slice(cursor, i + 1);
             cursor = i + 1;
             if (insertP) {
-                paragraphs.push({ startIndex: i });
+                paragraphs.push({ startIndex: i, paragraphId: createParagraphId(existingParagraphIds) });
             }
         }
     };

--- a/packages/core/src/docs/data-model/text-x/text-x.ts
+++ b/packages/core/src/docs/data-model/text-x/text-x.ts
@@ -22,11 +22,24 @@ import { Tools } from '../../../shared/tools';
 import { ActionIterator } from './action-iterator';
 import { TextXActionType } from './action-types';
 import { textXApply } from './apply';
+import { normalizeInsertedParagraphIdsForDocument, RESTORE_INSERTED_PARAGRAPH_IDS } from './apply-utils/common';
 import { transformBody } from './transform-utils';
 import { composeBody, getBodySlice, isUselessRetainAction } from './utils';
 
 function onlyHasDataStream(body: IDocumentBody) {
     return Object.keys(body).length === 1;
+}
+
+function normalizeInsertActionParagraphIds(
+    body: IDocumentBody,
+    doc: IDocumentBody,
+    currentIndex: number,
+    reservedParagraphIds: Set<string>
+) {
+    normalizeInsertedParagraphIdsForDocument(doc.paragraphs, body.paragraphs, currentIndex, {
+        freshenSplitParagraph: false,
+        reservedParagraphIds,
+    });
 }
 
 export type TPriority = 'left' | 'right';
@@ -230,6 +243,10 @@ export class TextX {
                     throw new Error('Can not invert DELETE action without body property, makeInvertible must be called first.');
                 }
 
+                if (action.body.paragraphs?.length) {
+                    (action.body as IDocumentBody & Record<string, unknown>)[RESTORE_INSERTED_PARAGRAPH_IDS] = true;
+                }
+
                 invertedActions.push({
                     t: TextXActionType.INSERT,
                     body: action.body,
@@ -261,8 +278,13 @@ export class TextX {
         const invertibleActions: TextXAction[] = [];
 
         let index = 0;
+        const reservedParagraphIds = new Set<string>();
 
         for (const action of actions) {
+            if (action.t === TextXActionType.INSERT) {
+                normalizeInsertActionParagraphIds(action.body, doc, index, reservedParagraphIds);
+            }
+
             if (action.t === TextXActionType.DELETE && (action.body == null || (action.body && action.body.dataStream.length !== action.len))) {
                 const body = getBodySlice(doc, index, index + action.len, false);
                 action.len = body.dataStream.length;

--- a/packages/core/src/docs/data-model/text-x/transform-utils.ts
+++ b/packages/core/src/docs/data-model/text-x/transform-utils.ts
@@ -266,6 +266,7 @@ function transformParagraph(
 ): IParagraph {
     const paragraph: IParagraph = {
         startIndex: targetParagraph.startIndex,
+        paragraphId: targetParagraph.paragraphId,
     };
 
     if (targetParagraph.paragraphStyle) {
@@ -350,6 +351,10 @@ function transformParagraph(
                 }
             }
         }
+    }
+
+    if (paragraph.bullet === undefined) {
+        delete paragraph.bullet;
     }
 
     return paragraph;
@@ -483,6 +488,7 @@ export function transformBody(
         if (thisStart === otherStart) {
             let paragraph: IParagraph = {
                 startIndex: thisStart,
+                paragraphId: otherParagraph.paragraphId,
             };
 
             if (priority) {

--- a/packages/core/src/docs/paragraph-id.ts
+++ b/packages/core/src/docs/paragraph-id.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IDocumentBody, IDocumentData, IParagraph } from '../types/interfaces/i-document-data';
+import type { IDocumentBody, IParagraph } from '../types/interfaces/i-document-data';
 import { generateRandomId } from '../shared/tools';
 
 export const PARAGRAPH_ID_PREFIX = 'para_';
@@ -36,45 +36,7 @@ export function createParagraphId(existingIds: Set<string>): string {
     return paragraphId;
 }
 
-export function normalizeDocumentParagraphIds(documentData: IDocumentData): IDocumentData {
-    if (documentData.body) {
-        normalizeBodyParagraphIds(documentData.body, { unitId: documentData.id, segmentId: '' });
-    }
-
-    Object.values(documentData.headers ?? {}).forEach((header) => {
-        if (header.body) {
-            normalizeBodyParagraphIds(header.body, { unitId: documentData.id, segmentId: header.headerId });
-        }
-    });
-
-    Object.values(documentData.footers ?? {}).forEach((footer) => {
-        if (footer.body) {
-            normalizeBodyParagraphIds(footer.body, { unitId: documentData.id, segmentId: footer.footerId });
-        }
-    });
-
-    return documentData;
-}
-
-export function normalizeBodyParagraphIds(body: IDocumentBody, scope: IParagraphIdScope): IDocumentBody {
-    ensureUniqueParagraphIds(body, scope);
-    return body;
-}
-
-export function ensureUniqueParagraphIds(body: IDocumentBody, _scope: IParagraphIdScope): void {
-    const existingIds = new Set<string>();
-
-    for (const paragraph of body.paragraphs ?? []) {
-        if (!isValidParagraphId(paragraph.paragraphId) || existingIds.has(paragraph.paragraphId)) {
-            paragraph.paragraphId = createParagraphId(existingIds);
-            continue;
-        }
-
-        existingIds.add(paragraph.paragraphId);
-    }
-}
-
-export function cloneBodyWithFreshParagraphIds(body: IDocumentBody, scope: IParagraphIdScope): IDocumentBody {
+export function cloneBodyWithFreshParagraphIds(body: IDocumentBody, _scope: IParagraphIdScope): IDocumentBody {
     const cloned = cloneBody(body);
     const existingIds = new Set<string>();
 
@@ -82,7 +44,6 @@ export function cloneBodyWithFreshParagraphIds(body: IDocumentBody, scope: IPara
         paragraph.paragraphId = createParagraphId(existingIds);
     }
 
-    ensureUniqueParagraphIds(cloned, scope);
     return cloned;
 }
 

--- a/packages/core/src/docs/paragraph-id.ts
+++ b/packages/core/src/docs/paragraph-id.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IDocumentBody, IDocumentData, IParagraph } from '../types/interfaces/i-document-data';
+import { generateRandomId } from '../shared/tools';
+
+export const PARAGRAPH_ID_PREFIX = 'para_';
+
+// Reserved so callers can pass the document segment context before ids become scoped.
+export interface IParagraphIdScope {
+    unitId: string;
+    segmentId?: string;
+}
+
+export function createParagraphId(existingIds: Set<string>): string {
+    let paragraphId = `${PARAGRAPH_ID_PREFIX}${generateRandomId(12)}`;
+
+    while (existingIds.has(paragraphId)) {
+        paragraphId = `${PARAGRAPH_ID_PREFIX}${generateRandomId(12)}`;
+    }
+
+    existingIds.add(paragraphId);
+    return paragraphId;
+}
+
+export function normalizeDocumentParagraphIds(documentData: IDocumentData): IDocumentData {
+    if (documentData.body) {
+        normalizeBodyParagraphIds(documentData.body, { unitId: documentData.id, segmentId: '' });
+    }
+
+    Object.values(documentData.headers ?? {}).forEach((header) => {
+        if (header.body) {
+            normalizeBodyParagraphIds(header.body, { unitId: documentData.id, segmentId: header.headerId });
+        }
+    });
+
+    Object.values(documentData.footers ?? {}).forEach((footer) => {
+        if (footer.body) {
+            normalizeBodyParagraphIds(footer.body, { unitId: documentData.id, segmentId: footer.footerId });
+        }
+    });
+
+    return documentData;
+}
+
+export function normalizeBodyParagraphIds(body: IDocumentBody, scope: IParagraphIdScope): IDocumentBody {
+    ensureUniqueParagraphIds(body, scope);
+    return body;
+}
+
+export function ensureUniqueParagraphIds(body: IDocumentBody, _scope: IParagraphIdScope): void {
+    const existingIds = new Set<string>();
+
+    for (const paragraph of body.paragraphs ?? []) {
+        if (!isValidParagraphId(paragraph.paragraphId) || existingIds.has(paragraph.paragraphId)) {
+            paragraph.paragraphId = createParagraphId(existingIds);
+            continue;
+        }
+
+        existingIds.add(paragraph.paragraphId);
+    }
+}
+
+export function cloneBodyWithFreshParagraphIds(body: IDocumentBody, scope: IParagraphIdScope): IDocumentBody {
+    const cloned = cloneBody(body);
+    const existingIds = new Set<string>();
+
+    for (const paragraph of cloned.paragraphs ?? []) {
+        paragraph.paragraphId = createParagraphId(existingIds);
+    }
+
+    ensureUniqueParagraphIds(cloned, scope);
+    return cloned;
+}
+
+export function cloneParagraphWithId(paragraph: IParagraph, existingIds: Set<string>, preserveId?: boolean): IParagraph {
+    const cloned = cloneParagraph(paragraph);
+
+    if (preserveId !== false && isValidParagraphId(cloned.paragraphId) && !existingIds.has(cloned.paragraphId)) {
+        existingIds.add(cloned.paragraphId);
+        return cloned;
+    }
+
+    cloned.paragraphId = createParagraphId(existingIds);
+    return cloned;
+}
+
+function isValidParagraphId(value: unknown): value is string {
+    return typeof value === 'string' && value.startsWith(PARAGRAPH_ID_PREFIX) && value.length > PARAGRAPH_ID_PREFIX.length;
+}
+
+function cloneBody(body: IDocumentBody): IDocumentBody {
+    return JSON.parse(JSON.stringify(body)) as IDocumentBody;
+}
+
+function cloneParagraph(paragraph: IParagraph): IParagraph {
+    return JSON.parse(JSON.stringify(paragraph)) as IParagraph;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,16 @@ export { mergeSets } from './common/set';
 export { UnitModel, UniverInstanceType } from './common/unit';
 export { isSafeUrl, normalizeUrl, resolveWithBasePath } from './common/url';
 export * from './docs/data-model';
+export {
+    cloneBodyWithFreshParagraphIds,
+    cloneParagraphWithId,
+    createParagraphId,
+    ensureUniqueParagraphIds,
+    normalizeBodyParagraphIds,
+    normalizeDocumentParagraphIds,
+    PARAGRAPH_ID_PREFIX,
+    type IParagraphIdScope,
+} from './docs/paragraph-id';
 export { JSON1, JSONX } from './docs/data-model/json-x/json-x';
 export type { JSONXActions, JSONXPath } from './docs/data-model/json-x/json-x';
 export { replaceInDocumentBody } from './docs/data-model/replacement';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,9 +103,6 @@ export {
     cloneBodyWithFreshParagraphIds,
     cloneParagraphWithId,
     createParagraphId,
-    ensureUniqueParagraphIds,
-    normalizeBodyParagraphIds,
-    normalizeDocumentParagraphIds,
     PARAGRAPH_ID_PREFIX,
     type IParagraphIdScope,
 } from './docs/paragraph-id';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,16 +58,6 @@ export { mergeSets } from './common/set';
 export { UnitModel, UniverInstanceType } from './common/unit';
 export { isSafeUrl, normalizeUrl, resolveWithBasePath } from './common/url';
 export * from './docs/data-model';
-export {
-    cloneBodyWithFreshParagraphIds,
-    cloneParagraphWithId,
-    createParagraphId,
-    ensureUniqueParagraphIds,
-    normalizeBodyParagraphIds,
-    normalizeDocumentParagraphIds,
-    PARAGRAPH_ID_PREFIX,
-    type IParagraphIdScope,
-} from './docs/paragraph-id';
 export { JSON1, JSONX } from './docs/data-model/json-x/json-x';
 export type { JSONXActions, JSONXPath } from './docs/data-model/json-x/json-x';
 export { replaceInDocumentBody } from './docs/data-model/replacement';
@@ -109,6 +99,16 @@ export {
     normalizeBody,
     SliceBodyType,
 } from './docs/data-model/text-x/utils';
+export {
+    cloneBodyWithFreshParagraphIds,
+    cloneParagraphWithId,
+    createParagraphId,
+    ensureUniqueParagraphIds,
+    normalizeBodyParagraphIds,
+    normalizeDocumentParagraphIds,
+    PARAGRAPH_ID_PREFIX,
+    type IParagraphIdScope,
+} from './docs/paragraph-id';
 export { EventState, EventSubject, fromEventSubject, type IEventObserver } from './observer/observable';
 export { AuthzIoLocalService } from './services/authz-io/authz-io-local.service';
 export { IAuthzIoService } from './services/authz-io/type';

--- a/packages/core/src/sheets/__tests__/cell-data.spec.ts
+++ b/packages/core/src/sheets/__tests__/cell-data.spec.ts
@@ -46,6 +46,7 @@ const DOCUMENT_DATA = {
         paragraphs: [
             {
                 startIndex: 10,
+                paragraphId: 'para_fixture_1080',
             },
         ],
     },

--- a/packages/core/src/sheets/__tests__/sheet-skeleton.integration.spec.ts
+++ b/packages/core/src/sheets/__tests__/sheet-skeleton.integration.spec.ts
@@ -241,7 +241,7 @@ describe('SheetSkeleton integration', () => {
             id: 'doc-in-skeleton',
             body: {
                 dataStream: 'Hello\r\n',
-                paragraphs: [{ startIndex: 5 }],
+                paragraphs: [{ startIndex: 5, paragraphId: 'para_fixture_17' }],
             },
             documentStyle: {
                 marginTop: 9,
@@ -281,6 +281,7 @@ describe('SheetSkeleton integration', () => {
             body: {
                 paragraphs: [{
                     startIndex: 5,
+                    paragraphId: 'para_fixture_17',
                     paragraphStyle: {
                         horizontalAlign: HorizontalAlign.CENTER,
                     },

--- a/packages/core/src/sheets/__tests__/util.spec.ts
+++ b/packages/core/src/sheets/__tests__/util.spec.ts
@@ -41,7 +41,11 @@ describe('sheet util helpers', () => {
         expect(documentModel.getBody()).toMatchObject({
             dataStream: 'Cell\r\n',
             textRuns: [{ st: 0, ed: 4, ts: { ff: 'Inter', fs: 12, va: BaselineOffset.SUPERSCRIPT } }],
-            paragraphs: [{ startIndex: 4, paragraphStyle: { horizontalAlign: HorizontalAlign.CENTER } }],
+            paragraphs: [{
+                startIndex: 4,
+                paragraphId: expect.stringMatching(/^para_/),
+                paragraphStyle: { horizontalAlign: HorizontalAlign.CENTER },
+            }],
         });
         expect(documentModel.getSnapshot().documentStyle).toMatchObject({
             marginTop: 1,

--- a/packages/core/src/sheets/util.ts
+++ b/packages/core/src/sheets/util.ts
@@ -20,6 +20,7 @@ import type { IDocumentData, IPaddingData, IStyleBase, IStyleData, ITextRotation
 import type { ICellData, IRange, IUnitRange } from './typedef';
 import { DEFAULT_EMPTY_DOCUMENT_VALUE } from '../common/const';
 import { BuildTextUtils, DocumentDataModel } from '../docs';
+import { createParagraphId } from '../docs/paragraph-id';
 import { TextX } from '../docs/data-model/text-x/text-x';
 import { convertTextRotation } from '../docs/data-model/utils';
 import { Rectangle } from '../shared';
@@ -95,6 +96,7 @@ export function createDocumentModelWithStyle(content: string, textStyle: ITextSt
             paragraphs: [
                 {
                     startIndex: contentLength,
+                    paragraphId: createParagraphId(new Set()),
                     paragraphStyle: {
                         horizontalAlign,
                     },

--- a/packages/core/src/types/interfaces/i-document-data.ts
+++ b/packages/core/src/types/interfaces/i-document-data.ts
@@ -572,7 +572,7 @@ export interface ISectionColumnProperties {
 export interface IParagraph {
     // elements: IElement[]; // elements
     startIndex: number;
-    paragraphId?: string;
+    paragraphId: string;
     paragraphStyle?: IParagraphStyle; // paragraphStyle
     bullet?: IBullet; // bullet
     // dIds?: string[]; // drawingIds drawingId

--- a/packages/core/src/types/interfaces/i-document-data.ts
+++ b/packages/core/src/types/interfaces/i-document-data.ts
@@ -572,6 +572,7 @@ export interface ISectionColumnProperties {
 export interface IParagraph {
     // elements: IElement[]; // elements
     startIndex: number;
+    paragraphId?: string;
     paragraphStyle?: IParagraphStyle; // paragraphStyle
     bullet?: IBullet; // bullet
     // dIds?: string[]; // drawingIds drawingId

--- a/packages/docs-drawing-ui/src/__tests__/create-doc-ui-test-bed.ts
+++ b/packages/docs-drawing-ui/src/__tests__/create-doc-ui-test-bed.ts
@@ -49,7 +49,7 @@ const DEFAULT_DOC_DATA: IDocumentData = {
                 bl: BooleanNumber.FALSE,
             },
         }],
-        paragraphs: [{ startIndex: 11 }],
+        paragraphs: [{ startIndex: 11, paragraphId: 'para_drawing_test' }],
         sectionBreaks: [],
         customBlocks: [],
     },

--- a/packages/docs-hyper-link-ui/src/__tests__/create-doc-ui-test-bed.ts
+++ b/packages/docs-hyper-link-ui/src/__tests__/create-doc-ui-test-bed.ts
@@ -49,7 +49,7 @@ const DEFAULT_DOC_DATA: IDocumentData = {
                 bl: BooleanNumber.FALSE,
             },
         }],
-        paragraphs: [{ startIndex: 11 }],
+        paragraphs: [{ startIndex: 11, paragraphId: 'para_hyper_link_test' }],
         sectionBreaks: [],
         customBlocks: [],
     },

--- a/packages/docs-mention-ui/src/__tests__/create-doc-ui-test-bed.ts
+++ b/packages/docs-mention-ui/src/__tests__/create-doc-ui-test-bed.ts
@@ -49,7 +49,7 @@ const DEFAULT_DOC_DATA: IDocumentData = {
                 bl: BooleanNumber.FALSE,
             },
         }],
-        paragraphs: [{ startIndex: 11 }],
+        paragraphs: [{ startIndex: 11, paragraphId: 'para_mention_test' }],
         sectionBreaks: [],
         customBlocks: [],
     },

--- a/packages/docs-quick-insert-ui/src/services/__tests__/doc-quick-insert-popup.service.spec.ts
+++ b/packages/docs-quick-insert-ui/src/services/__tests__/doc-quick-insert-popup.service.spec.ts
@@ -59,7 +59,7 @@ function createServiceTestBed() {
     const docDataModel = {
         getBody: () => ({
             dataStream,
-            paragraphs: [{ startIndex: 1 }],
+            paragraphs: [{ startIndex: 1, paragraphId: 'para_quick_insert_test' }],
         }),
     };
     const docEventManagerService = {

--- a/packages/docs-ui/src/commands/commands/__tests__/break-line.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/break-line.command.spec.ts
@@ -31,13 +31,10 @@ function getDocumentData(): IDocumentData {
                 ed: 5,
                 ts: {},
             }],
-            paragraphs: [{
-                startIndex: 5,
-                paragraphStyle: {
-                    headingId: 'heading-1',
-                    namedStyleType: NamedStyleType.HEADING_1,
-                },
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_1', startIndex: 5, paragraphStyle: {
+                headingId: 'heading-1',
+                namedStyleType: NamedStyleType.HEADING_1,
+            } }],
         },
         documentStyle: {
             pageSize: {

--- a/packages/docs-ui/src/commands/commands/__tests__/clipboard.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/clipboard.command.spec.ts
@@ -52,16 +52,11 @@ function getDocumentData() {
                 },
             ],
             paragraphs: [
-                {
-                    startIndex: 22,
-                },
-                {
-                    startIndex: 68,
-                    paragraphStyle: {
-                        spaceAbove: { v: 20 },
-                        indentFirstLine: { v: 20 },
-                    },
-                },
+                { paragraphId: 'para_docs_ui_fixture_2', startIndex: 22 },
+                { paragraphId: 'para_docs_ui_fixture_3', startIndex: 68, paragraphStyle: {
+                    spaceAbove: { v: 20 },
+                    indentFirstLine: { v: 20 },
+                } },
             ],
             sectionBreaks: [],
             customBlocks: [],

--- a/packages/docs-ui/src/commands/commands/__tests__/core-editing.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/core-editing.command.spec.ts
@@ -85,12 +85,9 @@ function getCenteredSingleCharacterDocumentData(): IDocumentData {
                 ed: 1,
                 ts: {},
             }],
-            paragraphs: [{
-                startIndex: 1,
-                paragraphStyle: {
-                    horizontalAlign: HorizontalAlign.CENTER,
-                },
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_4', startIndex: 1, paragraphStyle: {
+                horizontalAlign: HorizontalAlign.CENTER,
+            } }],
         },
         documentStyle: {
             pageSize: {
@@ -110,12 +107,9 @@ function getCenteredEmptyParagraphDocumentData(): IDocumentData {
         id: 'test-doc',
         body: {
             dataStream: '\r\n',
-            paragraphs: [{
-                startIndex: 0,
-                paragraphStyle: {
-                    horizontalAlign: HorizontalAlign.CENTER,
-                },
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_5', startIndex: 0, paragraphStyle: {
+                horizontalAlign: HorizontalAlign.CENTER,
+            } }],
         },
         documentStyle: {
             pageSize: {
@@ -135,12 +129,9 @@ function getIndentedBlockRangeDocumentData(): IDocumentData {
         id: 'test-doc',
         body: {
             dataStream: `${DataStreamTreeTokenType.BLOCK_START}A${DataStreamTreeTokenType.PARAGRAPH}${DataStreamTreeTokenType.BLOCK_END}\n`,
-            paragraphs: [{
-                startIndex: 2,
-                paragraphStyle: {
-                    indentStart: { v: 22 },
-                },
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_6', startIndex: 2, paragraphStyle: {
+                indentStart: { v: 22 },
+            } }],
             blockRanges: [{
                 blockId: 'quote-1',
                 blockType: DocumentBlockRangeType.QUOTE,

--- a/packages/docs-ui/src/commands/commands/__tests__/create-command-test-bed.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/create-command-test-bed.ts
@@ -69,16 +69,11 @@ const TEST_DOCUMENT_DATA_EN: IDocumentData = {
             },
         ],
         paragraphs: [
-            {
-                startIndex: 22,
-            },
-            {
-                startIndex: 68,
-                paragraphStyle: {
-                    spaceAbove: { v: 20 },
-                    indentFirstLine: { v: 20 },
-                },
-            },
+            { paragraphId: 'para_docs_ui_fixture_7', startIndex: 22 },
+            { paragraphId: 'para_docs_ui_fixture_8', startIndex: 68, paragraphStyle: {
+                spaceAbove: { v: 20 },
+                indentFirstLine: { v: 20 },
+            } },
         ],
         sectionBreaks: [],
         customBlocks: [],

--- a/packages/docs-ui/src/commands/commands/__tests__/doc-block-move.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/doc-block-move.command.spec.ts
@@ -22,7 +22,7 @@ import { buildMoveDocBlockActions } from '../doc-block-move.command';
 describe('buildMoveDocBlockActions', () => {
     it('moves a paragraph and remaps paragraph indexes', () => {
         const documentData = createDocument('A\rB\rC\r\n', {
-            paragraphs: [{ startIndex: 1 }, { startIndex: 3 }, { startIndex: 5 }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_9', startIndex: 1 }, { paragraphId: 'para_docs_ui_fixture_10', startIndex: 3 }, { paragraphId: 'para_docs_ui_fixture_11', startIndex: 5 }],
             sectionBreaks: [{ startIndex: 6 }],
         });
 
@@ -39,7 +39,7 @@ describe('buildMoveDocBlockActions', () => {
 
     it('moves a block range as one unit', () => {
         const documentData = createDocument('aa\rBB\rcc\r\n', {
-            paragraphs: [{ startIndex: 2 }, { startIndex: 5 }, { startIndex: 8 }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_12', startIndex: 2 }, { paragraphId: 'para_docs_ui_fixture_13', startIndex: 5 }, { paragraphId: 'para_docs_ui_fixture_14', startIndex: 8 }],
             sectionBreaks: [{ startIndex: 9 }],
             blockRanges: [{ blockId: 'quote-1', blockType: DocumentBlockRangeType.QUOTE, startIndex: 3, endIndex: 5 }],
         });
@@ -58,7 +58,7 @@ describe('buildMoveDocBlockActions', () => {
 
     it('moves a table range and remaps custom ranges and text runs', () => {
         const documentData = createDocument('aa\rTT\rcc\r\n', {
-            paragraphs: [{ startIndex: 2 }, { startIndex: 5 }, { startIndex: 8 }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_15', startIndex: 2 }, { paragraphId: 'para_docs_ui_fixture_16', startIndex: 5 }, { paragraphId: 'para_docs_ui_fixture_17', startIndex: 8 }],
             sectionBreaks: [{ startIndex: 9 }],
             tables: [{ tableId: 'table-1', startIndex: 3, endIndex: 6 }],
             customRanges: [{ rangeId: 'comment-1', rangeType: CustomRangeType.COMMENT, startIndex: 6, endIndex: 7 }],
@@ -79,7 +79,7 @@ describe('buildMoveDocBlockActions', () => {
 
     it('moves a custom block paragraph and keeps the custom block attached', () => {
         const documentData = createDocument('\b\raa\r\n', {
-            paragraphs: [{ startIndex: 1 }, { startIndex: 4 }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_18', startIndex: 1 }, { paragraphId: 'para_docs_ui_fixture_19', startIndex: 4 }],
             sectionBreaks: [{ startIndex: 5 }],
             customBlocks: [{ blockId: 'custom-1', blockType: BlockType.CUSTOM, startIndex: 0 }],
         });

--- a/packages/docs-ui/src/commands/commands/__tests__/list.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/list.command.spec.ts
@@ -37,8 +37,8 @@ function getDocumentData(): IDocumentData {
         body: {
             dataStream: 'Alpha\rBeta\r\n',
             paragraphs: [
-                { startIndex: 5 },
-                { startIndex: 10 },
+                { paragraphId: 'para_docs_ui_fixture_20', startIndex: 5 },
+                { paragraphId: 'para_docs_ui_fixture_21', startIndex: 10 },
             ],
         },
         documentStyle: {

--- a/packages/docs-ui/src/commands/commands/__tests__/misc.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/misc.command.spec.ts
@@ -52,9 +52,7 @@ function createBaseDoc(dataStream = 'Hello world\r\n'): IDocumentData {
                 ed: dataStream.length - 2,
                 ts: {},
             }],
-            paragraphs: [{
-                startIndex: dataStream.length - 2,
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_22', startIndex: dataStream.length - 2 }],
             sectionBreaks: [{
                 startIndex: dataStream.length - 1,
             }],
@@ -83,15 +81,10 @@ function createMultiParagraphDoc(): IDocumentData {
                 ed: 10,
                 ts: {},
             }],
-            paragraphs: [{
-                startIndex: 5,
-                paragraphStyle: {
-                    namedStyleType: NamedStyleType.HEADING_1,
-                    headingId: 'heading-1',
-                },
-            }, {
-                startIndex: 10,
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_23', startIndex: 5, paragraphStyle: {
+                namedStyleType: NamedStyleType.HEADING_1,
+                headingId: 'heading-1',
+            } }, { paragraphId: 'para_docs_ui_fixture_24', startIndex: 10 }],
             sectionBreaks: [{
                 startIndex: 11,
             }],
@@ -130,9 +123,7 @@ function createTableDoc(): IDocumentData {
                     ...paragraph,
                     startIndex: paragraph.startIndex + prefix.length,
                 })),
-                {
-                    startIndex: dataStream.length - 2,
-                },
+                { paragraphId: 'para_docs_ui_fixture_25', startIndex: dataStream.length - 2 },
             ],
             sectionBreaks: [
                 ...table.sectionBreaks.map((sectionBreak) => ({
@@ -179,15 +170,13 @@ function createTableDocWithParagraphsBeforeTable(): IDocumentData {
                 ts: {},
             }],
             paragraphs: [
-                { startIndex: 5 },
-                { startIndex: 10 },
+                { paragraphId: 'para_docs_ui_fixture_26', startIndex: 5 },
+                { paragraphId: 'para_docs_ui_fixture_27', startIndex: 10 },
                 ...table.paragraphs.map((paragraph) => ({
                     ...paragraph,
                     startIndex: paragraph.startIndex + prefix.length,
                 })),
-                {
-                    startIndex: dataStream.length - 2,
-                },
+                { paragraphId: 'para_docs_ui_fixture_28', startIndex: dataStream.length - 2 },
             ],
             sectionBreaks: [
                 ...table.sectionBreaks.map((sectionBreak) => ({

--- a/packages/docs-ui/src/commands/commands/__tests__/set-heading.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/set-heading.command.spec.ts
@@ -26,9 +26,7 @@ function getHeadingDocumentData(): IDocumentData {
         id: 'test-doc',
         body: {
             dataStream: 'Heading\r\n',
-            paragraphs: [{
-                startIndex: 7,
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_29', startIndex: 7 }],
         },
         documentStyle: {
             pageSize: {
@@ -48,9 +46,7 @@ function getQuickHeadingDocumentData(): IDocumentData {
         id: 'test-doc',
         body: {
             dataStream: '# Heading\r\n',
-            paragraphs: [{
-                startIndex: 9,
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_30', startIndex: 9 }],
         },
         documentStyle: {
             pageSize: {

--- a/packages/docs-ui/src/commands/commands/break-line.command.ts
+++ b/packages/docs-ui/src/commands/commands/break-line.command.ts
@@ -16,7 +16,7 @@
 
 import type { DocumentDataModel, ICommand, IDocumentBody, IMutationInfo, IParagraph, IParagraphBorder, ITextRangeParam } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
-import { BuildTextUtils, CommandType, DataStreamTreeTokenType, generateRandomId, getRichTextEditPath, ICommandService, IUniverInstanceService, JSONX, PresetListType, TextX, TextXActionType, Tools, UniverInstanceType, UpdateDocsAttributeType } from '@univerjs/core';
+import { BuildTextUtils, CommandType, createParagraphId, DataStreamTreeTokenType, generateRandomId, getRichTextEditPath, ICommandService, IUniverInstanceService, JSONX, PresetListType, TextX, TextXActionType, Tools, UniverInstanceType, UpdateDocsAttributeType } from '@univerjs/core';
 import { DocSelectionManagerService, RichTextEditingMutation } from '@univerjs/docs';
 import { getTextRunAtPosition } from '../../basics/paragraph';
 import { DocMenuStyleService } from '../../services/doc-menu-style.service';
@@ -27,6 +27,7 @@ export function generateParagraphs(
     borderBottom?: IParagraphBorder
 ): IParagraph[] {
     const paragraphs: IParagraph[] = [];
+    const existingParagraphIds = new Set<string>();
 
     for (let i = 0, len = dataStream.length; i < len; i++) {
         const char = dataStream[i];
@@ -37,6 +38,7 @@ export function generateParagraphs(
 
         paragraphs.push({
             startIndex: i,
+            paragraphId: createParagraphId(existingParagraphIds),
         });
     }
 

--- a/packages/docs-ui/src/commands/commands/doc-delete.command.ts
+++ b/packages/docs-ui/src/commands/commands/doc-delete.command.ts
@@ -513,7 +513,7 @@ export const DeleteLeftCommand: ICommand = {
 
             const paragraphIndex = paragraph?.startIndex;
 
-            const updateParagraph: IParagraph = { startIndex: 0 };
+            const updateParagraph: IParagraph = { startIndex: 0, paragraphId: paragraph.paragraphId };
 
             const paragraphStyle = paragraph.paragraphStyle;
 

--- a/packages/docs-ui/src/commands/commands/doc-header-footer.command.ts
+++ b/packages/docs-ui/src/commands/commands/doc-header-footer.command.ts
@@ -17,7 +17,7 @@
 import type { DocumentDataModel, ICommand, IDocumentBody, IMutationInfo, JSONXActions } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
 import type { ITextRangeWithStyle } from '@univerjs/engine-render';
-import { BooleanNumber, CommandType, generateRandomId, ICommandService, IUniverInstanceService, JSONX } from '@univerjs/core';
+import { BooleanNumber, CommandType, createParagraphId, generateRandomId, ICommandService, IUniverInstanceService, JSONX } from '@univerjs/core';
 import { DocSelectionManagerService, DocSkeletonManagerService, RichTextEditingMutation } from '@univerjs/docs';
 import { DocumentEditArea, IRenderManagerService } from '@univerjs/engine-render';
 import { findFirstCursorOffset } from '../../basics/selection';
@@ -39,6 +39,7 @@ function getEmptyHeaderFooterBody(): IDocumentBody {
         paragraphs: [
             {
                 startIndex: 0,
+                paragraphId: createParagraphId(new Set()),
                 paragraphStyle: {
                     spaceAbove: { v: 0 },
                     lineSpacing: 1.5,

--- a/packages/docs-ui/src/commands/commands/insert-below/insert-bullet-below.command.ts
+++ b/packages/docs-ui/src/commands/commands/insert-below/insert-bullet-below.command.ts
@@ -16,7 +16,7 @@
 
 import type { DocumentDataModel, ICommand, IDocumentBody, IMutationInfo, PresetListType } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
-import { BuildTextUtils, CommandType, getRichTextEditPath, ICommandService, IUniverInstanceService, JSONX, UniverInstanceType } from '@univerjs/core';
+import { BuildTextUtils, CommandType, createParagraphId, getRichTextEditPath, ICommandService, IUniverInstanceService, JSONX, UniverInstanceType } from '@univerjs/core';
 import { DocSelectionManagerService, RichTextEditingMutation } from '@univerjs/docs';
 
 interface IInsertBulletBelowCommandParams {
@@ -56,6 +56,7 @@ export const InsertBulletBelowCommand: ICommand<IInsertBulletBelowCommandParams>
             dataStream: '\r',
             paragraphs: [{
                 startIndex: 0,
+                paragraphId: createParagraphId(new Set(paragraphs.map((paragraph) => paragraph.paragraphId))),
                 bullet: {
                     listType,
                     listId: listType === currentParagraph.bullet?.listType ? currentParagraph.bullet.listId : '',

--- a/packages/docs-ui/src/commands/commands/list.command.ts
+++ b/packages/docs-ui/src/commands/commands/list.command.ts
@@ -20,6 +20,7 @@ import type { ITextRangeWithStyle } from '@univerjs/engine-render';
 import {
     BuildTextUtils,
     CommandType,
+    createParagraphId,
     generateRandomId,
     getRichTextEditPath,
     ICommandService,
@@ -453,6 +454,7 @@ export const QuickListCommand: ICommand<IQuickListCommandParams> = {
                 paragraphs: [
                     {
                         startIndex: 0,
+                        paragraphId: paragraph.paragraphId,
                         paragraphStyle: {
                             ...paragraphStyle,
                             textStyle: {
@@ -515,6 +517,7 @@ function insertList(accessor: IAccessor, listType: PresetListType) {
             paragraphs: [
                 {
                     startIndex: 0,
+                    paragraphId: createParagraphId(new Set()),
                     paragraphStyle: {
                         ...(sourceParagraph?.paragraphStyle ?? {}),
                     },

--- a/packages/docs-ui/src/commands/commands/set-heading.command.ts
+++ b/packages/docs-ui/src/commands/commands/set-heading.command.ts
@@ -20,6 +20,7 @@ import type { ITextRangeWithStyle } from '@univerjs/engine-render';
 import {
     BuildTextUtils,
     CommandType,
+    createParagraphId,
     generateRandomId,
     getRichTextEditPath,
     ICommandService,
@@ -121,6 +122,7 @@ function insertNamedStyleParagraph(
             dataStream: '\r',
             paragraphs: [{
                 startIndex: 0,
+                paragraphId: createParagraphId(new Set()),
                 paragraphStyle: {
                     namedStyleType,
                     headingId: !namedStyleType || namedStyleType === NamedStyleType.NORMAL_TEXT ? undefined : generateRandomId(6),

--- a/packages/docs-ui/src/commands/commands/table/table.ts
+++ b/packages/docs-ui/src/commands/commands/table/table.ts
@@ -16,7 +16,7 @@
 
 import type { IParagraph, ISectionBreak, ITable, ITableCell, ITableColumn, ITableRow, Nullable } from '@univerjs/core';
 import type { DataStreamTreeNode, DocumentViewModel, ITextRangeWithStyle } from '@univerjs/engine-render';
-import { DataStreamTreeTokenType, generateRandomId, ObjectRelativeFromH, ObjectRelativeFromV, TableAlignmentType, TableRowHeightRule, TableSizeType, TableTextWrapType, Tools } from '@univerjs/core';
+import { createParagraphId, DataStreamTreeTokenType, generateRandomId, ObjectRelativeFromH, ObjectRelativeFromV, TableAlignmentType, TableRowHeightRule, TableSizeType, TableTextWrapType, Tools } from '@univerjs/core';
 
 export enum INSERT_ROW_POSITION {
     ABOVE,
@@ -32,6 +32,7 @@ export function genEmptyTable(rowCount: number, colCount: number) {
     let dataStream: string = DataStreamTreeTokenType.TABLE_START;
     const paragraphs: IParagraph[] = [];
     const sectionBreaks: ISectionBreak[] = [];
+    const existingParagraphIds = new Set<string>();
 
     for (let i = 0; i < rowCount; i++) {
         dataStream += DataStreamTreeTokenType.TABLE_ROW_START;
@@ -40,6 +41,7 @@ export function genEmptyTable(rowCount: number, colCount: number) {
             dataStream += `${DataStreamTreeTokenType.TABLE_CELL_START}\r\n${DataStreamTreeTokenType.TABLE_CELL_END}`;
             paragraphs.push({
                 startIndex: dataStream.length - 3,
+                paragraphId: createParagraphId(existingParagraphIds),
                 paragraphStyle: {
                     spaceAbove: { v: 3 },
                     lineSpacing: 2,
@@ -217,11 +219,13 @@ export function getInsertRowBody(col: number) {
     let dataStream: string = DataStreamTreeTokenType.TABLE_ROW_START;
     const paragraphs: IParagraph[] = [];
     const sectionBreaks: ISectionBreak[] = [];
+    const existingParagraphIds = new Set<string>();
 
     for (let i = 0; i < col; i++) {
         dataStream += `${DataStreamTreeTokenType.TABLE_CELL_START}\r\n${DataStreamTreeTokenType.TABLE_CELL_END}`;
         paragraphs.push({
             startIndex: dataStream.length - 3,
+            paragraphId: createParagraphId(existingParagraphIds),
             paragraphStyle: {
                 spaceAbove: { v: 3 },
                 lineSpacing: 2,
@@ -249,6 +253,7 @@ export function getInsertColumnBody() {
 
     paragraphs.push({
         startIndex: 1,
+        paragraphId: createParagraphId(new Set()),
         paragraphStyle: {
             spaceAbove: { v: 3 },
             lineSpacing: 2,

--- a/packages/docs-ui/src/components/editor/utils.ts
+++ b/packages/docs-ui/src/components/editor/utils.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IDocumentData } from '@univerjs/core';
-import { DEFAULT_EMPTY_DOCUMENT_VALUE, DocumentFlavor } from '@univerjs/core';
+import { createParagraphId, DEFAULT_EMPTY_DOCUMENT_VALUE, DocumentFlavor } from '@univerjs/core';
 
 /**
  *
@@ -26,11 +26,13 @@ export function genSnapShotByValue(id = '', value = '') {
     const dataStream = `${value}${DEFAULT_EMPTY_DOCUMENT_VALUE}`;
     const paragraphs = [];
     const sectionBreaks = [];
+    const existingParagraphIds = new Set<string>();
 
     for (let i = 0; i < dataStream.length; i++) {
         if (dataStream[i] === '\r') {
             paragraphs.push({
                 startIndex: i,
+                paragraphId: createParagraphId(existingParagraphIds),
             });
         }
 

--- a/packages/docs-ui/src/controllers/__tests__/doc-auto-format.controller.spec.ts
+++ b/packages/docs-ui/src/controllers/__tests__/doc-auto-format.controller.spec.ts
@@ -60,16 +60,12 @@ describe('doc auto format controller', () => {
 
         expect(listTabRule.match({
             selection: { startOffset: 4 },
-            paragraphs: [{
-                paragraphStart: 4,
-                startIndex: 4,
-                bullet: { listId: 'list-1' },
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_31', paragraphStart: 4, startIndex: 4, bullet: { listId: 'list-1' } }],
             unit: {
                 getBody: () => ({
                     paragraphs: [
-                        { startIndex: 1, bullet: { listId: 'list-1' } },
-                        { startIndex: 4, bullet: { listId: 'list-1' } },
+                        { paragraphId: 'para_docs_ui_fixture_32', startIndex: 1, bullet: { listId: 'list-1' } },
+                        { paragraphId: 'para_docs_ui_fixture_33', startIndex: 4, bullet: { listId: 'list-1' } },
                     ],
                 }),
             },
@@ -97,14 +93,14 @@ describe('doc auto format controller', () => {
         const quickListText = Object.keys(QuickListTypeMap)[0];
         expect(spaceRule.match({
             selection: { collapsed: true, startOffset: quickListText.length + 1 },
-            paragraphs: [{ paragraphStart: 0 }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_34', paragraphStart: 0 }],
             unit: {
                 getBody: () => ({ dataStream: `${quickListText} \r\n` }),
             },
         })).toBe(true);
         expect(spaceRule.getMutations({
             selection: { startOffset: quickListText.length + 1 },
-            paragraphs: [{ paragraphStart: 0, startIndex: 0 }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_35', paragraphStart: 0, startIndex: 0 }],
             unit: {
                 getBody: () => ({ dataStream: `${quickListText} \r\n` }),
             },
@@ -112,14 +108,14 @@ describe('doc auto format controller', () => {
             id: QuickListCommand.id,
             params: {
                 listType: QuickListTypeMap[quickListText as keyof typeof QuickListTypeMap],
-                paragraph: { paragraphStart: 0, startIndex: 0 },
+                paragraph: { paragraphId: 'para_docs_ui_fixture_35', paragraphStart: 0, startIndex: 0 },
             },
         }]);
 
         const quickHeadingText = Object.keys(QUICK_HEADING_MAP)[0];
         expect(spaceRule.getMutations({
             selection: { startOffset: quickHeadingText.length + 1 },
-            paragraphs: [{ paragraphStart: 0 }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_36', paragraphStart: 0 }],
             unit: {
                 getBody: () => ({ dataStream: `${quickHeadingText} \r\n` }),
             },
@@ -131,16 +127,10 @@ describe('doc auto format controller', () => {
         }]);
 
         expect(exitListRule.match({
-            paragraphs: [{
-                bullet: { listType: 'bullet', nestingLevel: 0 },
-                paragraphStart: 0,
-                paragraphEnd: 0,
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_37', bullet: { listType: 'bullet', nestingLevel: 0 }, paragraphStart: 0, paragraphEnd: 0 }],
         })).toBe(true);
         expect(exitListRule.getMutations({
-            paragraphs: [{
-                bullet: { listType: 'bullet', nestingLevel: 1 },
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_38', bullet: { listType: 'bullet', nestingLevel: 1 } }],
         })).toEqual([{
             id: ChangeListNestingLevelCommand.id,
             params: {
@@ -148,9 +138,7 @@ describe('doc auto format controller', () => {
             },
         }]);
         expect(exitListRule.getMutations({
-            paragraphs: [{
-                bullet: { listType: 'bullet', nestingLevel: 0 },
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_39', bullet: { listType: 'bullet', nestingLevel: 0 } }],
         })).toEqual([{
             id: ListOperationCommand.id,
             params: {

--- a/packages/docs-ui/src/controllers/render-controllers/__tests__/doc-paragraph-placeholder.render-controller.spec.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/__tests__/doc-paragraph-placeholder.render-controller.spec.ts
@@ -17,8 +17,8 @@
 import type { IDocumentBody, IParagraph } from '@univerjs/core';
 import type { IDocumentSkeletonLine, IDocumentSkeletonPage } from '@univerjs/engine-render';
 import { DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY, DocumentFlavor, NamedStyleType } from '@univerjs/core';
-import { describe, expect, it } from 'vitest';
 import { DocumentSkeletonPageType, GlyphType, LineType } from '@univerjs/engine-render';
+import { describe, expect, it } from 'vitest';
 import { getParagraphPlaceholderLayouts, shouldRenderParagraphPlaceholder } from '../doc-paragraph-placeholder.render-controller';
 
 const locale = {
@@ -205,7 +205,7 @@ describe('doc paragraph placeholder render controller', () => {
 
     it('shows normal text placeholder for an empty normal paragraph', () => {
         const page = createPage([createLine(0, { fontSize: 13, fontFamily: 'Inter' })]);
-        const body = createBody('\r\n', [{ startIndex: 0 }]);
+        const body = createBody('\r\n', [{ startIndex: 0, paragraphId: 'para_placeholder_normal' }]);
 
         const placeholders = getParagraphPlaceholderLayouts(page, body, locale);
 
@@ -223,6 +223,7 @@ describe('doc paragraph placeholder render controller', () => {
         const page = createPage([createLine(0, { fontSize: 20 })]);
         const body = createBody('\r\n', [{
             startIndex: 0,
+            paragraphId: 'para_placeholder_heading',
             paragraphStyle: {
                 namedStyleType: NamedStyleType.HEADING_1,
             },
@@ -241,6 +242,7 @@ describe('doc paragraph placeholder render controller', () => {
         const page = createPage([createLine(0, { bullet: true, fontSize: 14 })]);
         const body = createBody('\r\n', [{
             startIndex: 0,
+            paragraphId: 'para_placeholder_list',
             bullet: {
                 listId: 'list-1',
                 listType: 'decimal',
@@ -259,7 +261,7 @@ describe('doc paragraph placeholder render controller', () => {
 
     it('hides placeholder once the paragraph has text', () => {
         const page = createPage([createLine(5, { st: 0 })]);
-        const body = createBody('Hello\r\n', [{ startIndex: 5 }]);
+        const body = createBody('Hello\r\n', [{ startIndex: 5, paragraphId: 'para_placeholder_text' }]);
 
         const placeholders = getParagraphPlaceholderLayouts(page, body, locale);
 
@@ -271,7 +273,10 @@ describe('doc paragraph placeholder render controller', () => {
             createLine(0, { st: 0, top: 20 }),
             createLine(1, { st: 1, top: 50 }),
         ]);
-        const body = createBody('\r\r\n', [{ startIndex: 0 }, { startIndex: 1 }]);
+        const body = createBody('\r\r\n', [
+            { startIndex: 0, paragraphId: 'para_placeholder_active_1' },
+            { startIndex: 1, paragraphId: 'para_placeholder_active_2' },
+        ]);
 
         const placeholders = getParagraphPlaceholderLayouts(page, body, locale, 0, 0, 1);
 

--- a/packages/docs-ui/src/services/__tests__/doc-services.spec.ts
+++ b/packages/docs-ui/src/services/__tests__/doc-services.spec.ts
@@ -37,11 +37,7 @@ function createDocData(): IDocumentData {
                 ed: 22,
                 ts: {},
             }],
-            paragraphs: [{
-                startIndex: 11,
-            }, {
-                startIndex: 23,
-            }],
+            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_44', startIndex: 11 }, { paragraphId: 'para_docs_ui_fixture_45', startIndex: 23 }],
             sectionBreaks: [{
                 startIndex: 24,
             }],

--- a/packages/docs-ui/src/services/clipboard/__test__/clipboard.service.spec.ts
+++ b/packages/docs-ui/src/services/clipboard/__test__/clipboard.service.spec.ts
@@ -31,10 +31,10 @@ describe('DocClipboardService table copy helpers', () => {
         const body: IDocumentBody = {
             dataStream,
             paragraphs: [
-                { startIndex: 5 },
-                { startIndex: tableStart + tokens.TABLE_START.length + tokens.TABLE_ROW_START.length + tokens.TABLE_CELL_START.length + 1 },
-                { startIndex: tableStart + tokens.TABLE_START.length + tokens.TABLE_ROW_START.length + tokens.TABLE_CELL_START.length + 'A\r\n'.length + tokens.TABLE_CELL_END.length + tokens.TABLE_CELL_START.length + 1 },
-                { startIndex: dataStream.length - 1 },
+                { paragraphId: 'para_docs_ui_fixture_46', startIndex: 5 },
+                { paragraphId: 'para_docs_ui_fixture_47', startIndex: tableStart + tokens.TABLE_START.length + tokens.TABLE_ROW_START.length + tokens.TABLE_CELL_START.length + 1 },
+                { paragraphId: 'para_docs_ui_fixture_48', startIndex: tableStart + tokens.TABLE_START.length + tokens.TABLE_ROW_START.length + tokens.TABLE_CELL_START.length + 'A\r\n'.length + tokens.TABLE_CELL_END.length + tokens.TABLE_CELL_START.length + 1 },
+                { paragraphId: 'para_docs_ui_fixture_49', startIndex: dataStream.length - 1 },
             ],
             sectionBreaks: [],
             tables: [{

--- a/packages/docs-ui/src/services/clipboard/__test__/html-and-udm-convert.spec.ts
+++ b/packages/docs-ui/src/services/clipboard/__test__/html-and-udm-convert.spec.ts
@@ -289,10 +289,10 @@ describe('test case in html and udm convert', () => {
                         { blockId: 'callout-1', blockType: DocumentBlockRangeType.CALLOUT, startIndex: 11, endIndex: 18 },
                     ],
                     paragraphs: [
-                        { startIndex: 5 },
-                        { startIndex: 10 },
-                        { startIndex: 18 },
-                        { startIndex: 23, bullet: { listId: 'list-1', listType: 'ORDER_LIST', nestingLevel: 0 } },
+                        { paragraphId: 'para_docs_ui_fixture_50', startIndex: 5 },
+                        { paragraphId: 'para_docs_ui_fixture_51', startIndex: 10 },
+                        { paragraphId: 'para_docs_ui_fixture_52', startIndex: 18 },
+                        { paragraphId: 'para_docs_ui_fixture_53', startIndex: 23, bullet: { listId: 'list-1', listType: 'ORDER_LIST', nestingLevel: 0 } },
                     ],
                 },
             }]);
@@ -332,10 +332,10 @@ describe('test case in html and udm convert', () => {
                     dataStream,
                     tables: [{ startIndex: 0, endIndex: dataStream.length, tableId: 'table-1' }],
                     paragraphs: [
-                        { startIndex: 9, paragraphStyle: { horizontalAlign: HorizontalAlign.CENTER } },
-                        { startIndex: 13 },
-                        { startIndex: 21 },
-                        { startIndex: 27 },
+                        { paragraphId: 'para_docs_ui_fixture_54', startIndex: 9, paragraphStyle: { horizontalAlign: HorizontalAlign.CENTER } },
+                        { paragraphId: 'para_docs_ui_fixture_55', startIndex: 13 },
+                        { paragraphId: 'para_docs_ui_fixture_56', startIndex: 21 },
+                        { paragraphId: 'para_docs_ui_fixture_57', startIndex: 27 },
                     ],
                     sectionBreaks: [{ startIndex: 10 }, { startIndex: 14 }, { startIndex: 22 }, { startIndex: 28 }],
                 },
@@ -394,9 +394,9 @@ describe('test case in html and udm convert', () => {
                 body: {
                     dataStream: 'One\rNested\rTwo\r',
                     paragraphs: [
-                        { startIndex: 3, bullet: { listId: 'list-1', listType: 'ORDER_LIST', nestingLevel: 0 } },
-                        { startIndex: 10, bullet: { listId: 'list-1', listType: 'BULLET_LIST', nestingLevel: 1 } },
-                        { startIndex: 14, bullet: { listId: 'list-1', listType: 'ORDER_LIST', nestingLevel: 0 } },
+                        { paragraphId: 'para_docs_ui_fixture_58', startIndex: 3, bullet: { listId: 'list-1', listType: 'ORDER_LIST', nestingLevel: 0 } },
+                        { paragraphId: 'para_docs_ui_fixture_59', startIndex: 10, bullet: { listId: 'list-1', listType: 'BULLET_LIST', nestingLevel: 1 } },
+                        { paragraphId: 'para_docs_ui_fixture_60', startIndex: 14, bullet: { listId: 'list-1', listType: 'ORDER_LIST', nestingLevel: 0 } },
                     ],
                 },
             }]);
@@ -418,16 +418,11 @@ describe('test case in html and udm convert', () => {
                         endIndex: 10,
                         tableId: 'table-1',
                     }],
-                    paragraphs: [{
-                        startIndex: 5,
-                    }, {
-                        startIndex: 19,
-                        bullet: {
-                            listId: 'list-1',
-                            listType: PresetListType.BULLET_LIST,
-                            nestingLevel: 0,
-                        },
-                    }],
+                    paragraphs: [{ paragraphId: 'para_docs_ui_fixture_61', startIndex: 5 }, { paragraphId: 'para_docs_ui_fixture_62', startIndex: 19, bullet: {
+                        listId: 'list-1',
+                        listType: PresetListType.BULLET_LIST,
+                        nestingLevel: 0,
+                    } }],
                 },
                 tableSource: {
                     'table-1': {
@@ -466,9 +461,7 @@ describe('test case in html and udm convert', () => {
                             endIndex: dataStream.length,
                             tableId,
                         }],
-                        paragraphs: [{
-                            startIndex: DataStreamTreeTokenType.TABLE_START.length + DataStreamTreeTokenType.TABLE_ROW_START.length + DataStreamTreeTokenType.TABLE_CELL_START.length + text.length,
-                        }],
+                        paragraphs: [{ paragraphId: 'para_docs_ui_fixture_63', startIndex: DataStreamTreeTokenType.TABLE_START.length + DataStreamTreeTokenType.TABLE_ROW_START.length + DataStreamTreeTokenType.TABLE_CELL_START.length + text.length }],
                     },
                     tableSource: {
                         [tableId]: {
@@ -540,7 +533,7 @@ describe('test case in html and udm convert', () => {
             const fragment = createInternalClipboardFragment({
                 body: {
                     dataStream: 'Internal\r',
-                    paragraphs: [{ startIndex: 8 }],
+                    paragraphs: [{ paragraphId: 'para_docs_ui_fixture_64', startIndex: 8 }],
                 },
             });
             const html = wrapClipboardHtml(embedInternalClipboardFragment('<p>Internal</p>', fragment));

--- a/packages/docs-ui/src/services/clipboard/html-to-udm/converter.ts
+++ b/packages/docs-ui/src/services/clipboard/html-to-udm/converter.ts
@@ -18,6 +18,7 @@ import type { IDocumentBody, IDocumentData, IParagraph, ITable, ITableCell, ITab
 import type { IAfterProcessRule, IPastePlugin, IStyleRule } from './paste-plugins/type';
 import {
     ColorKit,
+    createParagraphId,
     CustomRangeType,
     DataStreamTreeTokenType,
     DocumentBlockRangeType,
@@ -101,6 +102,10 @@ export class HtmlToUDMService {
     private _listStack: IListContext[] = [];
 
     private _lastParagraphIndex = -1;
+
+    private _createParagraphId(body: IDocumentBody): string {
+        return createParagraphId(new Set(body.paragraphs?.map((paragraph) => paragraph.paragraphId)));
+    }
 
     convert(html: string, metaConfig: { unitId?: string } = {}): Partial<IDocumentData> {
         const pastePlugin = HtmlToUDMService._pluginList.find((plugin) => plugin.checkPasteType(html));
@@ -346,6 +351,7 @@ export class HtmlToUDMService {
         body.paragraphs ??= [];
         const paragraph: IParagraph = {
             startIndex: body.dataStream.length,
+            paragraphId: this._createParagraphId(body),
         };
 
         const heading = getHeadingNamedStyleType(node);
@@ -398,6 +404,7 @@ export class HtmlToUDMService {
             body.paragraphs ??= [];
             body.paragraphs.push({
                 startIndex: body.dataStream.length - 1,
+                paragraphId: this._createParagraphId(body),
             });
         }
 
@@ -492,6 +499,7 @@ export class HtmlToUDMService {
 
                     body.paragraphs?.push({
                         startIndex: body.dataStream.length - 1,
+                        paragraphId: this._createParagraphId(body),
                     });
                 }
 
@@ -585,6 +593,7 @@ export class HtmlToUDMService {
                 if (body.dataStream[body.dataStream.length - 1] !== '\r') {
                     body.paragraphs?.push({
                         startIndex: body.dataStream.length,
+                        paragraphId: this._createParagraphId(body),
                     });
 
                     body.dataStream += '\r';

--- a/packages/docs-ui/src/services/clipboard/html-to-udm/paste-plugins/plugin-lark.ts
+++ b/packages/docs-ui/src/services/clipboard/html-to-udm/paste-plugins/plugin-lark.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IPastePlugin } from './type';
-import { BooleanNumber } from '@univerjs/core';
+import { BooleanNumber, createParagraphId } from '@univerjs/core';
 import { extractNodeStyle as getInlineStyle } from '../parse-node-style';
 
 const LarkPastePlugin: IPastePlugin = {
@@ -53,6 +53,7 @@ const LarkPastePlugin: IPastePlugin = {
 
                 body.paragraphs.push({
                     startIndex: body.dataStream.length,
+                    paragraphId: createParagraphId(new Set(body.paragraphs.map((paragraph) => paragraph.paragraphId))),
                 });
                 body.dataStream += '\r';
             },

--- a/packages/docs-ui/src/services/clipboard/html-to-udm/paste-plugins/plugin-univer.ts
+++ b/packages/docs-ui/src/services/clipboard/html-to-udm/paste-plugins/plugin-univer.ts
@@ -16,6 +16,7 @@
 
 import type { IParagraph } from '@univerjs/core';
 import type { IPastePlugin } from './type';
+import { createParagraphId } from '@univerjs/core';
 import { getParagraphStyle } from '../utils';
 
 const UniverPastePlugin: IPastePlugin = {
@@ -39,6 +40,7 @@ const UniverPastePlugin: IPastePlugin = {
 
                 const paragraph: IParagraph = {
                     startIndex: body.dataStream.length,
+                    paragraphId: createParagraphId(new Set(body.paragraphs.map((p) => p.paragraphId))),
                 };
 
                 const paragraphStyle = getParagraphStyle(el);

--- a/packages/docs-ui/src/services/clipboard/html-to-udm/paste-plugins/plugin-word.ts
+++ b/packages/docs-ui/src/services/clipboard/html-to-udm/paste-plugins/plugin-word.ts
@@ -16,7 +16,7 @@
 
 import type { IParagraph } from '@univerjs/core';
 import type { IPastePlugin } from './type';
-import { BooleanNumber } from '@univerjs/core';
+import { BooleanNumber, createParagraphId } from '@univerjs/core';
 import { extractNodeStyle as getInlineStyle } from '../parse-node-style';
 import { getParagraphStyle } from '../utils';
 
@@ -70,6 +70,7 @@ const WordPastePlugin: IPastePlugin = {
 
                 const paragraph: IParagraph = {
                     startIndex: body.dataStream.length,
+                    paragraphId: createParagraphId(new Set(body.paragraphs.map((p) => p.paragraphId))),
                 };
 
                 const paragraphStyle = getParagraphStyle(el);

--- a/packages/docs-ui/src/services/clipboard/udm-to-html/__test__/convertor.spec.ts
+++ b/packages/docs-ui/src/services/clipboard/udm-to-html/__test__/convertor.spec.ts
@@ -37,22 +37,16 @@ function getTestBody() {
             },
         ],
         paragraphs: [
-            {
-                startIndex: 4,
-                paragraphStyle: {
-                    spaceAbove: { v: 10 },
-                    lineSpacing: 2,
-                    spaceBelow: { v: 0 },
-                },
-            },
-            {
-                startIndex: 11,
-                paragraphStyle: {
-                    spaceAbove: { v: 10 },
-                    lineSpacing: 2,
-                    spaceBelow: { v: 0 },
-                },
-            },
+            { paragraphId: 'para_docs_ui_fixture_65', startIndex: 4, paragraphStyle: {
+                spaceAbove: { v: 10 },
+                lineSpacing: 2,
+                spaceBelow: { v: 0 },
+            } },
+            { paragraphId: 'para_docs_ui_fixture_66', startIndex: 11, paragraphStyle: {
+                spaceAbove: { v: 10 },
+                lineSpacing: 2,
+                spaceBelow: { v: 0 },
+            } },
         ],
     } as IDocumentBody;
 }
@@ -75,12 +69,9 @@ describe('test case in html and udm convert', () => {
                     },
                 ],
                 paragraphs: [
-                    {
-                        startIndex: 13,
-                        paragraphStyle: {
-                            horizontalAlign: 0,
-                        },
-                    },
+                    { paragraphId: 'para_docs_ui_fixture_67', startIndex: 13, paragraphStyle: {
+                        horizontalAlign: 0,
+                    } },
                 ],
             },
         ];
@@ -152,8 +143,8 @@ describe('test case in html and udm convert', () => {
             body: {
                 dataStream,
                 paragraphs: [
-                    { startIndex: prefix.length - 1 },
-                    { startIndex: tableStart + tokens.TABLE_START.length + tokens.TABLE_ROW_START.length + tokens.TABLE_CELL_START.length + cellText.length },
+                    { paragraphId: 'para_docs_ui_fixture_68', startIndex: prefix.length - 1 },
+                    { paragraphId: 'para_docs_ui_fixture_69', startIndex: tableStart + tokens.TABLE_START.length + tokens.TABLE_ROW_START.length + tokens.TABLE_CELL_START.length + cellText.length },
                 ],
                 sectionBreaks: [],
                 tables: [{
@@ -184,15 +175,10 @@ describe('test case in html and udm convert', () => {
             body: {
                 dataStream,
                 paragraphs: [
-                    {
-                        startIndex: title.length,
-                        paragraphStyle: {
-                            namedStyleType: NamedStyleType.TITLE,
-                        },
-                    },
-                    {
-                        startIndex: dataStream.length - 2,
-                    },
+                    { paragraphId: 'para_docs_ui_fixture_70', startIndex: title.length, paragraphStyle: {
+                        namedStyleType: NamedStyleType.TITLE,
+                    } },
+                    { paragraphId: 'para_docs_ui_fixture_71', startIndex: dataStream.length - 2 },
                 ],
                 sectionBreaks: [],
                 blockRanges: [{
@@ -216,17 +202,14 @@ describe('test case in html and udm convert', () => {
             documentStyle: {},
             body: {
                 dataStream: `${title}\r\n`,
-                paragraphs: [{
-                    startIndex: title.length,
-                    paragraphStyle: {
-                        textStyle: {
-                            fs: 22,
-                            bl: BooleanNumber.TRUE,
-                            cl: { rgb: '#4B5563' },
-                            ff: 'Arial',
-                        },
+                paragraphs: [{ paragraphId: 'para_docs_ui_fixture_72', startIndex: title.length, paragraphStyle: {
+                    textStyle: {
+                        fs: 22,
+                        bl: BooleanNumber.TRUE,
+                        cl: { rgb: '#4B5563' },
+                        ff: 'Arial',
                     },
-                }],
+                } }],
                 sectionBreaks: [],
             },
         });

--- a/packages/docs-ui/src/services/clipboard/udm-to-html/convertor.ts
+++ b/packages/docs-ui/src/services/clipboard/udm-to-html/convertor.ts
@@ -20,6 +20,7 @@ import type { DataStreamTreeNode } from '@univerjs/engine-render';
 import {
     BaselineOffset,
     BooleanNumber,
+    createParagraphId,
     CustomRangeType,
     DataStreamTreeNodeType,
     DocumentBlockRangeType,
@@ -245,6 +246,7 @@ export function convertBodyToHtml(doc: IDocumentData): string {
 
         paragraphs.push({
             startIndex: dataStream.length - 2,
+            paragraphId: createParagraphId(new Set(paragraphs.map((paragraph) => paragraph.paragraphId))),
         });
 
         sectionBreaks.push({

--- a/packages/docs-ui/src/services/editor/editor-manager.service.ts
+++ b/packages/docs-ui/src/services/editor/editor-manager.service.ts
@@ -18,7 +18,7 @@ import type { DocumentDataModel, IDisposable, IDocumentBody, IDocumentData, Null
 import type { DocBackground, ISuccinctDocRangeParam, Scene } from '@univerjs/engine-render';
 import type { Observable } from 'rxjs';
 import type { IEditorConfigParams } from './editor';
-import { createIdentifier, DEFAULT_EMPTY_DOCUMENT_VALUE, Disposable, EDITOR_ACTIVATED, FOCUSING_COMMENT_EDITOR, FOCUSING_EDITOR_STANDALONE, HorizontalAlign, ICommandService, IContextService, Inject, Injector, isCommentEditorID, isInternalEditorID, IUndoRedoService, IUniverInstanceService, toDisposable, UniverInstanceType, VerticalAlign } from '@univerjs/core';
+import { createIdentifier, createParagraphId, DEFAULT_EMPTY_DOCUMENT_VALUE, Disposable, EDITOR_ACTIVATED, FOCUSING_COMMENT_EDITOR, FOCUSING_EDITOR_STANDALONE, HorizontalAlign, ICommandService, IContextService, Inject, Injector, isCommentEditorID, isInternalEditorID, IUndoRedoService, IUniverInstanceService, toDisposable, UniverInstanceType, VerticalAlign } from '@univerjs/core';
 import { DocSelectionManagerService } from '@univerjs/docs';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { fromEvent, Subject } from 'rxjs';
@@ -289,6 +289,7 @@ export class EditorService extends Disposable implements IEditorService, IDispos
                 paragraphs: [
                     {
                         startIndex: 0,
+                        paragraphId: createParagraphId(new Set()),
                     },
                 ],
             },

--- a/packages/docs-ui/src/services/editor/editor.ts
+++ b/packages/docs-ui/src/services/editor/editor.ts
@@ -19,7 +19,7 @@ import type { DocSelectionManagerService } from '@univerjs/docs';
 import type { IDocSelectionInnerParam, IRender, ISuccinctDocRangeParam, ITextRangeWithStyle } from '@univerjs/engine-render';
 import type { Observable } from 'rxjs';
 import type { IEditorInputConfig } from '../selection/doc-selection-render.service';
-import { Disposable, isInternalEditorID, UniverInstanceType } from '@univerjs/core';
+import { createParagraphId, Disposable, isInternalEditorID, UniverInstanceType } from '@univerjs/core';
 import { DocSkeletonManagerService } from '@univerjs/docs';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { KeyCode } from '@univerjs/ui';
@@ -331,6 +331,7 @@ export class Editor extends Disposable implements IEditor {
                     dataStream: `${text}\r\n`,
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: createParagraphId(new Set()),
                     }],
                     customRanges: [],
                     sectionBreaks: [],

--- a/packages/docs-ui/src/views/rich-text-editor/hooks/use-editor.ts
+++ b/packages/docs-ui/src/views/rich-text-editor/hooks/use-editor.ts
@@ -17,7 +17,7 @@
 import type { IDocumentData, Nullable } from '@univerjs/core';
 import type { RefObject } from 'react';
 import type { Editor, IEditorCanvasStyle } from '../../../services/editor/editor';
-import { Tools } from '@univerjs/core';
+import { createParagraphId, Tools } from '@univerjs/core';
 import { useDependency } from '@univerjs/ui';
 import { useLayoutEffect, useMemo, useState } from 'react';
 import { IEditorService } from '../../../services/editor/editor-manager.service';
@@ -49,6 +49,7 @@ export function useEditor(opts: IUseEditorProps) {
                     customRanges: [],
                     paragraphs: [{
                         startIndex: 0,
+                        paragraphId: createParagraphId(new Set()),
                     }],
                 },
                 ...initialDoc,

--- a/packages/docs/src/__tests__/facade-utils.spec.ts
+++ b/packages/docs/src/__tests__/facade-utils.spec.ts
@@ -21,6 +21,14 @@ import {
     getRemovedLeadingParagraphBreakLength,
 } from '../facade/utils';
 
+function expectParagraphIds(paragraphs: NonNullable<ReturnType<typeof buildPlainTextInsertBody>['paragraphs']>): void {
+    for (const paragraph of paragraphs) {
+        expect(paragraph.paragraphId).toMatch(/^para_/);
+    }
+
+    expect(new Set(paragraphs.map((paragraph) => paragraph.paragraphId)).size).toBe(paragraphs.length);
+}
+
 describe('facade utils', () => {
     it('removes a leading paragraph break when plain text is inserted at the document start', () => {
         const body = buildPlainTextInsertBody('\r\nHello', { removeLeadingParagraphBreak: true });
@@ -37,21 +45,37 @@ describe('facade utils', () => {
         const body = buildPlainTextInsertBody('\r\nHello');
 
         expect(body.dataStream).toBe('\rHello');
-        expect(body.paragraphs).toEqual([{ startIndex: 0 }]);
+        expect(body.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual([0]);
+        expectParagraphIds(body.paragraphs!);
     });
 
     it('normalizes plain text line feeds and adds paragraph metadata', () => {
         const body = buildPlainTextInsertBody('Hello\nWorld\rAgain');
 
         expect(body.dataStream).toBe('Hello\rWorld\rAgain');
-        expect(body.paragraphs).toEqual([{ startIndex: 5 }, { startIndex: 11 }]);
+        expect(body.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual([5, 11]);
+        expectParagraphIds(body.paragraphs!);
+    });
+
+    it('preserves cloned paragraph style for generated paragraph metadata', () => {
+        const paragraphStyle = { horizontalAlign: 2 };
+        const body = buildPlainTextInsertBody('A\nB\nC', { paragraphStyle });
+
+        expect(body.dataStream).toBe('A\rB\rC');
+        expect(body.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual([1, 3]);
+        expectParagraphIds(body.paragraphs!);
+        expect(body.paragraphs?.map((paragraph) => paragraph.paragraphStyle)).toEqual([paragraphStyle, paragraphStyle]);
+        expect(body.paragraphs?.[0].paragraphStyle).not.toBe(paragraphStyle);
+        expect(body.paragraphs?.[1].paragraphStyle).not.toBe(paragraphStyle);
+        expect(body.paragraphs?.[0].paragraphStyle).not.toBe(body.paragraphs?.[1].paragraphStyle);
     });
 
     it('adds paragraph metadata for a trailing paragraph break', () => {
         const body = buildPlainTextInsertBody('Hello\n');
 
         expect(body.dataStream).toBe('Hello\r');
-        expect(body.paragraphs).toEqual([{ startIndex: 5 }]);
+        expect(body.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual([5]);
+        expectParagraphIds(body.paragraphs!);
     });
 
     it('reports removed leading paragraph break length for cursor offsets', () => {

--- a/packages/docs/src/facade/__tests__/create-test-bed.ts
+++ b/packages/docs/src/facade/__tests__/create-test-bed.ts
@@ -16,7 +16,7 @@
 
 import type { DocumentDataModel, IDocumentData, Injector } from '@univerjs/core';
 import type { FUniver } from '@univerjs/core/facade';
-import { DisposableCollection, ILogService, IUniverInstanceService, LogLevel, normalizeDocumentParagraphIds, Univer, UniverInstanceType } from '@univerjs/core';
+import { DisposableCollection, ILogService, IUniverInstanceService, LogLevel, Univer, UniverInstanceType } from '@univerjs/core';
 import { FUniver as FUniverCtor } from '@univerjs/core/facade';
 import { IRenderManagerService, RenderManagerService } from '@univerjs/engine-render';
 import { BehaviorSubject } from 'rxjs';
@@ -28,7 +28,7 @@ function getTestDocumentDataDemo(): IDocumentData {
         id: 'test',
         body: {
             dataStream: 'Hello,\r\n',
-            paragraphs: [{ startIndex: 6 }],
+            paragraphs: [{ startIndex: 6, paragraphId: 'para_fixture_19' }],
         },
         documentStyle: {
             pageSize: {
@@ -62,10 +62,10 @@ export function createTestBed(documentConfig?: IDocumentData): ITestBed {
     injector.add([IRenderManagerService, { useClass: RenderManagerService }]);
 
     univer.registerPlugin(UniverDocsPlugin);
-    const normalizedDocumentConfig = normalizeDocumentParagraphIds(cloneDocumentData(documentConfig ?? getTestDocumentDataDemo()));
+    const documentConfigWithIds = cloneDocumentData(documentConfig ?? getTestDocumentDataDemo());
     const doc = univer.createUnit<IDocumentData, DocumentDataModel>(
         UniverInstanceType.UNIVER_DOC,
-        normalizedDocumentConfig
+        documentConfigWithIds
     );
 
     injector.get(IUniverInstanceService).focusUnit(doc.getUnitId());

--- a/packages/docs/src/facade/__tests__/create-test-bed.ts
+++ b/packages/docs/src/facade/__tests__/create-test-bed.ts
@@ -16,7 +16,7 @@
 
 import type { DocumentDataModel, IDocumentData, Injector } from '@univerjs/core';
 import type { FUniver } from '@univerjs/core/facade';
-import { DisposableCollection, ILogService, IUniverInstanceService, LogLevel, Univer, UniverInstanceType } from '@univerjs/core';
+import { DisposableCollection, ILogService, IUniverInstanceService, LogLevel, normalizeDocumentParagraphIds, Univer, UniverInstanceType } from '@univerjs/core';
 import { FUniver as FUniverCtor } from '@univerjs/core/facade';
 import { IRenderManagerService, RenderManagerService } from '@univerjs/engine-render';
 import { BehaviorSubject } from 'rxjs';
@@ -43,6 +43,10 @@ function getTestDocumentDataDemo(): IDocumentData {
     };
 }
 
+function cloneDocumentData(documentData: IDocumentData): IDocumentData {
+    return JSON.parse(JSON.stringify(documentData)) as IDocumentData;
+}
+
 export interface ITestBed {
     univer: Univer;
     get: Injector['get'];
@@ -58,9 +62,10 @@ export function createTestBed(documentConfig?: IDocumentData): ITestBed {
     injector.add([IRenderManagerService, { useClass: RenderManagerService }]);
 
     univer.registerPlugin(UniverDocsPlugin);
+    const normalizedDocumentConfig = normalizeDocumentParagraphIds(cloneDocumentData(documentConfig ?? getTestDocumentDataDemo()));
     const doc = univer.createUnit<IDocumentData, DocumentDataModel>(
         UniverInstanceType.UNIVER_DOC,
-        documentConfig ?? getTestDocumentDataDemo()
+        normalizedDocumentConfig
     );
 
     injector.get(IUniverInstanceService).focusUnit(doc.getUnitId());

--- a/packages/docs/src/facade/__tests__/f-document-node.spec.ts
+++ b/packages/docs/src/facade/__tests__/f-document-node.spec.ts
@@ -46,7 +46,11 @@ function createDocumentData(id: string, body: NonNullable<IDocumentData['body']>
 function createSimpleDocument(id = 'test'): IDocumentData {
     return createDocumentData(id, {
         dataStream: 'Alpha\rBeta\rGamma\r\n',
-        paragraphs: [{ startIndex: 5 }, { startIndex: 10 }, { startIndex: 16 }],
+        paragraphs: [
+            { startIndex: 5, paragraphId: 'para_alpha' },
+            { startIndex: 10, paragraphId: 'para_beta' },
+            { startIndex: 16, paragraphId: 'para_gamma' },
+        ],
         sectionBreaks: [{ startIndex: 17 }],
     });
 }
@@ -54,7 +58,11 @@ function createSimpleDocument(id = 'test'): IDocumentData {
 function createDuplicateDocument(id = 'test'): IDocumentData {
     return createDocumentData(id, {
         dataStream: 'Same\rSame\rTail\r\n',
-        paragraphs: [{ startIndex: 4 }, { startIndex: 9 }, { startIndex: 14 }],
+        paragraphs: [
+            { startIndex: 4, paragraphId: 'para_same_1' },
+            { startIndex: 9, paragraphId: 'para_same_2' },
+            { startIndex: 14, paragraphId: 'para_tail' },
+        ],
         sectionBreaks: [{ startIndex: 15 }],
     });
 }
@@ -71,7 +79,7 @@ function createTaskDocument(id = 'test'): IDocumentData {
                     nestingLevel: 0,
                 },
             },
-            { startIndex: 9 },
+            { startIndex: 9, paragraphId: 'para_done' },
         ],
         sectionBreaks: [{ startIndex: 10 }],
     });
@@ -89,7 +97,7 @@ function createBulletDocument(id = 'test'): IDocumentData {
                     nestingLevel: 0,
                 },
             },
-            { startIndex: 11 },
+            { startIndex: 11, paragraphId: 'para_bullet_tail' },
         ],
         sectionBreaks: [{ startIndex: 12 }],
     });
@@ -244,7 +252,10 @@ describe('FDocument facade in Node', () => {
         const first = body.getChild(0);
         const second = body.getChild(1).asParagraph();
         expect(first.getType()).toBe('paragraph');
-        expect(first.getKey()).toMatch(/^paragraph-/);
+        expect(first.getKey()).toBe('para_alpha');
+        expect(first.asParagraph().getId()).toBe('para_alpha');
+        expect(second.getId()).toBe('para_beta');
+        expect(second.getKey()).toBe('para_beta');
         expect(first.getParent()).toBe(body);
         expect(first.getNextSibling()?.asParagraph().getText()).toBe('Beta');
         expect(body.getChild(1).getPreviousSibling()?.asParagraph().getText()).toBe('Alpha');
@@ -254,10 +265,15 @@ describe('FDocument facade in Node', () => {
         expect(body.insertText(0, 'Hello ')).toBe(true);
         expect(document.save().body?.dataStream).toBe('Hello Alpha\rBeta\rGamma\r\n');
 
-        expect(body.insertParagraph(0, 'Title')).toBe(true);
+        const title = body.insertParagraph(0, 'Title');
+        expect(title.getId()).toMatch(/^para_/);
+        expect(title.getKey()).toBe(title.getId());
+        expect(title.getText()).toBe('Title');
+        expect(document.save().body?.paragraphs?.[0].paragraphId).toBe(title.getId());
         expect(document.save().body?.dataStream).toBe('Title\rHello Alpha\rBeta\rGamma\r\n');
 
-        expect(body.appendParagraph('Tail')).toBe(true);
+        const tail = body.appendParagraph('Tail');
+        expect(tail.getText()).toBe('Tail');
         expect(document.save().body?.dataStream).toBe('Title\rHello Alpha\rBeta\rGamma\rTail\r\n');
 
         expect(body.deleteRange({ startOffset: 0, endOffset: 6 })).toBe(true);
@@ -297,10 +313,13 @@ describe('FDocument facade in Node', () => {
         const body = document.getBody();
         const secondSame = body.getChild(1).asParagraph();
 
-        expect(body.insertParagraph(0, 'X')).toBe(true);
+        expect(secondSame.getId()).toBe('para_same_2');
+        expect(body.insertParagraph(0, 'X').getText()).toBe('X');
         expect(body.getChildIndex(secondSame)).toBe(2);
         expect(secondSame.setText('Picked')).toBe(true);
         expect(document.save().body?.dataStream).toBe('X\rSame\rPicked\rTail\r\n');
+        expect(secondSame.removeFromParent()).toBe(true);
+        expect(document.save().body?.dataStream).toBe('X\rSame\rTail\r\n');
     });
 
     it('marks deleted paragraph wrappers as stale', () => {
@@ -310,6 +329,28 @@ describe('FDocument facade in Node', () => {
         const paragraph = document.getBody().getChild(1).asParagraph();
         expect(paragraph.removeFromParent()).toBe(true);
         expect(() => paragraph.getText()).toThrow(DocElementStaleError);
+        expect(() => paragraph.removeFromParent()).toThrow(DocElementStaleError);
+    });
+
+    it('throws stale errors for duplicate paragraph ids', () => {
+        univer.dispose();
+        createDocumentFacade(createSimpleDocument());
+
+        const body = document.getBody();
+        document.getDocumentDataModel().getBody()!.paragraphs![1].paragraphId = 'para_alpha';
+
+        expect(() => body.resolveParagraph('para_alpha')).toThrow(DocElementStaleError);
+    });
+
+    it('throws a stale error when a paragraph child is missing its id', () => {
+        univer.dispose();
+        createDocumentFacade(createSimpleDocument());
+
+        const body = document.getBody();
+        delete document.getDocumentDataModel().getBody()!.paragraphs![0].paragraphId;
+
+        expect(() => body.getChild(0)).toThrow(DocElementStaleError);
+        expect(() => body.getChild(0)).toThrow('Paragraph at index 0 is missing paragraphId.');
     });
 
     it('runs FDocParagraph list and task APIs in Node', () => {
@@ -319,7 +360,8 @@ describe('FDocument facade in Node', () => {
         const bulletBody = document.getBody();
         const listItem = bulletBody.getChild(0).asParagraph();
         expect(listItem.getType()).toBe('paragraph');
-        expect(listItem.getKey()).toMatch(/^paragraph-/);
+        expect(listItem.getKey()).toMatch(/^para_/);
+        expect(listItem.getId()).toBe(listItem.getKey());
         expect(listItem.getParent()).toBe(bulletBody);
         expect(listItem.isListItem()).toBe(true);
         expect(listItem.isTask()).toBe(false);
@@ -369,7 +411,7 @@ describe('FDocument facade in Node', () => {
             expect(block.getText()).toBe('Block');
             expect(body.getBlockRange(block.getKey()).blockType).toBe(blockType);
             expect(body.getBlockRangeText(block.getKey())).toBe('Block');
-            expect(body.insertParagraph(0, 'Intro')).toBe(true);
+            expect(body.insertParagraph(0, 'Intro').getText()).toBe('Intro');
             expect(block.getText()).toBe('Block');
             expect(block.setText('Updated')).toBe(true);
             expect(body.getBlockRangeText(block.getKey())).toBe('Updated');

--- a/packages/docs/src/facade/__tests__/f-document-node.spec.ts
+++ b/packages/docs/src/facade/__tests__/f-document-node.spec.ts
@@ -15,10 +15,10 @@
  */
 
 import type { IDocumentData, Univer } from '@univerjs/core';
-import type { FDocument } from '../f-document';
 import { DocumentBlockRangeType, IResourceManagerService, PresetListType, UniverInstanceType } from '@univerjs/core';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DocElementStaleError } from '../doc-element-registry';
+import { FDocument } from '../f-document';
 import { createTestBed } from './create-test-bed';
 
 const DOCUMENT_STYLE: IDocumentData['documentStyle'] = {
@@ -127,6 +127,11 @@ function createCustomBlockDocument(id = 'test'): IDocumentData {
     });
 }
 
+function expectParagraphIds(paragraphs: NonNullable<IDocumentData['body']>['paragraphs']): void {
+    expect(paragraphs?.every((paragraph) => paragraph.paragraphId?.startsWith('para_'))).toBe(true);
+    expect(new Set(paragraphs?.map((paragraph) => paragraph.paragraphId)).size).toBe(paragraphs?.length);
+}
+
 describe('FDocument facade in Node', () => {
     let univer: Univer;
     let document: FDocument;
@@ -199,6 +204,34 @@ describe('FDocument facade in Node', () => {
                 data: '{"value":1}',
             },
         ]);
+    });
+
+    it('normalizes paragraph ids at test-bed and save snapshot boundaries', () => {
+        univer.dispose();
+        createDocumentFacade(createSimpleDocument());
+
+        const savedParagraphs = document.save().body?.paragraphs;
+
+        expect(savedParagraphs?.map((paragraph) => paragraph.startIndex)).toEqual([5, 10, 16]);
+        expectParagraphIds(savedParagraphs);
+    });
+
+    it('normalizes paragraph ids when saving an old snapshot without pre-normalized ids', () => {
+        const oldSnapshot = createSimpleDocument();
+        const saveUnit = vi.fn(() => oldSnapshot);
+        const legacyDocument = new FDocument(
+            { getUnitId: () => 'legacy-doc' } as never,
+            {} as never,
+            {} as never,
+            { saveUnit } as never,
+            {} as never
+        );
+
+        const savedParagraphs = legacyDocument.save().body?.paragraphs;
+
+        expect(saveUnit).toHaveBeenCalledWith('legacy-doc');
+        expect(savedParagraphs?.map((paragraph) => paragraph.startIndex)).toEqual([5, 10, 16]);
+        expectParagraphIds(savedParagraphs);
     });
 
     it('runs FDocBody paragraph and range APIs in Node', () => {

--- a/packages/docs/src/facade/__tests__/f-document-node.spec.ts
+++ b/packages/docs/src/facade/__tests__/f-document-node.spec.ts
@@ -73,6 +73,7 @@ function createTaskDocument(id = 'test'): IDocumentData {
         paragraphs: [
             {
                 startIndex: 4,
+                paragraphId: 'para_todo',
                 bullet: {
                     listId: 'task-list',
                     listType: PresetListType.CHECK_LIST,
@@ -91,6 +92,7 @@ function createBulletDocument(id = 'test'): IDocumentData {
         paragraphs: [
             {
                 startIndex: 6,
+                paragraphId: 'para_bullet',
                 bullet: {
                     listId: 'bullet-list',
                     listType: PresetListType.BULLET_LIST,
@@ -106,7 +108,7 @@ function createBulletDocument(id = 'test'): IDocumentData {
 function createBlockRangeDocument(blockType = DocumentBlockRangeType.QUOTE, id = 'test'): IDocumentData {
     return createDocumentData(id, {
         dataStream: 'Block\rAfter\r\n',
-        paragraphs: [{ startIndex: 5 }, { startIndex: 11 }],
+        paragraphs: [{ startIndex: 5, paragraphId: 'para_fixture_20' }, { startIndex: 11, paragraphId: 'para_after_block' }],
         blockRanges: [{
             blockId: `${blockType}-1`,
             blockType,
@@ -120,7 +122,7 @@ function createBlockRangeDocument(blockType = DocumentBlockRangeType.QUOTE, id =
 function createTableDocument(id = 'test'): IDocumentData {
     return createDocumentData(id, {
         dataStream: 'TT\raa\r\n',
-        paragraphs: [{ startIndex: 2 }, { startIndex: 5 }],
+        paragraphs: [{ startIndex: 2, paragraphId: 'para_fixture_21' }, { startIndex: 5, paragraphId: 'para_after_table' }],
         tables: [{ tableId: 'table-1', startIndex: 0, endIndex: 2 }],
         sectionBreaks: [{ startIndex: 6 }],
     });
@@ -129,7 +131,7 @@ function createTableDocument(id = 'test'): IDocumentData {
 function createCustomBlockDocument(id = 'test'): IDocumentData {
     return createDocumentData(id, {
         dataStream: '\b\raa\r\n',
-        paragraphs: [{ startIndex: 1 }, { startIndex: 4 }],
+        paragraphs: [{ startIndex: 1, paragraphId: 'para_fixture_22' }, { startIndex: 4, paragraphId: 'para_after_custom_block' }],
         customBlocks: [{ blockId: 'custom-1', blockType: 'custom' as never, startIndex: 0 }],
         sectionBreaks: [{ startIndex: 5 }],
     });
@@ -214,7 +216,7 @@ describe('FDocument facade in Node', () => {
         ]);
     });
 
-    it('normalizes paragraph ids at test-bed and save snapshot boundaries', () => {
+    it('preserves required paragraph ids at test-bed and save snapshot boundaries', () => {
         univer.dispose();
         createDocumentFacade(createSimpleDocument());
 
@@ -224,21 +226,21 @@ describe('FDocument facade in Node', () => {
         expectParagraphIds(savedParagraphs);
     });
 
-    it('normalizes paragraph ids when saving an old snapshot without pre-normalized ids', () => {
-        const oldSnapshot = createDocumentData('legacy-doc', {
+    it('returns saved snapshots with required paragraph ids unchanged', () => {
+        const snapshot = createDocumentData('doc-with-ids', {
             dataStream: 'Alpha\rBeta\rGamma\r\n',
             paragraphs: [
-                { startIndex: 5 },
-                { startIndex: 10 },
-                { startIndex: 16 },
+                { startIndex: 5, paragraphId: 'para_fixture_23' },
+                { startIndex: 10, paragraphId: 'para_fixture_24' },
+                { startIndex: 16, paragraphId: 'para_fixture_25' },
             ],
             sectionBreaks: [{ startIndex: 17 }],
         });
-        const saveUnit = vi.fn(() => oldSnapshot);
-        const legacyDocument = new FDocument(
+        const saveUnit = vi.fn(() => snapshot);
+        const facadeDocument = new FDocument(
             {
-                getSnapshot: () => ({ id: 'legacy-doc', documentStyle: {} }),
-                getUnitId: () => 'legacy-doc',
+                getSnapshot: () => ({ id: 'doc-with-ids', documentStyle: {} }),
+                getUnitId: () => 'doc-with-ids',
             } as never,
             {} as never,
             {} as never,
@@ -246,27 +248,27 @@ describe('FDocument facade in Node', () => {
             {} as never
         );
 
-        const savedParagraphs = legacyDocument.save().body?.paragraphs;
+        const savedParagraphs = facadeDocument.save().body?.paragraphs;
 
-        expect(saveUnit).toHaveBeenCalledWith('legacy-doc');
+        expect(saveUnit).toHaveBeenCalledWith('doc-with-ids');
         expect(savedParagraphs?.map((paragraph) => paragraph.startIndex)).toEqual([5, 10, 16]);
         expectParagraphIds(savedParagraphs);
     });
 
-    it('normalizes live paragraph ids before creating body facade wrappers', () => {
-        const oldSnapshot = createDocumentData('legacy-doc', {
+    it('uses existing paragraph ids when creating body facade wrappers', () => {
+        const snapshot = createDocumentData('doc-with-ids', {
             dataStream: 'Legacy\r\n',
-            paragraphs: [{ startIndex: 6 }],
+            paragraphs: [{ startIndex: 6, paragraphId: 'para_fixture_26' }],
             sectionBreaks: [{ startIndex: 7 }],
         });
         const model = {
-            getUnitId: () => 'legacy-doc',
-            getSnapshot: () => oldSnapshot,
+            getUnitId: () => 'doc-with-ids',
+            getSnapshot: () => snapshot,
             getSelfOrHeaderFooterModel: () => ({
-                getBody: () => oldSnapshot.body,
+                getBody: () => snapshot.body,
             }),
         };
-        const legacyDocument = new FDocument(
+        const facadeDocument = new FDocument(
             model as never,
             {} as never,
             {} as never,
@@ -274,10 +276,10 @@ describe('FDocument facade in Node', () => {
             {} as never
         );
 
-        const paragraph = legacyDocument.getBody().getChild(0).asParagraph();
+        const paragraph = facadeDocument.getBody().getChild(0).asParagraph();
 
         expect(paragraph.getId()).toMatch(/^para_/);
-        expect(oldSnapshot.body?.paragraphs?.[0].paragraphId).toBe(paragraph.getId());
+        expect(snapshot.body?.paragraphs?.[0].paragraphId).toBe(paragraph.getId());
     });
 
     it('runs FDocBody paragraph and range APIs in Node', () => {
@@ -385,7 +387,8 @@ describe('FDocument facade in Node', () => {
         createDocumentFacade(createSimpleDocument());
 
         const body = document.getBody();
-        delete document.getDocumentDataModel().getBody()!.paragraphs![0].paragraphId;
+        const invalidParagraph = document.getDocumentDataModel().getBody()!.paragraphs![0] as { paragraphId?: string };
+        delete invalidParagraph.paragraphId;
 
         expect(() => body.getChild(0)).toThrow(DocElementStaleError);
         expect(() => body.getChild(0)).toThrow('Paragraph at index 0 is missing paragraphId.');

--- a/packages/docs/src/facade/__tests__/f-document-node.spec.ts
+++ b/packages/docs/src/facade/__tests__/f-document-node.spec.ts
@@ -225,10 +225,21 @@ describe('FDocument facade in Node', () => {
     });
 
     it('normalizes paragraph ids when saving an old snapshot without pre-normalized ids', () => {
-        const oldSnapshot = createSimpleDocument();
+        const oldSnapshot = createDocumentData('legacy-doc', {
+            dataStream: 'Alpha\rBeta\rGamma\r\n',
+            paragraphs: [
+                { startIndex: 5 },
+                { startIndex: 10 },
+                { startIndex: 16 },
+            ],
+            sectionBreaks: [{ startIndex: 17 }],
+        });
         const saveUnit = vi.fn(() => oldSnapshot);
         const legacyDocument = new FDocument(
-            { getUnitId: () => 'legacy-doc' } as never,
+            {
+                getSnapshot: () => ({ id: 'legacy-doc', documentStyle: {} }),
+                getUnitId: () => 'legacy-doc',
+            } as never,
             {} as never,
             {} as never,
             { saveUnit } as never,
@@ -240,6 +251,33 @@ describe('FDocument facade in Node', () => {
         expect(saveUnit).toHaveBeenCalledWith('legacy-doc');
         expect(savedParagraphs?.map((paragraph) => paragraph.startIndex)).toEqual([5, 10, 16]);
         expectParagraphIds(savedParagraphs);
+    });
+
+    it('normalizes live paragraph ids before creating body facade wrappers', () => {
+        const oldSnapshot = createDocumentData('legacy-doc', {
+            dataStream: 'Legacy\r\n',
+            paragraphs: [{ startIndex: 6 }],
+            sectionBreaks: [{ startIndex: 7 }],
+        });
+        const model = {
+            getUnitId: () => 'legacy-doc',
+            getSnapshot: () => oldSnapshot,
+            getSelfOrHeaderFooterModel: () => ({
+                getBody: () => oldSnapshot.body,
+            }),
+        };
+        const legacyDocument = new FDocument(
+            model as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never
+        );
+
+        const paragraph = legacyDocument.getBody().getChild(0).asParagraph();
+
+        expect(paragraph.getId()).toMatch(/^para_/);
+        expect(oldSnapshot.body?.paragraphs?.[0].paragraphId).toBe(paragraph.getId());
     });
 
     it('runs FDocBody paragraph and range APIs in Node', () => {

--- a/packages/docs/src/facade/doc-element-registry.ts
+++ b/packages/docs/src/facade/doc-element-registry.ts
@@ -15,25 +15,19 @@
  */
 
 import type { IDocumentBody } from '@univerjs/core';
-import { generateRandomId } from '@univerjs/core';
 
 /**
  * The top-level document body element types supported by the doc facade.
  */
 export type FDocElementType = 'paragraph' | 'table' | 'blockRange' | 'customBlock';
 
-interface IParagraphRegistryEntry {
-    key: string;
-    segmentId: string;
-    startIndex: number;
-    stale: boolean;
-}
+const PARAGRAPH_REGISTRY_MIGRATION_ERROR = 'DocElementRegistry no longer tracks paragraph identity; use paragraphId.';
 
 /**
  * Error thrown when a facade element key can no longer be resolved uniquely.
  *
- * A stale paragraph usually means the paragraph was deleted, or an external edit
- * changed the document in a way that the runtime temporary key cannot follow.
+ * A stale paragraph usually means the paragraph was deleted, or the document no
+ * longer contains exactly one paragraph with the requested `paragraphId`.
  *
  * @example
  * ```ts
@@ -64,134 +58,50 @@ export class DocElementStaleError extends Error {
 }
 
 /**
- * Runtime registry for temporary paragraph keys.
- *
- * The registry is owned by an `FDocument` instance. It never writes keys into the
- * document snapshot. Facade edits notify the registry before text changes so
- * paragraph keys can move with their source paragraph or become stale when the
- * source paragraph is removed.
+ * @deprecated Paragraph facade identity is now resolved directly from persisted
+ * `paragraphId` values. This class remains as a compatibility shell for callers
+ * that constructed document facade internals directly.
  *
  * @hideconstructor
  */
 export class DocElementRegistry {
-    private readonly _paragraphsBySegment = new Map<string, IParagraphRegistryEntry[]>();
-
     /**
-     * Get or create the runtime key for a paragraph in a segment.
-     * @param {string} segmentId The header/footer segment id, or an empty string for the main body.
-     * @param {IDocumentBody} body The current document body snapshot.
-     * @param {number} paragraphIndex The zero-based paragraph index.
-     * @returns {string} The runtime key for the paragraph.
+     * @deprecated Paragraph facade identity is now the persisted `paragraphId`.
+     * @throws {Error} Always throws; use `paragraph.paragraphId` instead.
      */
-    getParagraphKey(segmentId: string, body: IDocumentBody, paragraphIndex: number): string {
-        const paragraph = body.paragraphs?.[paragraphIndex];
-        if (!paragraph) {
-            throw new RangeError(`Paragraph index ${paragraphIndex} is out of range.`);
-        }
-
-        const entries = this._getSegmentEntries(segmentId);
-        const activeEntry = entries.find((entry) => !entry.stale && entry.startIndex === paragraph.startIndex);
-        if (activeEntry) {
-            return activeEntry.key;
-        }
-
-        const key = `paragraph-${generateRandomId(10)}`;
-        entries.push({
-            key,
-            segmentId,
-            startIndex: paragraph.startIndex,
-            stale: false,
-        });
-
-        return key;
+    getParagraphKey(_segmentId: string, _body: IDocumentBody, _paragraphIndex: number): string {
+        throw new Error(PARAGRAPH_REGISTRY_MIGRATION_ERROR);
     }
 
     /**
-     * Resolve a paragraph runtime key to its tracked paragraph break offset.
-     * @param {string} segmentId The header/footer segment id, or an empty string for the main body.
-     * @param {string} key The runtime paragraph key.
-     * @returns {number} The tracked paragraph `startIndex`.
-     * @throws {DocElementStaleError} If the key is missing or stale.
+     * @deprecated Paragraph facade identity is now the persisted `paragraphId`.
+     * @throws {Error} Always throws; resolve paragraph handles by `paragraphId` instead.
      */
-    resolveParagraphStartIndex(segmentId: string, key: string): number {
-        const entry = this._getSegmentEntries(segmentId).find((item) => item.key === key);
-        if (!entry || entry.stale) {
-            throw new DocElementStaleError();
-        }
-
-        return entry.startIndex;
+    resolveParagraphStartIndex(_segmentId: string, _key: string): number {
+        throw new Error(PARAGRAPH_REGISTRY_MIGRATION_ERROR);
     }
 
     /**
-     * Resolve a paragraph runtime key against the current body.
-     * @param {string} segmentId The header/footer segment id, or an empty string for the main body.
-     * @param {string} key The runtime paragraph key.
-     * @param {IDocumentBody} body The current document body snapshot.
-     * @returns {number} The current paragraph index in `body.paragraphs`.
-     * @throws {DocElementStaleError} If the tracked paragraph no longer exists.
+     * @deprecated Paragraph facade identity is now the persisted `paragraphId`.
+     * @throws {Error} Always throws; resolve paragraph handles by `paragraphId` instead.
      */
-    syncParagraph(segmentId: string, key: string, body: IDocumentBody): number {
-        const startIndex = this.resolveParagraphStartIndex(segmentId, key);
-        const paragraphIndex = body.paragraphs?.findIndex((paragraph) => paragraph.startIndex === startIndex) ?? -1;
-
-        if (paragraphIndex < 0) {
-            this.markStale(segmentId, key);
-            throw new DocElementStaleError();
-        }
-
-        return paragraphIndex;
+    syncParagraph(_segmentId: string, _key: string, _body: IDocumentBody): number {
+        throw new Error(PARAGRAPH_REGISTRY_MIGRATION_ERROR);
     }
 
     /**
-     * Mark a paragraph runtime key as stale.
-     * @param {string} segmentId The header/footer segment id, or an empty string for the main body.
-     * @param {string} key The runtime paragraph key.
-     * @returns {void}
+     * @deprecated Paragraph facade identity is now the persisted `paragraphId`.
+     * @throws {Error} Always throws; stale state is detected from live `paragraphId` lookups.
      */
-    markStale(segmentId: string, key: string): void {
-        const entry = this._getSegmentEntries(segmentId).find((item) => item.key === key);
-        if (entry) {
-            entry.stale = true;
-        }
+    markStale(_segmentId: string, _key: string): void {
+        throw new Error(PARAGRAPH_REGISTRY_MIGRATION_ERROR);
     }
 
     /**
-     * Update tracked paragraph offsets before a facade text edit is applied.
-     *
-     * Paragraphs inside the deleted range are marked stale. Paragraphs after the
-     * edited range move by the inserted length minus deleted length.
-     *
-     * @param {string} segmentId The header/footer segment id, or an empty string for the main body.
-     * @param {number} startOffset The inclusive start offset of the edit.
-     * @param {number} endOffset The exclusive end offset of the replaced range.
-     * @param {number} insertLength The data stream length inserted by the edit.
-     * @returns {void}
+     * @deprecated Paragraph facade identity is now the persisted `paragraphId`.
+     * @throws {Error} Always throws; text edits no longer need registry offset tracking.
      */
-    beforeTextEdit(segmentId: string, startOffset: number, endOffset: number, insertLength: number): void {
-        const deleteLength = Math.max(0, endOffset - startOffset);
-        const delta = insertLength - deleteLength;
-
-        for (const entry of this._getSegmentEntries(segmentId)) {
-            if (entry.stale) {
-                continue;
-            }
-
-            if (entry.startIndex >= startOffset && entry.startIndex < endOffset) {
-                entry.stale = true;
-            } else if (entry.startIndex >= endOffset) {
-                entry.startIndex += delta;
-            }
-        }
-    }
-
-    private _getSegmentEntries(segmentId: string): IParagraphRegistryEntry[] {
-        const key = segmentId || '';
-        let entries = this._paragraphsBySegment.get(key);
-        if (!entries) {
-            entries = [];
-            this._paragraphsBySegment.set(key, entries);
-        }
-
-        return entries;
+    beforeTextEdit(_segmentId: string, _startOffset: number, _endOffset: number, _insertLength: number): void {
+        throw new Error(PARAGRAPH_REGISTRY_MIGRATION_ERROR);
     }
 }

--- a/packages/docs/src/facade/f-doc-body.ts
+++ b/packages/docs/src/facade/f-doc-body.ts
@@ -19,6 +19,7 @@ import type { IRichTextEditingMutationParams } from '@univerjs/docs';
 import type { DocElementRegistry, FDocElementType } from './doc-element-registry';
 import { getRichTextEditPath, JSONX, PresetListType, TextX, TextXActionType, UpdateDocsAttributeType } from '@univerjs/core';
 import { RichTextEditingMutation } from '@univerjs/docs';
+import { DocElementStaleError } from './doc-element-registry';
 import { buildPlainTextInsertBody } from './utils';
 import { FDocElement } from './f-doc-element';
 import { FDocParagraph } from './f-doc-paragraph';
@@ -59,7 +60,7 @@ export interface IFDocElementHandle {
      */
     getType(): FDocElementType;
     /**
-     * Get the runtime or persisted key used by the facade to resolve the element.
+     * Get the persisted key used by the facade to resolve the element.
      * @returns {string} The facade key.
      */
     getKey(): string;
@@ -88,13 +89,14 @@ interface IFDocChildInfo {
 }
 
 const FACADE_TRIGGER = 'doc-facade';
+const RESTORE_INSERTED_PARAGRAPH_IDS = '__textXRestoreParagraphIds';
 
 /**
  * A Facade API object bounded to a document body or header/footer segment.
  * It provides Google Docs-like element access and range editing methods.
  *
- * Paragraph elements use runtime temporary keys that remain stable for this `FDocument`
- * facade instance. Tables, block ranges, and custom blocks use their persisted ids.
+ * Paragraph elements use their persisted `paragraphId`. Tables, block ranges, and
+ * custom blocks use their persisted ids.
  *
  * @hideconstructor
  */
@@ -102,7 +104,7 @@ export class FDocBody {
     constructor(
         private readonly _documentDataModel: DocumentDataModel,
         private readonly _commandService: ICommandService,
-        private readonly _registry: DocElementRegistry,
+        _registry: DocElementRegistry,
         private readonly _segmentId = ''
     ) {}
 
@@ -195,35 +197,44 @@ export class FDocBody {
      * Insert a plain-text paragraph before the paragraph at the given paragraph index.
      * @param {number} index The zero-based paragraph insertion index.
      * @param {string} text The paragraph text. Defaults to an empty paragraph.
-     * @returns {boolean} `true` if the paragraph was inserted.
+     * @returns {FDocParagraph} The inserted paragraph wrapper.
      * @example
      * ```ts
      * const doc = univerAPI.getActiveDocument();
      * if (!doc) throw new Error('No active document');
      *
      * const body = doc.getBody();
-     * body.insertParagraph(0, 'Document title');
+     * const paragraph = body.insertParagraph(0, 'Document title');
+     * paragraph.appendText(' suffix');
      * ```
      */
-    insertParagraph(index: number, text = ''): boolean {
+    insertParagraph(index: number, text = ''): FDocParagraph {
         const offset = this._getParagraphInsertOffset(index);
-        return this._replaceBodyRange({ startOffset: offset, endOffset: offset }, buildPlainTextInsertBody(`${text}\r`));
+        const result = this._replaceBodyRange({ startOffset: offset, endOffset: offset }, buildPlainTextInsertBody(`${text}\r`));
+        if (!result) {
+            throw new Error('Failed to insert paragraph.');
+        }
+
+        const paragraphIndex = this._normalizeInsertedParagraphIndex(index);
+        const paragraph = this._getBody().paragraphs?.[paragraphIndex];
+        return new FDocParagraph(this, this._getParagraphId(paragraph, paragraphIndex));
     }
 
     /**
      * Append a plain-text paragraph at the end of the body.
      * @param {string} text The paragraph text. Defaults to an empty paragraph.
-     * @returns {boolean} `true` if the paragraph was appended.
+     * @returns {FDocParagraph} The appended paragraph wrapper.
      * @example
      * ```ts
      * const doc = univerAPI.getActiveDocument();
      * if (!doc) throw new Error('No active document');
      *
      * const body = doc.getBody();
-     * body.appendParagraph('Summary');
+     * const paragraph = body.appendParagraph('Summary');
+     * console.log(paragraph.getText());
      * ```
      */
-    appendParagraph(text = ''): boolean {
+    appendParagraph(text = ''): FDocParagraph {
         return this.insertParagraph(this._getBody().paragraphs?.length ?? 0, text);
     }
 
@@ -331,6 +342,7 @@ export class FDocBody {
                 },
             }],
         };
+        this._preserveExplicitParagraphIds(updateBody);
 
         return this._retainBodyRange(
             { startOffset: resolved.endOffset, endOffset: resolved.endOffset + 1 },
@@ -340,8 +352,8 @@ export class FDocBody {
     }
 
     /**
-     * Get the text content of a paragraph by runtime key.
-     * @param {string} key The paragraph runtime key.
+     * Get the text content of a paragraph by paragraph id.
+     * @param {string} key The paragraph id.
      * @returns {string} The paragraph text without the trailing paragraph break.
      * @example
      * ```ts
@@ -358,8 +370,8 @@ export class FDocBody {
     }
 
     /**
-     * Replace the text content of a paragraph by runtime key.
-     * @param {string} key The paragraph runtime key.
+     * Replace the text content of a paragraph by paragraph id.
+     * @param {string} key The paragraph id.
      * @param {string} text The replacement paragraph text.
      * @returns {boolean} `true` if the paragraph text was replaced.
      * @example
@@ -377,8 +389,8 @@ export class FDocBody {
     }
 
     /**
-     * Append text to a paragraph by runtime key.
-     * @param {string} key The paragraph runtime key.
+     * Append text to a paragraph by paragraph id.
+     * @param {string} key The paragraph id.
      * @param {string} text The text to append before the paragraph break.
      * @returns {boolean} `true` if the text was appended.
      * @example
@@ -396,8 +408,8 @@ export class FDocBody {
     }
 
     /**
-     * Remove a paragraph by runtime key.
-     * @param {string} key The paragraph runtime key.
+     * Remove a paragraph by paragraph id.
+     * @param {string} key The paragraph id.
      * @returns {boolean} `true` if the paragraph was removed.
      * @example
      * ```ts
@@ -414,8 +426,8 @@ export class FDocBody {
     }
 
     /**
-     * Get a paragraph text range by runtime key.
-     * @param {string} key The paragraph runtime key.
+     * Get a paragraph text range by paragraph id.
+     * @param {string} key The paragraph id.
      * @returns {IFDocTextRange} The paragraph range excluding the trailing paragraph break.
      * @example
      * ```ts
@@ -434,7 +446,7 @@ export class FDocBody {
 
     /**
      * Check whether a paragraph has list metadata.
-     * @param {string} key The paragraph runtime key.
+     * @param {string} key The paragraph id.
      * @returns {boolean} `true` if the paragraph is a list item.
      * @example
      * ```ts
@@ -451,7 +463,7 @@ export class FDocBody {
 
     /**
      * Check whether a paragraph is a task/checklist item.
-     * @param {string} key The paragraph runtime key.
+     * @param {string} key The paragraph id.
      * @returns {boolean} `true` if the paragraph is an unchecked or checked task item.
      * @example
      * ```ts
@@ -469,7 +481,7 @@ export class FDocBody {
 
     /**
      * Set the checked state of a task/checklist paragraph.
-     * @param {string} key The paragraph runtime key.
+     * @param {string} key The paragraph id.
      * @param {boolean} checked Whether the task should be checked.
      * @returns {boolean} `true` if the task state was updated, or `false` if the paragraph is not a task item.
      * @example
@@ -499,6 +511,7 @@ export class FDocBody {
                 },
             }],
         };
+        this._preserveExplicitParagraphIds(updateBody);
 
         return this._retainBodyRange(
             { startOffset: resolved.endOffset, endOffset: resolved.endOffset + 1 },
@@ -508,8 +521,8 @@ export class FDocBody {
     }
 
     /**
-     * Resolve a paragraph runtime key to its current paragraph metadata.
-     * @param {string} key The paragraph runtime key.
+     * Resolve a paragraph id to its current paragraph metadata.
+     * @param {string} key The paragraph id.
      * @returns {IFDocResolvedParagraph} The current paragraph metadata.
      * @example
      * ```ts
@@ -523,8 +536,18 @@ export class FDocBody {
      */
     resolveParagraph(key: string): IFDocResolvedParagraph {
         const body = this._getBody();
-        const paragraphIndex = this._registry.syncParagraph(this._segmentId, key, body);
-        const paragraph = body.paragraphs![paragraphIndex];
+        const paragraphs = body.paragraphs ?? [];
+        const matches = paragraphs
+            .map((paragraph, paragraphIndex) => ({ paragraph, paragraphIndex }))
+            .filter(({ paragraph }) => paragraph.paragraphId === key);
+
+        if (matches.length !== 1) {
+            throw new DocElementStaleError(matches.length > 1
+                ? `Doc paragraph id "${key}" is duplicated.`
+                : `Doc paragraph id "${key}" is stale.`);
+        }
+
+        const { paragraph, paragraphIndex } = matches[0];
         const startOffset = paragraphIndex > 0 ? body.paragraphs![paragraphIndex - 1].startIndex + 1 : 0;
 
         return {
@@ -538,7 +561,7 @@ export class FDocBody {
     /**
      * Resolve an element key to its current child metadata.
      * @param {FDocElementType} type The element type.
-     * @param {string} key The runtime or persisted element key.
+     * @param {string} key The persisted element key.
      * @returns {object} The current child metadata used by the facade.
      * @example
      * ```ts
@@ -758,7 +781,7 @@ export class FDocBody {
             const paragraph = body.paragraphs![index];
             children.push({
                 type: 'paragraph',
-                key: this._registry.getParagraphKey(this._segmentId, body, index),
+                key: this._getParagraphId(paragraph, index),
                 position: index > 0 ? body.paragraphs![index - 1].startIndex + 1 : 0,
                 priority: 3,
             });
@@ -819,6 +842,27 @@ export class FDocBody {
         return paragraphs[index - 1].startIndex + 1;
     }
 
+    private _normalizeInsertedParagraphIndex(index: number): number {
+        const paragraphs = this._getBody().paragraphs ?? [];
+        return Math.max(0, Math.min(index, paragraphs.length - 1));
+    }
+
+    private _getParagraphId(paragraph: IParagraph | undefined, paragraphIndex: number): string {
+        if (!paragraph) {
+            throw new RangeError(`Paragraph index ${paragraphIndex} is out of range.`);
+        }
+
+        if (!paragraph.paragraphId) {
+            throw new DocElementStaleError(`Paragraph at index ${paragraphIndex} is missing paragraphId.`);
+        }
+
+        return paragraph.paragraphId;
+    }
+
+    private _preserveExplicitParagraphIds(body: IDocumentBody): void {
+        (body as IDocumentBody & Record<string, unknown>)[RESTORE_INSERTED_PARAGRAPH_IDS] = true;
+    }
+
     private _findParagraphByRange(range: IFDocTextRange): IFDocResolvedParagraph {
         const paragraphs = this._getBody().paragraphs ?? [];
         const paragraphIndex = paragraphs.findIndex((paragraph, index) => {
@@ -860,7 +904,7 @@ export class FDocBody {
             });
         }
 
-        return this._executeTextX(range, textX, insertBody.dataStream.length);
+        return this._executeTextX(textX);
     }
 
     private _retainBodyRange(range: IFDocTextRange, body: IDocumentBody, coverType: UpdateDocsAttributeType): boolean {
@@ -880,7 +924,7 @@ export class FDocBody {
             len: range.endOffset - range.startOffset,
         });
 
-        return this._executeTextX(range, textX, range.endOffset - range.startOffset, false);
+        return this._executeTextX(textX);
     }
 
     private _ensureTextRuns(): void {
@@ -909,11 +953,7 @@ export class FDocBody {
         );
     }
 
-    private _executeTextX(range: IFDocTextRange, textX: TextX, insertLength: number, trackTextEdit = true): boolean {
-        if (trackTextEdit) {
-            this._registry.beforeTextEdit(this._segmentId, range.startOffset, range.endOffset, insertLength);
-        }
-
+    private _executeTextX(textX: TextX): boolean {
         const jsonX = JSONX.getInstance();
         const actions = jsonX.editOp(textX.serialize(), getRichTextEditPath(this._documentDataModel, this._segmentId));
         const result = this._commandService.syncExecuteCommand<IRichTextEditingMutationParams>(

--- a/packages/docs/src/facade/f-doc-element.ts
+++ b/packages/docs/src/facade/f-doc-element.ts
@@ -27,8 +27,8 @@ import { FDocTable } from './f-doc-table';
  * Use this wrapper when you need to inspect an element type first, navigate to
  * neighboring elements, or cast the element to a more specific facade wrapper.
  *
- * Paragraph keys are runtime temporary keys for the current `FDocument` facade
- * lifecycle. Tables, block ranges, and custom blocks use their persisted ids.
+ * Paragraph keys are persisted `paragraphId` values. Tables, block ranges, and
+ * custom blocks use their persisted ids.
  *
  * @hideconstructor
  */
@@ -57,7 +57,7 @@ export class FDocElement {
 
     /**
      * Get the facade key used to resolve this element.
-     * @returns {string} The runtime paragraph key or persisted table/block id.
+     * @returns {string} The paragraph `paragraphId` or persisted table/block/custom block id.
      * @example
      * ```ts
      * const doc = univerAPI.getActiveDocument();

--- a/packages/docs/src/facade/f-doc-paragraph.ts
+++ b/packages/docs/src/facade/f-doc-paragraph.ts
@@ -19,10 +19,9 @@ import type { FDocBody, IFDocTextRange } from './f-doc-body';
 /**
  * A paragraph facade wrapper.
  *
- * Paragraph identity is backed by a runtime temporary key. The key is stable for
- * the current `FDocument` facade lifecycle and is re-resolved before each method
- * call, so insertions before this paragraph made through the facade do not break
- * the wrapper.
+ * Paragraph identity is backed by the persisted `paragraphId`. The id is
+ * re-resolved before each method call, so insertions before this paragraph do
+ * not break the wrapper.
  *
  * @hideconstructor
  */
@@ -49,8 +48,8 @@ export class FDocParagraph {
     }
 
     /**
-     * Get the runtime key used to resolve this paragraph.
-     * @returns {string} The paragraph runtime key for the current `FDocument` facade lifecycle.
+     * Get the persisted paragraph id.
+     * @returns {string} The paragraph id.
      * @example
      * ```ts
      * const doc = univerAPI.getActiveDocument();
@@ -61,6 +60,22 @@ export class FDocParagraph {
      * ```
      */
     getKey(): string {
+        return this._key;
+    }
+
+    /**
+     * Get the persisted paragraph id.
+     * @returns {string} The paragraph id.
+     * @example
+     * ```ts
+     * const doc = univerAPI.getActiveDocument();
+     * if (!doc) throw new Error('No active document');
+     *
+     * const paragraph = doc.getBody().getChild(0).asParagraph();
+     * console.log(paragraph.getId());
+     * ```
+     */
+    getId(): string {
         return this._key;
     }
 

--- a/packages/docs/src/facade/f-document.ts
+++ b/packages/docs/src/facade/f-document.ts
@@ -22,6 +22,7 @@ import {
     Injector,
     IResourceLoaderService,
     IUniverInstanceService,
+    normalizeDocumentParagraphIds,
     RedoCommand,
     UndoCommand,
 } from '@univerjs/core';
@@ -148,7 +149,7 @@ export class FDocument extends FBaseInitialable {
      */
     save(): IDocumentData {
         const snapshot = this._resourceLoaderService.saveUnit<IDocumentData>(this._documentDataModel.getUnitId())!;
-        return snapshot;
+        return normalizeDocumentParagraphIds(snapshot);
     }
 
     /**

--- a/packages/docs/src/facade/f-document.ts
+++ b/packages/docs/src/facade/f-document.ts
@@ -60,6 +60,7 @@ export class FDocument extends FBaseInitialable {
     ) {
         super(_injector);
 
+        normalizeDocumentParagraphIds(this._documentDataModel.getSnapshot());
         this.id = this._documentDataModel.getUnitId();
     }
 

--- a/packages/docs/src/facade/f-document.ts
+++ b/packages/docs/src/facade/f-document.ts
@@ -82,9 +82,8 @@ export class FDocument extends FBaseInitialable {
      *
      * The returned body facade provides synchronous Google Docs-like element APIs
      * for reading and editing top-level document body elements. Paragraph elements
-     * receive runtime temporary keys that remain stable for this `FDocument`
-     * facade lifecycle. Persisted elements, such as tables and custom blocks, use
-     * their existing ids.
+     * use their persisted `paragraphId` values. Persisted elements, such as tables
+     * and custom blocks, use their existing ids.
      *
      * @returns {FDocBody} The document body API instance.
      * @example

--- a/packages/docs/src/facade/f-document.ts
+++ b/packages/docs/src/facade/f-document.ts
@@ -22,7 +22,6 @@ import {
     Injector,
     IResourceLoaderService,
     IUniverInstanceService,
-    normalizeDocumentParagraphIds,
     RedoCommand,
     UndoCommand,
 } from '@univerjs/core';
@@ -60,7 +59,6 @@ export class FDocument extends FBaseInitialable {
     ) {
         super(_injector);
 
-        normalizeDocumentParagraphIds(this._documentDataModel.getSnapshot());
         this.id = this._documentDataModel.getUnitId();
     }
 
@@ -148,8 +146,7 @@ export class FDocument extends FBaseInitialable {
      * ```
      */
     save(): IDocumentData {
-        const snapshot = this._resourceLoaderService.saveUnit<IDocumentData>(this._documentDataModel.getUnitId())!;
-        return normalizeDocumentParagraphIds(snapshot);
+        return this._resourceLoaderService.saveUnit<IDocumentData>(this._documentDataModel.getUnitId())!;
     }
 
     /**

--- a/packages/docs/src/facade/utils.ts
+++ b/packages/docs/src/facade/utils.ts
@@ -15,6 +15,7 @@
  */
 
 import type { IDocumentBody } from '@univerjs/core';
+import { createParagraphId } from '@univerjs/core';
 
 type IParagraphStyle = NonNullable<IDocumentBody['paragraphs']>[number]['paragraphStyle'];
 
@@ -79,10 +80,12 @@ export function buildPlainTextInsertBody(
     };
 
     const paragraphs = [];
+    const existingParagraphIds = new Set<string>();
     for (let index = 0; index < normalizedDataStream.length; index++) {
         if (normalizedDataStream[index] === '\r') {
             paragraphs.push({
                 startIndex: index,
+                paragraphId: createParagraphId(existingParagraphIds),
                 ...(options.paragraphStyle == null ? {} : { paragraphStyle: cloneParagraphStyle(options.paragraphStyle) }),
             });
         }

--- a/packages/engine-formula/src/functions/__tests__/nested-functions.spec.ts
+++ b/packages/engine-formula/src/functions/__tests__/nested-functions.spec.ts
@@ -307,7 +307,7 @@ const getFunctionsTestWorkbookData = (): IWorkbookData => {
                                         { st: 1, ed: 2, ts: { ff: 'Arial', fs: 11, cl: { rgb: '#B20000' } } },
                                     ],
                                     paragraphs: [
-                                        { startIndex: 2, paragraphStyle: { horizontalAlign: 0 } },
+                                        { startIndex: 2, paragraphId: 'para_engine_formula_nested', paragraphStyle: { horizontalAlign: 0 } },
                                     ],
                                     sectionBreaks: [
                                         { startIndex: 3 },

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/create-paragraph-layout-test-bed.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/create-paragraph-layout-test-bed.ts
@@ -55,7 +55,7 @@ function createDocModel(
         body: {
             dataStream,
             textRuns: [{ st: 0, ed: dataStream.length, ts: {} }],
-            paragraphs: [{ startIndex: content.length }],
+            paragraphs: [{ startIndex: content.length, paragraphId: 'para_layout_test' }],
             sectionBreaks: [{ startIndex: content.length + 1 }],
             ...bodyOverride,
         },

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/language-ruler.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/language-ruler.spec.ts
@@ -27,7 +27,7 @@ function createViewModel(content: string) {
         body: {
             dataStream,
             textRuns: [{ st: 0, ed: dataStream.length, ts: {} }],
-            paragraphs: [{ startIndex: content.length }],
+            paragraphs: [{ startIndex: content.length, paragraphId: 'para_language_ruler_test' }],
             sectionBreaks: [{ startIndex: content.length + 1 }],
         },
         documentStyle: {},

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/line-adjustment.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/line-adjustment.ts
@@ -279,7 +279,7 @@ export function lineAdjustment(
     sectionBreakConfig: ISectionBreakConfig
 ) {
     const { endIndex } = paragraphNode;
-    const paragraph = viewModel.getParagraph(endIndex) || { startIndex: 0 };
+    const paragraph = viewModel.getParagraph(endIndex) || { startIndex: 0, paragraphId: 'para_render_fallback' };
 
     lineIterator(pages, (line) => {
         // Only need to adjust the current paragraph.

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/linebreaking.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/linebreaking.ts
@@ -265,7 +265,7 @@ export function lineBreaking(
     const { endIndex, blocks = [], children } = paragraphNode;
     const { segmentId } = curPage;
 
-    const paragraph = viewModel.getParagraph(endIndex) || { startIndex: 0 };
+    const paragraph = viewModel.getParagraph(endIndex) || { startIndex: 0, paragraphId: 'para_render_fallback' };
 
     const { paragraphStyle = {}, bullet } = paragraph;
     const useWordStyleLineHeight = _shouldApplyDocumentDefaultParagraphStyle(viewModel);

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/shaping.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/shaping.ts
@@ -123,7 +123,7 @@ export function shaping(
     const shapedTextList: IShapedText[] = [];
     let breaker = new LineBreaker(content);
     const { endIndex } = paragraphNode;
-    const paragraph = viewModel.getParagraph(endIndex) || { startIndex: 0 };
+    const paragraph = viewModel.getParagraph(endIndex) || { startIndex: 0, paragraphId: 'para_render_fallback' };
     const { paragraphStyle = {} } = paragraph;
     const { snapToGrid = BooleanNumber.TRUE } = paragraphStyle;
     let last = 0;

--- a/packages/engine-render/src/components/docs/layout/model/__tests__/page.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/model/__tests__/page.spec.ts
@@ -234,7 +234,7 @@ describe('page model', () => {
             dataModel: {
                 getBody: () => ({
                     blockRanges: [{ blockId: 'callout-1', blockType: DocumentBlockRangeType.CALLOUT, startIndex: 10, endIndex: 14 }],
-                    paragraphs: [{ startIndex: 12 }],
+                    paragraphs: [{ startIndex: 12, paragraphId: 'para_page_header' }],
                 }),
             },
             layoutStartPointer: {},
@@ -312,7 +312,10 @@ describe('page model', () => {
             dataModel: {
                 getBody: () => ({
                     blockRanges: [{ blockId: 'callout-1', blockType: DocumentBlockRangeType.CALLOUT, startIndex: 10, endIndex: 14 }],
-                    paragraphs: [{ startIndex: 12 }, { startIndex: 15 }],
+                    paragraphs: [
+                        { startIndex: 12, paragraphId: 'para_page_header_1' },
+                        { startIndex: 15, paragraphId: 'para_page_header_2' },
+                    ],
                 }),
             },
             layoutStartPointer: {},

--- a/packages/engine-render/src/components/docs/layout/shaping-engine/__tests__/text-shaping.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/shaping-engine/__tests__/text-shaping.spec.ts
@@ -51,6 +51,7 @@ function getDocumentBody(): IDocumentBody {
         paragraphs: [
             {
                 startIndex: 4,
+                paragraphId: 'para_text_shaping_1',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,
@@ -59,6 +60,7 @@ function getDocumentBody(): IDocumentBody {
             },
             {
                 startIndex: 36,
+                paragraphId: 'para_text_shaping_2',
                 paragraphStyle: {
                     spaceAbove: { v: 10 },
                     lineSpacing: 2,

--- a/packages/engine-render/src/components/docs/view-model/__tests__/document-view-model.spec.ts
+++ b/packages/engine-render/src/components/docs/view-model/__tests__/document-view-model.spec.ts
@@ -202,7 +202,7 @@ describe('DocumentViewModel', () => {
                 body: {
                     dataStream: bodyStream,
                     textRuns: [{ st: 0, ed: 2, ts: {} }],
-                    paragraphs: [{ startIndex: 0 }],
+                    paragraphs: [{ startIndex: 0, paragraphId: 'para_view_model_header' }],
                     sectionBreaks: [{ startIndex: 2 }],
                     customBlocks: [{ startIndex: 1, blockId: 'b1' }],
                     customRanges: [{ startIndex: 0, endIndex: 1, rangeId: 'r1' }],
@@ -262,7 +262,7 @@ describe('DocumentViewModel', () => {
                 body: {
                     dataStream: `Z${DataStreamTreeTokenType.PARAGRAPH}${DataStreamTreeTokenType.SECTION_BREAK}`,
                     textRuns: [{ st: 0, ed: 1, ts: { fs: 14 } }],
-                    paragraphs: [{ startIndex: 0 }],
+                    paragraphs: [{ startIndex: 0, paragraphId: 'para_view_model_footer' }],
                     sectionBreaks: [{ startIndex: 1 }],
                     customBlocks: [],
                     customRanges: [],

--- a/packages/engine-render/src/components/sheets/util.ts
+++ b/packages/engine-render/src/components/sheets/util.ts
@@ -15,7 +15,7 @@
  */
 
 import type { CellValueType, IDocumentData, IPaddingData, IStyleBase, IStyleData, ITextRotation, ITextStyle, Nullable, TextDirection } from '@univerjs/core';
-import { DEFAULT_EMPTY_DOCUMENT_VALUE, DocumentDataModel, DocumentFlavor, HorizontalAlign, VerticalAlign, WrapStrategy } from '@univerjs/core';
+import { createParagraphId, DEFAULT_EMPTY_DOCUMENT_VALUE, DocumentDataModel, DocumentFlavor, HorizontalAlign, VerticalAlign, WrapStrategy } from '@univerjs/core';
 import { convertTextRotation } from '../../basics/text-rotation';
 import { DEFAULT_PADDING_DATA } from './sheet.render-skeleton';
 
@@ -56,6 +56,7 @@ export function createDocumentModelWithStyle(content: string, textStyle: ITextSt
             paragraphs: [
                 {
                     startIndex: contentLength,
+                    paragraphId: createParagraphId(new Set()),
                     paragraphStyle: {
                         horizontalAlign,
                     },

--- a/packages/sheets-numfmt-ui/src/controllers/__tests__/editor.controller.spec.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/__tests__/editor.controller.spec.ts
@@ -254,6 +254,7 @@ describe('test editor', () => {
                     paragraphs: [
                         {
                             startIndex: 10,
+                            paragraphId: 'para_sheets_numfmt_edit_date',
                             paragraphStyle: {
                                 horizontalAlign: 0,
                             },
@@ -323,6 +324,7 @@ describe('test editor', () => {
                 paragraphs: [
                     {
                         startIndex: 9,
+                        paragraphId: 'para_sheets_numfmt_bullet',
                         paragraphStyle: {
                             horizontalAlign: 0,
                         },
@@ -678,6 +680,7 @@ describe('test get cell text/plain', () => {
                                         paragraphs: [
                                             {
                                                 startIndex: 6,
+                                                paragraphId: 'para_sheets_numfmt_rich_text',
                                                 paragraphStyle: {
                                                     horizontalAlign: 0,
                                                 },

--- a/packages/sheets-thread-comment/src/facade/__tests__/f-thread-comment.spec.ts
+++ b/packages/sheets-thread-comment/src/facade/__tests__/f-thread-comment.spec.ts
@@ -134,7 +134,8 @@ describe('thread comment facade', () => {
 
         await rootComment.deleteAsync();
         await replyComment.deleteAsync();
-        await rootComment.updateAsync(createBody('updated'));
+        const updatedBody = createBody('updated');
+        await rootComment.updateAsync(updatedBody);
         await rootComment.resolveAsync();
         await rootComment.resolveAsync(true);
         await rootComment.replyAsync(FTheadCommentBuilder.create().setContent(createBody('reply')));
@@ -145,7 +146,7 @@ describe('thread comment facade', () => {
             payload: expect.objectContaining({
                 commentId: root.id,
                 updated: true,
-                text: createBody('updated').getData().body,
+                text: updatedBody.getData().body,
             }),
         }));
         expect(commandService.executeCommand).toHaveBeenCalledWith(ResolveCommentCommand.id, expect.objectContaining({ resolved: true }));

--- a/packages/sheets-ui/src/commands/commands/__tests__/add-worksheet-merge.command.spec.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/add-worksheet-merge.command.spec.ts
@@ -400,12 +400,9 @@ describe('Test add worksheet merge commands', () => {
                                         },
                                     ],
                                     paragraphs: [
-                                        {
-                                            startIndex: 6,
-                                            paragraphStyle: {
-                                                horizontalAlign: 0,
-                                            },
-                                        },
+                                        { paragraphId: 'para_sheets_ui_fixture_1', startIndex: 6, paragraphStyle: {
+                                            horizontalAlign: 0,
+                                        } },
                                     ],
                                     sectionBreaks: [
                                         {

--- a/packages/sheets-ui/src/controllers/clipboard/utils.ts
+++ b/packages/sheets-ui/src/controllers/clipboard/utils.ts
@@ -29,6 +29,7 @@ import {
     cloneCellData,
     cloneCellDataMatrix,
     cloneValue,
+    createParagraphId,
     CustomRangeType,
     DEFAULT_STYLES,
     generateRandomId,
@@ -586,6 +587,7 @@ export function generateBody(text: string): IDocumentBody {
             dataStream: `${urlText}\r\n`,
             paragraphs: [{
                 startIndex: urlText.length,
+                paragraphId: createParagraphId(new Set()),
             }],
             customRanges: [range],
         };
@@ -597,10 +599,11 @@ export function generateBody(text: string): IDocumentBody {
         dataStream += '\r\n';
     }
     const paragraphs: IParagraph[] = [];
+    const existingParagraphIds = new Set<string>();
 
     for (let i = 0; i < dataStream.length; i++) {
         if (dataStream[i] === '\r') {
-            paragraphs.push({ startIndex: i });
+            paragraphs.push({ startIndex: i, paragraphId: createParagraphId(existingParagraphIds) });
         }
     }
 

--- a/packages/sheets-ui/src/controllers/editor/__tests__/end-edit.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/editor/__tests__/end-edit.controller.spec.ts
@@ -41,14 +41,11 @@ const richTextDemo: IDocumentData = {
             },
         ],
         paragraphs: [
-            {
-                startIndex: 489,
-                paragraphStyle: {
-                    horizontalAlign: 0,
-                    spaceAbove: { v: 10 },
-                    lineSpacing: 1.2,
-                },
-            },
+            { paragraphId: 'para_sheets_ui_fixture_2', startIndex: 489, paragraphStyle: {
+                horizontalAlign: 0,
+                spaceAbove: { v: 10 },
+                lineSpacing: 1.2,
+            } },
         ],
     },
     documentStyle: {
@@ -300,7 +297,7 @@ describe('Test EndEditController', () => {
                             { st: 1, ed: 2, ts: { ff: 'Arial', fs: 11, cl: { rgb: '#B20000' } } },
                         ],
                         paragraphs: [
-                            { startIndex: 2, paragraphStyle: { horizontalAlign: 0 } },
+                            { paragraphId: 'para_sheets_ui_fixture_3', startIndex: 2, paragraphStyle: { horizontalAlign: 0 } },
                         ],
                         sectionBreaks: [
                             { startIndex: 3 },
@@ -356,7 +353,7 @@ describe('Test EndEditController', () => {
                             { st: 1, ed: 2, ts: { ff: 'Arial', fs: 11, cl: { rgb: '#B20000' } } },
                         ],
                         paragraphs: [
-                            { startIndex: 2, paragraphStyle: { horizontalAlign: 0 } },
+                            { paragraphId: expect.stringMatching(/^para_/), startIndex: 2, paragraphStyle: { horizontalAlign: 0 } },
                         ],
                         sectionBreaks: [
                             { startIndex: 3 },
@@ -533,12 +530,9 @@ describe('Test EndEditController', () => {
                     },
                 ],
                 paragraphs: [
-                    {
-                        startIndex: 8,
-                        paragraphStyle: {
-                            horizontalAlign: 0,
-                        },
-                    },
+                    { paragraphId: 'para_sheets_ui_fixture_5', startIndex: 8, paragraphStyle: {
+                        horizontalAlign: 0,
+                    } },
                 ],
                 customRanges: [],
                 customDecorations: [],
@@ -562,12 +556,9 @@ describe('Test EndEditController', () => {
                     },
                 ],
                 paragraphs: [
-                    {
-                        startIndex: 4,
-                        paragraphStyle: {
-                            horizontalAlign: 0,
-                        },
-                    },
+                    { paragraphId: 'para_sheets_ui_fixture_6', startIndex: 4, paragraphStyle: {
+                        horizontalAlign: 0,
+                    } },
                 ],
                 customBlocks: [],
                 customRanges: [],

--- a/packages/sheets-ui/src/controllers/editor/data-sync.controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/data-sync.controller.ts
@@ -21,6 +21,7 @@ import type { IMoveRangeMutationParams, ISetRangeValuesMutationParams } from '@u
 import type { ICellEditorState } from '../../services/editor-bridge.service';
 import {
     BooleanNumber,
+    createParagraphId,
     Disposable,
     DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
     DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
@@ -123,6 +124,7 @@ export class EditorDataSyncController extends Disposable {
                 paragraphs: [
                     {
                         startIndex: 0,
+                        paragraphId: createParagraphId(new Set()),
                     },
                 ],
                 textRuns: [],

--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -36,6 +36,7 @@ import type { IUniverSheetsUIConfig } from '../../config/config';
 import type { IEditorBridgeServiceVisibleParam } from '../../services/editor-bridge.service';
 import {
     CellValueType,
+    createParagraphId,
     DEFAULT_EMPTY_DOCUMENT_VALUE,
     Direction,
     Disposable,
@@ -1006,6 +1007,7 @@ function emptyBody(body: IDocumentBody, removeStyle = false) {
         body.paragraphs = [
             {
                 startIndex: 0,
+                paragraphId: createParagraphId(new Set()),
             },
         ];
     }

--- a/packages/sheets-ui/src/services/clipboard/__tests__/__snapshots__/sheet-paste.spec.ts.snap
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/__snapshots__/sheet-paste.spec.ts.snap
@@ -28,6 +28,7 @@ exports[`Test clipboard > Test paste > test convert util func from excel 1`] = `
 ",
           "paragraphs": [
             {
+              "paragraphId": "<paragraphId>",
               "startIndex": 19,
             },
           ],
@@ -538,6 +539,7 @@ exports[`Test clipboard > Test paste > test convert util func from excel 1`] = `
 ",
           "paragraphs": [
             {
+              "paragraphId": "<paragraphId>",
               "startIndex": 29,
             },
           ],
@@ -3285,6 +3287,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
 ",
           "paragraphs": [
             {
+              "paragraphId": "<paragraphId>",
               "startIndex": 17,
             },
           ],
@@ -3574,6 +3577,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
 ",
           "paragraphs": [
             {
+              "paragraphId": "<paragraphId>",
               "startIndex": 53,
             },
           ],
@@ -4136,6 +4140,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
 ",
           "paragraphs": [
             {
+              "paragraphId": "<paragraphId>",
               "startIndex": 4,
             },
           ],
@@ -4203,6 +4208,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
 ",
           "paragraphs": [
             {
+              "paragraphId": "<paragraphId>",
               "startIndex": 10,
             },
           ],
@@ -4684,6 +4690,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
 ",
           "paragraphs": [
             {
+              "paragraphId": "<paragraphId>",
               "startIndex": 4,
             },
           ],
@@ -4751,6 +4758,7 @@ exports[`Test clipboard > Test paste > test convert util func from google 1`] = 
 ",
           "paragraphs": [
             {
+              "paragraphId": "<paragraphId>",
               "startIndex": 10,
             },
           ],

--- a/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-paste-form-excel.spec.ts
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-paste-form-excel.spec.ts
@@ -219,6 +219,7 @@ describe('Test clipboard', () => {
             expect(richTextStyle?.body?.dataStream).toBe('Univer\r\n');
             expect(richTextStyle?.body?.paragraphs).toStrictEqual([
                 {
+                    paragraphId: expect.stringMatching(/^para_/),
                     paragraphStyle: {
                         horizontalAlign: 0,
                     },

--- a/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-paste-from-google.spec.ts
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/clipboard-paste-from-google.spec.ts
@@ -203,6 +203,7 @@ describe('Test clipboard', () => {
             expect(richTextStyle?.body?.dataStream).toBe('univer\r\n');
             expect(richTextStyle?.body?.paragraphs).toStrictEqual([
                 {
+                    paragraphId: expect.stringMatching(/^para_/),
                     paragraphStyle: {
                         horizontalAlign: 0,
                     },

--- a/packages/sheets-ui/src/services/clipboard/__tests__/sheet-paste.spec.ts
+++ b/packages/sheets-ui/src/services/clipboard/__tests__/sheet-paste.spec.ts
@@ -37,6 +37,27 @@ function getHTMLString(filePath: string): string {
     return readFileSync(filePath, 'utf-8');
 }
 
+function normalizeParagraphIds(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map((item) => normalizeParagraphIds(item));
+    }
+
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(Object.entries(value).map(([key, item]) => [
+            key,
+            key === 'paragraphId' ? '<paragraphId>' : normalizeParagraphIds(item),
+        ]));
+    }
+
+    return value;
+}
+
+function normalizeSnapshotValue(value: unknown): unknown {
+    return normalizeParagraphIds(typeof (value as { toJSON?: unknown }).toJSON === 'function'
+        ? (value as { toJSON: () => unknown }).toJSON()
+        : value);
+}
+
 describe('Test clipboard', () => {
     let univer: Univer;
     let get: Injector['get'];
@@ -113,7 +134,7 @@ describe('Test clipboard', () => {
             const htmlPath = path.join(__dirname, 'assets', 'html', 'excel-base-sample.html');
             const html = getHTMLString(htmlPath);
             const cellMatrix = htmlToUSM.convert(html).cellMatrix;
-            expect(cellMatrix).toMatchSnapshot();
+            expect(normalizeSnapshotValue(cellMatrix)).toMatchSnapshot();
         });
 
         it('test convert util func from google', async () => {
@@ -125,7 +146,7 @@ describe('Test clipboard', () => {
             const htmlPath = path.join(__dirname, 'assets', 'html', 'google-base-sample.html');
             const html = getHTMLString(htmlPath);
             const cellMatrix = htmlToUSM.convert(html).cellMatrix;
-            expect(cellMatrix).toMatchSnapshot();
+            expect(normalizeSnapshotValue(cellMatrix)).toMatchSnapshot();
         });
     });
 });

--- a/packages/sheets-ui/src/services/clipboard/html-to-usm/converter.ts
+++ b/packages/sheets-ui/src/services/clipboard/html-to-usm/converter.ts
@@ -26,7 +26,7 @@ import type {
     IUniverSheetCopyDataModel,
 } from '../type';
 import type { IAfterProcessRule, IPastePlugin } from './paste-plugins/type';
-import { CustomRangeType, DEFAULT_WORKSHEET_ROW_HEIGHT, generateRandomId, getNumfmtParseValueFilter, isSafeUrl, numfmt, ObjectMatrix, skipParseTagNames } from '@univerjs/core';
+import { createParagraphId, CustomRangeType, DEFAULT_WORKSHEET_ROW_HEIGHT, generateRandomId, getNumfmtParseValueFilter, isSafeUrl, numfmt, ObjectMatrix, skipParseTagNames } from '@univerjs/core';
 import { handleStringToStyle, textTrim } from '@univerjs/ui';
 import { extractNodeStyle } from './parse-node-style';
 import parseToDom, { convertToCellStyle, generateParagraphs } from './utils';
@@ -551,7 +551,10 @@ export class HtmlToUSMService {
                 if (!doc.paragraphs) {
                     doc.paragraphs = [];
                 }
-                doc.paragraphs.push({ startIndex: doc.dataStream.length });
+                doc.paragraphs.push({
+                    startIndex: doc.dataStream.length,
+                    paragraphId: createParagraphId(new Set(doc.paragraphs.map((paragraph) => paragraph.paragraphId))),
+                });
                 doc.dataStream += '\r';
             } else if (node.nodeType === Node.ELEMENT_NODE) {
                 const currentNodeStyle = this._getStyle(node as HTMLElement, styleStr);
@@ -681,7 +684,10 @@ export class HtmlToUSMService {
                 if (!doc.paragraphs) {
                     doc.paragraphs = [];
                 }
-                doc.paragraphs.push({ startIndex: doc.dataStream.length });
+                doc.paragraphs.push({
+                    startIndex: doc.dataStream.length,
+                    paragraphId: createParagraphId(new Set(doc.paragraphs.map((paragraph) => paragraph.paragraphId))),
+                });
                 doc.dataStream += '\r';
             } else if (node.nodeType === Node.ELEMENT_NODE) {
                 if (node.nodeName === 'STYLE') {

--- a/packages/sheets-ui/src/services/clipboard/html-to-usm/paste-plugins/plugin-lark.ts
+++ b/packages/sheets-ui/src/services/clipboard/html-to-usm/paste-plugins/plugin-lark.ts
@@ -16,7 +16,7 @@
 
 import type { IPastePlugin } from './type';
 
-import { BooleanNumber } from '@univerjs/core';
+import { BooleanNumber, createParagraphId } from '@univerjs/core';
 import { extractNodeStyle as getInlineStyle } from '../parse-node-style';
 
 export const LarkPastePlugin: IPastePlugin = {
@@ -53,6 +53,7 @@ export const LarkPastePlugin: IPastePlugin = {
 
                 doc.paragraphs.push({
                     startIndex: doc.dataStream.length,
+                    paragraphId: createParagraphId(new Set(doc.paragraphs.map((paragraph) => paragraph.paragraphId))),
                 });
                 doc.dataStream += '\r';
             },

--- a/packages/sheets-ui/src/services/clipboard/html-to-usm/paste-plugins/plugin-univer.ts
+++ b/packages/sheets-ui/src/services/clipboard/html-to-usm/paste-plugins/plugin-univer.ts
@@ -16,6 +16,7 @@
 
 import type { IParagraph } from '@univerjs/core';
 import type { IPastePlugin } from './type';
+import { createParagraphId } from '@univerjs/core';
 import { getParagraphStyle } from '../utils';
 
 export const UniverPastePlugin: IPastePlugin = {
@@ -38,6 +39,7 @@ export const UniverPastePlugin: IPastePlugin = {
 
                 const paragraph: IParagraph = {
                     startIndex: doc.dataStream.length,
+                    paragraphId: createParagraphId(new Set(doc.paragraphs.map((p) => p.paragraphId))),
                 };
 
                 const paragraphStyle = getParagraphStyle(el);

--- a/packages/sheets-ui/src/services/clipboard/html-to-usm/paste-plugins/plugin-word.ts
+++ b/packages/sheets-ui/src/services/clipboard/html-to-usm/paste-plugins/plugin-word.ts
@@ -16,7 +16,7 @@
 
 import type { IParagraph } from '@univerjs/core';
 import type { IPastePlugin } from './type';
-import { BooleanNumber } from '@univerjs/core';
+import { BooleanNumber, createParagraphId } from '@univerjs/core';
 import { extractNodeStyle as getInlineStyle } from '../parse-node-style';
 import { getParagraphStyle } from '../utils';
 
@@ -49,6 +49,7 @@ export const WordPastePlugin: IPastePlugin = {
 
                 const paragraph: IParagraph = {
                     startIndex: doc.dataStream.length,
+                    paragraphId: createParagraphId(new Set(doc.paragraphs.map((p) => p.paragraphId))),
                 };
 
                 const paragraphStyle = getParagraphStyle(el);

--- a/packages/sheets-ui/src/services/clipboard/html-to-usm/utils.ts
+++ b/packages/sheets-ui/src/services/clipboard/html-to-usm/utils.ts
@@ -16,7 +16,7 @@
 
 import type { IParagraph, IParagraphStyle, ITextRun, Nullable } from '@univerjs/core';
 import type { ICellDataWithSpanInfo } from '../type';
-import { DataStreamTreeTokenType, Tools } from '@univerjs/core';
+import { createParagraphId, DataStreamTreeTokenType, Tools } from '@univerjs/core';
 import { ptToPixel } from '@univerjs/engine-render';
 import { sanitizeParsedHtml } from '@univerjs/ui';
 
@@ -96,6 +96,7 @@ export function getParagraphStyle(el: HTMLElement): Nullable<IParagraphStyle> {
 
 export function generateParagraphs(dataStream: string, prevParagraph?: IParagraph): IParagraph[] {
     const paragraphs: IParagraph[] = [];
+    const existingParagraphIds = new Set<string>();
 
     for (let i = 0, len = dataStream.length; i < len; i++) {
         const char = dataStream[i];
@@ -106,6 +107,7 @@ export function generateParagraphs(dataStream: string, prevParagraph?: IParagrap
 
         paragraphs.push({
             startIndex: i,
+            paragraphId: createParagraphId(existingParagraphIds),
         });
     }
 

--- a/packages/sheets/src/commands/commands/__tests__/set-range-values.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-range-values.command.spec.ts
@@ -230,6 +230,7 @@ describe('Test set range values commands', () => {
                             paragraphs: [
                                 {
                                     startIndex: 489,
+                                    paragraphId: 'para_sheets_set_range_values_1',
                                     paragraphStyle: {
                                         spaceAbove: { v: 10 },
                                         lineSpacing: 1.2,
@@ -772,6 +773,7 @@ describe('Test set range values commands', () => {
                             paragraphs: [
                                 {
                                     startIndex: 489,
+                                    paragraphId: 'para_sheets_set_range_values_2',
                                     paragraphStyle: {
                                         spaceAbove: { v: 10 },
                                         lineSpacing: 1.2,
@@ -839,6 +841,7 @@ describe('Test set range values commands', () => {
                             paragraphs: [
                                 {
                                     startIndex: 489,
+                                    paragraphId: 'para_sheets_set_range_values_3',
                                     paragraphStyle: {
                                         spaceAbove: { v: 10 },
                                         lineSpacing: 1.2,

--- a/packages/slides-ui/src/controllers/slide-editing.render-controller.ts
+++ b/packages/slides-ui/src/controllers/slide-editing.render-controller.ts
@@ -35,6 +35,7 @@ import type {
 import type { SlideDataModel } from '@univerjs/slides';
 import type { IEditorBridgeServiceVisibleParam } from '../services/slide-editor-bridge.service';
 import {
+    createParagraphId,
     DEFAULT_EMPTY_DOCUMENT_VALUE,
     Direction,
     Disposable,
@@ -633,6 +634,7 @@ export class SlideEditingRenderController extends Disposable implements IRenderM
                 body.paragraphs = [
                     {
                         startIndex: 0,
+                        paragraphId: createParagraphId(new Set()),
                     },
                 ];
             }

--- a/packages/slides-ui/src/views/editor-container/EditorContainer.tsx
+++ b/packages/slides-ui/src/views/editor-container/EditorContainer.tsx
@@ -15,7 +15,7 @@
  */
 
 import type { IDocumentData } from '@univerjs/core';
-import { DEFAULT_EMPTY_DOCUMENT_VALUE, DocumentFlavor, IContextService } from '@univerjs/core';
+import { createParagraphId, DEFAULT_EMPTY_DOCUMENT_VALUE, DocumentFlavor, IContextService } from '@univerjs/core';
 import { borderClassName, clsx } from '@univerjs/design';
 import { IEditorService } from '@univerjs/docs-ui';
 import { FIX_ONE_PIXEL_BLUR_OFFSET } from '@univerjs/engine-render';
@@ -60,6 +60,7 @@ export function SlideEditorContainer() {
             paragraphs: [
                 {
                     startIndex: 0,
+                    paragraphId: createParagraphId(new Set()),
                 },
             ],
         },

--- a/packages/slides/src/basics/demo-data.ts
+++ b/packages/slides/src/basics/demo-data.ts
@@ -128,6 +128,7 @@ export const docsDemoData: IDocumentData = {
         ],
         paragraphs: [
             {
+                paragraphId: 'para_slides_demo_order_1',
                 startIndex: 60,
                 bullet: {
                     listId: 'orderList',
@@ -139,6 +140,7 @@ export const docsDemoData: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_slides_demo_order_2',
                 startIndex: 91,
                 bullet: {
                     listId: 'orderList',
@@ -150,6 +152,7 @@ export const docsDemoData: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_slides_demo_order_3',
                 startIndex: 234,
                 bullet: {
                     listId: 'orderList',
@@ -161,6 +164,7 @@ export const docsDemoData: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_slides_demo_order_4',
                 startIndex: 327,
                 bullet: {
                     listId: 'orderList',
@@ -172,6 +176,7 @@ export const docsDemoData: IDocumentData = {
                 },
             },
             {
+                paragraphId: 'para_slides_demo_order_5',
                 startIndex: 406,
                 bullet: {
                     listId: 'orderList',

--- a/packages/thread-comment-ui/src/views/thread-comment-editor/util.ts
+++ b/packages/thread-comment-ui/src/views/thread-comment-editor/util.ts
@@ -16,7 +16,7 @@
 
 import type { IDocumentBody } from '@univerjs/core';
 import type { IThreadCommentMention } from '@univerjs/thread-comment';
-import { CustomRangeType, getBodySlice } from '@univerjs/core';
+import { createParagraphId, CustomRangeType, getBodySlice } from '@univerjs/core';
 
 interface IThreadCommentEditorFocusService {
     focus: (editorId: string) => void;
@@ -114,6 +114,7 @@ export const transformTextNodes2Document = (nodes: TextNode[]): IDocumentBody =>
         paragraphs: [
             {
                 startIndex: str.length - 2,
+                paragraphId: createParagraphId(new Set()),
                 paragraphStyle: {},
             },
         ],


### PR DESCRIPTION
## Summary
- add persisted `paragraphId` identity to Docs paragraphs
- preserve paragraph ids through TextX edit, invert, undo, and redo paths
- generate and normalize paragraph ids for inserted text, save, and facade live models
- resolve Docs Facade paragraph wrappers by persisted id instead of runtime keys

## Tests
- pnpm --filter @univerjs/core test src/docs/__tests__/paragraph-id.spec.ts src/docs/data-model/text-x/__tests__/paragraph-id.spec.ts
- pnpm --filter @univerjs/docs test src/__tests__/facade-utils.spec.ts src/facade/__tests__/f-document-node.spec.ts
- pnpm --filter @univerjs/core typecheck
- pnpm --filter @univerjs/docs typecheck