### PR TITLE
fix(ui): align title-only ribbon styling

### DIFF
--- a/packages/ui/src/views/components/ribbon/Ribbon.tsx
+++ b/packages/ui/src/views/components/ribbon/Ribbon.tsx
@@ -238,15 +238,19 @@ export function Ribbon(props: IRibbonProps) {
             >
                 {!toolbarOnly && ribbonOverride?.placeholderTitle && ribbon.length === 0 && (
                     <div
-                        className={clsx('univer-flex univer-h-9 univer-items-end univer-px-3', {
+                        className={clsx(`
+                          univer-flex univer-h-9 univer-items-end univer-rounded-md univer-bg-gray-50 univer-px-3
+                          dark:!univer-bg-gray-900
+                        `, {
                             'univer-justify-center': hideToolbar,
                         })}
                     >
                         <span
                             className="
                               univer-relative univer-inline-flex univer-h-8 univer-items-center univer-justify-center
-                              univer-rounded-t univer-bg-primary-50 univer-px-3 univer-text-sm univer-font-medium
-                              univer-text-primary-600
+                              univer-rounded-t univer-bg-primary-50 univer-px-3 univer-text-sm univer-font-semibold
+                              univer-text-primary-600 univer-shadow-sm
+                              dark:!univer-bg-primary-900 dark:!univer-text-primary-300
                             "
                         >
                             {ribbonOverride.placeholderTitle}

--- a/packages/ui/src/views/components/ribbon/__tests__/RibbonOverride.spec.tsx
+++ b/packages/ui/src/views/components/ribbon/__tests__/RibbonOverride.spec.tsx
@@ -78,6 +78,8 @@ describe('Ribbon override chrome', () => {
 
         const placeholder = getByText('Bases');
         expect(placeholder?.parentElement?.className).toContain('univer-justify-center');
+        expect(placeholder?.parentElement?.className).toContain('univer-bg-gray-50');
+        expect(placeholder.className).toContain('univer-font-semibold');
         expect(container.querySelectorAll('[data-embed-ribbon-override="true"]')).toHaveLength(1);
         expect(observeCount).toBe(0);
     });


### PR DESCRIPTION
## What changed

- Gives title-only ribbon overrides the same gray header background as the classic Ribbon menu.
- Uses the active Ribbon tab font weight, shadow, theme colors, and dark-mode colors.
- Extends the existing Ribbon override test to cover the shared styling contract.

## Why

Embedded tab/page blocks with title-only host chrome rendered their title on a white strip with medium-weight text, so switching to a Board block looked visually disconnected from the main Ribbon menu.

## Validation

- `@univerjs/ui`: 62 test files, 264 tests passed.
- Targeted ESLint: 0 errors.