### PR TITLE
fix(engine-render): force canvas ltr direction as RTL fallback

### DIFF
--- a/packages/engine-render/src/basics/__tests__/tools.spec.ts
+++ b/packages/engine-render/src/basics/__tests__/tools.spec.ts
@@ -118,6 +118,7 @@ describe('tools extra', () => {
         expect(requester2.cancelAnimationFrame).toHaveBeenCalledWith(12);
 
         expect(createCanvasElement().tagName).toBe('CANVAS');
+        expect(createCanvasElement().dir).toBe('ltr');
         expect(createImageElement().tagName).toBe('IMG');
     });
 

--- a/packages/engine-render/src/basics/tools.ts
+++ b/packages/engine-render/src/basics/tools.ts
@@ -134,6 +134,9 @@ export const cancelRequestFrame = (requestID: number, requester?: any) => {
 
 export const createCanvasElement = (): HTMLCanvasElement => {
     const canvas = document.createElement('canvas');
+    // TODO: Remove this fallback when canvas/docs rendering fully supports RTL.
+    // Keep canvas text rendering isolated from an RTL ancestor's inherited direction.
+    canvas.dir = 'ltr';
     // on some environments canvas.style is readonly
     try {
         (canvas as any).style = canvas.style || {};


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
