### PR TITLE
fix(drawing-ui): align chart interactions across editors

### DIFF
--- a/packages/docs-drawing-ui/src/commands/commands/__tests__/drawing-commands.spec.ts
+++ b/packages/docs-drawing-ui/src/commands/commands/__tests__/drawing-commands.spec.ts
@@ -646,6 +646,7 @@ describe('docs drawing commands integration', () => {
 
     it('moves a focused floating drawing by updating the persisted doc transform', async () => {
         const testBed = setupDrawingTestBed(createDrawingDocData());
+        vi.spyOn(testBed.get(DocSkeletonManagerService), 'getSkeleton').mockReturnValue({} as never);
 
         testBed.docDrawingService.focusDrawing([{ unitId: 'test-doc', subUnitId: 'test-doc', drawingId: 'shape-1' }]);
 
@@ -882,6 +883,9 @@ describe('docs drawing commands integration', () => {
 
     it('updates drawing doc transform through the command pipeline', async () => {
         const testBed = setupDrawingTestBed(createDrawingDocData());
+        const skeleton = {} as never;
+        vi.spyOn(testBed.get(DocSkeletonManagerService), 'getSkeleton').mockReturnValue(skeleton);
+        const refreshDrawings = vi.spyOn(testBed.get(DocRefreshDrawingsService), 'refreshDrawings');
 
         expect(await testBed.commandService.executeCommand(UpdateDrawingDocTransformCommand.id, {
             unitId: 'test-doc',
@@ -901,6 +905,7 @@ describe('docs drawing commands integration', () => {
 
         expect(doc.getSnapshot().drawings?.['shape-1'].docTransform.positionV).toEqual({ posOffset: 18 });
         expect(testBed.refreshControls).toHaveBeenCalled();
+        expect(refreshDrawings).toHaveBeenCalledWith(skeleton);
 
         testBed.univer.dispose();
     });

--- a/packages/docs-drawing-ui/src/commands/commands/update-doc-drawing.command.ts
+++ b/packages/docs-drawing-ui/src/commands/commands/update-doc-drawing.command.ts
@@ -649,6 +649,11 @@ export const UpdateDrawingDocTransformCommand: ICommand = {
             IRichTextEditingMutationParams
         >(doMutation.id, doMutation.params);
 
+        // RichTextEditingMutation recalculates the document skeleton before the
+        // synchronous command returns. Publish that fresh geometry so the drawing
+        // manager, renderer, and transformer do not keep the pre-mutation size.
+        const skeleton = renderObject?.with(DocSkeletonManagerService).getSkeleton() ?? null;
+        accessor.get(DocRefreshDrawingsService).refreshDrawings(skeleton);
         transformer.refreshControls();
 
         return Boolean(result);

--- a/packages/docs-drawing-ui/src/commands/commands/update-doc-drawing.command.ts
+++ b/packages/docs-drawing-ui/src/commands/commands/update-doc-drawing.command.ts
@@ -652,8 +652,10 @@ export const UpdateDrawingDocTransformCommand: ICommand = {
         // RichTextEditingMutation recalculates the document skeleton before the
         // synchronous command returns. Publish that fresh geometry so the drawing
         // manager, renderer, and transformer do not keep the pre-mutation size.
-        const skeleton = renderObject?.with(DocSkeletonManagerService).getSkeleton() ?? null;
-        accessor.get(DocRefreshDrawingsService).refreshDrawings(skeleton);
+        if (accessor.has(DocRefreshDrawingsService)) {
+            const skeleton = renderObject?.with(DocSkeletonManagerService).getSkeleton() ?? null;
+            accessor.get(DocRefreshDrawingsService).refreshDrawings(skeleton);
+        }
         transformer.refreshControls();
 
         return Boolean(result);

--- a/packages/docs-drawing-ui/src/menu/drawing-popup-menu.controller.ts
+++ b/packages/docs-drawing-ui/src/menu/drawing-popup-menu.controller.ts
@@ -184,15 +184,17 @@ export class DocDrawingPopupMenuController extends RxDisposable {
 
                 const { unitId, subUnitId, drawingId, drawingType } = drawingParam;
                 const isImage = drawingType === DrawingTypeEnum.DRAWING_IMAGE;
+                // Charts use the document toolbar placement, while retaining chart-specific actions and controls.
+                const isChart = drawingType === DrawingTypeEnum.DRAWING_CHART;
                 const popup = this._canvasPopManagerService.attachPopupToObject(
                     object,
                     {
                         componentKey: COMPONENT_IMAGE_POPUP_MENU,
-                        direction: isImage ? 'top-center' : 'horizontal',
-                        offset: isImage ? [0, 8] : [2, 0],
+                        direction: isImage || isChart ? 'top-center' : 'horizontal',
+                        offset: isImage || isChart ? [0, 8] : [2, 0],
                         extraProps: {
                             menuItems: this._getDrawingPopupMenuItems(unitId, subUnitId, drawingId, drawingType),
-                            variant: isImage ? 'doc-floating-toolbar' : undefined,
+                            variant: isImage ? 'doc-floating-toolbar' : isChart ? 'doc-chart-floating-toolbar' : undefined,
                             unitId,
                             subUnitId,
                             drawingId,

--- a/packages/drawing-ui/src/views/image-popup-menu/ImagePopupMenu.tsx
+++ b/packages/drawing-ui/src/views/image-popup-menu/ImagePopupMenu.tsx
@@ -26,21 +26,26 @@ import {
     UniverInstanceType,
 } from '@univerjs/core';
 import { borderClassName, clsx, Dropdown, DropdownMenu, Separator, Tooltip } from '@univerjs/design';
-import { AutofillDoubleIcon, CropIcon, DeleteIcon, DocSettingIcon, MoreDownIcon, TextWrapShapeIcon } from '@univerjs/icons';
+import { AutofillDoubleIcon, ChartIcon, CropIcon, DeleteIcon, DocSettingIcon, MoreDownIcon, TextWrapShapeIcon } from '@univerjs/icons';
 import { useDependency } from '@univerjs/ui';
 import { useState } from 'react';
 
 export interface IImagePopupMenuItem {
-    label: LocaleKey;
+    label: string;
     index: number;
     commandId: string;
     commandParams?: object;
     disable: boolean;
+    type?: 'button' | 'select';
+    value?: string;
+    options?: Array<{ label: unknown; value: string }>;
+    commandParamsFactory?: (value: string) => object;
+    icon?: string;
 }
 
 export interface IImagePopupMenuExtraProps {
     menuItems: IImagePopupMenuItem[];
-    variant?: 'doc-floating-toolbar';
+    variant?: 'doc-floating-toolbar' | 'doc-chart-floating-toolbar';
     unitId?: string;
     subUnitId?: string;
     drawingId?: string;
@@ -73,6 +78,10 @@ export function ImagePopupMenu(props: IImagePopupMenuProps) {
                 drawingId={popup.extraProps.drawingId}
             />
         );
+    }
+
+    if (popup.extraProps?.variant === 'doc-chart-floating-toolbar') {
+        return <DocChartFloatingToolbar menuItems={menuItems} />;
     }
 
     const commandService = useDependency(ICommandService);
@@ -109,7 +118,7 @@ export function ImagePopupMenu(props: IImagePopupMenuProps) {
                 align="start"
                 items={menuItems.map((item) => ({
                     type: 'item',
-                    children: localeService.t<LocaleKey>(item.label),
+                    children: localeService.t(item.label as LocaleKey),
                     disabled: item.disable,
                     onSelect: () => handleClick(item),
                 }))}
@@ -195,7 +204,7 @@ function ToolbarButton(props: { titleKey: string; active?: boolean; disabled?: b
     const localeService = useDependency(LocaleService);
 
     return (
-        <Tooltip title={localeService.t(props.titleKey)} placement="bottom">
+        <Tooltip title={localeService.t(props.titleKey as LocaleKey)} placement="bottom">
             <button
                 type="button"
                 disabled={props.disabled}
@@ -401,6 +410,81 @@ function DocImageFloatingToolbar(props: IDocImageFloatingToolbarProps) {
                     <DeleteIcon />
                 </ToolbarButton>
             </ToolbarGroup>
+        </div>
+    );
+}
+
+function DocChartFloatingToolbar(props: Pick<IDocImageFloatingToolbarProps, 'menuItems'>) {
+    const commandService = useDependency(ICommandService);
+    const localeService = useDependency(LocaleService);
+    const chartTypeItem = props.menuItems.find((item) => item.type === 'select');
+    const editItem = props.menuItems.find((item) => item.icon === 'edit');
+    const deleteItem = props.menuItems.find((item) => item.icon === 'delete');
+    const chartTypeOptions = (chartTypeItem?.options ?? []).map((option) => ({
+        label: String(option.label),
+        value: option.value,
+        icon: <ChartIcon />,
+    }));
+
+    const executeMenuItem = (item: IImagePopupMenuItem | undefined) => {
+        if (!item || item.disable) {
+            return;
+        }
+        commandService.executeCommand(item.commandId, item.commandParams);
+    };
+
+    return (
+        <div
+            data-u-comp="doc-chart-floating-toolbar"
+            onMouseDown={(event) => {
+                event.stopPropagation();
+                event.preventDefault();
+            }}
+            className={clsx(`
+              univer-box-border univer-flex univer-items-center univer-rounded univer-bg-white univer-px-1 univer-py-1
+              univer-shadow-sm
+              dark:!univer-border-gray-700 dark:!univer-bg-gray-900
+            `, borderClassName)}
+        >
+            {chartTypeItem && (
+                <>
+                    <ToolbarGroup>
+                        <ToolbarDropdownButton
+                            title={localeService.t(chartTypeItem.label as LocaleKey)}
+                            value={chartTypeItem.value ?? chartTypeOptions[0]?.value ?? ''}
+                            options={chartTypeOptions}
+                            onChange={(value) => {
+                                if (!chartTypeItem.disable) {
+                                    commandService.executeCommand(chartTypeItem.commandId, chartTypeItem.commandParamsFactory?.(value));
+                                }
+                            }}
+                        />
+                    </ToolbarGroup>
+                    {(editItem || deleteItem) && <Separator orientation="vertical" />}
+                </>
+            )}
+            {(editItem || deleteItem) && (
+                <ToolbarGroup>
+                    {editItem && (
+                        <ToolbarButton
+                            titleKey={editItem.label}
+                            disabled={editItem.disable}
+                            onClick={() => executeMenuItem(editItem)}
+                        >
+                            <DocSettingIcon />
+                        </ToolbarButton>
+                    )}
+                    {deleteItem && (
+                        <ToolbarButton
+                            titleKey={deleteItem.label}
+                            disabled={deleteItem.disable}
+                            onClick={() => executeMenuItem(deleteItem)}
+                        >
+                            <DeleteIcon />
+                        </ToolbarButton>
+                    )}
+                </ToolbarGroup>
+            )}
         </div>
     );
 }

--- a/packages/engine-render/src/basics/index.ts
+++ b/packages/engine-render/src/basics/index.ts
@@ -31,5 +31,6 @@ export * from './scroll-xy';
 export * from './text-rotation';
 export * from './tools';
 export * from './transform';
+export type { ITransformerConfig } from './transformer-config';
 export * from './vector2';
 export * from './zoom';

--- a/packages/sheets-drawing-ui/src/services/__tests__/canvas-float-dom-manager.service.spec.ts
+++ b/packages/sheets-drawing-ui/src/services/__tests__/canvas-float-dom-manager.service.spec.ts
@@ -40,6 +40,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createSheetsDrawingUiTestBed } from '../../__tests__/create-sheets-drawing-ui-test-bed';
 import {
     applyFloatDomTransformerConfig,
+    applySheetChartTransformerConfig,
     calcSheetFloatDomPosition,
     createFloatDomHostClickIntent,
     createFloatDomMoveDragState,
@@ -636,6 +637,20 @@ describe('SheetCanvasFloatDomManagerService', () => {
             keepRatio: true,
             rotateEnabled: false,
             resizeEnabled: true,
+        }));
+    });
+
+    it('keeps the chart transformer outside the chart frame', () => {
+        const rect = {};
+
+        applySheetChartTransformerConfig(rect as any);
+
+        expect((rect as any).transformerConfig).toEqual(expect.objectContaining({
+            borderEnabled: true,
+            borderStroke: '#4086f4',
+            borderSpacing: 2,
+            anchorStyle: 'canva',
+            rotateEnabled: false,
         }));
     });
 

--- a/packages/sheets-drawing-ui/src/services/canvas-float-dom-manager.service.ts
+++ b/packages/sheets-drawing-ui/src/services/canvas-float-dom-manager.service.ts
@@ -31,6 +31,7 @@ import type {
     IBoundRectNoAngle,
     IRectProps,
     IRender,
+    ITransformerConfig,
     Scene,
     SpreadsheetSkeleton,
 } from '@univerjs/engine-render';
@@ -235,6 +236,27 @@ const SHEET_EMBED_FLOAT_DOM_TRANSFORMER_CONFIG = {
     moveBoundaryEnabled: false,
 } as const;
 
+/**
+ * Keep a chart selection outline outside the chart's own rounded frame.
+ * Charts retain resize handles but do not expose a rotation control.
+ */
+export const SHEET_CHART_TRANSFORMER_CONFIG = {
+    borderEnabled: true,
+    borderStroke: '#4086f4',
+    borderStrokeWidth: 1,
+    borderSpacing: 2,
+    anchorFill: '#ffffff',
+    anchorStroke: '#4086f4',
+    anchorStrokeWidth: 1.5,
+    anchorSize: 8,
+    anchorCornerRadius: 2,
+    anchorStyle: 'canva',
+    rotateEnabled: false,
+    resizeEnabled: true,
+    keepRatio: false,
+    moveBoundaryEnabled: false,
+} as const satisfies ITransformerConfig;
+
 const FLOAT_DOM_RUNTIME_ACTIVATION_EVENT_PRIORITY = -100;
 const FLOAT_DOM_STAGE2_CLICK_DISTANCE_THRESHOLD = 4;
 const FLOAT_DOM_PREVIEW_OBJECT_SUFFIX = '__preview';
@@ -323,6 +345,13 @@ export function applyFloatDomTransformerConfig(rect: BaseObject, floatDomParam: 
     rect.transformerConfig = {
         ...SHEET_EMBED_FLOAT_DOM_TRANSFORMER_CONFIG,
         keepRatio: embedData.resizeBehavior === 'aspect-ratio',
+    };
+}
+
+export function applySheetChartTransformerConfig(rect: BaseObject): void {
+    rect.transformerConfig = {
+        ...rect.transformerConfig,
+        ...SHEET_CHART_TRANSFORMER_CONFIG,
     };
 }
 
@@ -1207,6 +1236,9 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
                     if (rectShape != null) {
                         this._removeTopLevelDuplicateIfGrouped(scene, rectShapeKey, rectShape);
                         applyFloatDomTransformerConfig(rectShape, floatDomParam);
+                        if (drawingType === DrawingTypeEnum.DRAWING_CHART) {
+                            applySheetChartTransformerConfig(rectShape);
+                        }
                         rectShape.transformByState({ left, top, width, height, angle, flipX, flipY, skewX, skewY });
                         this._syncFloatDomRect(drawingId, rectShape);
                         if (shouldUseFloatDomPreviewObject(floatDomParam)) {
@@ -1240,7 +1272,6 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
                         }
                         imageConfig.paintFirst = 'stroke';
                         imageConfig.strokeWidth = 1;
-                        imageConfig.borderEnabled = false;
                         imageConfig.radius = 8;
                     }
 
@@ -1254,6 +1285,9 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
                         data,
                     });
                     applyFloatDomTransformerConfig(rect, floatDomParam);
+                    if (isChart) {
+                        applySheetChartTransformerConfig(rect);
+                    }
 
                     if (isChart) {
                         rect.objectType = ObjectType.CHART;
@@ -1922,6 +1956,9 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
 
             if (rectShape != null) {
                 this._removeTopLevelDuplicateIfGrouped(scene, rectShapeKey, rectShape);
+                if (drawingType === DrawingTypeEnum.DRAWING_CHART) {
+                    applySheetChartTransformerConfig(rectShape);
+                }
                 rectShape.transformByState({ left, top, width, height, angle, flipX, flipY, skewX, skewY });
                 this._syncFloatDomRect(drawingId, rectShape);
                 return;
@@ -1948,7 +1985,6 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
                 }
                 domConfig.paintFirst = 'stroke';
                 domConfig.strokeWidth = 1;
-                domConfig.borderEnabled = false;
                 domConfig.radius = 8;
             }
 
@@ -1964,6 +2000,7 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
 
             if (isChart) {
                 domRect.setObjectType(ObjectType.CHART);
+                applySheetChartTransformerConfig(domRect);
             }
 
             scene.addObject(domRect, DRAWING_OBJECT_LAYER_INDEX);


### PR DESCRIPTION
## What
- refresh document drawing geometry after transform mutations so chart hosts and transformers resize together
- add the document chart floating toolbar variant and align its placement
- use the modern chart transformer configuration for sheet float DOM drawings

## Why
Document chart transforms could leave drawing state, the active DOM host, and the transformer on different sizes. Chart controls also differed across document and sheet surfaces.

## Impact
- document chart resize now publishes fresh skeleton geometry
- document chart actions use the aligned floating toolbar
- sheet chart selection uses the modern transformer outline

## Checks
- docs-drawing-ui focused tests: 22 passed
- sheets-drawing-ui focused tests: 45 passed
- typecheck: docs-drawing-ui, drawing-ui, sheets-drawing-ui passed
- diff check passed

Process-only browser artifacts, screenshots, documentation, and non-actionable UI tests were excluded.