### PR TITLE
fix(sheets-drawing-ui): guard getAllFloatDoms against float doms without a backing drawing param

### DIFF
--- a/packages/sheets-drawing-ui/src/facade/__tests__/f-worksheet.spec.ts
+++ b/packages/sheets-drawing-ui/src/facade/__tests__/f-worksheet.spec.ts
@@ -547,8 +547,14 @@ describe('sheets-drawing-ui facade', () => {
 
         const worksheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
         const sheetDrawingService = injector.get(ISheetDrawingService);
-        worksheet.addFloatDomToPosition({ componentKey: 'OrderCard' }, 'order-card');
-        worksheet.addFloatDomToPosition({ componentKey: 'MissingCard' }, 'missing-card');
+        worksheet.addFloatDomToPosition({
+            componentKey: 'OrderCard',
+            initPosition: { startX: 20, startY: 30, endX: 140, endY: 90 },
+        }, 'order-card');
+        worksheet.addFloatDomToPosition({
+            componentKey: 'MissingCard',
+            initPosition: { startX: 40, startY: 50, endX: 160, endY: 110 },
+        }, 'missing-card');
         await Promise.resolve();
 
         const drawingData = sheetDrawingService.getDrawingData('test', 'sheet1');

--- a/packages/sheets-drawing-ui/src/facade/__tests__/f-worksheet.spec.ts
+++ b/packages/sheets-drawing-ui/src/facade/__tests__/f-worksheet.spec.ts
@@ -306,6 +306,22 @@ function createRender(skeleton: SpreadsheetSkeleton, scene: Scene): IRender {
     } as unknown as IRender;
 }
 
+function createDrawingUITestBedWithRender() {
+    const testBed = createDrawingUITestBed([
+        [IRenderManagerService, { useClass: TestRenderManagerService }],
+    ]);
+    const modelWorksheet = testBed.workbook.getActiveSheet();
+    const skeleton = testBed.injector.createInstance(
+        SpreadsheetSkeleton,
+        modelWorksheet,
+        testBed.workbook.getStyles()
+    ).calculate() as SpreadsheetSkeleton;
+    const renderManager = testBed.injector.get(IRenderManagerService) as unknown as TestRenderManagerService;
+    renderManager.configure(createRender(skeleton, new TestRenderScene() as unknown as Scene));
+
+    return testBed;
+}
+
 describe('sheets-drawing-ui facade', () => {
     let univer: Univer;
     let injector: Injector;
@@ -384,21 +400,11 @@ describe('sheets-drawing-ui facade', () => {
 
     it('adds, reads, updates, batch updates and disposes float doms through the worksheet facade', async () => {
         univer.dispose();
-        const testBed = createDrawingUITestBed([
-            [IRenderManagerService, { useClass: TestRenderManagerService }],
-        ]);
+        const testBed = createDrawingUITestBedWithRender();
         univer = testBed.univer;
         injector = testBed.injector;
         univerAPI = FUniver.newAPI(injector);
 
-        const modelWorksheet = testBed.workbook.getActiveSheet();
-        const skeleton = injector.createInstance(
-            SpreadsheetSkeleton,
-            modelWorksheet,
-            testBed.workbook.getStyles()
-        ).calculate() as SpreadsheetSkeleton;
-        const renderManager = injector.get(IRenderManagerService) as unknown as TestRenderManagerService;
-        renderManager.configure(createRender(skeleton, new TestRenderScene() as unknown as Scene));
         const sheetDrawingService = injector.get(ISheetDrawingService);
         const worksheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
 
@@ -530,6 +536,26 @@ describe('sheets-drawing-ui facade', () => {
         expect(worksheet.getFloatDomById('order-card')).toBeNull();
         worksheet.removeFloatDom('status-card');
         expect(worksheet.getAllFloatDoms()).toEqual([]);
+    });
+
+    it('omits float doms without backing drawing params', async () => {
+        univer.dispose();
+        const testBed = createDrawingUITestBedWithRender();
+        univer = testBed.univer;
+        injector = testBed.injector;
+        univerAPI = FUniver.newAPI(injector);
+
+        const worksheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+        const sheetDrawingService = injector.get(ISheetDrawingService);
+        worksheet.addFloatDomToPosition({ componentKey: 'OrderCard' }, 'order-card');
+        worksheet.addFloatDomToPosition({ componentKey: 'MissingCard' }, 'missing-card');
+        await Promise.resolve();
+
+        const drawingData = sheetDrawingService.getDrawingData('test', 'sheet1');
+        delete drawingData['missing-card'];
+
+        expect(sheetDrawingService.getDrawingByParam({ unitId: 'test', subUnitId: 'sheet1', drawingId: 'missing-card' })).toBeUndefined();
+        expect(worksheet.getAllFloatDoms().map((dom) => dom.id)).toEqual(['order-card']);
     });
 
     it('saves cell images from range and worksheet selections', async () => {

--- a/packages/sheets-drawing-ui/src/facade/f-worksheet.ts
+++ b/packages/sheets-drawing-ui/src/facade/f-worksheet.ts
@@ -471,6 +471,8 @@ export class FWorksheetDrawingUIMixin extends FWorksheet implements IFWorksheetD
                     subUnitId,
                 })! as ISheetFloatDom;
 
+                if (!drawingParm) return null;
+
                 const { left, top, width, height, flipX, flipY, angle, skewX, skewY } = rect.getState();
 
                 return {
@@ -490,7 +492,8 @@ export class FWorksheetDrawingUIMixin extends FWorksheet implements IFWorksheetD
                     data: drawingParm.data,
                     id: info.id,
                 };
-            });
+            })
+            .filter((dom): dom is IFCanvasFloatDomResult => dom != null);
     }
 
     override updateFloatDom(id: string, config: Partial<Omit<IFCanvasFloatDomResult, 'id'>>): this {

--- a/packages/sheets-drawing-ui/src/facade/f-worksheet.ts
+++ b/packages/sheets-drawing-ui/src/facade/f-worksheet.ts
@@ -463,7 +463,7 @@ export class FWorksheetDrawingUIMixin extends FWorksheet implements IFWorksheetD
         const subUnitId = this._worksheet.getSheetId();
 
         return Array.from(floatDomService.getFloatDomsBySubUnitId(unitId, subUnitId).values())
-            .map((info) => {
+            .map((info): IFCanvasFloatDomResult | null => {
                 const { rect } = info;
                 const drawingParm = this._injector.get(ISheetDrawingService).getDrawingByParam({
                     drawingId: info.id,


### PR DESCRIPTION
Closes #7132

## Summary

`FWorksheet.getAllFloatDoms()` crashed with a TypeError when a worksheet contained a float dom that the drawing manager tracked but for which `getDrawingByParam(...)` could not resolve a backing drawing param. The method non-null-asserted that lookup and then read `.componentKey`/`.data` off the result inside `.map()`, so a single unresolvable entry threw and took down the entire call, leaving `getAllFloatDoms` unusable for the whole sheet.

## Why

The sibling accessor `getFloatDomById()` already guards the exact same `getDrawingByParam(...)` lookup with an early `if (!drawingParm) return null;`, so the two paths disagreed: fetching one float dom degraded gracefully while fetching all of them threw. That inconsistency is the reported crash. The fix brings `getAllFloatDoms()` in line with its sibling: skip entries whose drawing param cannot be resolved, then filter the resulting nulls out with a type guard so the method's return type is preserved and callers still get a clean array of resolvable float doms.

## How to test

Added a regression test in `packages/sheets-drawing-ui/src/facade/__tests__/f-worksheet.spec.ts` ("omits float doms without backing drawing params") that registers a float dom whose backing drawing param is absent and asserts `getAllFloatDoms()` returns the resolvable entries without throwing. Run it with:

```
npx vitest run packages/sheets-drawing-ui/src/facade/__tests__/f-worksheet.spec.ts -t "omits float doms without backing drawing params"
```

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
