### PR TITLE
fix(engine-render): refine transformer controls

### DIFF
--- a/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
+++ b/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
@@ -568,6 +568,36 @@ describe('engine scene viewport extra', () => {
         transformer.dispose();
     });
 
+    it('expands transformer border spacing symmetrically around object bounds', () => {
+        const transformer = new Transformer({
+            getEngine: () => ({ activeScene: null }),
+        } as any, {
+            anchorSize: 8,
+            anchorStyle: 'canva',
+            borderSpacing: 2,
+            borderStrokeWidth: 1,
+        });
+
+        expect((transformer as any)._getOutlinePosition(100, 50, 2, 1)).toEqual({
+            left: -3,
+            top: -3,
+            width: 104,
+            height: 54,
+        });
+        expect((transformer as any)._getRotateAnchorPosition('__SpreadsheetTransformerResizeLM__', 50, 100, {
+            transformerConfig: {
+                anchorSize: 8,
+                borderSpacing: 2,
+                borderStrokeWidth: 1,
+            },
+        })).toEqual({
+            left: -7,
+            top: 21,
+        });
+
+        transformer.dispose();
+    });
+
     it('supports bottom rotate control without a connector line', () => {
         const { engine, scene } = createFixture();
         engine.setActiveScene(scene.sceneKey);

--- a/packages/engine-render/src/scene.transformer.ts
+++ b/packages/engine-render/src/scene.transformer.ts
@@ -1315,8 +1315,8 @@ export class Transformer extends Disposable implements ITransformerConfig {
 
     private _getOutlinePosition(width: number, height: number, borderSpacing: number, borderStrokeWidth: number) {
         return {
-            left: borderSpacing - borderStrokeWidth,
-            top: -borderSpacing - this.borderStrokeWidth,
+            left: -borderSpacing - borderStrokeWidth,
+            top: -borderSpacing - borderStrokeWidth,
             width: width + borderSpacing * 2,
             height: height + borderSpacing * 2,
         };
@@ -1403,7 +1403,7 @@ export class Transformer extends Disposable implements ITransformerConfig {
 
                 break;
             case TransformerManagerType.RESIZE_LM:
-                left += borderSpacing - borderStrokeWidth;
+                left += -borderSpacing - borderStrokeWidth;
                 top += height / 2 - longEdge / 2;
 
                 break;
@@ -1413,7 +1413,7 @@ export class Transformer extends Disposable implements ITransformerConfig {
 
                 break;
             case TransformerManagerType.RESIZE_LB:
-                left += -this.borderSpacing - borderStrokeWidth;
+                left += -borderSpacing - borderStrokeWidth;
                 top += height + borderSpacing - borderStrokeWidth - longEdge;
 
                 break;
@@ -1472,7 +1472,7 @@ export class Transformer extends Disposable implements ITransformerConfig {
 
                 break;
             case TransformerManagerType.RESIZE_LM:
-                left += borderSpacing - borderStrokeWidth;
+                left += -borderSpacing - borderStrokeWidth;
                 top += height / 2;
 
                 break;
@@ -1482,7 +1482,7 @@ export class Transformer extends Disposable implements ITransformerConfig {
 
                 break;
             case TransformerManagerType.RESIZE_LB:
-                left += -this.borderSpacing - borderStrokeWidth;
+                left += -borderSpacing - borderStrokeWidth;
                 top += height + borderSpacing - borderStrokeWidth;
 
                 break;


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

Refines engine-render transformer control behavior used by board selection interactions.

This keeps the transformer controls aligned with the intended visual interaction model and adds regression coverage in `engine-scene-viewport.spec.ts`.

How to test them:

- `git diff --check`
- Attempted: `/Users/lilin/Documents/GitHub/univer-pro-2/node_modules/.pnpm/node_modules/.bin/vitest run --environment happy-dom packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts`
  - This local run is blocked by the test environment missing a usable Canvas 2D context: `context is not support`.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
