### PR TITLE
fix(eslint): explain facade import boundary

### DIFF
--- a/common/shared/eslint/plugins/no-external-imports-in-facade.spec.ts
+++ b/common/shared/eslint/plugins/no-external-imports-in-facade.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+import noExternalImportsInFacade from './no-external-imports-in-facade';
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+    },
+});
+
+describe('no-external-imports-in-facade', () => {
+    it('explains the facade package-entry migration path', () => {
+        ruleTester.run('no-external-imports-in-facade', noExternalImportsInFacade, {
+            valid: [
+                {
+                    code: 'import { PublicCommand } from "@univerjs/example";',
+                    filename: '/repo/packages/example/src/facade/f-univer.ts',
+                },
+                {
+                    code: 'import { FThing } from "./f-thing";',
+                    filename: '/repo/packages/example/src/facade/f-univer.ts',
+                },
+            ],
+            invalid: [
+                {
+                    code: 'import { PrivateCommand } from "../commands/private.command";',
+                    filename: '/repo/packages/example/src/facade/f-univer.ts',
+                    errors: [
+                        {
+                            message: 'Facade files are published as a separate package entry. Do not import package-internal runtime modules through "../commands/private.command"; it can duplicate module singletons when consumers import both the package root and the facade entry. Move the needed symbol to the package root export if necessary, then import it through the package name. Type-only imports should also use a public package entry.',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/common/shared/eslint/plugins/no-external-imports-in-facade.ts
+++ b/common/shared/eslint/plugins/no-external-imports-in-facade.ts
@@ -33,7 +33,7 @@ const rule: Rule.RuleModule = {
             description: 'Disallow imports from outside facade directory in facade files',
         },
         messages: {
-            noExternalImports: 'Imports from outside facade directory are not allowed in facade files: "{{importPath}}"',
+            noExternalImports: 'Facade files are published as a separate package entry. Do not import package-internal runtime modules through "{{importPath}}"; it can duplicate module singletons when consumers import both the package root and the facade entry. Move the needed symbol to the package root export if necessary, then import it through the package name. Type-only imports should also use a public package entry.',
         },
     },
 


### PR DESCRIPTION
## Background

`univer/no-external-imports-in-facade` already prevents facade files from importing modules outside the facade directory via relative imports, but the current error only says the import is not allowed, without explaining the reason or the migration steps. The actual problem is that facade is published as an independent package entry; importing into the package's internal runtime modules can cause consumers who import both the package root and the facade entry to duplicate module singletons.

## Fix

- Updated the error message of `no-external-imports-in-facade` to explain the risk of facade being published as an independent entry.
- Clarified the migration steps: promote the needed symbols to the package root public exports first, then import them via the package name; type-only imports should also use the public package entry.
- Added RuleTester cases covering the message text.

## Verification

- `pnpm install --frozen-lockfile`: passed.
- `pnpm --filter @univerjs-infra/shared exec vitest run eslint/plugins/no-external-imports-in-facade.spec.ts`: passed, 1 test.
- `pnpm --filter @univerjs-infra/shared typecheck`: passed.
- `pnpm exec eslint common/shared/eslint/plugins/no-external-imports-in-facade.ts common/shared/eslint/plugins/no-external-imports-in-facade.spec.ts --no-warn-ignored`: passed.
- `git diff --check`: passed.

## Notes

This PR is not merged directly; it awaits review by colleagues. The companion PR that removes the local disables in univer-pro and fixes the facade imports of bases/bases-ui has been submitted separately.
