### PR TITLE
fix(docs-drawing-ui): use i18n keys for shape menu titles

### DIFF
--- a/packages/docs-drawing-ui/src/locale/ar-SA.ts
+++ b/packages/docs-drawing-ui/src/locale/ar-SA.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'إدراج صورة',
         },
+        shape: {
+            insert: {
+                title: 'إدراج شكل',
+                rectangle: 'إدراج مستطيل',
+                ellipse: 'إدراج قطع ناقص',
+            },
+        },
         panel: {
             title: 'تحرير الصورة',
         },

--- a/packages/docs-drawing-ui/src/locale/ca-ES.ts
+++ b/packages/docs-drawing-ui/src/locale/ca-ES.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Insereix imatge',
         },
+        shape: {
+            insert: {
+                title: 'Insereix forma',
+                rectangle: 'Insereix rectangle',
+                ellipse: 'Insereix el·lipse',
+            },
+        },
         panel: {
             title: 'Edita la imatge',
         },

--- a/packages/docs-drawing-ui/src/locale/de-DE.ts
+++ b/packages/docs-drawing-ui/src/locale/de-DE.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Bild einfügen',
         },
+        shape: {
+            insert: {
+                title: 'Form einfügen',
+                rectangle: 'Rechteck einfügen',
+                ellipse: 'Ellipse einfügen',
+            },
+        },
         panel: {
             title: 'Bild bearbeiten',
         },

--- a/packages/docs-drawing-ui/src/locale/en-US.ts
+++ b/packages/docs-drawing-ui/src/locale/en-US.ts
@@ -20,6 +20,13 @@ const locale = {
         upload: {
             float: 'Insert Image',
         },
+        shape: {
+            insert: {
+                title: 'Insert Shape',
+                rectangle: 'Insert Rectangle',
+                ellipse: 'Insert Ellipse',
+            },
+        },
         panel: {
             title: 'Edit Image',
         },

--- a/packages/docs-drawing-ui/src/locale/es-ES.ts
+++ b/packages/docs-drawing-ui/src/locale/es-ES.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Insertar imagen',
         },
+        shape: {
+            insert: {
+                title: 'Insertar forma',
+                rectangle: 'Insertar rectángulo',
+                ellipse: 'Insertar elipse',
+            },
+        },
         panel: {
             title: 'Editar imagen',
         },

--- a/packages/docs-drawing-ui/src/locale/fa-IR.ts
+++ b/packages/docs-drawing-ui/src/locale/fa-IR.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'درج تصویر',
         },
+        shape: {
+            insert: {
+                title: 'درج شکل',
+                rectangle: 'درج مستطیل',
+                ellipse: 'بیضی را درج کنید',
+            },
+        },
         panel: {
             title: 'ویرایش تصویر',
         },

--- a/packages/docs-drawing-ui/src/locale/fr-FR.ts
+++ b/packages/docs-drawing-ui/src/locale/fr-FR.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Insérer une image',
         },
+        shape: {
+            insert: {
+                title: 'Insérer une forme',
+                rectangle: 'Insérer un rectangle',
+                ellipse: 'Insérer une ellipse',
+            },
+        },
         panel: {
             title: 'Modifier l\'image',
         },

--- a/packages/docs-drawing-ui/src/locale/id-ID.ts
+++ b/packages/docs-drawing-ui/src/locale/id-ID.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Sisipkan Gambar',
         },
+        shape: {
+            insert: {
+                title: 'Sisipkan Bentuk',
+                rectangle: 'Sisipkan Persegi Panjang',
+                ellipse: 'Sisipkan Elips',
+            },
+        },
         panel: {
             title: 'Edit Gambar',
         },

--- a/packages/docs-drawing-ui/src/locale/it-IT.ts
+++ b/packages/docs-drawing-ui/src/locale/it-IT.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Inserisci immagine',
         },
