### PR TITLE
feat(docs-drawing-ui): expose floating toolbar adapter items

### DIFF
--- a/packages/docs-drawing-ui/src/index.ts
+++ b/packages/docs-drawing-ui/src/index.ts
@@ -33,5 +33,14 @@ export { DocFloatDomController } from './controllers/doc-float-dom.controller';
 export { DOCS_IMAGE_MENU_ID } from './menu/image.menu';
 export { DOCS_SHAPE_BELOW_MENU_ID, DOCS_SHAPE_MENU_ID } from './menu/shape.menu';
 export { UniverDocsDrawingUIPlugin } from './plugin';
+export { DocDrawingFloatingToolbarAdapterService } from './services/doc-drawing-floating-toolbar-adapter.service';
+export type {
+    IDocDrawingFloatingToolbarAdapter,
+    IDocDrawingFloatingToolbarButtonItem,
+    IDocDrawingFloatingToolbarItem,
+    IDocDrawingFloatingToolbarOption,
+    IDocDrawingFloatingToolbarParams,
+    IDocDrawingFloatingToolbarSelectItem,
+} from './services/doc-drawing-floating-toolbar-adapter.service';
 export { DocDrawingPosition } from './views/doc-image-panel/DocDrawingPosition';
 export { DocDrawingTextWrap } from './views/doc-image-panel/DocDrawingTextWrap';

--- a/packages/docs-drawing-ui/src/menu/drawing-popup-menu.controller.ts
+++ b/packages/docs-drawing-ui/src/menu/drawing-popup-menu.controller.ts
@@ -28,8 +28,8 @@ import {
     RxDisposable,
     UniverInstanceType,
 } from '@univerjs/core';
-import { DocCanvasPopManagerService } from '@univerjs/docs-ui';
 import { IDocDrawingAdapterService } from '@univerjs/docs-drawing';
