### PR TITLE
fix(design): make accordion spacing configurable

### DIFF
--- a/packages/design/src/components/accordion/Accordion.stories.tsx
+++ b/packages/design/src/components/accordion/Accordion.stories.tsx
@@ -74,3 +74,25 @@ export const AccordionBasic = {
         );
     },
 };
+
+export const AccordionWithCustomSpacing = {
+    render() {
+        const items = [{
+            label: 'Accordion A',
+            children: <div>Content A</div>,
+        }, {
+            label: 'Accordion B',
+            children: <div>Content B</div>,
+        }];
+
+        return (
+            <Accordion
+                classNames={{
+                    trigger: 'univer-px-4 univer-py-3',
+                    contentInner: 'univer-px-4 univer-py-2',
+                }}
+                items={items}
+            />
+        );
+    },
+};

--- a/packages/design/src/components/accordion/Accordion.tsx
+++ b/packages/design/src/components/accordion/Accordion.tsx
@@ -25,8 +25,18 @@ interface IAccordionItem {
     children: ReactNode;
 }
 
+export interface IAccordionClassNames {
+    item?: string;
+    trigger?: string;
+    icon?: string;
+    label?: string;
+    content?: string;
+    contentInner?: string;
+}
+
 export interface IAccordionProps {
     className?: string;
+    classNames?: IAccordionClassNames;
     items: IAccordionItem[];
     defaultOpenIndex?: number | null;
     openIndex?: number | null;
@@ -34,7 +44,7 @@ export interface IAccordionProps {
 }
 
 export function Accordion(props: IAccordionProps) {
-    const { className, defaultOpenIndex = null, items, onOpenIndexChange } = props;
+    const { className, classNames, defaultOpenIndex = null, items, onOpenIndexChange } = props;
     const [innerOpenIndex, setInnerOpenIndex] = useState<number | null>(defaultOpenIndex);
     const openIndex = props.openIndex ?? innerOpenIndex;
 
@@ -55,38 +65,37 @@ export function Accordion(props: IAccordionProps) {
             `, className)}
         >
             {items.map((item, index) => (
-                <div key={item.id ?? index}>
+                <div key={item.id ?? index} className={classNames?.item}>
                     <button
-                        className={`
+                        className={clsx(`
                           univer-box-border univer-flex univer-w-full univer-cursor-pointer univer-items-center
-                          univer-gap-1.5 univer-border-none univer-bg-transparent univer-p-4 univer-text-left
-                          univer-text-gray-700
+                          univer-gap-1.5 univer-border-none univer-bg-transparent univer-text-left univer-text-gray-700
                           hover:univer-text-gray-900
                           focus:univer-outline-none
                           dark:!univer-text-gray-200
                           dark:hover:!univer-text-white
-                        `}
+                        `, classNames?.trigger)}
                         type="button"
                         onClick={() => toggleItem(index)}
                     >
                         <DownIcon
-                            className={clsx('univer-size-2.5 univer-flex-shrink-0 univer-transition-transform', {
+                            className={clsx('univer-size-2.5 univer-flex-shrink-0 univer-transition-transform', classNames?.icon, {
                                 '-univer-rotate-90': openIndex !== index,
                                 'univer-rotate-0': openIndex === index,
                             })}
                         />
-                        <span className="univer-font-medium">{item.label}</span>
+                        <span className={clsx('univer-font-medium', classNames?.label)}>{item.label}</span>
                     </button>
                     <div
                         className={clsx(`
                           univer-overflow-hidden univer-transition-[max-height,opacity] univer-duration-500
                           univer-ease-in-out
-                        `, {
+                        `, classNames?.content, {
                             'univer-max-h-screen': openIndex === index,
                             'univer-max-h-0': openIndex !== index,
                         })}
                     >
-                        <div className="univer-box-border univer-px-4 univer-py-1.5">{item.children}</div>
+                        <div className={clsx('univer-box-border univer-py-1.5', classNames?.contentInner)}>{item.children}</div>
                     </div>
                 </div>
             ))}

--- a/packages/design/src/components/accordion/__tests__/index.spec.tsx
+++ b/packages/design/src/components/accordion/__tests__/index.spec.tsx
@@ -50,4 +50,32 @@ describe('Accordion', () => {
         fireEvent.click(getByText('Item 2'));
         expect(queryByText('Content 2')?.parentElement?.parentElement?.className).toContain('univer-max-h-0');
     });
+
+    it('does not apply global horizontal padding to triggers or content', () => {
+        const { getByText } = render(<Accordion items={[{ label: 'Item 1', children: <div>Content 1</div> }]} />);
+
+        const trigger = getByText('Item 1').closest('button');
+        const contentInner = getByText('Content 1').parentElement;
+
+        expect(trigger?.className).not.toContain('univer-p-4');
+        expect(contentInner?.className).not.toContain('univer-px-4');
+        expect(contentInner?.className).toContain('univer-py-1.5');
+    });
+
+    it('accepts scoped classes for accordion slots', () => {
+        const { getByText } = render(
+            <Accordion
+                classNames={{
+                    trigger: 'test-trigger-padding',
+                    contentInner: 'test-content-padding',
+                    label: 'test-label',
+                }}
+                items={[{ label: 'Item 1', children: <div>Content 1</div> }]}
+            />
+        );
+
+        expect(getByText('Item 1').closest('button')?.className).toContain('test-trigger-padding');
+        expect(getByText('Item 1').className).toContain('test-label');
+        expect(getByText('Content 1').parentElement?.className).toContain('test-content-padding');
+    });
 });

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -17,7 +17,7 @@
 import './global.css';
 
 export { Accordion } from './components/accordion/Accordion';
-export type { IAccordionProps } from './components/accordion/Accordion';
+export type { IAccordionClassNames, IAccordionProps } from './components/accordion/Accordion';
 export { Avatar } from './components/avatar/Avatar';
 export type { IAvatarProps } from './components/avatar/Avatar';
 export { Badge } from './components/badge/Badge';


### PR DESCRIPTION
## Summary
- remove default horizontal padding from Accordion trigger and content wrappers
- add slot-level classNames for scoped Accordion styling
- add Storybook coverage for custom Accordion spacing

## Testing
- ./node_modules/.bin/vitest run packages/design/src/components/accordion/__tests__/index.spec.tsx --configLoader runner --environment jsdom
- ./node_modules/.bin/eslint packages/design/src/components/accordion/Accordion.tsx packages/design/src/components/accordion/__tests__/index.spec.tsx packages/design/src/components/accordion/Accordion.stories.tsx packages/design/src/index.ts
- ./node_modules/.bin/tsc --noEmit (from packages/design)
- git diff --check -- packages/design/src/components/accordion/Accordion.tsx packages/design/src/components/accordion/__tests__/index.spec.tsx packages/design/src/components/accordion/Accordion.stories.tsx packages/design/src/index.ts