+        shape: {
+            insert: {
+                title: 'Inserisci Forma',
+                rectangle: 'Inserisci Rettangolo',
+                ellipse: 'Inserisci Ellisse',
+            },
+        },
         panel: {
             title: 'Modifica immagine',
         },

--- a/packages/docs-drawing-ui/src/locale/ja-JP.ts
+++ b/packages/docs-drawing-ui/src/locale/ja-JP.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: '画像を挿入',
         },
+        shape: {
+            insert: {
+                title: '図形の挿入',
+                rectangle: '四角形を挿入',
+                ellipse: '楕円を挿入',
+            },
+        },
         panel: {
             title: '画像の編集',
         },

--- a/packages/docs-drawing-ui/src/locale/ko-KR.ts
+++ b/packages/docs-drawing-ui/src/locale/ko-KR.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: '이미지 삽입',
         },
+        shape: {
+            insert: {
+                title: '도형 삽입',
+                rectangle: '사각형 삽입',
+                ellipse: '타원 삽입',
+            },
+        },
         panel: {
             title: '이미지 편집',
         },

--- a/packages/docs-drawing-ui/src/locale/pl-PL.ts
+++ b/packages/docs-drawing-ui/src/locale/pl-PL.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Wstaw obraz',
         },
+        shape: {
+            insert: {
+                title: 'Wstaw kształt',
+                rectangle: 'Wstaw prostokąt',
+                ellipse: 'Wstaw elipsę',
+            },
+        },
         panel: {
             title: 'Edytuj obraz',
         },

--- a/packages/docs-drawing-ui/src/locale/pt-BR.ts
+++ b/packages/docs-drawing-ui/src/locale/pt-BR.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Inserir imagem',
         },
+        shape: {
+            insert: {
+                title: 'Inserir Forma',
+                rectangle: 'Inserir Retângulo',
+                ellipse: 'Inserir Elipse',
+            },
+        },
         panel: {
             title: 'Editar imagem',
         },

--- a/packages/docs-drawing-ui/src/locale/ru-RU.ts
+++ b/packages/docs-drawing-ui/src/locale/ru-RU.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Вставить изображение',
         },
+        shape: {
+            insert: {
+                title: 'Insert Shape',
+                rectangle: 'Insert Rectangle',
+                ellipse: 'Insert Ellipse',
+            },
+        },
         panel: {
             title: 'Редактировать изображение',
         },

--- a/packages/docs-drawing-ui/src/locale/sk-SK.ts
+++ b/packages/docs-drawing-ui/src/locale/sk-SK.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Vložiť obrázok',
         },
+        shape: {
+            insert: {
+                title: 'Vložiť tvar',
+                rectangle: 'Vložiť obdĺžnik',
+                ellipse: 'Vložiť elipsu',
+            },
+        },
         panel: {
             title: 'Upraviť obrázok',
         },

--- a/packages/docs-drawing-ui/src/locale/vi-VN.ts
+++ b/packages/docs-drawing-ui/src/locale/vi-VN.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: 'Chèn hình ảnh',
         },
+        shape: {
+            insert: {
+                title: 'Insert Shape',
+                rectangle: 'Insert Rectangle',
+                ellipse: 'Insert Ellipse',
+            },
+        },
         panel: {
             title: 'Chỉnh sửa hình ảnh',
         },

--- a/packages/docs-drawing-ui/src/locale/zh-CN.ts
+++ b/packages/docs-drawing-ui/src/locale/zh-CN.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: '插入图片',
         },
+        shape: {
+            insert: {
+                title: '插入图形',
+                rectangle: '插入矩形',
+                ellipse: '插入椭圆',
+            },
+        },
         panel: {
             title: '编辑图片',
         },

--- a/packages/docs-drawing-ui/src/locale/zh-HK.ts
+++ b/packages/docs-drawing-ui/src/locale/zh-HK.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: '插入圖片',
         },
+        shape: {
+            insert: {
+                title: 'Insert Shape',
+                rectangle: 'Insert Rectangle',
+                ellipse: 'Insert Ellipse',
+            },
+        },
         panel: {
             title: '編圖',
         },

