### PR TITLE
fix(sheets): validate createWorkbook sheet ids

### DIFF
--- a/packages/core/src/sheets/typedef.ts
+++ b/packages/core/src/sheets/typedef.ts
@@ -58,11 +58,13 @@ export interface IWorkbookData {
      */
     styles: Record<string, Nullable<IStyleData>>;
 
-    /** Ids of {@link IWorksheetData}s of this Univer Sheet in sequence order. */
+    /**
+     * Sheet ids of {@link IWorksheetData}s in sequence order. Each entry must reference a key in {@link IWorkbookData.sheets}.
+     */
     sheetOrder: string[];
 
     /**
-     * Data of each {@link IWorksheetData} in this Univer Sheet.
+     * Data of each {@link IWorksheetData} in this Univer Sheet. The map key is the canonical sheet id and must match the nested worksheet data id when it is provided.
      */
     sheets: { [sheetId: string]: Partial<IWorksheetData> };
 

--- a/packages/sheets/src/facade/__tests__/f-univer.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-univer.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IUniverInstanceService } from '@univerjs/core';
+import { describe, expect, it } from 'vitest';
+import { createFacadeTestBed } from './create-test-bed';
+
+describe('Test FUniver sheets facade', () => {
+    it('rejects createWorkbook snapshots whose sheet map keys do not match sheet ids', () => {
+        const { get, univer, univerAPI } = createFacadeTestBed();
+        try {
+            expect(() =>
+                univerAPI.createWorkbook({
+                    id: 'workbook-demo',
+                    name: 'Demo Workbook',
+                    sheetOrder: ['Sheet1'],
+                    sheets: {
+                        Sheet1: {
+                            id: 'sheet-demo-1',
+                            name: 'Sheet1',
+                            rowCount: 10,
+                            columnCount: 10,
+                            cellData: { 0: { 0: { v: 'bad-key-visible-data', t: 1 } } },
+                        },
+                    },
+                })
+            ).toThrow('createWorkbook snapshot is invalid: sheets["Sheet1"].id must equal "Sheet1", got "sheet-demo-1". Use sheet ids for sheetOrder and sheets map keys.');
+
+            expect(get(IUniverInstanceService).getUnit('workbook-demo')).toBeUndefined();
+        } finally {
+            univer.dispose();
+        }
+    });
+});

--- a/packages/sheets/src/facade/f-univer.ts
+++ b/packages/sheets/src/facade/f-univer.ts
@@ -89,6 +89,25 @@ export interface IFUniverSheetsMixin {
      * const fWorkbook = univerAPI.createWorkbook({ id: 'workbook-01', name: 'Workbook1' }, { makeCurrent: false });
      * console.log(fWorkbook);
      * ```
+     *
+     * When `data` includes sheet snapshots, `sheetOrder` entries enumerate the `sheets` map keys.
+     * Each `sheets` map key is the canonical sheet id.
+     * Each `sheets[sheetId].id`, when provided, must match the enclosing `sheetId`.
+     * ```ts
+     * const fWorkbook = univerAPI.createWorkbook({
+     *   id: 'workbook-01',
+     *   name: 'Workbook1',
+     *   sheetOrder: ['sheet-01'],
+     *   sheets: {
+     *     'sheet-01': {
+     *       id: 'sheet-01',
+     *       name: 'Sheet1',
+     *       rowCount: 100,
+     *       columnCount: 20,
+     *     },
+     *   },
+     * });
+     * ```
      */
     createWorkbook(data: Partial<IWorkbookData>, options?: ICreateUnitOptions): FWorkbook;
 
@@ -160,6 +179,7 @@ export interface IFUniverSheetsMixin {
 
 export class FUniverSheetsMixin extends FUniver implements IFUniverSheetsMixin {
     override createWorkbook(data: Partial<IWorkbookData>, options?: ICreateUnitOptions): FWorkbook {
+        validateWorkbookSnapshotSheetIds(data);
         const instanceService = this._injector.get(IUniverInstanceService);
         const workbook = instanceService.createUnit<IWorkbookData, Workbook>(UniverInstanceType.UNIVER_SHEET, data, options);
         return this._injector.createInstance(FWorkbook, workbook);
@@ -736,6 +756,27 @@ export class FUniverSheetsMixin extends FUniver implements IFUniverSheetsMixin {
                 })
             )
         );
+    }
+}
+
+function validateWorkbookSnapshotSheetIds(data: Partial<IWorkbookData>): void {
+    const { sheets, sheetOrder } = data;
+    if (sheets == null) {
+        return;
+    }
+
+    if (sheetOrder != null) {
+        for (const sheetId of sheetOrder) {
+            if (!Object.prototype.hasOwnProperty.call(sheets, sheetId)) {
+                throw new Error(`createWorkbook snapshot is invalid: sheetOrder contains "${sheetId}" but sheets["${sheetId}"] is missing. Use sheet ids for sheetOrder and sheets map keys.`);
+            }
+        }
+    }
+
+    for (const [sheetKey, sheet] of Object.entries(sheets)) {
+        if (sheet?.id != null && sheet.id !== sheetKey) {
+            throw new Error(`createWorkbook snapshot is invalid: sheets["${sheetKey}"].id must equal "${sheetKey}", got "${sheet.id}". Use sheet ids for sheetOrder and sheets map keys.`);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- validate `createWorkbook(data)` sheet snapshot identity before creating a sheet unit
- reject `sheetOrder` entries missing from `sheets` and `sheets[key].id` values that do not match their map key
- add a sheets facade regression that confirms invalid snapshots fail before unit creation

This closes the upstream SDK contract gap behind dream-num/univer-cli#464.

## Validation
- `pnpm --filter @univerjs/sheets test -- src/facade/__tests__/f-univer.spec.ts`
- `pnpm --filter @univerjs/sheets typecheck`
