### PR TITLE
fix: clarify doc editor backgrounds

### DIFF
--- a/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
@@ -23,7 +23,7 @@ import { DocBackground, Documents, IRenderManagerService, Layer, PageLayoutType,
 import { takeUntil } from 'rxjs';
 import { DOCS_COMPONENT_BACKGROUND_LAYER_INDEX, DOCS_COMPONENT_DEFAULT_Z_INDEX, DOCS_COMPONENT_HEADER_LAYER_INDEX, DOCS_COMPONENT_MAIN_LAYER_INDEX, DOCS_VIEW_KEY, VIEWPORT_KEY } from '../../basics/docs-view-key';
 import { DocPageLayoutService } from '../../services/doc-page-layout.service';
-import { resolveDocsCanvasBackground } from '../../services/docs-render.service';
+import { resolveDocRenderBackground } from '../../services/doc-render-background';
 import { IEditorService } from '../../services/editor/editor-manager.service';
 import { DocSelectionRenderService } from '../../services/selection/doc-selection-render.service';
 
@@ -305,7 +305,7 @@ export class DocRenderController extends RxDisposable implements IRenderModule {
     private _syncCanvasBackground(documentFlavor = this._context.unit.getSnapshot().documentStyle.documentFlavor) {
         const editorRenderConfig = this._editorService.getEditorRenderConfig(this._context.unitId);
         const editorBackgroundColor = editorRenderConfig?.canvasStyle.backgroundColor;
-        const resolvedBackground = resolveDocsCanvasBackground({
+        const resolvedBackground = resolveDocRenderBackground({
             documentFlavor,
             canvasColorService: this._context.engine.canvasColorService,
             editorBackgroundColor,

--- a/packages/docs-ui/src/services/__tests__/doc-services.spec.ts
+++ b/packages/docs-ui/src/services/__tests__/doc-services.spec.ts
@@ -25,7 +25,8 @@ import { DocAutoFormatService } from '../doc-auto-format.service';
 import { getListMarkerFallbackBound, getListMarkerFallbackHit, getListParagraphContextMenuHit, isChecklistListType } from '../doc-event-manager.service';
 import { DocMenuStyleService } from '../doc-menu-style.service';
 import { DocPrintInterceptorService } from '../doc-print-interceptor.service';
-import { DocsRenderService, getDocsCanvasBackgroundColor, resolveDocsCanvasBackground } from '../docs-render.service';
+import { resolveDocRenderBackground } from '../doc-render-background';
+import { DocsRenderService, getDocsCanvasBackgroundColor } from '../docs-render.service';
 
 function createDocData(): IDocumentData {
     return {
@@ -324,16 +325,14 @@ describe('docs ui services', () => {
         expect(renderManagerService.removeRender).toHaveBeenCalledWith('doc-3');
     });
 
-    it('resolves the docs canvas background through the canvas color service', () => {
+    it('resolves doc render backgrounds by render role', () => {
         const canvasColorService = {
             getRenderColor: vi.fn((color: string) => `rendered:${color}`),
         };
 
         expect(getDocsCanvasBackgroundColor(DocumentFlavor.MODERN, canvasColorService as never)).toBe('rendered:#fff');
         expect(getDocsCanvasBackgroundColor(DocumentFlavor.TRADITIONAL, canvasColorService as never)).toBe('rendered:#fafafa');
-        expect(getDocsCanvasBackgroundColor(DocumentFlavor.MODERN, canvasColorService as never, '#123456')).toBe('rendered:#123456');
-        expect(getDocsCanvasBackgroundColor(DocumentFlavor.UNSPECIFIED, canvasColorService as never, '#fff', true)).toBe('#fff');
-        expect(resolveDocsCanvasBackground({
+        expect(resolveDocRenderBackground({
             documentFlavor: DocumentFlavor.UNSPECIFIED,
             canvasColorService: canvasColorService as never,
             editorBackgroundColor: '#fff',
@@ -342,7 +341,7 @@ describe('docs ui services', () => {
             canvasElementBackgroundColor: '#fff',
             docBackgroundFillColor: 'transparent',
         });
-        expect(resolveDocsCanvasBackground({
+        expect(resolveDocRenderBackground({
             documentFlavor: DocumentFlavor.UNSPECIFIED,
             canvasColorService: canvasColorService as never,
             isEditor: true,

--- a/packages/docs-ui/src/services/doc-render-background.ts
+++ b/packages/docs-ui/src/services/doc-render-background.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ICanvasColorService } from '@univerjs/engine-render';
+import { DocumentFlavor } from '@univerjs/core';
+
+const DOC_TRADITIONAL_WORKSPACE_BACKGROUND_COLOR = '#fafafa';
+const DOC_MODERN_WORKSPACE_BACKGROUND_COLOR = '#fff';
+const DOC_EDITOR_INTERNAL_BACKGROUND_COLOR = 'transparent';
+
+export interface IResolveDocRenderBackgroundOptions {
+    documentFlavor?: DocumentFlavor;
+    canvasColorService?: ICanvasColorService;
+    editorBackgroundColor?: string;
+    isEditor?: boolean;
+}
+
+export interface IResolvedDocRenderBackground {
+    canvasElementBackgroundColor: string;
+    docBackgroundFillColor?: string;
+}
+
+export function resolveDocRenderBackground(options: IResolveDocRenderBackgroundOptions): IResolvedDocRenderBackground {
+    const { documentFlavor, canvasColorService, editorBackgroundColor, isEditor } = options;
+    const backgroundColor = editorBackgroundColor ?? getDefaultDocCanvasBackgroundColor(documentFlavor, isEditor);
+
+    if (isEditor) {
+        return {
+            canvasElementBackgroundColor: backgroundColor,
+            docBackgroundFillColor: DOC_EDITOR_INTERNAL_BACKGROUND_COLOR,
+        };
+    }
+
+    return {
+        canvasElementBackgroundColor: canvasColorService?.getRenderColor(backgroundColor) ?? backgroundColor,
+        docBackgroundFillColor: undefined,
+    };
+}
+
+export function getDefaultDocCanvasBackgroundColor(documentFlavor?: DocumentFlavor, isEditor?: boolean) {
+    if (isEditor) {
+        return DOC_EDITOR_INTERNAL_BACKGROUND_COLOR;
+    }
+
+    return documentFlavor === DocumentFlavor.MODERN
+        ? DOC_MODERN_WORKSPACE_BACKGROUND_COLOR
+        : DOC_TRADITIONAL_WORKSPACE_BACKGROUND_COLOR;
+}

--- a/packages/docs-ui/src/services/docs-render.service.ts
+++ b/packages/docs-ui/src/services/docs-render.service.ts
@@ -14,58 +14,17 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel } from '@univerjs/core';
+import type { DocumentDataModel, DocumentFlavor } from '@univerjs/core';
 import type { ICanvasColorService } from '@univerjs/engine-render';
-import { DocumentFlavor, isInternalEditorID, IUniverInstanceService, RxDisposable, UniverInstanceType } from '@univerjs/core';
+import { isInternalEditorID, IUniverInstanceService, RxDisposable, UniverInstanceType } from '@univerjs/core';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { takeUntil } from 'rxjs';
+import { resolveDocRenderBackground } from './doc-render-background';
 
 const DOC_MAIN_CANVAS_ID = 'univer-doc-main-canvas';
-const DOC_TRADITIONAL_WORKSPACE_BACKGROUND_COLOR = '#fafafa';
-const DOC_MODERN_WORKSPACE_BACKGROUND_COLOR = '#fff';
-const DOC_EDITOR_DEFAULT_BACKGROUND_COLOR = 'transparent';
-
-export interface IResolveDocsCanvasBackgroundOptions {
-    documentFlavor?: DocumentFlavor;
-    canvasColorService?: ICanvasColorService;
-    editorBackgroundColor?: string;
-    isEditor?: boolean;
-}
-
-export interface IResolvedDocsCanvasBackground {
-    canvasElementBackgroundColor: string;
-    docBackgroundFillColor?: string;
-}
-
-export function resolveDocsCanvasBackground(options: IResolveDocsCanvasBackgroundOptions): IResolvedDocsCanvasBackground {
-    const { documentFlavor, canvasColorService, editorBackgroundColor, isEditor } = options;
-    const backgroundColor = editorBackgroundColor ?? getDefaultDocsCanvasBackgroundColor(documentFlavor, isEditor);
-
-    if (isEditor) {
-        return {
-            canvasElementBackgroundColor: backgroundColor,
-            docBackgroundFillColor: DOC_EDITOR_DEFAULT_BACKGROUND_COLOR,
-        };
-    }
-
-    return {
-        canvasElementBackgroundColor: canvasColorService?.getRenderColor(backgroundColor) ?? backgroundColor,
-        docBackgroundFillColor: undefined,
-    };
-}
-
-function getDefaultDocsCanvasBackgroundColor(documentFlavor?: DocumentFlavor, isEditor?: boolean) {
-    if (isEditor) {
-        return DOC_EDITOR_DEFAULT_BACKGROUND_COLOR;
-    }
-
-    return documentFlavor === DocumentFlavor.MODERN
-        ? DOC_MODERN_WORKSPACE_BACKGROUND_COLOR
-        : DOC_TRADITIONAL_WORKSPACE_BACKGROUND_COLOR;
-}
 
 export function getDocsCanvasBackgroundColor(documentFlavor?: DocumentFlavor, canvasColorService?: ICanvasColorService, editorBackgroundColor?: string, isEditor?: boolean) {
-    return resolveDocsCanvasBackground({
+    return resolveDocRenderBackground({
         documentFlavor,
         canvasColorService,
         editorBackgroundColor,

--- a/packages/docs-ui/src/services/editor/editor-manager.service.ts
+++ b/packages/docs-ui/src/services/editor/editor-manager.service.ts
@@ -23,7 +23,7 @@ import { DocSelectionManagerService } from '@univerjs/docs';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { fromEvent, Subject } from 'rxjs';
 import { DOCS_VIEW_KEY } from '../../basics/docs-view-key';
-import { resolveDocsCanvasBackground } from '../docs-render.service';
+import { resolveDocRenderBackground } from '../doc-render-background';
 import { Editor } from './editor';
 
 export interface IEditorRenderConfig {
@@ -263,7 +263,7 @@ export class EditorService extends Disposable implements IEditorService, IDispos
 
             this._editors.set(editorUnitId, editor);
 
-            const resolvedEditorBackground = resolveDocsCanvasBackground({
+            const resolvedEditorBackground = resolveDocRenderBackground({
                 canvasColorService: render.engine.canvasColorService,
                 editorBackgroundColor: canvasStyle.backgroundColor,
                 isEditor: true,

--- a/packages/sheets-ui/src/views/editor-container/EditorContainer.tsx
+++ b/packages/sheets-ui/src/views/editor-container/EditorContainer.tsx
@@ -41,6 +41,7 @@ const EDITOR_DEFAULT_POSITION = {
 };
 
 const CELL_EDITOR_DARK_SURFACE_THEME_COLOR = 'gray.800';
+const CELL_EDITOR_LIGHT_SURFACE_THEME_COLOR = 'white';
 
 interface ICellEditorHostBackgroundOptions {
     darkMode?: boolean;
@@ -50,16 +51,23 @@ interface ICellEditorHostBackgroundOptions {
 /**
  * @returns the host background color for the cell editor.
  */
-function getCellEditorHostBackgroundColor(
+export function getCellEditorHostBackgroundColor(
     editState: Nullable<Pick<ICellEditorState, 'documentLayoutObject'>>,
     options: ICellEditorHostBackgroundOptions = {}
 ): string | undefined {
     const cellFill = editState?.documentLayoutObject.fill;
-    if (cellFill) {
+    if (cellFill && !isTransparentColor(cellFill)) {
         return cellFill;
     }
 
-    return options.darkMode ? options.getColorFromTheme?.(CELL_EDITOR_DARK_SURFACE_THEME_COLOR) : undefined;
+    return options.getColorFromTheme?.(
+        options.darkMode ? CELL_EDITOR_DARK_SURFACE_THEME_COLOR : CELL_EDITOR_LIGHT_SURFACE_THEME_COLOR
+    );
+}
+
+function isTransparentColor(color: string) {
+    const normalizedColor = color.trim().toLowerCase().replace(/\s+/g, '');
+    return normalizedColor === 'transparent' || normalizedColor === 'rgba(0,0,0,0)';
 }
 
 /**

--- a/packages/sheets-ui/src/views/editor-container/__tests__/EditorContainer.spec.ts
+++ b/packages/sheets-ui/src/views/editor-container/__tests__/EditorContainer.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getCellEditorHostBackgroundColor } from '../EditorContainer';
+
+describe('cell editor host background', () => {
+    const themeOptions = {
+        getColorFromTheme: (color: string) => `theme:${color}`,
+    };
+
+    it('uses the current cell fill as the editor host surface', () => {
+        expect(getCellEditorHostBackgroundColor({
+            documentLayoutObject: {
+                fill: '#dae9f8',
+            },
+        } as never, themeOptions)).toBe('#dae9f8');
+    });
+
+    it('uses a light sheet surface when the cell fill is missing or transparent', () => {
+        expect(getCellEditorHostBackgroundColor({
+            documentLayoutObject: {},
+        } as never, themeOptions)).toBe('theme:white');
+
+        expect(getCellEditorHostBackgroundColor({
+            documentLayoutObject: {
+                fill: 'transparent',
+            },
+        } as never, themeOptions)).toBe('theme:white');
+    });
+
+    it('uses a dark sheet surface when the cell fill is missing in dark mode', () => {
+        expect(getCellEditorHostBackgroundColor({
+            documentLayoutObject: {},
+        } as never, {
+            ...themeOptions,
+            darkMode: true,
+        })).toBe('theme:gray.800');
+    });
+});


### PR DESCRIPTION
## Summary
- move doc render background resolution into a focused resolver for workspace/page/editor-internal surfaces
- keep editor-internal doc backgrounds transparent while letting hosts pass an explicit surface
- give the sheet cell editor host an opaque theme surface when cell fill is missing or transparent, preventing text ghosting over the sheet canvas

## Verification
- pnpm --filter @univerjs/engine-render test -- src/services/__tests__/canvas-color.spec.ts
- pnpm --filter @univerjs/docs-ui test -- src/controllers/__tests__/doc-render-controller.spec.ts src/services/__tests__/doc-services.spec.ts
- pnpm --filter @univerjs/sheets-ui test -- src/views/editor-container/__tests__/EditorContainer.spec.ts
- pnpm eslint packages/docs-ui/src/services/doc-render-background.ts packages/docs-ui/src/services/docs-render.service.ts packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts packages/docs-ui/src/services/editor/editor-manager.service.ts packages/docs-ui/src/services/__tests__/doc-services.spec.ts packages/docs-ui/src/controllers/__tests__/doc-render-controller.spec.ts packages/engine-render/src/services/canvas-color.service.ts packages/engine-render/src/services/__tests__/canvas-color.spec.ts packages/sheets-ui/src/views/editor-container/EditorContainer.tsx packages/sheets-ui/src/views/editor-container/__tests__/EditorContainer.spec.ts packages/sheets-formula-ui/src/views/formula-editor/index.tsx packages/sheets-ui/src/services/editor-bridge.service.ts packages/sheets-ui/src/views/formula-bar/FormulaBar.tsx
- pnpm --dir examples build:demo