--- a/packages/docs-drawing-ui/src/locale/zh-TW.ts
+++ b/packages/docs-drawing-ui/src/locale/zh-TW.ts
@@ -22,6 +22,13 @@ const locale: typeof enUS = {
         upload: {
             float: '插入圖片',
         },
+        shape: {
+            insert: {
+                title: 'Insert Shape',
+                rectangle: 'Insert Rectangle',
+                ellipse: 'Insert Ellipse',
+            },
+        },
         panel: {
             title: '編圖',
         },

--- a/packages/docs-drawing-ui/src/menu/shape.menu.ts
+++ b/packages/docs-drawing-ui/src/menu/shape.menu.ts
@@ -28,8 +28,8 @@ export function ShapeMenuFactory(accessor: IAccessor): IMenuItem {
         id: DOCS_SHAPE_MENU_ID,
         type: MenuItemType.SUBITEMS,
         icon: 'ShapeIcon',
-        title: 'Insert Shape',
-        tooltip: 'Insert Shape',
+        title: 'docs-drawing-ui.shape.insert.title',
+        tooltip: 'docs-drawing-ui.shape.insert.title',
         hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_DOC),
     };
 }
@@ -39,8 +39,8 @@ export function ShapeBelowMenuFactory(accessor: IAccessor): IMenuItem {
         id: DOCS_SHAPE_BELOW_MENU_ID,
         type: MenuItemType.SUBITEMS,
         icon: 'ShapeIcon',
-        title: 'Insert Shape',
-        tooltip: 'Insert Shape',
+        title: 'docs-drawing-ui.shape.insert.title',
+        tooltip: 'docs-drawing-ui.shape.insert.title',
         hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_DOC),
     };
 }
@@ -48,7 +48,7 @@ export function ShapeBelowMenuFactory(accessor: IAccessor): IMenuItem {
 export function InsertRectangleShapeMenuFactory(accessor: IAccessor): IMenuButtonItem {
     return {
         id: InsertDocRectangleShapeCommand.id,
-        title: 'Insert Rectangle',
+        title: 'docs-drawing-ui.shape.insert.rectangle',
         type: MenuItemType.BUTTON,
         hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_DOC),
     };
@@ -57,7 +57,7 @@ export function InsertRectangleShapeMenuFactory(accessor: IAccessor): IMenuButto
 export function InsertEllipseShapeMenuFactory(accessor: IAccessor): IMenuButtonItem {
     return {
         id: InsertDocEllipseShapeCommand.id,
-        title: 'Insert Ellipse',
+        title: 'docs-drawing-ui.shape.insert.ellipse',
         type: MenuItemType.BUTTON,
         hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_DOC),
     };
@@ -67,7 +67,7 @@ export function InsertRectangleShapeBelowMenuFactory(accessor: IAccessor): IMenu
     return {
         id: `${InsertDocRectangleShapeCommand.id}.below`,
         commandId: InsertDocRectangleShapeCommand.id,
-        title: 'Insert Rectangle',
+        title: 'docs-drawing-ui.shape.insert.rectangle',
         type: MenuItemType.BUTTON,
         params: {
             paragraphMenuPlacement: 'below',
@@ -80,7 +80,7 @@ export function InsertEllipseShapeBelowMenuFactory(accessor: IAccessor): IMenuBu
     return {
         id: `${InsertDocEllipseShapeCommand.id}.below`,
         commandId: InsertDocEllipseShapeCommand.id,
-        title: 'Insert Ellipse',
+        title: 'docs-drawing-ui.shape.insert.ellipse',
         type: MenuItemType.BUTTON,
         params: {
             paragraphMenuPlacement: 'below',


### PR DESCRIPTION
Replace hardcoded menu titles in shape.menu.ts with i18n locale keys and add corresponding entries to all 19 locale files so the "Insert Shape", "Insert Rectangle", and "Insert Ellipse" menu items can be translated across locales.

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
