### PR TITLE
fix(engine-render): preserve fractional document font sizes

### DIFF
--- a/packages/engine-render/src/basics/__tests__/tools.spec.ts
+++ b/packages/engine-render/src/basics/__tests__/tools.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BaselineOffset, BooleanNumber, GridType, NumberUnitType, Rectangle, Tools } from '@univerjs/core';
+import { BaselineOffset, BooleanNumber, DEFAULT_STYLES, GridType, NumberUnitType, Rectangle, Tools } from '@univerjs/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FontCache } from '../../components/docs/layout/shaping-engine/font-cache';
 import {
@@ -179,6 +179,20 @@ describe('tools extra', () => {
         } as any);
         expect(fontStack.fontFamily).toBe('"SF Mono", "Cascadia Code", Consolas, monospace');
         expect(fontStack.fontString).toContain('"SF Mono", "Cascadia Code", Consolas, monospace');
+
+        for (const fontSize of [8, 9.2, 10.4]) {
+            const fractional = getFontStyleString({ ff: 'Arial', fs: fontSize } as any);
+            expect(fractional.fontSize).toBe(fontSize);
+            expect(fractional.originFontSize).toBe(fontSize);
+            expect(fractional.fontCache).toContain(`${fontSize}pt Arial`);
+            expect(fractional.fontString).toContain(`${fontSize}pt Arial`);
+        }
+
+        for (const fontSize of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+            const invalid = getFontStyleString({ ff: 'Arial', fs: fontSize } as any);
+            expect(invalid.fontSize).toBe(DEFAULT_STYLES.fs);
+            expect(invalid.originFontSize).toBe(DEFAULT_STYLES.fs);
+        }
 
         const superscript = getFontStyleString({
             fs: 12,

--- a/packages/engine-render/src/basics/tools.ts
+++ b/packages/engine-render/src/basics/tools.ts
@@ -281,8 +281,8 @@ export function getFontStyleString(
 
     // font-size/line-height
     let originFontSize = defaultFontSize;
-    if (textStyle.fs) {
-        originFontSize = Math.ceil(textStyle.fs);
+    if (typeof textStyle.fs === 'number' && Number.isFinite(textStyle.fs) && textStyle.fs > 0) {
+        originFontSize = textStyle.fs;
     }
     let fontSize = originFontSize;
 


### PR DESCRIPTION
## Summary
- preserve positive finite fractional font sizes instead of rounding them up
- reject zero, negative, NaN, and infinite font sizes and fall back to the default
- add regression coverage for 8pt, 9.2pt, and 10.4pt document typography

## Validation
- pnpm --filter @univerjs/engine-render exec vitest run src/basics/__tests__/tools.spec.ts
- pnpm --filter @univerjs/engine-render typecheck
- pnpm exec eslint packages/engine-render/src/basics/tools.ts packages/engine-render/src/basics/__tests__/tools.spec.ts (0 errors; existing warnings only)