+import { DocCanvasPopManagerService } from '@univerjs/docs-ui';
 import { IDrawingManagerService } from '@univerjs/drawing';
 import {
     COMPONENT_IMAGE_POPUP_MENU,
@@ -42,6 +42,7 @@ import { takeUntil } from 'rxjs';
 import { RemoveDocDrawingCommand } from '../commands/commands/remove-doc-drawing.command';
 import { EditDocDrawingOperation } from '../commands/operations/edit-doc-drawing.operation';
 import { SidebarDocDrawingOperation } from '../commands/operations/open-drawing-panel.operation';
+import { DocDrawingFloatingToolbarAdapterService } from '../services/doc-drawing-floating-toolbar-adapter.service';
 
 export class DocDrawingPopupMenuController extends RxDisposable {
     private _initImagePopupMenu = new Set<string>();
@@ -55,6 +56,7 @@ export class DocDrawingPopupMenuController extends RxDisposable {
         @IUniverInstanceService private readonly _univerInstanceService: IUniverInstanceService,
         @IContextService private readonly _contextService: IContextService,
         @IDocDrawingAdapterService private readonly _drawingAdapterService: IDocDrawingAdapterService,
+        @Inject(DocDrawingFloatingToolbarAdapterService) private readonly _floatingToolbarAdapterService: DocDrawingFloatingToolbarAdapterService,
         @ICommandService private readonly _commandService: ICommandService
 
     ) {
@@ -189,7 +191,7 @@ export class DocDrawingPopupMenuController extends RxDisposable {
                         direction: isImage ? 'top-center' : 'horizontal',
                         offset: isImage ? [0, 8] : [2, 0],
                         extraProps: {
-                            menuItems: this._getImageMenuItems(unitId, subUnitId, drawingId, drawingType),
+                            menuItems: this._getDrawingPopupMenuItems(unitId, subUnitId, drawingId, drawingType),
                             variant: isImage ? 'doc-floating-toolbar' : undefined,
                             unitId,
                             subUnitId,
@@ -242,8 +244,15 @@ export class DocDrawingPopupMenuController extends RxDisposable {
         );
     }
 
-    private _getImageMenuItems(unitId: string, subUnitId: string, drawingId: string, drawingType: number) {
+    private _getDrawingPopupMenuItems(unitId: string, subUnitId: string, drawingId: string, drawingType: number) {
         const drawing = this._drawingManagerService.getDrawingByParam({ unitId, subUnitId, drawingId }) as IDocDrawing | null;
+        const floatingToolbarMenuItems = drawing
+            ? this._floatingToolbarAdapterService.getItems({ unitId, subUnitId, drawing })
+            : null;
+        if (floatingToolbarMenuItems) {
+            return floatingToolbarMenuItems;
+        }
+
         const editCommandInfo = drawing
             ? this._drawingAdapterService.getEditDrawingCommandInfo({ unitId, subUnitId, drawing })
             : null;

--- a/packages/docs-drawing-ui/src/plugin.ts
+++ b/packages/docs-drawing-ui/src/plugin.ts
@@ -37,6 +37,7 @@ import {
 } from './controllers/render-controllers/doc-drawing-update.render-controller';
 import { DocDrawingUIController } from './controllers/ui.controller';
 import { DocDrawingPopupMenuController } from './menu/drawing-popup-menu.controller';
+import { DocDrawingFloatingToolbarAdapterService } from './services/doc-drawing-floating-toolbar-adapter.service';
 import { DocRefreshDrawingsService } from './services/doc-refresh-drawings.service';
 
 @DependentOn(UniverDrawingUIPlugin, UniverDrawingPlugin, UniverDocsDrawingPlugin, UniverUIPlugin)
@@ -71,6 +72,7 @@ export class UniverDocsDrawingUIPlugin extends Plugin {
             [DocDrawingTransformerController],
             [DocDrawingAddRemoveController],
             [DocRefreshDrawingsService],
+            [DocDrawingFloatingToolbarAdapterService],
             [DocFloatDomController],
             [DocDrawingPrintingController],
         ];

--- a/packages/docs-drawing-ui/src/services/__tests__/doc-drawing-floating-toolbar-adapter.service.spec.ts
+++ b/packages/docs-drawing-ui/src/services/__tests__/doc-drawing-floating-toolbar-adapter.service.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DocDrawingFloatingToolbarAdapterService } from '../doc-drawing-floating-toolbar-adapter.service';
+
+describe('DocDrawingFloatingToolbarAdapterService', () => {
+    it('returns the first matching adapter items sorted by index', () => {
+        const service = new DocDrawingFloatingToolbarAdapterService();
+        service.registerAdapter({
+            getItems: () => null,
+        });
+        service.registerAdapter({
+            getItems: () => [
+                {
+                    label: 'delete',
+                    index: 2,
+                    commandId: 'delete-command',
+                    disable: false,
+                },
+                {
+                    label: 'edit',
+                    index: 1,
+                    commandId: 'edit-command',
+                    disable: false,
+                },
+            ],
+        });
+
+        expect(service.getItems({
+            unitId: 'doc-1',
+            subUnitId: 'doc-1',
+            drawing: { drawingId: 'drawing-1' } as never,
+        })?.map((item) => item.commandId)).toEqual(['edit-command', 'delete-command']);
+    });
+
+    it('unregisters disposed adapters', () => {
+        const service = new DocDrawingFloatingToolbarAdapterService();
+        const disposable = service.registerAdapter({
+            getItems: () => [{
+                label: 'edit',
+                index: 0,
+                commandId: 'edit-command',
+                disable: false,
+            }],
+        });
+
+        disposable.dispose();
+
+        expect(service.getItems({
+            unitId: 'doc-1',
+            subUnitId: 'doc-1',
+            drawing: { drawingId: 'drawing-1' } as never,
+        })).toBeNull();
+    });
+});

--- a/packages/docs-drawing-ui/src/services/doc-drawing-floating-toolbar-adapter.service.ts
+++ b/packages/docs-drawing-ui/src/services/doc-drawing-floating-toolbar-adapter.service.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IDisposable } from '@univerjs/core';
+import type { IDocDrawing } from '@univerjs/docs-drawing';
+import { toDisposable } from '@univerjs/core';
+
+export interface IDocDrawingFloatingToolbarParams {
+    unitId: string;
+    subUnitId: string;
+    drawing: IDocDrawing;
+}
+
+export interface IDocDrawingFloatingToolbarOption {
+    label: unknown;
+    value: string;
+}
+
+interface IDocDrawingFloatingToolbarBaseItem {
+    label: string;
+    index: number;
+    commandId: string;
+    commandParams?: object;
+    disable: boolean;
+    hideOnClick?: boolean;
+    icon?: string;
+}
+
+export interface IDocDrawingFloatingToolbarButtonItem extends IDocDrawingFloatingToolbarBaseItem {
+    type?: 'button';
+}
+
+export interface IDocDrawingFloatingToolbarSelectItem extends IDocDrawingFloatingToolbarBaseItem {
+    type: 'select';
+    value: string;
+    options: IDocDrawingFloatingToolbarOption[];
+    commandParamsFactory: (value: string) => object;
+}
+
+export type IDocDrawingFloatingToolbarItem =
+    | IDocDrawingFloatingToolbarButtonItem
+    | IDocDrawingFloatingToolbarSelectItem;
+
+export interface IDocDrawingFloatingToolbarAdapter {
+    getItems: (
+        params: IDocDrawingFloatingToolbarParams
+    ) => readonly IDocDrawingFloatingToolbarItem[] | null | undefined;
+}
+
+export class DocDrawingFloatingToolbarAdapterService {
+    private readonly _adapters: IDocDrawingFloatingToolbarAdapter[] = [];
+
+    registerAdapter(adapter: IDocDrawingFloatingToolbarAdapter): IDisposable {
+        this._adapters.push(adapter);
+
+        return toDisposable(() => {
+            const index = this._adapters.indexOf(adapter);
+            if (index >= 0) {
+                this._adapters.splice(index, 1);
+            }
+        });
+    }
+
+    getItems(params: IDocDrawingFloatingToolbarParams): IDocDrawingFloatingToolbarItem[] | null {
+        for (const adapter of this._adapters) {
+            const items = adapter.getItems(params);
+            if (items) {
+                return [...items].sort((a, b) => a.index - b.index);
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a docs-drawing-ui adapter seam for floating toolbar command items
- keep docs-drawing focused on drawing lifecycle/edit/remove seams instead of toolbar UI protocol
- let docs drawing UI use adapter-provided floating toolbar items before falling back to the default image menu

## Verification
- node_modules/.bin/eslint submodules/univer/packages/docs-drawing/src/services/doc-drawing-adapter.service.ts submodules/univer/packages/docs-drawing/src/index.ts submodules/univer/packages/docs-drawing-ui/src/index.ts submodules/univer/packages/docs-drawing-ui/src/plugin.ts submodules/univer/packages/docs-drawing-ui/src/menu/drawing-popup-menu.controller.ts submodules/univer/packages/docs-drawing-ui/src/services/doc-drawing-floating-toolbar-adapter.service.ts submodules/univer/packages/docs-drawing-ui/src/services/__tests__/doc-drawing-floating-toolbar-adapter.service.spec.ts
- node_modules/.bin/tsc -p submodules/univer/packages/docs-drawing/tsconfig.json --noEmit --pretty false
- node_modules/.bin/tsc -p submodules/univer/packages/docs-drawing-ui/tsconfig.json --noEmit --pretty false
- submodules/univer/node_modules/.bin/vitest run --config submodules/univer/packages/docs-drawing-ui/vitest.config.ts --configLoader runner submodules/univer/packages/docs-drawing-ui/src/services/__tests__/doc-drawing-floating-toolbar-adapter.service.spec.ts