### PR TITLE
feat(core): add rich text container alignment

### DIFF
--- a/packages/core/src/docs/data-model/__tests__/rich-text-builder.test.ts
+++ b/packages/core/src/docs/data-model/__tests__/rich-text-builder.test.ts
@@ -16,7 +16,7 @@
 
 import type { IBullet } from '../../../types/interfaces';
 import { describe, expect, it } from 'vitest';
-import { BaselineOffset, BooleanNumber, HorizontalAlign, TextDecoration, TextDirection } from '../../../types/enum';
+import { BaselineOffset, BooleanNumber, HorizontalAlign, TextDecoration, TextDirection, VerticalAlign } from '../../../types/enum';
 import { CustomRangeType, SpacingRule } from '../../../types/interfaces';
 import { PresetListType } from '../preset-list-type';
 import { ParagraphStyleBuilder, RichTextBuilder, RichTextValue, TextDecorationBuilder, TextStyleBuilder } from '../rich-text-builder';
@@ -575,6 +575,25 @@ describe('RichTextBuilder', () => {
     });
 
     describe('paragraph management', () => {
+        it('should apply portable horizontal and vertical block alignment', () => {
+            const builder = RichTextBuilder.create()
+                .align({
+                    horizontal: HorizontalAlign.CENTER,
+                    vertical: VerticalAlign.MIDDLE,
+                })
+                .text('First')
+                .paragraph()
+                .text('Second');
+
+            const data = builder.getData();
+
+            expect(data.documentStyle?.renderConfig).toMatchObject({
+                horizontalAlign: HorizontalAlign.CENTER,
+                verticalAlign: VerticalAlign.MIDDLE,
+            });
+            expect(data.body?.paragraphs?.[0]?.paragraphStyle?.horizontalAlign).toBe(HorizontalAlign.CENTER);
+        });
+
         it('should start a paragraph chain without a leading blank paragraph', () => {
             const builder = RichTextBuilder.create()
                 .paragraph()

--- a/packages/core/src/docs/data-model/rich-text-builder.ts
+++ b/packages/core/src/docs/data-model/rich-text-builder.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Nullable } from '../../shared';
-import type { BaselineOffset, HorizontalAlign, TextDecoration, TextDirection } from '../../types/enum';
+import type { BaselineOffset, HorizontalAlign, TextDecoration, TextDirection, VerticalAlign } from '../../types/enum';
 import type {
     IBorderData,
     IColorStyle,
@@ -188,6 +188,19 @@ export interface IRichTextParagraphStyle {
     keepLines?: boolean;
     /** Keeps this paragraph with the following paragraph when pagination applies. */
     keepNext?: boolean;
+}
+
+/**
+ * Portable text-container alignment accepted by `RichTextBuilder.align()`.
+ *
+ * Unlike `paragraph({ align })`, which styles one paragraph, this alignment is a document-level presentation hint that
+ * can be consumed consistently by shapes, table cells, and other rich-text hosts.
+ */
+export interface IRichTextAlignment {
+    /** Horizontal alignment for the rich-text block. */
+    horizontal?: HorizontalAlign;
+    /** Vertical alignment inside the host text container. */
+    vertical?: VerticalAlign;
 }
 
 /**
@@ -1970,6 +1983,46 @@ export class RichTextBuilder extends RichTextValue {
      */
     text(text: string): RichTextBuilder {
         return this.insertText(text);
+    }
+
+    /**
+     * Aligns the rich-text block inside its host container.
+     *
+     * This is the preferred facade-friendly API for alignment shared by shapes and table cells. It keeps callers away
+     * from `IDocumentData.documentStyle.renderConfig`. Use `paragraph({ align })` when individual paragraphs need
+     * different horizontal alignment.
+     *
+     * @param alignment Horizontal and/or vertical container alignment.
+     * @returns The current builder for chaining.
+     * @example
+     * ```ts
+     * const text = univerAPI.newRichText()
+     *   .align({
+     *     horizontal: univerAPI.Enum.HorizontalAlign.CENTER,
+     *     vertical: univerAPI.Enum.VerticalAlign.MIDDLE,
+     *   })
+     *   .text('Centered text');
+     * ```
+     */
+    align(alignment: IRichTextAlignment): RichTextBuilder {
+        const documentStyle = this._data.documentStyle ??= {};
+        const renderConfig = documentStyle.renderConfig ??= {};
+
+        if (alignment.horizontal !== undefined) {
+            renderConfig.horizontalAlign = alignment.horizontal;
+            for (const paragraph of this._data.body?.paragraphs ?? []) {
+                paragraph.paragraphStyle = {
+                    ...paragraph.paragraphStyle,
+                    horizontalAlign: alignment.horizontal,
+                };
+            }
+        }
+
+        if (alignment.vertical !== undefined) {
+            renderConfig.verticalAlign = alignment.vertical;
+        }
+
+        return this;
     }
 
     /**

--- a/packages/core/src/facade/__tests__/f-univer.spec.ts
+++ b/packages/core/src/facade/__tests__/f-univer.spec.ts
@@ -287,7 +287,7 @@ describe('FUniver integration', () => {
         expect(extendedAPI.fireEvent(extendedAPI.Event.CommandExecuted, { id: 'manual', type: CommandType.COMMAND, params: undefined })).toBeUndefined();
 
         const documentData = createDocData('facade-builder') as IDocumentData;
-        expect(extendedAPI.newRichText(documentData).getData().id).toBe('facade-builder');
+        expect(extendedAPI.newRichTextFromDocumentData(documentData).getData().id).toBe('facade-builder');
         expect(extendedAPI.newParagraphStyleValue({ horizontalAlign: HorizontalAlign.RIGHT }).horizontalAlign).toBe(HorizontalAlign.RIGHT);
         expect(extendedAPI.newTextStyleValue({ ff: 'Inter', fs: 14, bl: BooleanNumber.TRUE }).fontFamily).toBe('Inter');
         expect(extendedAPI.newTextStyleValue({ ff: 'Inter', fs: 14, bl: BooleanNumber.TRUE }).bold).toBe(true);

--- a/packages/core/src/facade/f-univer.ts
+++ b/packages/core/src/facade/f-univer.ts
@@ -587,33 +587,42 @@ export class FUniver extends Disposable {
 
     /**
      * Create a new rich text.
-     * @param {IDocumentData} data
      * @returns {RichTextBuilder} The new rich text instance
      * @example
      * ```ts
-     * const richText = univerAPI.newRichText({ body: { dataStream: 'Hello World\r\n' } });
-     * const fWorksheet = univerAPI.getActiveWorkbook().getSheetByName('Sheet1');
-     * if (!fWorksheet) return;
-     * const range = fWorksheet.getRange('A1');
-     * range.setRichTextValueForCell(richText);
+     * const richText = univerAPI.newRichText()
+     *   .align({ horizontal: univerAPI.Enum.HorizontalAlign.CENTER })
+     *   .text('Status: ')
+     *   .span('Ready', { bold: true, color: '#16a34a' });
      * ```
      */
-    newRichText(data?: IDocumentData): RichTextBuilder {
+    newRichText(): RichTextBuilder {
+        return RichTextBuilder.create();
+    }
+
+    /**
+     * Create a rich-text builder from raw Univer document data.
+     *
+     * This is an advanced integration escape hatch for importers and adapters. Application and agent code should use
+     * the fluent builder returned by `newRichText()`.
+     *
+     * @param data Raw Univer document data.
+     * @returns A rich-text builder initialized with the supplied document data.
+     * @advanced
+     */
+    newRichTextFromDocumentData(data: IDocumentData): RichTextBuilder {
         return RichTextBuilder.create(data);
     }
 
     /**
      * Create a new rich text value.
-     * @param {IDocumentData} data - The rich text data
+     *
+     * This is an advanced integration escape hatch for callers that already own Univer document data. Application and
+     * agent code should prefer the fluent value returned by `newRichText()`.
+     *
+     * @param {IDocumentData} data The raw Univer document data.
      * @returns {RichTextValue} The new rich text value instance
-     * @example
-     * ```ts
-     * const richTextValue = univerAPI.newRichTextValue({ body: { dataStream: 'Hello World\r\n' } });
-     * const fWorksheet = univerAPI.getActiveWorkbook().getSheetByName('Sheet1');
-     * if (!fWorksheet) return;
-     * const range = fWorksheet.getRange('A1');
-     * range.setRichTextValueForCell(richTextValue);
-     * ```
+     * @advanced
      */
     newRichTextValue(data: IDocumentData): RichTextValue {
         return RichTextValue.create(data);
@@ -621,18 +630,13 @@ export class FUniver extends Disposable {
 
     /**
      * Create a new paragraph style.
-     * @param {IParagraphStyle} style - The paragraph style
+     *
+     * This is an advanced document-model API. Application and agent code should normally use
+     * `newRichText().paragraph({ ... })`.
+     *
+     * @param {IParagraphStyle} style The paragraph style
      * @returns {ParagraphStyleBuilder} The new paragraph style instance
-     * @example
-     * ```ts
-     * const richText = univerAPI.newRichText({ body: { dataStream: 'Hello World\r\n' } });
-     * const paragraphStyle = univerAPI.newParagraphStyle({ textStyle: { ff: 'Arial', fs: 12, it: univerAPI.Enum.BooleanNumber.TRUE, bl: univerAPI.Enum.BooleanNumber.TRUE } });
-     * richText.insertParagraph(paragraphStyle);
-     * const fWorksheet = univerAPI.getActiveWorkbook().getSheetByName('Sheet1');
-     * if (!fWorksheet) return;
-     * const range = fWorksheet.getRange('A1');
-     * range.setRichTextValueForCell(richText);
-     * ```
+     * @advanced
      */
     newParagraphStyle(style?: IParagraphStyle): ParagraphStyleBuilder {
         return ParagraphStyleBuilder.create(style);

--- a/packages/sheets/src/facade/f-range.ts
+++ b/packages/sheets/src/facade/f-range.ts
@@ -498,7 +498,8 @@ export class FRange extends FBaseInitialable {
      * console.log(fRange.getValue(true));
      *
      * // set the first cell value to 123
-     * const richText = univerAPI.newRichText({ body: { dataStream: 'Hello World\r\n' } })
+     * const richText = univerAPI.newRichText()
+     *   .text('Hello World')
      *   .setStyle(0, 1, { bl: 1, cl: { rgb: '#c81e1e' } })
      *   .setStyle(6, 7, { bl: 1, cl: { rgb: '#c81e1e' } });
      * fRange.setRichTextValueForCell(richText);


### PR DESCRIPTION
## Summary

- add `RichTextBuilder.align({ horizontal, vertical })` as the facade-friendly container alignment API
- keep per-paragraph alignment in `paragraph({ align })`
- move raw document initialization behind `newRichTextFromDocumentData()` and mark raw-value helpers as advanced
- update Sheets facade examples to use the fluent rich-text builder

## Example

```ts
const text = univerAPI.newRichText()
    .align({
        horizontal: univerAPI.Enum.HorizontalAlign.CENTER,
        vertical: univerAPI.Enum.VerticalAlign.MIDDLE,
    })
    .text('Centered text');
```

## Tests

- `pnpm vitest run packages/core/src/facade/__tests__/f-univer.spec.ts packages/core/src/docs/data-model/__tests__/rich-text-builder.test.ts`
- `pnpm --filter @univerjs/core typecheck`
- `pnpm --filter @univerjs/sheets typecheck`