### PR TITLE
fix(docs): keep table end boundary stable

### DIFF
--- a/packages/core/src/docs/data-model/text-x/__tests__/action-iterator.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/action-iterator.spec.ts
@@ -158,11 +158,12 @@ describe('Test action iterator', () => {
     it('preserves table metadata on the chunk containing the table end when an insert action is split', () => {
         const T = DataStreamTreeTokenType;
         const tableStream = `${T.TABLE_START}${T.TABLE_ROW_START}${T.TABLE_CELL_START}Cell${T.PARAGRAPH}${T.SECTION_BREAK}${T.TABLE_CELL_END}${T.TABLE_ROW_END}${T.TABLE_END}${T.PARAGRAPH}`;
+        const tableEnd = tableStream.length - 1;
         const iterator = new ActionIterator([{
             t: TextXActionType.INSERT,
             body: {
                 dataStream: tableStream,
-                tables: [{ startIndex: 0, endIndex: tableStream.length, tableId: 'table-1' }],
+                tables: [{ startIndex: 0, endIndex: tableEnd, tableId: 'table-1' }],
             },
             len: tableStream.length,
         }]);
@@ -171,24 +172,24 @@ describe('Test action iterator', () => {
         const restAction = iterator.next();
 
         expect(partialAction.body?.tables).toBeUndefined();
-        expect(restAction.body?.tables).toEqual([{ startIndex: -4, endIndex: tableStream.length - 4, tableId: 'table-1' }]);
+        expect(restAction.body?.tables).toEqual([{ startIndex: -4, endIndex: tableEnd - 4, tableId: 'table-1' }]);
 
         const body = { dataStream: '' };
         TextX.apply(body, [partialAction, restAction]);
         expect(body).toMatchObject({
             dataStream: tableStream,
-            tables: [{ startIndex: 0, endIndex: tableStream.length, tableId: 'table-1' }],
+            tables: [{ startIndex: 0, endIndex: tableEnd, tableId: 'table-1' }],
         });
 
         const fullIterator = new ActionIterator([{
             t: TextXActionType.INSERT,
             body: {
                 dataStream: tableStream,
-                tables: [{ startIndex: 0, endIndex: tableStream.length, tableId: 'table-1' }],
+                tables: [{ startIndex: 0, endIndex: tableEnd, tableId: 'table-1' }],
             },
             len: tableStream.length,
         }]);
 
-        expect(fullIterator.next().body?.tables).toEqual([{ startIndex: 0, endIndex: tableStream.length, tableId: 'table-1' }]);
+        expect(fullIterator.next().body?.tables).toEqual([{ startIndex: 0, endIndex: tableEnd, tableId: 'table-1' }]);
     });
 });

--- a/packages/core/src/docs/data-model/text-x/__tests__/body-structure-validator.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/body-structure-validator.spec.ts
@@ -83,6 +83,28 @@ describe('validateDocBodyStructure', () => {
         expect(validateDocBodyStructure(body).map((issue) => issue.code)).toContain('empty-table-cell');
     });
 
+    it('keeps table metadata anchored to the table end token when the following paragraph has text', () => {
+        const T = DataStreamTreeTokenType;
+        const tableStream = `${T.TABLE_START}${T.TABLE_ROW_START}${T.TABLE_CELL_START}A${T.PARAGRAPH}${T.SECTION_BREAK}${T.TABLE_CELL_END}${T.TABLE_ROW_END}${T.TABLE_END}`;
+        const body: IDocumentBody = {
+            dataStream: `${tableStream}After${T.PARAGRAPH}${T.SECTION_BREAK}`,
+            paragraphs: [
+                { startIndex: 4, paragraphId: 'cell' },
+                { startIndex: tableStream.length + 5, paragraphId: 'after-table' },
+            ],
+            sectionBreaks: [
+                { startIndex: 5 },
+                { startIndex: tableStream.length + 6 },
+            ],
+            tables: [{ startIndex: 0, endIndex: tableStream.length, tableId: 'table-1' }],
+        };
+
+        expect(validateDocBodyStructure(body)).toEqual([]);
+
+        body.tables![0].endIndex = tableStream.length + 5;
+        expect(validateDocBodyStructure(body).map((issue) => issue.code)).toContain('table-end-token-mismatch');
+    });
+
     it('reports unbalanced structural tokens', () => {
         const T = DataStreamTreeTokenType;
         const body: IDocumentBody = {

--- a/packages/core/src/docs/data-model/text-x/__tests__/tables.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/tables.spec.ts
@@ -150,7 +150,7 @@ describe('TextX tables', () => {
         expect(body.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual([9, 20]);
     });
 
-    it('shifts table end metadata when text is inserted before the paragraph after a table', () => {
+    it('keeps the half-open table end fixed when text is inserted after a table', () => {
         const T = DataStreamTreeTokenType;
         const body: IDocumentBody = {
             dataStream: `${T.TABLE_START}${T.TABLE_ROW_START}${T.TABLE_CELL_START}Cell${T.PARAGRAPH}${T.SECTION_BREAK}${T.TABLE_CELL_END}${T.TABLE_ROW_END}${T.TABLE_END}${T.PARAGRAPH}${T.SECTION_BREAK}`,
@@ -171,7 +171,78 @@ describe('TextX tables', () => {
         ]);
 
         expect(body.dataStream).toBe(`${T.TABLE_START}${T.TABLE_ROW_START}${T.TABLE_CELL_START}Cell${T.PARAGRAPH}${T.SECTION_BREAK}${T.TABLE_CELL_END}${T.TABLE_ROW_END}${T.TABLE_END}啊手${T.PARAGRAPH}${T.SECTION_BREAK}`);
-        expect(body.tables).toEqual([{ startIndex: 0, endIndex: 14, tableId: 'table-1' }]);
+        expect(body.tables).toEqual([{ startIndex: 0, endIndex: 12, tableId: 'table-1' }]);
+        expect(body.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual([7, 14]);
+    });
+
+    it('keeps a following column group outside the table when typing at the table end', () => {
+        const T = DataStreamTreeTokenType;
+        const tableStream = `${T.TABLE_START}${T.TABLE_ROW_START}${T.TABLE_CELL_START}Cell${T.PARAGRAPH}${T.SECTION_BREAK}${T.TABLE_CELL_END}${T.TABLE_ROW_END}${T.TABLE_END}`;
+        const columnGroupStream = `${T.COLUMN_GROUP_START}${T.COLUMN_START}Lane${T.PARAGRAPH}${T.COLUMN_END}${T.COLUMN_GROUP_END}${T.SECTION_BREAK}`;
+        const tableEnd = tableStream.length;
+        const columnGroupStart = tableEnd + 1;
+        const body: IDocumentBody = {
+            dataStream: `${tableStream}${T.PARAGRAPH}${columnGroupStream}`,
+            paragraphs: [
+                { startIndex: 7, paragraphId: 'cell' },
+                { startIndex: tableEnd, paragraphId: 'after-table' },
+                { startIndex: columnGroupStart + 6, paragraphId: 'column' },
+            ],
+            sectionBreaks: [
+                { startIndex: 8 },
+                { startIndex: columnGroupStart + columnGroupStream.length - 1 },
+            ],
+            tables: [{ startIndex: 0, endIndex: tableEnd, tableId: 'table-1' }],
+            columnGroups: [{
+                startIndex: columnGroupStart,
+                endIndex: columnGroupStart + columnGroupStream.length - 2,
+                columnGroupId: 'column-group-1',
+            }],
+        };
+
+        TextX.apply(body, [
+            { t: TextXActionType.RETAIN, len: tableEnd },
+            { t: TextXActionType.INSERT, body: { dataStream: 'After' }, len: 5 },
+        ]);
+
+        expect(body.tables).toEqual([{ startIndex: 0, endIndex: tableEnd, tableId: 'table-1' }]);
+        expect(body.columnGroups).toEqual([{
+            startIndex: columnGroupStart + 5,
+            endIndex: columnGroupStart + columnGroupStream.length + 3,
+            columnGroupId: 'column-group-1',
+        }]);
+        expect(body.dataStream.slice(tableEnd, tableEnd + 5)).toBe('After');
+        expect(body.dataStream[tableEnd + 5]).toBe(T.PARAGRAPH);
+    });
+
+    it('keeps the table end fixed across composed IME updates after a table', () => {
+        const T = DataStreamTreeTokenType;
+        const body: IDocumentBody = {
+            dataStream: `${T.TABLE_START}${T.TABLE_ROW_START}${T.TABLE_CELL_START}Cell${T.PARAGRAPH}${T.SECTION_BREAK}${T.TABLE_CELL_END}${T.TABLE_ROW_END}${T.TABLE_END}${T.PARAGRAPH}${T.SECTION_BREAK}`,
+            paragraphs: [
+                { startIndex: 7, paragraphId: 'cell' },
+                { startIndex: 12, paragraphId: 'after' },
+            ],
+            sectionBreaks: [
+                { startIndex: 8 },
+                { startIndex: 13 },
+            ],
+            tables: [{ startIndex: 0, endIndex: 12, tableId: 'table-1' }],
+        };
+        const firstUpdate: TextXAction[] = [
+            { t: TextXActionType.RETAIN, len: 12 },
+            { t: TextXActionType.INSERT, body: { dataStream: 'A' }, len: 1 },
+        ];
+        const secondUpdate: TextXAction[] = [
+            { t: TextXActionType.RETAIN, len: 12 },
+            { t: TextXActionType.DELETE, len: 1 },
+            { t: TextXActionType.INSERT, body: { dataStream: 'AB' }, len: 2 },
+        ];
+
+        TextX.apply(body, TextX.compose(firstUpdate, secondUpdate));
+
+        expect(body.dataStream).toBe(`${T.TABLE_START}${T.TABLE_ROW_START}${T.TABLE_CELL_START}Cell${T.PARAGRAPH}${T.SECTION_BREAK}${T.TABLE_CELL_END}${T.TABLE_ROW_END}${T.TABLE_END}AB${T.PARAGRAPH}${T.SECTION_BREAK}`);
+        expect(body.tables).toEqual([{ startIndex: 0, endIndex: 12, tableId: 'table-1' }]);
         expect(body.paragraphs?.map((paragraph) => paragraph.startIndex)).toEqual([7, 14]);
     });
 

--- a/packages/core/src/docs/data-model/text-x/apply-utils/common.ts
+++ b/packages/core/src/docs/data-model/text-x/apply-utils/common.ts
@@ -429,7 +429,7 @@ export function insertTables(body: IDocumentBody, insertBody: IDocumentBody, tex
         if (startIndex >= currentIndex) {
             table.startIndex += textLength;
             table.endIndex += textLength;
-        } else if (endIndex > currentIndex || (endIndex === currentIndex && body.dataStream[currentIndex + textLength] === DataStreamTreeTokenType.PARAGRAPH)) {
+        } else if (endIndex > currentIndex) {
             table.endIndex += textLength;
         }
     }

--- a/packages/core/src/docs/data-model/text-x/structure-validator.ts
+++ b/packages/core/src/docs/data-model/text-x/structure-validator.ts
@@ -22,6 +22,8 @@ export type DocStructureIssueCode =
     | 'missing-root-section-break'
     | 'paragraph-token-mismatch'
     | 'section-break-token-mismatch'
+    | 'table-start-token-mismatch'
+    | 'table-end-token-mismatch'
     | 'empty-column'
     | 'empty-table-cell'
     | 'unbalanced-column-group'
@@ -85,6 +87,33 @@ function validateSectionBreakMetadata(body: IDocumentBody, issues: IDocStructure
                 'section-break-token-mismatch',
                 'Section break metadata must point to a section break sentinel.',
                 sectionBreak.startIndex
+            ));
+        }
+    }
+}
+
+function validateTableMetadata(body: IDocumentBody, issues: IDocStructureIssue[], context: IValidationContext) {
+    for (const table of body.tables ?? []) {
+        if (!Number.isInteger(table.startIndex) || body.dataStream[table.startIndex] !== DataStreamTreeTokenType.TABLE_START) {
+            issues.push(createIssue(
+                context,
+                'table-start-token-mismatch',
+                'Table startIndex must point to a table start sentinel.',
+                table.startIndex
+            ));
+        }
+
+        if (
+            !Number.isInteger(table.endIndex) ||
+            table.endIndex <= table.startIndex ||
+            table.endIndex > body.dataStream.length ||
+            body.dataStream[table.endIndex - 1] !== DataStreamTreeTokenType.TABLE_END
+        ) {
+            issues.push(createIssue(
+                context,
+                'table-end-token-mismatch',
+                'Table endIndex must be the exclusive boundary immediately after a table end sentinel.',
+                table.endIndex
             ));
         }
     }
@@ -185,6 +214,7 @@ export function validateDocBodyStructure(
     validateMinimumRootSentinels(body, issues, context);
     validateParagraphMetadata(body, issues, context);
     validateSectionBreakMetadata(body, issues, context);
+    validateTableMetadata(body, issues, context);
     validateStructuralContainers(body, issues, context);
 
     return issues;


### PR DESCRIPTION
## Summary
- keep docs table ranges half-open so text inserted at table.endIndex remains outside the table
- shift following column groups while preserving the table end boundary
- validate TABLE_START/TABLE_END markers in the shared body structure validator

## Tests
- pnpm --filter @univerjs/core test
- pnpm --filter @univerjs/docs test
- pnpm --filter @univerjs/core typecheck