### PR TITLE
fix(sheets): preserve formatted cell edit semantics

### DIFF
--- a/packages/sheets-numfmt-ui/src/controllers/__tests__/editor.controller.spec.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/__tests__/editor.controller.spec.ts
@@ -27,8 +27,8 @@ import {
     UniverInstanceType,
 } from '@univerjs/core';
 import { excelDateSerial } from '@univerjs/engine-formula';
-import { SetNumfmtMutation, SheetInterceptorService } from '@univerjs/sheets';
-import { SheetsNumfmtCellContentController } from '@univerjs/sheets-numfmt';
+import { SetNumfmtMutation, SetRangeValuesCommand, SheetInterceptorService } from '@univerjs/sheets';
+import { getPatternType, SheetsNumfmtCellContentController } from '@univerjs/sheets-numfmt';
 import { getMatrixPlainText, IEditorBridgeService } from '@univerjs/sheets-ui';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { NumfmtEditorController } from '../numfmt.editor.controller';
@@ -68,6 +68,36 @@ describe('test editor', () => {
         workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
         worksheet = workbook.getActiveSheet()!;
     });
+
+    function setCellNumfmt(row: number, col: number, pattern: string) {
+        const params: ISetNumfmtMutationParams = {
+            unitId,
+            subUnitId,
+            values: {
+                1: {
+                    ranges: [{ startRow: row, endRow: row, startColumn: col, endColumn: col }],
+                },
+            },
+            refMap: {
+                1: {
+                    pattern,
+                },
+            },
+        };
+        commandService.syncExecuteCommand(SetNumfmtMutation.id, params);
+    }
+
+    function createLocation(row: number, col: number, cellData: ICellDataForSheetInterceptor) {
+        return {
+            workbook,
+            worksheet,
+            unitId,
+            subUnitId,
+            row,
+            col,
+            origin: cellData,
+        };
+    }
 
     it('before edit with currency', () => {
         const params: ISetNumfmtMutationParams = {
@@ -206,6 +236,83 @@ describe('test editor', () => {
         const result = sheetInterceptorService.writeCellInterceptor.fetchThroughInterceptors(AFTER_CELL_EDIT)(cellData, location);
         // The date-time drop is a numeric value, not a literal string
         expect(result?.v).toBe(0.5231712962962963);
+    });
+
+    it('after edit with percent keeps bare numeric input in display units', () => {
+        setCellNumfmt(10, 0, '0.00%');
+        const sheetInterceptorService = testBed.get(SheetInterceptorService);
+        const cellData = { v: '35' };
+        const location = createLocation(10, 0, cellData);
+
+        const result = sheetInterceptorService.writeCellInterceptor.fetchThroughInterceptors(AFTER_CELL_EDIT)(cellData, location);
+
+        expect(result?.v).toBe(0.35);
+        expect(result?.t).toBe(CellValueType.NUMBER);
+    });
+
+    it('after edit with percent keeps explicit percent input unchanged', () => {
+        setCellNumfmt(10, 0, '0.00%');
+        const sheetInterceptorService = testBed.get(SheetInterceptorService);
+        const cellData = { v: '35%' };
+        const location = createLocation(10, 0, cellData);
+
+        const result = sheetInterceptorService.writeCellInterceptor.fetchThroughInterceptors(AFTER_CELL_EDIT)(cellData, location);
+
+        expect(result?.v).toBe(0.35);
+        expect(result?.t).toBe(CellValueType.NUMBER);
+    });
+
+    it('after edit with percent handles decimal display values', () => {
+        setCellNumfmt(10, 0, '0.00%');
+        const sheetInterceptorService = testBed.get(SheetInterceptorService);
+        const cellData = { v: '35.5' };
+        const location = createLocation(10, 0, cellData);
+
+        const result = sheetInterceptorService.writeCellInterceptor.fetchThroughInterceptors(AFTER_CELL_EDIT)(cellData, location);
+
+        expect(result?.v).toBe(0.355);
+        expect(result?.t).toBe(CellValueType.NUMBER);
+    });
+
+    it('after edit with percent accepts explicit currency input and changes format', () => {
+        setCellNumfmt(10, 0, '0.00%');
+        const sheetInterceptorService = testBed.get(SheetInterceptorService);
+        const cellData = { v: '$30' };
+        const location = createLocation(10, 0, cellData);
+
+        const result = sheetInterceptorService.writeCellInterceptor.fetchThroughInterceptors(AFTER_CELL_EDIT)(cellData, location);
+        const effects = sheetInterceptorService.onCommandExecute({
+            id: SetRangeValuesCommand.id,
+            params: {},
+        });
+        const params = effects.redos[0].params as ISetNumfmtMutationParams;
+        const pattern = Object.values(params.refMap)[0].pattern;
+
+        expect(result?.v).toBe(30);
+        expect(result?.t).toBe(CellValueType.NUMBER);
+        expect(getPatternType(pattern)).toBe('currency');
+    });
+
+    it('after edit with currency and number formats keeps bare numeric input in raw units', () => {
+        const sheetInterceptorService = testBed.get(SheetInterceptorService);
+
+        setCellNumfmt(0, 0, '$#,##0;(#,##0)');
+        const currencyCellData = { v: '35' };
+        const currencyResult = sheetInterceptorService.writeCellInterceptor.fetchThroughInterceptors(AFTER_CELL_EDIT)(
+            currencyCellData,
+            createLocation(0, 0, currencyCellData)
+        );
+        expect(currencyResult?.v).toBe(35);
+        expect(currencyResult?.t).toBe(CellValueType.NUMBER);
+
+        setCellNumfmt(0, 1, '0.00');
+        const numberCellData = { v: '35' };
+        const numberResult = sheetInterceptorService.writeCellInterceptor.fetchThroughInterceptors(AFTER_CELL_EDIT)(
+            numberCellData,
+            createLocation(0, 1, numberCellData)
+        );
+        expect(numberResult?.v).toBe(35);
+        expect(numberResult?.t).toBe(CellValueType.NUMBER);
     });
 
     it('edit number will throw style in this editing', () => {

--- a/packages/sheets-numfmt-ui/src/controllers/numfmt.editor.controller.ts
+++ b/packages/sheets-numfmt-ui/src/controllers/numfmt.editor.controller.ts
@@ -243,7 +243,7 @@ export class NumfmtEditorController extends Disposable {
                                 );
                             }
 
-                            const v = stripErrorMargin(Number(numfmtInfo.v), 16);
+                            const v = getParsedNumfmtValue(numfmtInfo.v, currentNumfmtValue?.pattern, numfmtInfo.z);
 
                             return next({ ...value, p: undefined, v, t: CellValueType.NUMBER });
                         }
@@ -355,4 +355,14 @@ function canConvertRichTextToNumfmt(body: IDocumentBody): boolean {
         Boolean(customRanges?.length) ||
         customBlocks.length > 0
     );
+}
+
+function getParsedNumfmtValue(parsedValue: string | number | boolean, currentPattern?: string, parsedPattern?: string): number {
+    const value = Number(parsedValue);
+
+    if (!parsedPattern && currentPattern && getPatternType(currentPattern) === 'percent') {
+        return stripErrorMargin(value / 100, 16);
+    }
+
+    return stripErrorMargin(value, 16);
 }

--- a/packages/sheets-ui/src/views/formula-bar/FormulaBar.tsx
+++ b/packages/sheets-ui/src/views/formula-bar/FormulaBar.tsx
@@ -274,6 +274,7 @@ export function FormulaBar(props: IProps) {
 
             // Open the normal editor first, and then we mark formula editor as activated.
             contextService.setContextValue(FOCUSING_FX_BAR_EDITOR, true);
+            editorService.focus(DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY);
         } catch (e) {
             shouldSkipFocus.current = true;
             throw e;

--- a/packages/sheets-ui/src/views/formula-bar/__tests__/FormulaBar.spec.tsx
+++ b/packages/sheets-ui/src/views/formula-bar/__tests__/FormulaBar.spec.tsx
@@ -24,6 +24,7 @@ import type {
     IEditorBridgeServiceVisibleParam,
 } from '../../../services/editor-bridge.service';
 import {
+    DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
     DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
     ICommandService,
     IConfigService,
@@ -265,6 +266,7 @@ function createFormulaBarTestBed() {
         injector,
         workbook,
         editorBridgeService,
+        editorService: injector.get(IEditorService) as unknown as TestEditorService,
         restoreResizeObserver: () => {
             globalThis.ResizeObserver = originalResizeObserver;
         },
@@ -303,8 +305,16 @@ function getActionElement(container: HTMLElement, index: number): HTMLElement {
 }
 
 async function clickElement(element: HTMLElement): Promise<void> {
+    await dispatchMouseEvent(element, 'click');
+}
+
+async function pointerDownElement(element: HTMLElement): Promise<void> {
+    await dispatchMouseEvent(element, 'pointerdown');
+}
+
+async function dispatchMouseEvent(element: HTMLElement, type: 'click' | 'pointerdown'): Promise<void> {
     await act(async () => {
-        element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        element.dispatchEvent(new MouseEvent(type, { bubbles: true }));
         await Promise.resolve();
     });
 }
@@ -355,5 +365,30 @@ describe('FormulaBar', () => {
             eventType: DeviceInputEventType.PointerDown,
             unitId: UNIT_ID,
         });
+    });
+
+    it('focuses the formula editor when the formula bar starts editing', async () => {
+        currentBed = createFormulaBarTestBed();
+        currentBed.editorBridgeService.changeVisible({
+            visible: false,
+            eventType: DeviceInputEventType.PointerDown,
+            unitId: UNIT_ID,
+        });
+        const rendered = renderWithDependencies(<FormulaBar disableDefinedName />, currentBed.injector);
+        root = rendered.root;
+        container = rendered.container;
+        const formulaEditor = rendered.container.querySelector(`[data-editor-id="${DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY}"]`);
+        if (!(formulaEditor instanceof HTMLElement) || !(formulaEditor.parentElement instanceof HTMLElement)) {
+            throw new TypeError('Formula editor not rendered');
+        }
+
+        await pointerDownElement(formulaEditor.parentElement);
+
+        expect(currentBed.editorBridgeService.visibleHistory.at(-1)).toEqual({
+            visible: true,
+            eventType: DeviceInputEventType.PointerDown,
+            unitId: UNIT_ID,
+        });
+        expect(currentBed.editorService.focusedEditorIds.at(-1)).toBe(DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY);
     });
 });


### PR DESCRIPTION
Closes #7108

## Summary
- preserve Excel-style replacement semantics for percent-formatted cells so bare numeric input is interpreted in display units
- keep explicit formatted input authoritative, allowing `$30` entered in a percent-formatted cell to switch the cell to currency formatting
- focus the formula bar editor when formula-bar editing starts so typed content commits through the same cell-edit pipeline

## Test plan
- [x] `pnpm --filter @univerjs/sheets-numfmt-ui test -- src/controllers/__tests__/editor.controller.spec.ts`
- [x] `pnpm --filter @univerjs/sheets-ui test -- src/views/formula-bar/__tests__/FormulaBar.spec.tsx`
- [x] `pnpm --filter @univerjs/sheets-numfmt-ui typecheck`
- [x] `pnpm --filter @univerjs/sheets-ui typecheck`
- [x] Manual verification in local sheets demo: selected percent-formatted cell accepts direct replacement input as displayed percent value

## Notes
- The working tree still contains unrelated local `packages/sheets-formula-ui` edits that are not included in this PR branch diff.