### PR TITLE
fix(sheets-ui): scope permission checks to sheet editors

### DIFF
--- a/packages/sheets-ui/src/controllers/permission/__tests__/sheet-permission-check-ui.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/permission/__tests__/sheet-permission-check-ui.controller.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ICommandInfo } from '@univerjs/core';
+import {
+    createInternalEditorID,
+    DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
+    DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
+} from '@univerjs/core';
+import { InsertTextCommand } from '@univerjs/docs';
+import { IMEInputCommand } from '@univerjs/docs-ui';
+import { EMPTY } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { SheetPermissionCheckUIController } from '../sheet-permission-check-ui.controller';
+
+type ControllerConstructorArgs = ConstructorParameters<typeof SheetPermissionCheckUIController>;
+
+function createController() {
+    let beforeCommandExecuted: ((commandInfo: ICommandInfo) => void) | undefined;
+    const permissionCheckWithoutRange = vi.fn(() => false);
+    const blockExecuteWithoutPermission = vi.fn();
+    const controller = new SheetPermissionCheckUIController(
+        {
+            beforeCommandExecuted: vi.fn((listener: (commandInfo: ICommandInfo) => void) => {
+                beforeCommandExecuted = listener;
+                return { dispose: vi.fn() };
+            }),
+        } as unknown as ControllerConstructorArgs[0],
+        {} as unknown as ControllerConstructorArgs[1],
+        { getShowComponents: vi.fn(() => true) } as unknown as ControllerConstructorArgs[2],
+        { open: vi.fn(), close: vi.fn() } as unknown as ControllerConstructorArgs[3],
+        {} as unknown as ControllerConstructorArgs[4],
+        { t: vi.fn((key: string) => `translated:${key}`) } as unknown as ControllerConstructorArgs[5],
+        { getContextValue: vi.fn(() => false) } as unknown as ControllerConstructorArgs[6],
+        {
+            triggerPermissionUIEvent$: EMPTY,
+            permissionCheckWithoutRange,
+            blockExecuteWithoutPermission,
+        } as unknown as ControllerConstructorArgs[7]
+    );
+
+    return {
+        controller,
+        executeBefore: (commandInfo: ICommandInfo) => beforeCommandExecuted?.(commandInfo),
+        permissionCheckWithoutRange,
+        blockExecuteWithoutPermission,
+    };
+}
+
+describe('SheetPermissionCheckUIController', () => {
+    it.each([
+        [InsertTextCommand.id, 'document editor', 'host-doc'],
+        [IMEInputCommand.id, 'document editor', 'host-doc'],
+        [InsertTextCommand.id, 'shape text editor', createInternalEditorID('SHAPE_TEXT')],
+        [IMEInputCommand.id, 'shape text editor', createInternalEditorID('SHAPE_TEXT')],
+        [InsertTextCommand.id, 'slide text editor', createInternalEditorID('SLIDE_SHAPE_TEXT')],
+    ])('does not apply sheet permissions to %s input from a %s', (id, _, unitId) => {
+        const { controller, executeBefore, permissionCheckWithoutRange, blockExecuteWithoutPermission } = createController();
+
+        executeBefore({
+            id,
+            params: { unitId },
+        });
+
+        expect(permissionCheckWithoutRange).not.toHaveBeenCalled();
+        expect(blockExecuteWithoutPermission).not.toHaveBeenCalled();
+        controller.dispose();
+    });
+
+    it.each([
+        [InsertTextCommand.id, DOCS_NORMAL_EDITOR_UNIT_ID_KEY],
+        [IMEInputCommand.id, DOCS_NORMAL_EDITOR_UNIT_ID_KEY],
+        [InsertTextCommand.id, DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY],
+    ])('keeps applying sheet permissions to %s from %s', (id, unitId) => {
+        const { controller, executeBefore, permissionCheckWithoutRange, blockExecuteWithoutPermission } = createController();
+
+        executeBefore({
+            id,
+            params: { unitId },
+        });
+
+        expect(permissionCheckWithoutRange).toHaveBeenCalledOnce();
+        expect(blockExecuteWithoutPermission).toHaveBeenCalledWith('translated:sheets-ui.permission.dialog.editErr');
+        controller.dispose();
+    });
+});

--- a/packages/sheets-ui/src/controllers/permission/sheet-permission-check-ui.controller.ts
+++ b/packages/sheets-ui/src/controllers/permission/sheet-permission-check-ui.controller.ts
@@ -31,6 +31,7 @@ import {
     IPermissionService,
     IUniverInstanceService,
     LocaleService,
+    SHEET_EDITOR_UNITS,
 } from '@univerjs/core';
 import { InsertTextCommand } from '@univerjs/docs';
 import { IMEInputCommand } from '@univerjs/docs-ui';
@@ -128,11 +129,15 @@ export class SheetPermissionCheckUIController extends Disposable {
         switch (id) {
             case InsertTextCommand.id:
             case IMEInputCommand.id:
-                if (this._contextService.getContextValue(FOCUSING_EDITOR_STANDALONE) === true || this._contextService.getContextValue(FOCUSING_COMMENT_EDITOR) === true) {
+                params = commandInfo.params as IInsertTextCommandParams | IIMEInputCommandParams;
+
+                if (!params || !SHEET_EDITOR_UNITS.includes(params.unitId)) {
                     break;
                 }
 
-                params = commandInfo.params as IInsertTextCommandParams | IIMEInputCommandParams;
+                if (this._contextService.getContextValue(FOCUSING_EDITOR_STANDALONE) === true || this._contextService.getContextValue(FOCUSING_COMMENT_EDITOR) === true) {
+                    break;
+                }
 
                 permission = this._sheetPermissionCheckController.permissionCheckWithoutRange({
                     workbookTypes: [WorkbookEditablePermission],


### PR DESCRIPTION
## Summary

- Restrict text-input permission interception to the internal Sheet cell and formula-bar editors.
- Prevent protected-range alerts from leaking into document, shape, slide, board, and fullscreen editors.
- Preserve the existing standalone-editor and comment-editor guards.

## Test plan

- [x] `pnpm exec vitest run src/controllers/permission/__tests__/sheet-permission-check-ui.controller.spec.ts` (8 passed)
- [x] `pnpm typecheck`
- [x] ESLint on the changed controller and regression test (0 errors)

## Pull Request Checklist

- [x] No related ticket was provided.
- [x] Naming convention is followed.
- [x] Regression tests cover both non-Sheet and Sheet editor inputs.
- [x] No breaking changes are introduced.