### PR TITLE
fix(core): preserve facade accessor descriptors

### DIFF
--- a/packages/core/src/facade/__tests__/f-base.spec.ts
+++ b/packages/core/src/facade/__tests__/f-base.spec.ts
@@ -106,4 +106,60 @@ describe('FBase', () => {
         expect(initLog.get(manual)).toEqual(['a:true']);
         expect(manual.steps).toEqual(['mark:manual']);
     });
+
+    it('should copy initialable accessor descriptors without invoking getters during extend', () => {
+        const accessLog: string[] = [];
+        const initLog = new WeakMap<object, string[]>();
+
+        class AccessorInitialable extends FBaseInitialable {
+            value = 'instance';
+
+            constructor(@Inject(Injector) injector: IInjector) {
+                super(injector);
+            }
+        }
+
+        class AccessorSourceA {
+            _initialize(injector: IInjector) {
+                const current = initLog.get(this) ?? [];
+                current.push(`a:${Boolean(injector)}`);
+                initLog.set(this, current);
+            }
+
+            get marker() {
+                const instance = this as unknown as AccessorInitialable;
+                accessLog.push(`get:${instance.value}`);
+                return instance.value;
+            }
+
+            set marker(value: string) {
+                const instance = this as unknown as AccessorInitialable;
+                accessLog.push(`set:${value}`);
+                instance.value = value;
+            }
+        }
+
+        class AccessorSourceB {
+            _initialize() {
+                const current = initLog.get(this) ?? [];
+                current.push('b');
+                initLog.set(this, current);
+            }
+        }
+
+        AccessorInitialable.extend(AccessorSourceA);
+        AccessorInitialable.extend(AccessorSourceB);
+
+        expect(accessLog).toEqual([]);
+        expect(typeof Object.getOwnPropertyDescriptor(AccessorInitialable.prototype, 'marker')?.get).toBe('function');
+
+        const injector = new Injector();
+        const instance = injector.createInstance(AccessorInitialable) as AccessorInitialable & { marker: string };
+
+        expect(initLog.get(instance)).toEqual(['a:true', 'b']);
+        expect(instance.marker).toBe('instance');
+        instance.marker = 'updated';
+        expect(instance.marker).toBe('updated');
+        expect(accessLog).toEqual(['get:instance', 'set:updated', 'get:updated']);
+    });
 });

--- a/packages/core/src/facade/__tests__/f-base.spec.ts
+++ b/packages/core/src/facade/__tests__/f-base.spec.ts
@@ -162,4 +162,37 @@ describe('FBase', () => {
         expect(instance.marker).toBe('updated');
         expect(accessLog).toEqual(['get:instance', 'set:updated', 'get:updated']);
     });
+
+    it('should fall back to assignment when an extension property descriptor is unavailable', () => {
+        class FallbackInitialable extends FBaseInitialable {
+            value = 'fallback';
+
+            constructor(@Inject(Injector) injector: IInjector) {
+                super(injector);
+            }
+        }
+
+        const legacySource = {
+            prototype: new Proxy({}, {
+                ownKeys: () => ['legacy'],
+                getOwnPropertyDescriptor: () => undefined,
+                get: (_target, key) => {
+                    if (key !== 'legacy') {
+                        return undefined;
+                    }
+
+                    return function (this: FallbackInitialable) {
+                        return `legacy:${this.value}`;
+                    };
+                },
+            }),
+        };
+
+        FallbackInitialable.extend(legacySource);
+
+        const injector = new Injector();
+        const instance = injector.createInstance(FallbackInitialable) as FallbackInitialable & { legacy: () => string };
+
+        expect(instance.legacy()).toBe('legacy:fallback');
+    });
 });

--- a/packages/core/src/facade/f-base.ts
+++ b/packages/core/src/facade/f-base.ts
@@ -115,8 +115,10 @@ export class FBaseInitialable extends Disposable {
 
                 initializers.push(source.prototype._initialize);
             } else if (name !== 'constructor') {
-                // @ts-ignore
-                this.prototype[name] = source.prototype[name];
+                const descriptor = Object.getOwnPropertyDescriptor(source.prototype, name);
+                if (descriptor) {
+                    Object.defineProperty(this.prototype, name, descriptor);
+                }
             }
         });
 

--- a/packages/core/src/facade/f-base.ts
+++ b/packages/core/src/facade/f-base.ts
@@ -118,6 +118,9 @@ export class FBaseInitialable extends Disposable {
                 const descriptor = Object.getOwnPropertyDescriptor(source.prototype, name);
                 if (descriptor) {
                     Object.defineProperty(this.prototype, name, descriptor);
+                } else {
+                    // @ts-ignore
+                    this.prototype[name] = source.prototype[name];
                 }
             }
         });


### PR DESCRIPTION
## Summary
- Preserve prototype accessor descriptors in FBaseInitialable.extend while keeping _initialize handling unchanged.
- Fall back to the previous assignment behavior when a descriptor is unavailable.
- Allow FWorksheet/FWorkbook/FRange/FDocument facade mixins to expose getter/setter APIs without invoking accessors during extend.

## Compatibility
- Existing method mixins continue to work because method descriptors are copied as callable prototype members.
- Non-standard extension sources without descriptors keep the legacy source.prototype[name] assignment path.
- Static extension behavior is untouched.
- FBase, FUniver, FEnum, FEventName, and FUtil are not changed.
- No public facade API is removed or renamed.

## Verification
- packages/core/node_modules/.bin/vitest run packages/core/src/facade/__tests__
- node_modules/.bin/tsc --noEmit (packages/core)
- packages/docs/node_modules/.bin/vitest run packages/docs/src/facade/__tests__
- packages/sheets/node_modules/.bin/vitest run --environment jsdom packages/sheets/src/facade/__tests__

Note: sheets facade tests fail in the default Node environment because existing FWorkbook.getUrl reads location.href; the same suite passes under jsdom.