### PR TITLE
feat(ui): support generic component framework adapters

### DIFF
--- a/packages/sheets-drawing-ui/src/facade/f-worksheet.ts
+++ b/packages/sheets-drawing-ui/src/facade/f-worksheet.ts
@@ -184,8 +184,8 @@ export interface IFWorksheetDrawingUIMixin {
      * const fWorksheet = univerAPI.getActiveWorkbook().getSheetByName('Sheet1');
      * if (!fWorksheet) return;
      *
-     * // You should register components at an appropriate time (e.g., when Univer is loaded)
-     * // This is a React component. For Vue3 components, the third parameter should be `{ framework: 'vue3' }`
+     * // You should register components at an appropriate time (e.g., when Univer is loaded).
+     * // This is a React component. For other frameworks, pass a matching adapter option, such as `{ framework: 'vue3' }`.
      * univerAPI.registerComponent(
      *   'myFloatDom',
      *   ({ data }) => (

--- a/packages/sheets-ui/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets-ui/src/facade/__tests__/f-range.spec.ts
@@ -68,17 +68,30 @@ describe('FRange UI mixin', () => {
         stringResult.disposableCollection.dispose();
         expect(componentManager.register).not.toHaveBeenCalled();
 
-        const componentResult = transformComponentKey(
-            { componentKey: () => null, isVue3: true },
+        const vueComponentResult = transformComponentKey(
+            { componentKey: () => null, framework: 'vue3' },
             componentManager as any
         );
-        expect(componentResult.key.startsWith('External_')).toBe(true);
+        expect(vueComponentResult.key.startsWith('External_')).toBe(true);
         expect(componentManager.register).toHaveBeenCalledWith(
-            componentResult.key,
+            vueComponentResult.key,
             expect.any(Function),
             { framework: 'vue3' }
         );
-        componentResult.disposableCollection.dispose();
+        vueComponentResult.disposableCollection.dispose();
+        expect(registerDisposable.dispose).toHaveBeenCalled();
+
+        const frameworkComponentResult = transformComponentKey(
+            { componentKey: () => null, framework: 'web-component' },
+            componentManager as any
+        );
+        expect(frameworkComponentResult.key.startsWith('external-')).toBe(true);
+        expect(componentManager.register).toHaveBeenCalledWith(
+            frameworkComponentResult.key,
+            expect.any(Function),
+            { framework: 'web-component' }
+        );
+        frameworkComponentResult.disposableCollection.dispose();
         expect(registerDisposable.dispose).toHaveBeenCalled();
     });
 

--- a/packages/sheets-ui/src/facade/f-range.ts
+++ b/packages/sheets-ui/src/facade/f-range.ts
@@ -27,14 +27,15 @@ import { ComponentManager } from '@univerjs/ui';
 export interface IFComponentKey {
     /**
      * The key of the component to be rendered in the popup.
-     * if key is a string, it will be query from the component registry.
-     * if key is a React or Vue3 component, it will be rendered directly.
+     * If key is a string, it will be queried from the component registry.
+     * If key is a component, it will be registered temporarily with the specified framework.
      */
     componentKey: string | ComponentType;
     /**
-     * If componentKey is a Vue3 component, this must be set to true
+     * The framework adapter used to render a direct component.
+     * Defaults to `react`.
      */
-    isVue3?: boolean;
+    framework?: string;
 }
 
 export interface IFCanvasPopup extends Omit<ICanvasPopup, 'componentKey'>, IFComponentKey { }
@@ -382,14 +383,15 @@ declare module '@univerjs/sheets/facade' {
  * @returns {string} The transformed component key.
  */
 export function transformComponentKey(component: IFComponentKey, componentManager: ComponentManager): { key: string; disposableCollection: DisposableCollection } {
-    const { componentKey, isVue3 } = component;
+    const { componentKey, framework } = component;
     let key: string;
     const disposableCollection = new DisposableCollection();
     if (typeof componentKey === 'string') {
         key = componentKey;
     } else {
-        key = `External_${generateRandomId(6)}`;
-        disposableCollection.add(componentManager.register(key, componentKey, { framework: isVue3 ? 'vue3' : 'react' }));
+        const resolvedFramework = framework ?? 'react';
+        key = resolvedFramework === 'web-component' ? `external-${generateRandomId(6).toLowerCase()}` : `External_${generateRandomId(6)}`;
+        disposableCollection.add(componentManager.register(key, componentKey, { framework: resolvedFramework }));
     }
 
     return {

--- a/packages/ui-adapter-web-component/README.md
+++ b/packages/ui-adapter-web-component/README.md
@@ -30,9 +30,20 @@ import { UniverWebComponentAdapterPlugin } from '@univerjs/ui-adapter-web-compon
 univer.registerPlugin(UniverWebComponentAdapterPlugin);
 ```
 
+Register custom elements with the `web-component` framework option. Runtime props are assigned to the created element as DOM properties, which supports object values such as `data` and `extraProps`.
+
+```ts
+class MyPopup extends HTMLElement {
+    set data(value) {
+        this.textContent = value?.label ?? '';
+    }
+}
+
+univerAPI.registerComponent('my-popup', MyPopup, { framework: 'web-component' });
+```
+
 ## Resources
 
 - [Documentation](https://docs.univer.ai)
 - [NPM package](https://npmjs.com/package/@univerjs/ui-adapter-web-component)
 - [GitHub repository](https://github.com/dream-num/univer)
-

--- a/packages/ui-adapter-web-component/src/plugin.ts
+++ b/packages/ui-adapter-web-component/src/plugin.ts
@@ -50,10 +50,11 @@ export class UniverWebComponentAdapterPlugin extends Plugin {
         const { createElement, useEffect, useRef } = this._componentManager.reactUtils;
 
         this._componentManager.setHandler('web-component', (component: IComponent['component'], name?: string) => {
-            return () => createElement(WebComponentComponentWrapper, {
+            return (props: Record<string, unknown>) => createElement(WebComponentComponentWrapper, {
                 component,
                 props: {
                     name,
+                    componentProps: props,
                 },
                 reactUtils: { createElement, useEffect, useRef },
             });
@@ -65,11 +66,12 @@ export function WebComponentComponentWrapper(options: {
     component: CustomElementConstructor;
     props?: {
         name?: string;
+        componentProps?: Record<string, unknown>;
     };
     reactUtils: typeof ComponentManager.prototype.reactUtils;
 }) {
     const { component, props, reactUtils } = options;
-    const { name } = props ?? {};
+    const { name, componentProps = {} } = props ?? {};
     const { createElement, useEffect, useRef } = reactUtils;
 
     if (!name) {
@@ -86,12 +88,18 @@ export function WebComponentComponentWrapper(options: {
         if (!domRef.current) return;
 
         const webComponent = document.createElement(name) as HTMLElement;
+        const webComponentWithProps = webComponent as HTMLElement & Record<string, unknown>;
+        Object.entries(componentProps).forEach(([key, value]) => {
+            if (key !== 'key') {
+                webComponentWithProps[key] = value;
+            }
+        });
         domRef.current.appendChild(webComponent);
 
         return () => {
             domRef.current?.removeChild(webComponent);
         };
-    }, []);
+    }, [componentProps]);
 
     return createElement('div', { ref: domRef });
 }


### PR DESCRIPTION
- replace direct component isVue3 flag with generic framework option
- pass runtime props into web component adapter instances
- add web component adapter tests for prop forwarding
- update adapter docs and facade comments

<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
