### PR TITLE
refactor: simplify UI compatibility helpers

### DIFF
--- a/packages/docs-ui/src/__tests__/embed-docs-custom-block-refresh-scroll.spec.ts
+++ b/packages/docs-ui/src/__tests__/embed-docs-custom-block-refresh-scroll.spec.ts
@@ -19,7 +19,7 @@
  */
 
 import { UniverInstanceType } from '@univerjs/core';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     collectDocsTableLikeEmbedChildUnitIds,
     createDocsCustomBlockSizeRefreshScheduler,
@@ -29,6 +29,10 @@ import {
 import { scrollDocsTableLikeCustomBlockLive } from '../embed-docs-custom-block-scroll';
 
 describe('docs custom block refresh and scroll helpers', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('collects table-like child units and matches command params', () => {
         const childUnitIds = collectDocsTableLikeEmbedChildUnitIds({
             sheet: { data: { childUnitId: 'sheet-1', childType: UniverInstanceType.UNIVER_SHEET } },
@@ -62,26 +66,24 @@ describe('docs custom block refresh and scroll helpers', () => {
     it('coalesces refresh scheduling and cancels pending frames on dispose', () => {
         const refresh = vi.fn();
         let callback: (() => void) | undefined;
-        const frameApi = {
-            cancelFrame: vi.fn(),
-            requestFrame: vi.fn((next: () => void) => {
-                callback = next;
-                return 7;
-            }),
-        };
-        const scheduler = createDocsCustomBlockSizeRefreshScheduler(refresh, frameApi);
+        const requestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((next) => {
+            callback = () => next(0);
+            return 7;
+        });
+        const cancelAnimationFrame = vi.spyOn(window, 'cancelAnimationFrame');
+        const scheduler = createDocsCustomBlockSizeRefreshScheduler(refresh);
 
         scheduler.schedule();
         scheduler.schedule();
-        expect(frameApi.requestFrame).toHaveBeenCalledTimes(1);
+        expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
         callback?.();
         expect(refresh).toHaveBeenCalledTimes(1);
 
         scheduler.schedule();
         scheduler.dispose();
-        expect(frameApi.cancelFrame).toHaveBeenCalledWith(7);
+        expect(cancelAnimationFrame).toHaveBeenCalledWith(7);
         scheduler.dispose();
-        expect(frameApi.cancelFrame).toHaveBeenCalledTimes(1);
+        expect(cancelAnimationFrame).toHaveBeenCalledTimes(1);
     });
 
     it('scrolls live block content within horizontal and vertical limits', () => {

--- a/packages/docs-ui/src/__tests__/embed-docs-custom-block-refresh.spec.ts
+++ b/packages/docs-ui/src/__tests__/embed-docs-custom-block-refresh.spec.ts
@@ -15,7 +15,11 @@
  */
 
 import { UniverInstanceType } from '@univerjs/core';
-import { describe, expect, it, vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     collectDocsTableLikeEmbedChildUnitIds,
     createDocsCustomBlockSizeRefreshScheduler,
@@ -23,6 +27,10 @@ import {
 } from '../embed-docs-custom-block-refresh';
 
 describe('docs custom block refresh helpers', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('collects only sheet-like custom block child unit ids', () => {
         expect([...collectDocsTableLikeEmbedChildUnitIds({
             base: { data: { childType: UniverInstanceType.UNIVER_BASE, childUnitId: 'base-1' } },
@@ -79,13 +87,11 @@ describe('docs custom block refresh helpers', () => {
     it('coalesces repeated refresh requests into one frame', () => {
         const refresh = vi.fn();
         let frameCallback: (() => void) | undefined;
-        const scheduler = createDocsCustomBlockSizeRefreshScheduler(refresh, {
-            cancelFrame: vi.fn(),
-            requestFrame: (callback) => {
-                frameCallback = callback;
-                return 1;
-            },
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+            frameCallback = () => callback(0);
+            return 1;
         });
+        const scheduler = createDocsCustomBlockSizeRefreshScheduler(refresh);
 
         scheduler.schedule();
         scheduler.schedule();
@@ -96,11 +102,9 @@ describe('docs custom block refresh helpers', () => {
 
     it('cancels a pending refresh when disposed', () => {
         const refresh = vi.fn();
-        const cancelFrame = vi.fn();
-        const scheduler = createDocsCustomBlockSizeRefreshScheduler(refresh, {
-            cancelFrame,
-            requestFrame: () => 7,
-        });
+        vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(7);
+        const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame');
+        const scheduler = createDocsCustomBlockSizeRefreshScheduler(refresh);
 
         scheduler.schedule();
         scheduler.dispose();

--- a/packages/docs-ui/src/embed-docs-custom-block-refresh.ts
+++ b/packages/docs-ui/src/embed-docs-custom-block-refresh.ts
@@ -100,11 +100,7 @@ export interface IDocsCustomBlockSizeRefreshScheduler {
 }
 
 export function createDocsCustomBlockSizeRefreshScheduler(
-    refresh: () => void,
-    frameApi: {
-        cancelFrame: (handle: number) => void;
-        requestFrame: (callback: () => void) => number;
-    } = getDefaultFrameApi()
+    refresh: () => void
 ): IDocsCustomBlockSizeRefreshScheduler {
     let pendingFrame: number | undefined;
 
@@ -114,7 +110,7 @@ export function createDocsCustomBlockSizeRefreshScheduler(
                 return;
             }
 
-            frameApi.cancelFrame(pendingFrame);
+            window.cancelAnimationFrame(pendingFrame);
             pendingFrame = undefined;
         },
         schedule: () => {
@@ -122,24 +118,10 @@ export function createDocsCustomBlockSizeRefreshScheduler(
                 return;
             }
 
-            pendingFrame = frameApi.requestFrame(() => {
+            pendingFrame = window.requestAnimationFrame(() => {
                 pendingFrame = undefined;
                 refresh();
             });
         },
-    };
-}
-
-function getDefaultFrameApi(): { cancelFrame: (handle: number) => void; requestFrame: (callback: () => void) => number } {
-    if (typeof requestAnimationFrame === 'function' && typeof cancelAnimationFrame === 'function') {
-        return {
-            cancelFrame: (handle) => cancelAnimationFrame(handle),
-            requestFrame: (callback) => requestAnimationFrame(callback),
-        };
-    }
-
-    return {
-        cancelFrame: (handle) => clearTimeout(handle),
-        requestFrame: (callback) => setTimeout(callback, 16) as unknown as number,
     };
 }

--- a/packages/docs-ui/src/views/SideMenu.tsx
+++ b/packages/docs-ui/src/views/SideMenu.tsx
@@ -47,11 +47,6 @@ export interface ISideMenuInstance {
     scrollTo: (id: string) => void;
 }
 
-const commonClass = 'univer-font-[500] univer-truncate univer-h-[24px] univer-mb-2 univer-leading-[24px] univer-cursor-pointer univer-pr-1 ';
-const titleClass = 'univer-text-base univer-font-semibold';
-const h1Class = 'univer-text-sm univer-font-semibold';
-const textClass = 'univer-text-sm';
-
 export const SideMenu = forwardRef<ISideMenuInstance, ISideMenuProps>((props, ref) => {
     const { menus, onClick, className, style, mode, maxHeight, activeId, open, onOpenChange, maxWidth, wrapperClass, wrapperStyle, iconClass, iconStyle } = props;
     const isSideBar = mode === 'side-bar';
@@ -136,11 +131,14 @@ export const SideMenu = forwardRef<ISideMenuInstance, ISideMenuProps>((props, re
                             id={`univer-side-menu-${menu.id}`}
                             key={menu.id}
                             className={clsx(
-                                commonClass,
+                                `
+                                  univer-mb-2 univer-h-[24px] univer-cursor-pointer univer-truncate univer-pr-1
+                                  univer-font-[500] univer-leading-[24px]
+                                `,
                                 {
-                                    [titleClass]: menu.isTitle,
-                                    [h1Class]: menu.level === 1,
-                                    [textClass]: menu.level > 1,
+                                    'univer-text-base univer-font-semibold': menu.isTitle,
+                                    'univer-text-sm univer-font-semibold': menu.level === 1,
+                                    'univer-text-sm': menu.level > 1,
                                     'univer-text-gray-500 dark:!univer-text-gray-400': menu.id !== activeId,
                                     'univer-text-gray-800 dark:!univer-text-gray-200': menu.id === activeId,
                                 }

--- a/packages/drawing-ui/src/views/object-list-panel/ObjectListPanelBase.tsx
+++ b/packages/drawing-ui/src/views/object-list-panel/ObjectListPanelBase.tsx
@@ -178,13 +178,6 @@ const iconButtonClassName = `
   dark:!univer-text-gray-300 dark:hover:!univer-bg-gray-800 dark:hover:!univer-text-gray-100
 `;
 
-const expandButtonClassName = `
-  univer-flex univer-size-5 univer-shrink-0 univer-items-center univer-justify-center univer-rounded
-  univer-border-0 univer-bg-transparent univer-p-0 univer-text-gray-500 univer-outline-none univer-transition-transform
-  hover:univer-bg-gray-100 hover:univer-text-gray-900
-  dark:!univer-text-gray-300 dark:hover:!univer-bg-gray-800 dark:hover:!univer-text-gray-100
-`;
-
 const sectionOrder = new Map([
     [OBJECT_LIST_FLOATING_SECTION_ID, 0],
     [OBJECT_LIST_CANVAS_SECTION_ID, 1],
@@ -649,7 +642,14 @@ function ObjectListRow(props: {
                 ? (
                     <button
                         type="button"
-                        className={expandButtonClassName}
+                        className="
+                          univer-flex univer-size-5 univer-shrink-0 univer-items-center univer-justify-center
+                          univer-rounded univer-border-0 univer-bg-transparent univer-p-0 univer-text-gray-500
+                          univer-outline-none univer-transition-transform
+                          hover:univer-bg-gray-100 hover:univer-text-gray-900
+                          dark:!univer-text-gray-300
+                          dark:hover:!univer-bg-gray-800 dark:hover:!univer-text-gray-100
+                        "
                         title={item.expanded ? labels.collapse : labels.expand}
                         aria-label={item.expanded ? labels.collapse : labels.expand}
                         onClick={(event) => {

--- a/packages/ui/src/views/components/ribbon/MobileRibbon.tsx
+++ b/packages/ui/src/views/components/ribbon/MobileRibbon.tsx
@@ -38,15 +38,6 @@ interface IMobileRibbonProps {
 
 const toolbarScrollOffset = 168;
 
-const nestedControlResetClassName = `
-[&_button]:!univer-m-0 [&_button]:!univer-appearance-none [&_button]:!univer-border-0
-[&_button]:!univer-bg-transparent [&_button]:!univer-p-0 [&_button]:!univer-leading-none
-[&_button]:!univer-outline-none
-[&_input]:!univer-m-0 [&_input]:!univer-appearance-none [&_input]:!univer-border-0
-[&_input]:!univer-bg-transparent [&_input]:!univer-p-0 [&_input]:!univer-leading-none
-[&_input]:!univer-outline-none
-`;
-
 export function MobileRibbon(props: IMobileRibbonProps) {
     const { headerMenuComponents, headerMenu = true } = props;
 
@@ -322,9 +313,16 @@ export function MobileRibbon(props: IMobileRibbonProps) {
                                               [&_[data-u-command]]:!univer-h-8 [&_[data-u-command]]:!univer-min-h-8
                                               [&_[data-u-command]]:!univer-rounded-md
                                               [&_[data-u-command]]:!univer-px-1.5
-                                              [&_button]:!univer-h-8 [&_button]:!univer-min-w-8
-                                              [&_button]:!univer-rounded-md [&_button]:!univer-px-1.5
-                                            `, nestedControlResetClassName)}
+                                              [&_button]:!univer-m-0 [&_button]:!univer-h-8 [&_button]:!univer-min-w-8
+                                              [&_button]:!univer-appearance-none [&_button]:!univer-rounded-md
+                                              [&_button]:!univer-border-0 [&_button]:!univer-bg-transparent
+                                              [&_button]:!univer-p-0 [&_button]:!univer-px-1.5
+                                              [&_button]:!univer-leading-none [&_button]:!univer-outline-none
+                                              [&_input]:!univer-m-0 [&_input]:!univer-appearance-none
+                                              [&_input]:!univer-border-0 [&_input]:!univer-bg-transparent
+                                              [&_input]:!univer-p-0 [&_input]:!univer-leading-none
+                                              [&_input]:!univer-outline-none
+                                            `)}
                                         >
                                             <ToolbarItem {...child.item} />
                                         </div>


### PR DESCRIPTION
## Summary

- preserve transforms for nested drawing groups during rendering
- retain enum extension descriptors and use available docs indent icons
- simplify UI compatibility helpers and keep animation-frame tests aligned with the browser API

## Testing

- `pnpm --filter @univerjs/docs-ui typecheck`
- `pnpm --filter @univerjs/drawing-ui typecheck`
- `pnpm --filter @univerjs/ui typecheck`
- `pnpm exec vitest run src/__tests__/embed-docs-custom-block-refresh.spec.ts src/__tests__/embed-docs-custom-block-refresh-scroll.spec.ts` (from `packages/docs-ui`)
- ESLint on all changed files (0 errors)

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes where applicable.
- [x] No breaking changes are introduced.