### PR TITLE
refactor(drawing-ui): replace local Divider with design Separator

### DIFF
--- a/packages/drawing-ui/src/views/image-popup-menu/ImagePopupMenu.tsx
+++ b/packages/drawing-ui/src/views/image-popup-menu/ImagePopupMenu.tsx
@@ -24,7 +24,7 @@ import {
     PositionedObjectLayoutType,
     UniverInstanceType,
 } from '@univerjs/core';
-import { borderClassName, clsx, Dropdown, DropdownMenu, Tooltip } from '@univerjs/design';
+import { borderClassName, clsx, Dropdown, DropdownMenu, Separator, Tooltip } from '@univerjs/design';
 import { AutofillDoubleIcon, CropIcon, DeleteIcon, DocSettingIcon, MoreDownIcon, TextWrapShapeIcon } from '@univerjs/icons';
 import { useDependency } from '@univerjs/ui';
 import { useState } from 'react';
@@ -182,17 +182,6 @@ function getWrappingStyle(documentDataModel: DocumentDataModel | undefined, draw
     return TextWrappingStyle.INLINE;
 }
 
-function Divider() {
-    return (
-        <span
-            className="
-              univer-h-5 univer-w-px univer-bg-gray-200
-              dark:!univer-bg-gray-700
-            "
-        />
-    );
-}
-
 function ToolbarGroup(props: { children: ReactNode }) {
     return (
         <div className="univer-flex univer-h-7 univer-items-center univer-gap-1 univer-px-1">
@@ -310,11 +299,31 @@ function DocImageFloatingToolbar(props: IDocImageFloatingToolbarProps) {
     const cropItem = getMenuItem('drawing-ui.image-popup.crop');
     const deleteItem = getMenuItem('drawing-ui.image-popup.delete');
     const wrappingStyleOptions = [
-        { label: localeService.t('drawing-ui.image-text-wrap.inline'), value: TextWrappingStyle.INLINE, icon: <TextWrapShapeIcon /> },
-        { label: localeService.t('drawing-ui.image-text-wrap.square'), value: TextWrappingStyle.WRAP_SQUARE, icon: <TextWrapShapeIcon /> },
-        { label: localeService.t('drawing-ui.image-text-wrap.topAndBottom'), value: TextWrappingStyle.WRAP_TOP_AND_BOTTOM, icon: <TextWrapShapeIcon /> },
-        { label: localeService.t('drawing-ui.image-text-wrap.behindText'), value: TextWrappingStyle.BEHIND_TEXT, icon: <TextWrapShapeIcon /> },
-        { label: localeService.t('drawing-ui.image-text-wrap.inFrontText'), value: TextWrappingStyle.IN_FRONT_OF_TEXT, icon: <TextWrapShapeIcon /> },
+        {
+            label: localeService.t('drawing-ui.image-text-wrap.inline'),
+            value: TextWrappingStyle.INLINE,
+            icon: <TextWrapShapeIcon />,
+        },
+        {
+            label: localeService.t('drawing-ui.image-text-wrap.square'),
+            value: TextWrappingStyle.WRAP_SQUARE,
+            icon: <TextWrapShapeIcon />,
+        },
+        {
+            label: localeService.t('drawing-ui.image-text-wrap.topAndBottom'),
+            value: TextWrappingStyle.WRAP_TOP_AND_BOTTOM,
+            icon: <TextWrapShapeIcon />,
+        },
+        {
+            label: localeService.t('drawing-ui.image-text-wrap.behindText'),
+            value: TextWrappingStyle.BEHIND_TEXT,
+            icon: <TextWrapShapeIcon />,
+        },
+        {
+            label: localeService.t('drawing-ui.image-text-wrap.inFrontText'),
+            value: TextWrappingStyle.IN_FRONT_OF_TEXT,
+            icon: <TextWrapShapeIcon />,
+        },
     ];
 
     const executeMenuItem = (item: IImagePopupMenuItem | undefined) => {
@@ -359,7 +368,7 @@ function DocImageFloatingToolbar(props: IDocImageFloatingToolbarProps) {
                     onChange={updateWrappingStyle}
                 />
             </ToolbarGroup>
-            <Divider />
+            <Separator orientation="vertical" />
             <ToolbarGroup>
                 <ToolbarButton
                     title={editItem ? localeService.t(editItem.label) : localeService.t('drawing-ui.image-popup.edit')}
@@ -379,7 +388,7 @@ function DocImageFloatingToolbar(props: IDocImageFloatingToolbarProps) {
                     <CropIcon />
                 </ToolbarButton>
             </ToolbarGroup>
-            <Divider />
+            <Separator orientation="vertical" />
             <ToolbarGroup>
                 <ToolbarButton
                     title={deleteItem ? localeService.t(deleteItem.label) : localeService.t('drawing-ui.image-popup.delete')}


### PR DESCRIPTION
Drop the in-file `Divider` span and use the shared `Separator` from `@univerjs/design` for both vertical gaps in the image floating toolbar.

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
