### PR TITLE
fix(docs): stabilize TextX metadata apply

### DIFF
--- a/packages/core/src/docs/data-model/text-x/__tests__/apply.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/apply.spec.ts
@@ -16,8 +16,8 @@
 
 import type { IDocumentBody } from '../../../../types/interfaces';
 import type { TextXAction } from '../action-types';
-import { describe, expect, it } from 'vitest';
-import { UpdateDocsAttributeType } from '../../../../shared';
+import { describe, expect, it, vi } from 'vitest';
+import { Tools, UpdateDocsAttributeType } from '../../../../shared';
 import { BooleanNumber, HorizontalAlign } from '../../../../types/enum';
 import { CustomRangeType } from '../../../../types/interfaces';
 import { PresetListType } from '../../preset-list-type';
@@ -114,6 +114,49 @@ function getDefaultDocWithCustomRange() {
 }
 
 describe('apply method', () => {
+    it('does not deep-clone plain typing and delete actions', () => {
+        const deepClone = vi.spyOn(Tools, 'deepClone');
+        const doc: IDocumentBody = { dataStream: 'A\r\n' };
+
+        try {
+            TextX.apply(doc, [
+                { t: TextXActionType.RETAIN, len: 1 },
+                { t: TextXActionType.INSERT, len: 1, body: { dataStream: 'B' } },
+                { t: TextXActionType.DELETE, len: 1 },
+            ]);
+
+            expect(doc.dataStream).toBe('AB\n');
+            expect(deepClone).not.toHaveBeenCalled();
+        } finally {
+            deepClone.mockRestore();
+        }
+    });
+
+    it('keeps structural insert action payloads immutable', () => {
+        const doc: IDocumentBody = {
+            dataStream: 'A\r\n',
+            paragraphs: [{ startIndex: 1, paragraphId: 'source' }],
+        };
+        const actions: TextXAction[] = [{
+            t: TextXActionType.INSERT,
+            len: 1,
+            body: {
+                dataStream: '\r',
+                paragraphs: [{
+                    startIndex: 0,
+                    paragraphId: 'inserted',
+                    paragraphStyle: { horizontalAlign: HorizontalAlign.CENTER },
+                }],
+            },
+        }];
+        const serializedActions = JSON.stringify(actions);
+
+        TextX.apply(doc, actions);
+
+        expect(JSON.stringify(actions)).toBe(serializedActions);
+        expect(doc.paragraphs?.[0]).not.toBe(actions[0].body?.paragraphs?.[0]);
+    });
+
     it('should get the same result when apply two actions by order OR composed first case 1', () => {
         const actionsA: TextXAction[] = [
             {

--- a/packages/core/src/docs/data-model/text-x/__tests__/column-groups.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/column-groups.spec.ts
@@ -25,6 +25,33 @@ import { TextX } from '../text-x';
 import { getBodySliceForTextXAction } from '../utils';
 
 describe('TextX column groups', () => {
+    it('creates missing paragraph and section-break collections from inserted column metadata', () => {
+        const T = DataStreamTreeTokenType;
+        const body: IDocumentBody = {
+            dataStream: `${T.COLUMN_GROUP_START}${T.COLUMN_START}${T.COLUMN_END}${T.COLUMN_GROUP_END}`,
+            columnGroups: [{ startIndex: 0, endIndex: 3, columnGroupId: 'cg-1' }],
+        };
+
+        TextX.apply(body, [
+            { t: TextXActionType.RETAIN, len: 2 },
+            {
+                t: TextXActionType.INSERT,
+                len: 2,
+                body: {
+                    dataStream: `${T.PARAGRAPH}${T.SECTION_BREAK}`,
+                    paragraphs: [{ startIndex: 0, paragraphId: 'inserted' }],
+                    sectionBreaks: [{ startIndex: 1 }],
+                },
+            },
+        ]);
+
+        expect(body.paragraphs).toEqual([{
+            startIndex: 2,
+            paragraphId: expect.any(String),
+        }]);
+        expect(body.sectionBreaks).toEqual([{ startIndex: 3 }]);
+    });
+
     it('adds inserted column group metadata to documents without existing column groups', () => {
         const T = DataStreamTreeTokenType;
         const body: IDocumentBody = {

--- a/packages/core/src/docs/data-model/text-x/apply-utils/common.ts
+++ b/packages/core/src/docs/data-model/text-x/apply-utils/common.ts
@@ -176,10 +176,12 @@ export function insertParagraphs(
     currentIndex: number,
     preserveMissingParagraphIds = false
 ) {
-    const { paragraphs } = body;
-    if (paragraphs == null) {
+    if (!body.paragraphs && !insertBody.paragraphs?.length) {
         return;
     }
+
+    body.paragraphs ??= [];
+    const { paragraphs } = body;
 
     const { paragraphs: insertParagraphs } = insertBody;
     normalizeInsertedParagraphIdsForDocument(paragraphs, insertParagraphs, currentIndex, {
@@ -344,11 +346,12 @@ export function insertSectionBreaks(
     textLength: number,
     currentIndex: number
 ) {
-    const { sectionBreaks } = body;
-
-    if (sectionBreaks == null) {
+    if (!body.sectionBreaks && !insertBody.sectionBreaks?.length) {
         return;
     }
+
+    body.sectionBreaks ??= [];
+    const { sectionBreaks } = body;
 
     for (let i = 0, len = sectionBreaks.length; i < len; i++) {
         const sectionBreak = sectionBreaks[i];

--- a/packages/core/src/docs/data-model/text-x/apply.ts
+++ b/packages/core/src/docs/data-model/text-x/apply.ts
@@ -66,15 +66,12 @@ export function textXApply(doc: IDocumentBody, actions: TextXAction[]): IDocumen
     memoryCursor.reset();
 
     actions.forEach((action) => {
-        // Since updateApply modifies the action(used in undo/redo),
-        // so make a deep copy here.
-        const clonedAction = Tools.deepClone(action);
-
-        switch (clonedAction.t) {
+        switch (action.t) {
             case TextXActionType.RETAIN: {
-                const { coverType, body, len } = clonedAction;
+                const { coverType, body, len } = action;
                 if (body != null) {
-                    updateApply(doc, body, len, memoryCursor.cursor, coverType);
+                    // Attribute apply mutates its payload while normalizing ranges.
+                    updateApply(doc, Tools.deepClone(body), len, memoryCursor.cursor, coverType);
                 }
 
                 memoryCursor.moveCursor(len);
@@ -82,22 +79,28 @@ export function textXApply(doc: IDocumentBody, actions: TextXAction[]): IDocumen
             }
 
             case TextXActionType.INSERT: {
-                const { body, len } = clonedAction;
+                const { body, len } = action;
+                // Plain typing only reads dataStream. Structural inserts still clone their local metadata payload.
+                const insertBody = onlyHasDataStream(body) ? body : Tools.deepClone(body);
 
-                insertApply(doc, body!, len, memoryCursor.cursor);
+                insertApply(doc, insertBody, len, memoryCursor.cursor);
                 memoryCursor.moveCursor(len);
                 break;
             }
 
             case TextXActionType.DELETE: {
-                const { len } = clonedAction;
+                const { len } = action;
                 deleteApply(doc, len, memoryCursor.cursor);
                 break;
             }
             default:
-                throw new Error(`Unknown action type for action: ${clonedAction}.`);
+                throw new Error(`Unknown action type for action: ${action}.`);
         }
     });
 
     return doc;
+}
+
+function onlyHasDataStream(body: IDocumentBody): boolean {
+    return Object.keys(body).length === 1 && typeof body.dataStream === 'string';
 }


### PR DESCRIPTION
## Summary
- initialize missing paragraph and section-break collections when structural TextX inserts carry that metadata
- avoid deep cloning plain typing, cursor retain, and delete actions during TextX apply
- preserve local payload isolation for structural and attribute actions

## Tests
- pnpm --filter @univerjs/core test (116 files, 670 tests)
- pnpm --filter @univerjs/core typecheck
- dependent docs-table, docs-column, and shape-editor-ui suites