### PR TITLE
fix(sheets-ui): clean up embedded editor state

### DIFF
--- a/packages/engine-render/src/components/docs/layout/__tests__/tools.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/__tests__/tools.spec.ts
@@ -29,6 +29,7 @@ import {
 } from '@univerjs/core';
 import { describe, expect, it, vi } from 'vitest';
 import { GlyphType } from '../../../../basics/i-document-skeleton-cached';
+import { getDocumentCompatibilityPolicy } from '../../document-compatibility';
 import {
     clearFontCreateConfigCache,
     columnIterator,
@@ -254,6 +255,33 @@ describe('docs layout tools extra', () => {
         const columns: any[] = [];
         columnIterator([page] as any, (col) => columns.push(col));
         expect(columns.length).toBe(1);
+    });
+
+    it('uses content width for unspecified editor documents when updating block indexes', () => {
+        const { page, column } = createPageSkeleton();
+
+        updateBlockIndex([page] as any, -1, getDocumentCompatibilityPolicy(DocumentFlavor.UNSPECIFIED));
+
+        expect(column.width).toBe(13);
+        expect(page.width).toBe(13);
+    });
+
+    it('keeps layout column width when updating block indexes without a policy', () => {
+        const { page, column } = createPageSkeleton();
+
+        updateBlockIndex([page] as any, -1);
+
+        expect(column.width).toBe(200);
+        expect(page.width).toBe(200);
+    });
+
+    it('keeps layout column width for traditional documents when updating block indexes', () => {
+        const { page, column } = createPageSkeleton();
+
+        updateBlockIndex([page] as any, -1, getDocumentCompatibilityPolicy(DocumentFlavor.TRADITIONAL));
+
+        expect(column.width).toBe(200);
+        expect(page.width).toBe(200);
     });
 
     it('copies paragraph background color to the rendered line', () => {

--- a/packages/engine-render/src/components/docs/layout/block/column.ts
+++ b/packages/engine-render/src/components/docs/layout/block/column.ts
@@ -22,6 +22,7 @@ import type { DocumentViewModel } from '../../view-model/document-view-model';
 import type { ILayoutContext } from '../tools';
 import { ColumnResponsiveType, DataStreamTreeNodeType } from '@univerjs/core';
 import { DocumentSkeletonPageType, LineType } from '../../../../basics/i-document-skeleton-cached';
+import { getDocumentCompatibilityPolicy } from '../../document-compatibility';
 import { applyTrailingBlockRangeSpaceBelow, createSkeletonPage } from '../model/page';
 import { getLastNotFullColumnInfo, updateBlockIndex } from '../tools';
 import { dealWidthParagraph } from './paragraph/paragraph-layout';
@@ -147,7 +148,11 @@ function createColumnContentPage(
         dealWidthParagraph(ctx, viewModel, paragraphNode, page, columnSectionBreakConfig);
     }
 
-    updateBlockIndex([page], columnNode.startIndex);
+    updateBlockIndex(
+        [page],
+        columnNode.startIndex,
+        sectionBreakConfig.documentCompatibilityPolicy ?? getDocumentCompatibilityPolicy()
+    );
     applyTrailingBlockRangeSpaceBelow([page], ctx.dataModel?.getBody?.(), columnNode.endIndex);
 
     return page;

--- a/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
+++ b/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
@@ -1328,7 +1328,7 @@ export class DocumentSkeleton extends Skeleton {
             ctx.sectionBreakConfigCache.set(sectionNode.endIndex, sectionBreakConfig);
 
             if (sectionType === SectionType.CONTINUOUS && curSkeletonPage != null) {
-                updateBlockIndex(allSkeletonPages);
+                updateBlockIndex(allSkeletonPages, -1, ctx.docsConfig.documentCompatibilityPolicy);
                 this._addNewSectionByContinuous(curSkeletonPage, columnProperties!, columnSeparatorType!);
                 isContinuous = true;
             } else if (layoutAnchor == null || curSkeletonPage == null) {
@@ -1379,7 +1379,7 @@ export class DocumentSkeleton extends Skeleton {
             // Calculate page and section position information
             this._iteratorCount = 0;
             removeDupPages(ctx);
-            updateBlockIndex(skeleton.pages);
+            updateBlockIndex(skeleton.pages, -1, ctx.docsConfig.documentCompatibilityPolicy);
             mergeContinuousDuplicatePages(skeleton.pages);
             // Calculate inline drawing position and update.
             updateInlineDrawingCoordsAndBorder(ctx, skeleton.pages);

--- a/packages/engine-render/src/components/docs/layout/model/page.ts
+++ b/packages/engine-render/src/components/docs/layout/model/page.ts
@@ -26,6 +26,7 @@ import type { DocumentViewModel } from '../../view-model/document-view-model';
 import type { ILayoutContext } from '../tools';
 import { BooleanNumber, PageOrientType, PositionedObjectLayoutType } from '@univerjs/core';
 import { BreakType, DocumentSkeletonPageType } from '../../../../basics/i-document-skeleton-cached';
+import { getDocumentCompatibilityPolicy } from '../../document-compatibility';
 import { dealWithSection } from '../block/section';
 import { resetContext, updateBlockIndex, updateInlineDrawingCoordsAndBorder } from '../tools';
 import { createSkeletonSection } from './section';
@@ -269,7 +270,7 @@ function _createSkeletonHeaderFooter(
         );
     }
 
-    updateBlockIndex([page]);
+    updateBlockIndex([page], -1, sectionBreakConfig.documentCompatibilityPolicy ?? getDocumentCompatibilityPolicy());
 
     if (isHeader) {
         Object.assign(page, {
@@ -393,7 +394,11 @@ export function createSkeletonCellPages(
         p.segmentId = tableConfig.tableId;
     }
 
-    updateBlockIndex(pages, cellNode.startIndex);
+    updateBlockIndex(
+        pages,
+        cellNode.startIndex,
+        sectionBreakConfig.documentCompatibilityPolicy ?? getDocumentCompatibilityPolicy()
+    );
 
     applyTrailingBlockRangeSpaceBelow(pages, ctx.dataModel?.getBody?.(), cellNode.endIndex);
 

--- a/packages/engine-render/src/components/docs/layout/tools.ts
+++ b/packages/engine-render/src/components/docs/layout/tools.ts
@@ -43,6 +43,7 @@ import type {
 } from '../../../basics/i-document-skeleton-cached';
 import type { IDocsConfig, IParagraphConfig, ISectionBreakConfig } from '../../../basics/interfaces';
 import type { IBoundRectNoAngle } from '../../../basics/vector2';
+import type { IDocumentCompatibilityPolicy } from '../document-compatibility';
 import type { DataStreamTreeNode } from '../view-model/data-stream-tree-node';
 import type { DocumentViewModel } from '../view-model/document-view-model';
 import type { Hyphen } from './hyphenation/hyphen';
@@ -349,8 +350,16 @@ export function getCharSpaceConfig(sectionBreakConfig: ISectionBreakConfig, para
     };
 }
 
-export function updateBlockIndex(pages: IDocumentSkeletonPage[], start: number = -1) {
+export function updateBlockIndex(
+    pages: IDocumentSkeletonPage[],
+    start: number = -1,
+    documentCompatibilityPolicy?: IDocumentCompatibilityPolicy
+) {
     let prePageStartIndex = start;
+    // Real docs declare a classic/modern compatibility mode, so their measured layout column
+    // width can be reused. Embedded editors keep the mode unspecified and must fall back to
+    // content width; otherwise a sheet cell editor may stretch to the far edge of the canvas.
+    const shouldUseLayoutColumnWidth = documentCompatibilityPolicy?.mode !== 'unspecified';
 
     for (const page of pages) {
         const { sections, skeTables, skeColumnGroups = new Map() } = page;
@@ -474,7 +483,7 @@ export function updateBlockIndex(pages: IDocumentSkeletonPage[], start: number =
                 column.ed = preLineStartIndex >= column.st ? preLineStartIndex : column.st;
                 column.height = columnHeight;
 
-                const measuredColumnWidth = Number.isFinite(column.width) && column.width > 0
+                const measuredColumnWidth = shouldUseLayoutColumnWidth && Number.isFinite(column.width) && column.width > 0
                     ? column.width
                     : maxColumnWidth;
                 column.width = measuredColumnWidth;

--- a/packages/sheets-ui/src/controllers/editor/__tests__/editing-render-business.spec.ts
+++ b/packages/sheets-ui/src/controllers/editor/__tests__/editing-render-business.spec.ts
@@ -51,6 +51,10 @@ function createController() {
         })),
     };
     const controller = Object.create(EditingRenderController.prototype) as any;
+    const formulaBarEditor = {
+        setSelectionRanges: vi.fn(),
+        blur: vi.fn(),
+    };
     controller._editingUnit = 'unit-1';
     controller._lexerTreeBuilder = new LexerTreeBuilder();
     controller._localService = { getCurrentLocale: vi.fn(() => LocaleType.EN_US) };
@@ -64,7 +68,10 @@ function createController() {
         getContextValue: vi.fn(() => false),
     };
     controller._cellEditorManagerService = { setState: vi.fn() };
-    controller._editorService = { isSheetEditor: vi.fn(() => true) };
+    controller._editorService = {
+        isSheetEditor: vi.fn(() => true),
+        getEditor: vi.fn((editorId: string) => editorId === DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY ? formulaBarEditor : null),
+    };
     controller._editorBridgeService = {
         getEditCellState: vi.fn(() => ({
             unitId: 'unit-1',
@@ -117,7 +124,7 @@ function createController() {
     }));
     controller._getEditorSkeleton = vi.fn(() => ({ resetInitialWidth: vi.fn() }));
 
-    return { controller, docModel, workbook, worksheet };
+    return { controller, docModel, formulaBarEditor, workbook, worksheet };
 }
 
 describe('EditingRenderController business methods', () => {
@@ -182,7 +189,7 @@ describe('EditingRenderController business methods', () => {
     });
 
     it('moves the cursor inside the editor and resets editor state on exit', () => {
-        const { controller } = createController();
+        const { controller, formulaBarEditor } = createController();
 
         controller._moveInEditor(KeyCode.ARROW_RIGHT, false);
         controller._moveInEditor(KeyCode.ARROW_UP, true);
@@ -197,5 +204,7 @@ describe('EditingRenderController business methods', () => {
         expect(controller._cellEditorManagerService.setState).toHaveBeenCalledWith({ show: false });
         expect(controller._undoRedoService.clearUndoRedo).toHaveBeenCalledWith(DOCS_NORMAL_EDITOR_UNIT_ID_KEY);
         expect(controller._undoRedoService.clearUndoRedo).toHaveBeenCalledWith(DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY);
+        expect(formulaBarEditor.setSelectionRanges).toHaveBeenCalledWith([], false);
+        expect(formulaBarEditor.blur).toHaveBeenCalled();
     });
 });

--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -714,6 +714,11 @@ export class EditingRenderController extends Disposable {
         this._cellEditorManagerService.setState({
             show: param.visible,
         });
+        // Formula range editing mirrors selections into the formula bar while the cell editor is
+        // active. Clear the formula-bar editor on exit so its hidden input/caret cannot remain visible.
+        const formulaBarEditor = this._editorService.getEditor(DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY);
+        formulaBarEditor?.setSelectionRanges([], false);
+        formulaBarEditor?.blur();
         const editorObject = this._getEditorObject();
         editorObject?.scene.getViewport(DOC_VIEWPORT_KEY.VIEW_MAIN)?.scrollToViewportPos({
             viewportScrollX: 0,

--- a/packages/sheets-ui/src/services/editor/__tests__/cell-editor-resize.service.spec.ts
+++ b/packages/sheets-ui/src/services/editor/__tests__/cell-editor-resize.service.spec.ts
@@ -189,6 +189,7 @@ class TestRenderManagerService {
 
     readonly docSkeleton = {
         calculate: () => { },
+        resetInitialWidth: () => { },
         getActualSize: () => ({ actualWidth: 120, actualHeight: 36 }),
     };
 
@@ -233,6 +234,23 @@ class TestRenderManagerService {
             };
         }
     }
+}
+
+class TestCachedWidthRenderManagerService extends TestRenderManagerService {
+    private _initialWidth = 696;
+
+    override readonly docSkeleton = {
+        calculate: () => { },
+        resetInitialWidth: () => {
+            this._initialWidth = 0;
+        },
+        getActualSize: () => {
+            const actualWidth = Math.max(this._initialWidth, 120);
+            this._initialWidth = actualWidth;
+
+            return { actualWidth, actualHeight: 36 };
+        },
+    };
 }
 
 describe('SheetCellEditorResizeService', () => {
@@ -308,6 +326,37 @@ describe('SheetCellEditorResizeService', () => {
         expect(renderManager.editorDocument.resized).toEqual({ width: 130, height: 44 });
         expect(renderManager.editorEngine.resized).toEqual({ width: 130, height: 44 });
         expect(callbackCalled).toBe(true);
+    });
+
+    it('does not use stale maximum skeleton width when fitting the active cell editor', async () => {
+        vi.stubGlobal('window', new EventTarget());
+        vi.stubGlobal('document', { activeElement: { dataset: {} } });
+        const injector = new Injector();
+        injector.add([ILogService, { useClass: DesktopLogService }]);
+        injector.add([IContextService, { useClass: ContextService }]);
+        injector.add([IUniverInstanceService, { useClass: TestUniverInstanceService as never }]);
+        injector.add([ICommandService, { useClass: CommandService }]);
+        injector.add([IUndoRedoService, { useClass: LocalUndoRedoService }]);
+        injector.add([ThemeService]);
+        injector.add([ILayoutService, { useClass: TestLayoutService as never }]);
+        injector.add([DocSelectionManagerService]);
+        injector.add([SheetInterceptorService]);
+        injector.add([SheetSkeletonService]);
+        injector.add([IEditorService, { useClass: EditorService }]);
+        injector.add([ICellEditorManagerService, { useClass: TestCellEditorManagerService as never }]);
+        injector.add([IEditorBridgeService, { useClass: TestEditorBridgeService as never }]);
+        injector.add([IRenderManagerService, { useClass: TestCachedWidthRenderManagerService as never }]);
+        injector.add([IConfigService, { useClass: ConfigService }]);
+        injector.add([SheetCellEditorResizeService]);
+
+        injector.get(SheetCellEditorResizeService).fitTextSize();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const editorManager = injector.get(ICellEditorManagerService) as unknown as TestCellEditorManagerService;
+        expect(editorManager.getState()).toEqual(expect.objectContaining({
+            endX: 250,
+            show: true,
+        }));
     });
 
     it('refits the editor when its container size drifts from the edited cell', async () => {

--- a/packages/sheets-ui/src/services/editor/cell-editor-resize.service.ts
+++ b/packages/sheets-ui/src/services/editor/cell-editor-resize.service.ts
@@ -100,6 +100,9 @@ export class SheetCellEditorResizeService extends Disposable {
 
         const documentSkeleton = this._getEditorSkeleton();
         if (!documentSkeleton) return;
+        // Cell editors are embedded docs with unspecified compatibility mode. Reset before
+        // measuring so stale page width from a previous resize does not leak into this editor.
+        documentSkeleton.resetInitialWidth();
 
         const info = this._predictingSize(
             position,


### PR DESCRIPTION
## Summary
- Keep sheet cell editors measured from embedded-editor content width instead of stretching to the canvas edge.
- Reset stale embedded editor skeleton width before measuring cell editor size.
- Clear formula-bar selection/caret state when exiting the cell editor.

## Test Plan
- `vitest run packages/engine-render/src/components/docs/layout/__tests__/tools.spec.ts packages/sheets-ui/src/services/editor/__tests__/cell-editor-resize.service.spec.ts packages/sheets-ui/src/controllers/editor/__tests__/editing-render-business.spec.ts`