### PR TITLE
fix(docs): support selection across column groups

### DIFF
--- a/packages/docs-ui/src/commands/commands/__tests__/misc.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/misc.command.spec.ts
@@ -225,6 +225,25 @@ function createBaseDoc(dataStream = 'Hello world\r\n'): IDocumentData {
     };
 }
 
+function createColumnGroupDoc(): IDocumentData {
+    const T = DataStreamTreeTokenType;
+    const dataStream = `P${T.PARAGRAPH}${T.COLUMN_GROUP_START}${T.COLUMN_START}A${T.PARAGRAPH}B${T.PARAGRAPH}${T.COLUMN_END}${T.COLUMN_START}C${T.PARAGRAPH}${T.COLUMN_END}${T.COLUMN_GROUP_END}Z${T.PARAGRAPH}${T.SECTION_BREAK}`;
+    const doc = createBaseDoc(dataStream);
+
+    return {
+        ...doc,
+        body: {
+            ...doc.body!,
+            columnGroups: [{ columnGroupId: 'cg-1', startIndex: 2, endIndex: 13 }],
+            paragraphs: [1, 5, 7, 11, 15].map((startIndex, index) => ({
+                paragraphId: `column-paragraph-${index}`,
+                startIndex,
+            })),
+            sectionBreaks: [{ sectionId: 'column-section', startIndex: 16 }],
+        },
+    };
+}
+
 function useLinearSkeleton(dataStream: string) {
     return {
         findNodeByCharIndex(index: number) {
@@ -905,6 +924,64 @@ describe('misc document commands', () => {
                 }),
             ],
         }));
+
+        subscription.unsubscribe();
+    });
+
+    it('expands select-all from paragraph to column, column group, and document', async () => {
+        ({ univer, get } = createCommandTestBed(createColumnGroupDoc()));
+        commandService = get(ICommandService);
+        commandService.registerCommand(DocSelectAllCommand);
+        commandService.registerCommand({
+            id: SetTextSelectionsOperation.id,
+            type: CommandType.OPERATION,
+            handler: () => true,
+        });
+        setCollapsedSelection(4);
+
+        const selectionManager = get(DocSelectionManagerService);
+        const refreshEvents: Array<{ docRanges: Array<{ startOffset?: number; endOffset?: number }> }> = [];
+        const subscription = selectionManager.refreshSelection$.subscribe((event) => event && refreshEvents.push(event));
+        const selectNextScope = async (expected: Array<{ startOffset: number; endOffset: number }>) => {
+            await commandService.executeCommand(DocSelectAllCommand.id);
+            expect(refreshEvents.at(-1)?.docRanges.map(({ startOffset, endOffset }) => ({ startOffset, endOffset }))).toEqual(expected);
+            selectionManager.__replaceTextRangesWithNoRefresh({
+                isEditing: false,
+                rectRanges: [],
+                segmentId: '',
+                segmentPage: -1,
+                style: null as never,
+                textRanges: expected.map((range, index) => ({
+                    ...range,
+                    collapsed: false,
+                    endOffset: range.endOffset - 1,
+                    isActive: index === 0,
+                    segmentId: '',
+                    style: null as never,
+                })),
+            }, {
+                subUnitId: 'test-doc',
+                unitId: 'test-doc',
+            });
+        };
+
+        await selectNextScope([{ startOffset: 4, endOffset: 5 }]);
+        await selectNextScope([
+            { startOffset: 4, endOffset: 5 },
+            { startOffset: 6, endOffset: 7 },
+        ]);
+        await selectNextScope([
+            { startOffset: 4, endOffset: 5 },
+            { startOffset: 6, endOffset: 7 },
+            { startOffset: 10, endOffset: 11 },
+        ]);
+        await selectNextScope([
+            { startOffset: 0, endOffset: 1 },
+            { startOffset: 4, endOffset: 5 },
+            { startOffset: 6, endOffset: 7 },
+            { startOffset: 10, endOffset: 11 },
+            { startOffset: 14, endOffset: 15 },
+        ]);
 
         subscription.unsubscribe();
     });

--- a/packages/docs-ui/src/commands/commands/doc-select-all.command.ts
+++ b/packages/docs-ui/src/commands/commands/doc-select-all.command.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel, ICommand, ICustomTable, IDocumentBody } from '@univerjs/core';
+import type { DocumentDataModel, ICommand, ICustomColumnGroup, ICustomTable, IDocumentBody } from '@univerjs/core';
 import type { ISuccinctDocRangeParam } from '@univerjs/engine-render';
-import { CommandType, DOC_RANGE_TYPE, getParagraphContentStartOffsets, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
+import { CommandType, DataStreamTreeTokenType, DOC_RANGE_TYPE, getParagraphContentStartOffsets, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
 import { DocSelectionManagerService } from '@univerjs/docs';
 
 interface ISelectAllCommandParams { }
@@ -46,9 +46,9 @@ export const DocSelectAllCommand: ICommand<ISelectAllCommandParams> = {
             return true;
         }
 
-        const wholeDocRanges = getWholeDocumentRanges(body);
-        const scopedRange = getScopedSelectAllRange(body, activeRange);
-        const textRanges = scopedRange && !isSameRanges(docRanges, scopedRange) ? scopedRange : wholeDocRanges;
+        const scopes = getSelectAllScopes(body, activeRange);
+        const currentScopeIndex = scopes.findIndex((scope) => isSameRanges(docRanges, scope));
+        const textRanges = scopes[Math.min(currentScopeIndex + 1, scopes.length - 1)];
 
         docSelectionManagerService.replaceDocRanges(textRanges, {
             unitId,
@@ -60,24 +60,64 @@ export const DocSelectAllCommand: ICommand<ISelectAllCommandParams> = {
 };
 
 function getWholeDocumentRanges(body: IDocumentBody): ISuccinctDocRangeParam[] {
-    const textRanges: ISuccinctDocRangeParam[] = [];
-    let offset = 0;
+    return getRangesForOffsets(body, 0, body.dataStream.length - 2);
+}
 
-    for (const table of body.tables ?? []) {
-        const { startIndex, endIndex } = table;
-        if (offset !== startIndex) {
-            textRanges.push(...getTextRangesByParagraphs(body, offset, startIndex - 1));
+function getRangesForOffsets(body: IDocumentBody, startOffset: number, endOffset: number): ISuccinctDocRangeParam[] {
+    const columnGroups = [...(body.columnGroups ?? [])].sort((left, right) => left.startIndex - right.startIndex);
+    const ranges: ISuccinctDocRangeParam[] = [];
+    let offset = startOffset;
+
+    for (const columnGroup of columnGroups) {
+        if (columnGroup.endIndex < startOffset || columnGroup.startIndex > endOffset) {
+            continue;
         }
 
-        textRanges.push(getTableRectRange(table));
+        if (offset < columnGroup.startIndex) {
+            ranges.push(...getRangesWithTables(body, offset, Math.min(endOffset, columnGroup.startIndex - 1)));
+        }
+
+        for (const column of getColumnRanges(body, columnGroup)) {
+            const start = Math.max(startOffset, column.startOffset!);
+            const end = Math.min(endOffset, column.endOffset!);
+            if (start <= end) {
+                ranges.push(...getRangesWithTables(body, start, end));
+            }
+        }
+
+        offset = columnGroup.endIndex + 1;
+    }
+
+    if (offset <= endOffset) {
+        ranges.push(...getRangesWithTables(body, offset, endOffset));
+    }
+
+    return ranges;
+}
+
+function getRangesWithTables(body: IDocumentBody, startOffset: number, endOffset: number): ISuccinctDocRangeParam[] {
+    const ranges: ISuccinctDocRangeParam[] = [];
+    let offset = startOffset;
+
+    for (const table of [...(body.tables ?? [])].sort((left, right) => left.startIndex - right.startIndex)) {
+        const { startIndex, endIndex } = table;
+        if (startIndex < startOffset || endIndex > endOffset) {
+            continue;
+        }
+
+        if (offset !== startIndex) {
+            ranges.push(...getTextRangesByParagraphs(body, offset, startIndex - 1));
+        }
+
+        ranges.push(getTableRectRange(table));
         offset = endIndex;
     }
 
-    if (offset !== body.dataStream.length - 2) {
-        textRanges.push(...getTextRangesByParagraphs(body, offset, body.dataStream.length - 2));
+    if (offset <= endOffset) {
+        ranges.push(...getTextRangesByParagraphs(body, offset, endOffset));
     }
 
-    return textRanges;
+    return ranges;
 }
 
 function getTextRangesByParagraphs(body: IDocumentBody, startOffset: number, endOffset: number): ISuccinctDocRangeParam[] {
@@ -117,43 +157,70 @@ function getTextRangesByParagraphs(body: IDocumentBody, startOffset: number, end
     return ranges;
 }
 
-function getScopedSelectAllRange(body: IDocumentBody, activeRange: ISuccinctDocRangeParam): ISuccinctDocRangeParam[] | null {
+function getSelectAllScopes(body: IDocumentBody, activeRange: ISuccinctDocRangeParam): ISuccinctDocRangeParam[][] {
+    const scopes: ISuccinctDocRangeParam[][] = [];
+    const addScope = (scope: ISuccinctDocRangeParam[] | null) => {
+        if (scope?.length && !scopes.some((existing) => isSameRanges(existing, scope))) {
+            scopes.push(scope);
+        }
+    };
     const startOffset = activeRange.startOffset;
     const endOffset = activeRange.endOffset;
     if (startOffset == null || endOffset == null) {
-        return null;
+        return [getWholeDocumentRanges(body)];
     }
 
     const table = (body.tables ?? []).find((item) => isRangeInside(startOffset, endOffset, item.startIndex, item.endIndex));
-    if (table) {
-        return [getTableRectRange(table)];
-    }
-
     const customBlock = (body.customBlocks ?? []).find((item) => item.startIndex >= startOffset && item.startIndex <= endOffset);
-    if (customBlock) {
-        return [{
+    const blockRange = (body.blockRanges ?? []).find((item) => isRangeInside(startOffset, endOffset, item.startIndex, item.endIndex));
+    if (table) {
+        addScope([getTableRectRange(table)]);
+    } else if (customBlock) {
+        addScope([{
             endOffset: customBlock.startIndex,
             rangeType: DOC_RANGE_TYPE.TEXT,
             startOffset: customBlock.startIndex,
-        }];
-    }
-
-    const blockRange = (body.blockRanges ?? []).find((item) => isRangeInside(startOffset, endOffset, item.startIndex, item.endIndex));
-    if (blockRange) {
-        return [{
+        }]);
+    } else if (blockRange) {
+        addScope([{
             endOffset: Math.max(blockRange.startIndex + 1, blockRange.endIndex - 1),
             rangeType: DOC_RANGE_TYPE.TEXT,
             startOffset: blockRange.startIndex + 1,
-        }];
+        }]);
+    } else {
+        const paragraphRange = clampParagraphRangeByTables(getParagraphRangeAtOffset(body, startOffset), body.tables ?? [], startOffset);
+        addScope(paragraphRange ? [{ ...paragraphRange, rangeType: DOC_RANGE_TYPE.TEXT }] : null);
     }
 
-    const paragraphRange = clampParagraphRangeByTables(getParagraphRangeAtOffset(body, startOffset), body.tables ?? [], startOffset);
-    return paragraphRange
-        ? [{
-            ...paragraphRange,
-            rangeType: DOC_RANGE_TYPE.TEXT,
-        }]
-        : null;
+    const columnGroup = (body.columnGroups ?? []).find((item) => isRangeInside(startOffset, endOffset, item.startIndex, item.endIndex));
+    if (columnGroup) {
+        const columns = getColumnRanges(body, columnGroup);
+        const column = columns.find((item) => isRangeInside(startOffset, endOffset, item.startOffset!, item.endOffset!));
+        if (column) {
+            addScope(getRangesForOffsets(body, column.startOffset!, column.endOffset!));
+        }
+        addScope(getRangesForOffsets(body, columnGroup.startIndex, columnGroup.endIndex));
+    }
+
+    addScope(getWholeDocumentRanges(body));
+    return scopes;
+}
+
+function getColumnRanges(body: IDocumentBody, columnGroup: ICustomColumnGroup): ISuccinctDocRangeParam[] {
+    const ranges: ISuccinctDocRangeParam[] = [];
+    let startOffset: number | undefined;
+
+    for (let index = columnGroup.startIndex; index <= columnGroup.endIndex; index++) {
+        const token = body.dataStream[index];
+        if (token === DataStreamTreeTokenType.COLUMN_START) {
+            startOffset = index + 1;
+        } else if (token === DataStreamTreeTokenType.COLUMN_END && startOffset != null) {
+            ranges.push({ startOffset, endOffset: index - 1, rangeType: DOC_RANGE_TYPE.TEXT });
+            startOffset = undefined;
+        }
+    }
+
+    return ranges;
 }
 
 function clampParagraphRangeByTables(
@@ -212,9 +279,15 @@ function isSameRanges(currentRanges: ISuccinctDocRangeParam[], nextRanges: ISucc
 
     return currentRanges.every((currentRange, index) => {
         const nextRange = nextRanges[index];
+        const sameType = getRangeType(currentRange) === getRangeType(nextRange);
+        const sameTextEnd = sameType &&
+            getRangeType(nextRange) === DOC_RANGE_TYPE.TEXT &&
+            !(currentRange as ISuccinctDocRangeParam & { collapsed?: boolean }).collapsed &&
+            currentRange.endOffset! + 1 === nextRange.endOffset;
+
         return currentRange.startOffset === nextRange.startOffset &&
-            currentRange.endOffset === nextRange.endOffset &&
-            getRangeType(currentRange) === getRangeType(nextRange);
+            (currentRange.endOffset === nextRange.endOffset || sameTextEnd) &&
+            sameType;
     });
 }
 

--- a/packages/docs-ui/src/services/selection/__tests__/selection-utils.spec.ts
+++ b/packages/docs-ui/src/services/selection/__tests__/selection-utils.spec.ts
@@ -15,10 +15,11 @@
  */
 
 import type { INodePosition } from '@univerjs/engine-render';
-import { getOffsetRectForDom, setDocsTableRenderViewportProvider } from '@univerjs/engine-render';
+import { DataStreamTreeNodeType } from '@univerjs/core';
+import { DocumentSkeletonPageType, getOffsetRectForDom, setDocsTableRenderViewportProvider } from '@univerjs/engine-render';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NodePositionConvertToRectRange } from '../convert-rect-range';
-import { RectRange } from '../rect-range';
+import { convertPositionsToRectRanges, RectRange } from '../rect-range';
 import {
     getCanvasOffsetByEngine,
     getParagraphInfoByGlyph,
@@ -406,6 +407,381 @@ describe('selection utils', () => {
         expect(getTextRangeFromCharIndex(1, 2, {} as never, document, skeleton as never, {} as never, '', -1)).toBeUndefined();
         expect(getRectRangeFromCharIndex(1, 2, {} as never, document, skeleton as never, {} as never, '', -1)).toBeUndefined();
         expect(getRangeListFromCharIndex(1, 2, {} as never, document, skeleton as never, {} as never, '', -1)).toBeUndefined();
+    });
+
+    it('disposes rect ranges created before a later range fails', () => {
+        const anchor = createNodePosition(['pages', 0, 'skeTables', 'table-1', 'rows', 0, 'cells', 0]);
+        const focus = createNodePosition(['pages', 0, 'skeTables', 'table-1', 'rows', 1, 'cells', 0]);
+        vi.spyOn(NodePositionConvertToRectRange.prototype, 'getNodePositionGroup').mockReturnValue([
+            { anchor, focus: anchor },
+            { anchor: focus, focus },
+        ]);
+        vi.mocked(RectRange.prototype.refresh)
+            .mockReset()
+            .mockImplementationOnce(() => {})
+            .mockImplementationOnce(() => {
+                throw new Error('invalid range');
+            });
+        const dispose = vi.spyOn(RectRange.prototype, 'dispose');
+
+        expect(() => convertPositionsToRectRanges(
+            {} as never,
+            createDocument(),
+            {} as never,
+            anchor,
+            focus
+        )).toThrow('invalid range');
+        expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it('disposes text ranges created before a later range fails', () => {
+        const startNode = createNodePosition(['pages', 0]);
+        const middleNode = createNodePosition(['pages', 0], 1);
+        const endNode = createNodePosition(['pages', 0], 2);
+        const tableStartNode = createNodePosition(['pages', 0, 'skeTables', 'table-1', 'rows', 0, 'cells', 0]);
+        const tableEndNode = createNodePosition(['pages', 0, 'skeTables', 'table-1', 'rows', 0, 'cells', 1]);
+        const skeleton = {
+            findCharIndexByPosition: vi
+                .fn()
+                .mockReturnValueOnce(0)
+                .mockReturnValueOnce(20),
+            findNodePositionByCharIndex: vi
+                .fn()
+                .mockReturnValueOnce(tableStartNode)
+                .mockReturnValueOnce(tableEndNode)
+                .mockReturnValueOnce(startNode)
+                .mockReturnValueOnce(middleNode)
+                .mockReturnValueOnce(middleNode)
+                .mockReturnValueOnce(endNode),
+            getViewModel: () => ({
+                getSelfOrHeaderFooterViewModel: () => ({
+                    getChildren: () => [{
+                        children: [{
+                            startIndex: 0,
+                            endIndex: 20,
+                            children: [{
+                                nodeType: DataStreamTreeNodeType.TABLE,
+                                startIndex: 5,
+                                endIndex: 15,
+                                children: [],
+                            }],
+                        }],
+                    }],
+                }),
+            }),
+        };
+        vi.spyOn(NodePositionConvertToRectRange.prototype, 'getNodePositionGroup').mockReturnValue([{
+            anchor: tableStartNode,
+            focus: tableEndNode,
+        }]);
+        vi.mocked(TextRange.prototype.refresh)
+            .mockReset()
+            .mockImplementationOnce(() => {})
+            .mockImplementationOnce(() => {
+                throw new Error('invalid range');
+            });
+        const disposeTextRange = vi.spyOn(TextRange.prototype, 'dispose');
+        const disposeRectRange = vi.spyOn(RectRange.prototype, 'dispose');
+
+        expect(() => getRangeListFromSelection(
+            startNode,
+            endNode,
+            {} as never,
+            createDocument(),
+            skeleton as never,
+            {} as never,
+            '',
+            -1
+        )).toThrow('invalid range');
+        expect(disposeTextRange).toHaveBeenCalledTimes(1);
+        expect(disposeRectRange).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not treat a column group child as a table', () => {
+        const startNode = createNodePosition(['pages', 0]);
+        const endNode = createNodePosition(['pages', 0], 1);
+        const skeleton = {
+            findCharIndexByPosition: vi
+                .fn()
+                .mockReturnValueOnce(0)
+                .mockReturnValueOnce(10),
+            findNodePositionByCharIndex: vi
+                .fn()
+                .mockReturnValueOnce(startNode)
+                .mockReturnValueOnce(endNode),
+            getViewModel: () => ({
+                getSelfOrHeaderFooterViewModel: () => ({
+                    getChildren: () => [{
+                        children: [{
+                            nodeType: DataStreamTreeNodeType.COLUMN_GROUP,
+                            startIndex: 0,
+                            endIndex: 20,
+                            children: [{
+                                nodeType: DataStreamTreeNodeType.COLUMN,
+                                startIndex: 1,
+                                endIndex: 19,
+                                children: [],
+                            }],
+                        }],
+                    }],
+                }),
+            }),
+        };
+
+        const result = getRangeListFromSelection(
+            createNodePosition(['pages', 0]),
+            createNodePosition(['pages', 0], 1),
+            {} as never,
+            createDocument(),
+            skeleton as never,
+            {} as never,
+            '',
+            -1
+        );
+
+        expect(result?.textRanges).toHaveLength(1);
+        expect(result?.rectRanges).toHaveLength(0);
+    });
+
+    it('splits a body drag across a column group into one range per render page', () => {
+        const bodyStart = createNodePosition(['pages', 0]);
+        const bodyBeforeColumns = createNodePosition(['pages', 0], 1);
+        const firstColumnStart = {
+            ...createNodePosition(['pages', 0, 'skeColumnGroups', 'cg-1', 'columns', 0, 'page']),
+            pageType: DocumentSkeletonPageType.CELL,
+        };
+        const firstColumnEnd = { ...firstColumnStart, glyph: 1 };
+        const secondColumnStart = {
+            ...createNodePosition(['pages', 0, 'skeColumnGroups', 'cg-1', 'columns', 1, 'page']),
+            pageType: DocumentSkeletonPageType.CELL,
+        };
+        const secondColumnEnd = { ...secondColumnStart, glyph: 1 };
+        const bodyAfterColumns = createNodePosition(['pages', 0], 2);
+        const bodyEnd = createNodePosition(['pages', 0], 3);
+        const skeleton = {
+            findCharIndexByPosition: vi
+                .fn()
+                .mockReturnValueOnce(0)
+                .mockReturnValueOnce(20),
+            findNodePositionByCharIndex: vi
+                .fn()
+                .mockReturnValueOnce(bodyStart)
+                .mockReturnValueOnce(bodyBeforeColumns)
+                .mockReturnValueOnce(firstColumnStart)
+                .mockReturnValueOnce(firstColumnEnd)
+                .mockReturnValueOnce(secondColumnStart)
+                .mockReturnValueOnce(secondColumnEnd)
+                .mockReturnValueOnce(bodyAfterColumns)
+                .mockReturnValueOnce(bodyEnd),
+            getViewModel: () => ({
+                getSelfOrHeaderFooterViewModel: () => ({
+                    getChildren: () => [{
+                        children: [
+                            { nodeType: DataStreamTreeNodeType.PARAGRAPH, startIndex: 0, endIndex: 2, children: [] },
+                            {
+                                nodeType: DataStreamTreeNodeType.COLUMN_GROUP,
+                                startIndex: 3,
+                                endIndex: 14,
+                                children: [
+                                    { nodeType: DataStreamTreeNodeType.COLUMN, startIndex: 4, endIndex: 8, children: [] },
+                                    { nodeType: DataStreamTreeNodeType.COLUMN, startIndex: 9, endIndex: 13, children: [] },
+                                ],
+                            },
+                            { nodeType: DataStreamTreeNodeType.PARAGRAPH, startIndex: 15, endIndex: 20, children: [] },
+                        ],
+                    }],
+                }),
+            }),
+        };
+
+        const result = getRangeListFromSelection(
+            bodyStart,
+            bodyEnd,
+            {} as never,
+            createDocument(),
+            skeleton as never,
+            {} as never,
+            '',
+            -1
+        );
+
+        expect(result?.textRanges.map((range) => [range.anchorNodePosition, range.focusNodePosition])).toEqual([
+            [bodyStart, bodyBeforeColumns],
+            [firstColumnStart, firstColumnEnd],
+            [secondColumnStart, secondColumnEnd],
+            [bodyAfterColumns, bodyEnd],
+        ]);
+        expect(result?.rectRanges).toHaveLength(0);
+    });
+
+    it('keeps a table inside a selected column as a rect range', () => {
+        const bodyStart = createNodePosition(['pages', 0]);
+        const bodyBeforeColumns = createNodePosition(['pages', 0], 1);
+        const columnStart = {
+            ...createNodePosition(['pages', 0, 'skeColumnGroups', 'cg-1', 'columns', 0, 'page']),
+            pageType: DocumentSkeletonPageType.CELL,
+        };
+        const columnBeforeTable = { ...columnStart, glyph: 1 };
+        const tablePosition = {
+            ...createNodePosition(['pages', 0, 'skeColumnGroups', 'cg-1', 'columns', 0, 'page', 'skeTables', 'table-1', 'rows', 0, 'cells', 0]),
+            pageType: DocumentSkeletonPageType.CELL,
+        };
+        const columnAfterTable = { ...columnStart, glyph: 2 };
+        const columnEnd = { ...columnStart, glyph: 3 };
+        const bodyAfterColumns = createNodePosition(['pages', 0], 2);
+        const bodyEnd = createNodePosition(['pages', 0], 3);
+        const table = {
+            nodeType: DataStreamTreeNodeType.TABLE,
+            startIndex: 8,
+            endIndex: 15,
+            children: [{ startIndex: 9, endIndex: 14 }],
+        };
+        const skeleton = {
+            findCharIndexByPosition: vi
+                .fn()
+                .mockReturnValueOnce(0)
+                .mockReturnValueOnce(25),
+            findNodePositionByCharIndex: vi
+                .fn()
+                .mockReturnValueOnce(bodyStart)
+                .mockReturnValueOnce(bodyBeforeColumns)
+                .mockReturnValueOnce(columnStart)
+                .mockReturnValueOnce(columnBeforeTable)
+                .mockReturnValueOnce(tablePosition)
+                .mockReturnValueOnce(tablePosition)
+                .mockReturnValueOnce(columnAfterTable)
+                .mockReturnValueOnce(columnEnd)
+                .mockReturnValueOnce(bodyAfterColumns)
+                .mockReturnValueOnce(bodyEnd),
+            getViewModel: () => ({
+                getSelfOrHeaderFooterViewModel: () => ({
+                    getChildren: () => [{
+                        children: [
+                            { nodeType: DataStreamTreeNodeType.PARAGRAPH, startIndex: 0, endIndex: 2, children: [] },
+                            {
+                                nodeType: DataStreamTreeNodeType.COLUMN_GROUP,
+                                startIndex: 3,
+                                endIndex: 20,
+                                children: [{
+                                    nodeType: DataStreamTreeNodeType.COLUMN,
+                                    startIndex: 4,
+                                    endIndex: 19,
+                                    children: [{
+                                        nodeType: DataStreamTreeNodeType.PARAGRAPH,
+                                        startIndex: 5,
+                                        endIndex: 18,
+                                        children: [table],
+                                    }],
+                                }],
+                            },
+                            { nodeType: DataStreamTreeNodeType.PARAGRAPH, startIndex: 21, endIndex: 25, children: [] },
+                        ],
+                    }],
+                }),
+            }),
+        };
+        vi.spyOn(NodePositionConvertToRectRange.prototype, 'getNodePositionGroup').mockReturnValue([{
+            anchor: tablePosition,
+            focus: tablePosition,
+        }]);
+
+        const result = getRangeListFromSelection(
+            bodyStart,
+            bodyEnd,
+            {} as never,
+            createDocument(),
+            skeleton as never,
+            {} as never,
+            '',
+            -1
+        );
+
+        expect(result?.textRanges).toHaveLength(4);
+        expect(result?.rectRanges).toHaveLength(1);
+        expect(result?.rectRanges[0].anchorNodePosition).toBe(tablePosition);
+    });
+
+    it('does not create one text range across different header pages', () => {
+        const startNode = {
+            ...createNodePosition(['pages', 0]),
+            pageType: DocumentSkeletonPageType.HEADER,
+            segmentPage: 0,
+        };
+        const endNode = {
+            ...createNodePosition(['pages', 1]),
+            pageType: DocumentSkeletonPageType.HEADER,
+            segmentPage: 1,
+        };
+        const skeleton = {
+            findCharIndexByPosition: vi
+                .fn()
+                .mockReturnValueOnce(0)
+                .mockReturnValueOnce(10),
+            findNodePositionByCharIndex: vi
+                .fn()
+                .mockReturnValueOnce(startNode)
+                .mockReturnValueOnce(endNode),
+            getViewModel: () => ({
+                getSelfOrHeaderFooterViewModel: () => ({
+                    getChildren: () => [{
+                        children: [{ startIndex: 0, endIndex: 10, children: [] }],
+                    }],
+                }),
+            }),
+        };
+
+        const result = getRangeListFromSelection(
+            startNode,
+            endNode,
+            {} as never,
+            createDocument(),
+            skeleton as never,
+            {} as never,
+            '',
+            -1
+        );
+
+        expect(result).toBeUndefined();
+    });
+
+    it('abandons a transient table selection when its end row cannot be resolved', () => {
+        const skeleton = {
+            findCharIndexByPosition: vi
+                .fn()
+                .mockReturnValueOnce(0)
+                .mockReturnValueOnce(24),
+            getViewModel: () => ({
+                getSelfOrHeaderFooterViewModel: () => ({
+                    getChildren: () => [{
+                        children: [{
+                            startIndex: 0,
+                            endIndex: 30,
+                            children: [{
+                                nodeType: DataStreamTreeNodeType.TABLE,
+                                startIndex: 5,
+                                endIndex: 25,
+                                children: [{ startIndex: 6, endIndex: 10 }],
+                            }],
+                        }],
+                    }],
+                }),
+            }),
+        };
+
+        let result: ReturnType<typeof getRangeListFromSelection>;
+        expect(() => {
+            result = getRangeListFromSelection(
+                createNodePosition(['pages', 0]),
+                createNodePosition(['pages', 0], 1),
+                {} as never,
+                createDocument(),
+                skeleton as never,
+                {} as never,
+                '',
+                -1
+            );
+        }).not.toThrow();
+        expect(result).toBeUndefined();
     });
 
     it('resolves collapsed ranges from the backward character boundary', () => {
@@ -1003,6 +1379,7 @@ describe('selection utils', () => {
             startIndex: 0,
             endIndex: 100,
             children: [{
+                nodeType: DataStreamTreeNodeType.TABLE,
                 startIndex: 20,
                 endIndex: 50,
                 children: [

--- a/packages/docs-ui/src/services/selection/doc-selection-render.service.ts
+++ b/packages/docs-ui/src/services/selection/doc-selection-render.service.ts
@@ -568,10 +568,10 @@ export class DocSelectionRenderService extends RxDisposable implements IRenderMo
                 return;
             }
 
-            this._moving(moveOffsetX, moveOffsetY);
+            this._tryMoving(moveOffsetX, moveOffsetY);
 
             scrollTimer.scrolling(moveOffsetX, moveOffsetY, () => {
-                this._moving(moveOffsetX, moveOffsetY);
+                this._tryMoving(moveOffsetX, moveOffsetY);
             });
 
             preMoveOffsetX = moveOffsetX;
@@ -1026,6 +1026,14 @@ export class DocSelectionRenderService extends RxDisposable implements IRenderMo
         canvasTop += y;
 
         this.activate(canvasLeft, canvasTop, forceFocus);
+    }
+
+    private _tryMoving(moveOffsetX: number, moveOffsetY: number) {
+        try {
+            this._moving(moveOffsetX, moveOffsetY);
+        } catch (error) {
+            this._logService.error('[DocSelectionRenderService] Failed to update moving selection', error);
+        }
     }
 
     private _moving(moveOffsetX: number, moveOffsetY: number) {

--- a/packages/docs-ui/src/services/selection/rect-range.ts
+++ b/packages/docs-ui/src/services/selection/rect-range.ts
@@ -38,17 +38,27 @@ export function convertPositionsToRectRanges(
     const documentOffsetConfig = document.getOffsetConfig();
     const convertor = new NodePositionConvertToRectRange(documentOffsetConfig, docSkeleton);
     const nodePositionGroup = convertor.getNodePositionGroup(anchorNodePosition, focusNodePosition);
+    const ranges: RectRange[] = [];
 
-    return (nodePositionGroup ?? []).map((position) => new RectRange(
-        scene,
-        document,
-        docSkeleton,
-        position.anchor,
-        position.focus,
-        style,
-        segmentId,
-        segmentPage
-    ));
+    try {
+        for (const position of nodePositionGroup ?? []) {
+            ranges.push(new RectRange(
+                scene,
+                document,
+                docSkeleton,
+                position.anchor,
+                position.focus,
+                style,
+                segmentId,
+                segmentPage
+            ));
+        }
+
+        return ranges;
+    } catch (error) {
+        ranges.forEach((range) => range.dispose());
+        throw error;
+    }
 }
 
 export class RectRange implements IDocRange {

--- a/packages/docs-ui/src/services/selection/selection-utils.ts
+++ b/packages/docs-ui/src/services/selection/selection-utils.ts
@@ -16,6 +16,7 @@
 
 import type { Nullable } from '@univerjs/core';
 import type {
+    DataStreamTreeNode,
     Documents,
     DocumentSkeleton,
     Engine,
@@ -27,8 +28,8 @@ import type {
     Scene,
 } from '@univerjs/engine-render';
 import type { IDocRange } from './range-interface';
-import { RANGE_DIRECTION, Tools } from '@univerjs/core';
-import { getDocumentSkeletonColumnPagePathInfo, getOffsetRectForDom } from '@univerjs/engine-render';
+import { DataStreamTreeNodeType, RANGE_DIRECTION, Tools } from '@univerjs/core';
+import { DocumentSkeletonPageType, getDocumentSkeletonColumnPagePathInfo, getOffsetRectForDom } from '@univerjs/engine-render';
 import { isInSameTableCell, isInSameTableCellData, isValidRectRange } from './convert-rect-range';
 import { compareNodePosition } from './convert-text-range';
 import { convertPositionsToRectRanges, RectRange } from './rect-range';
@@ -39,11 +40,55 @@ interface IDocRangeList {
     rectRanges: RectRange[];
 }
 
+function disposeRangeList({ textRanges, rectRanges }: IDocRangeList) {
+    textRanges.forEach((range) => range.dispose());
+    rectRanges.forEach((range) => range.dispose());
+}
+
+function isCompatibleTextRange(start: Nullable<INodePosition>, end: Nullable<INodePosition>) {
+    if (start == null || end == null || start.pageType !== end.pageType) {
+        return false;
+    }
+
+    if (
+        (start.pageType === DocumentSkeletonPageType.HEADER || start.pageType === DocumentSkeletonPageType.FOOTER) &&
+        start.segmentPage !== end.segmentPage
+    ) {
+        return false;
+    }
+
+    const startColumn = getDocumentSkeletonColumnPagePathInfo(start);
+    const endColumn = getDocumentSkeletonColumnPagePathInfo(end);
+
+    if (startColumn == null || endColumn == null) {
+        return startColumn == null && endColumn == null;
+    }
+
+    return startColumn.pageIndex === endColumn.pageIndex &&
+        startColumn.columnGroupId === endColumn.columnGroupId &&
+        startColumn.columnIndex === endColumn.columnIndex;
+}
+
+function getDescendantTables(node: DataStreamTreeNode): DataStreamTreeNode[] {
+    if (node.nodeType === DataStreamTreeNodeType.TABLE) {
+        return [node];
+    }
+
+    return node.children.flatMap(getDescendantTables);
+}
+
 function isInSameColumnPage(anchorPosition: INodePosition, focusPosition: INodePosition): boolean {
     const anchorColumnInfo = getDocumentSkeletonColumnPagePathInfo(anchorPosition);
     const focusColumnInfo = getDocumentSkeletonColumnPagePathInfo(focusPosition);
 
-    return !!anchorColumnInfo && !!focusColumnInfo &&
+    const anchorPageIndex = anchorPosition.path?.indexOf('page') ?? -1;
+    const focusPageIndex = focusPosition.path?.indexOf('page') ?? -1;
+
+    return anchorPageIndex >= 0 &&
+        focusPageIndex >= 0 &&
+        anchorPageIndex === anchorPosition.path!.length - 1 &&
+        focusPageIndex === focusPosition.path!.length - 1 &&
+        !!anchorColumnInfo && !!focusColumnInfo &&
         anchorColumnInfo.pageIndex === focusColumnInfo.pageIndex &&
         anchorColumnInfo.columnGroupId === focusColumnInfo.columnGroupId &&
         anchorColumnInfo.columnIndex === focusColumnInfo.columnIndex;
@@ -183,15 +228,6 @@ export function getRangeListFromSelection(
         };
     }
 
-    if (isInSameColumnPage(anchorPosition, focusPosition)) {
-        textRanges.push(new TextRange(...rangeParams));
-
-        return {
-            textRanges,
-            rectRanges,
-        };
-    }
-
     // TODO: @JOCS handle NEST table.
     // Handle selection in same table cell.
     if (isInSameTableCellData(skeleton, anchorPosition, focusPosition)) {
@@ -231,6 +267,15 @@ export function getRangeListFromSelection(
         };
     }
 
+    if (isInSameColumnPage(anchorPosition, focusPosition)) {
+        textRanges.push(new TextRange(...rangeParams));
+
+        return {
+            textRanges,
+            rectRanges,
+        };
+    }
+
     const viewModel = skeleton.getViewModel().getSelfOrHeaderFooterViewModel(segmentId);
     const anchorOffset = skeleton.findCharIndexByPosition(anchorPosition);
     const focusOffset = skeleton.findCharIndexByPosition(focusPosition);
@@ -253,96 +298,204 @@ export function getRangeListFromSelection(
         skeleton.findNodePositionByCharIndex(charIndex, isBack, segmentId, segmentPage) ??
         (charIndex === endOffset ? originRange.end : undefined);
 
+    const appendTextRange = (rangeStart: number, rangeEnd: number, endIsBack = true) => {
+        if (rangeStart > rangeEnd) {
+            return true;
+        }
+
+        const sp = findStartNodePositionByCharIndex(rangeStart, true);
+        const ep = findEndNodePositionByCharIndex(rangeEnd, endIsBack);
+        const ap = direction === RANGE_DIRECTION.FORWARD ? sp : ep;
+        const fp = direction === RANGE_DIRECTION.FORWARD ? ep : sp;
+        if (!isCompatibleTextRange(ap, fp)) {
+            return false;
+        }
+
+        textRanges.push(new TextRange(scene, document, skeleton, ap, fp, style, segmentId, segmentPage));
+        return true;
+    };
+
+    const appendTableRange = (table: DataStreamTreeNode, rangeStart: number, rangeEnd: number) => {
+        const { startIndex: tableStart, endIndex: tableEnd, children: rows } = table;
+        const startRow = rows.find((row) => row.startIndex <= rangeStart && row.endIndex >= rangeStart);
+        const endRow = rows.find((row) => row.startIndex <= rangeEnd && row.endIndex >= rangeEnd);
+        const tableStartOffset = rangeStart > tableStart && rangeStart < tableEnd
+            ? startRow?.startIndex == null ? undefined : startRow.startIndex + 2
+            : tableStart + 3;
+        const tableEndOffset = rangeEnd > tableStart && rangeEnd < tableEnd
+            ? endRow?.endIndex == null ? undefined : endRow.endIndex - 3
+            : tableEnd - 4;
+
+        if (tableStartOffset == null || tableEndOffset == null) {
+            return false;
+        }
+
+        const startPosition = skeleton.findNodePositionByCharIndex(tableStartOffset, true, segmentId, segmentPage);
+        const endPosition = skeleton.findNodePositionByCharIndex(tableEndOffset, true, segmentId, segmentPage);
+        if (startPosition == null || endPosition == null) {
+            return false;
+        }
+
+        const ap = direction === RANGE_DIRECTION.FORWARD ? startPosition : endPosition;
+        const fp = direction === RANGE_DIRECTION.FORWARD ? endPosition : startPosition;
+        rectRanges.push(...convertPositionsToRectRanges(scene, document, skeleton, ap, fp, style, segmentId, segmentPage));
+        return true;
+    };
+
+    const appendColumnRanges = (column: DataStreamTreeNode, rangeStart: number, rangeEnd: number) => {
+        let offset = rangeStart;
+        const tables = getDescendantTables(column).sort((left, right) => left.startIndex - right.startIndex);
+
+        for (const table of tables) {
+            if (table.endIndex < rangeStart || table.startIndex > rangeEnd) {
+                continue;
+            }
+
+            if (!appendTextRange(offset, Math.min(rangeEnd, table.startIndex - 1), false) ||
+                !appendTableRange(table, Math.max(rangeStart, table.startIndex), Math.min(rangeEnd, table.endIndex))) {
+                return false;
+            }
+            offset = table.endIndex + 1;
+        }
+
+        return appendTextRange(offset, rangeEnd);
+    };
+
     let start = startOffset;
     let end = endOffset;
 
-    // TODO: @JOCS handle in header and footer.
-    for (const section of viewModel.getChildren()) {
-        for (const paragraph of section.children) {
-            const { startIndex, endIndex, children } = paragraph;
-            const paragraphIndex = section.children.indexOf(paragraph);
-            const nextParagraph = section.children[paragraphIndex + 1];
-            const table = children[0];
+    try {
+        // TODO: @JOCS handle in header and footer.
+        for (const section of viewModel.getChildren()) {
+            for (const paragraph of section.children) {
+                const { startIndex, endIndex, children } = paragraph;
 
-            let endInTable = false;
-
-            if (table) {
-                const { startIndex: tableStart, endIndex: tableEnd, children } = table;
-                let tableStartPosition = null;
-                let tableEndPosition = null;
-
-                const startRow = children.find((row) => row.startIndex <= startOffset && row.endIndex >= startOffset)!;
-                const endRow = children.find((row) => row.startIndex <= endOffset && row.endIndex >= endOffset)!;
-
-                if (startOffset > tableStart && startOffset < tableEnd) {
-                    tableStartPosition = skeleton.findNodePositionByCharIndex(startRow.startIndex + 2, true, segmentId, segmentPage);
-                    tableEndPosition = skeleton.findNodePositionByCharIndex(tableEnd - 4, true, segmentId, segmentPage);
-                    start = tableEnd + 1;
-                } else if (endOffset > tableStart && endOffset < tableEnd) {
-                    tableStartPosition = skeleton.findNodePositionByCharIndex(tableStart + 3, true, segmentId, segmentPage);
-                    tableEndPosition = skeleton.findNodePositionByCharIndex(endRow.endIndex - 3, true, segmentId, segmentPage);
-                    end = tableStart - 1;
-
-                    endInTable = true;
-                } else if (tableStart > startOffset && tableEnd < endOffset) {
-                    tableStartPosition = skeleton.findNodePositionByCharIndex(tableStart + 3, true, segmentId, segmentPage);
-                    tableEndPosition = skeleton.findNodePositionByCharIndex(tableEnd - 4, true, segmentId, segmentPage);
-
-                    if (start <= tableStart - 1) {
-                        const sp = findStartNodePositionByCharIndex(start, true);
-                        const ep = findEndNodePositionByCharIndex(tableStart - 1, false);
-                        const ap = direction === RANGE_DIRECTION.FORWARD ? sp : ep;
-                        const fp = direction === RANGE_DIRECTION.FORWARD ? ep : sp;
-
-                        textRanges.push(new TextRange(scene, document, skeleton, ap, fp, style, segmentId, segmentPage));
+                if (paragraph.nodeType === DataStreamTreeNodeType.COLUMN_GROUP && start <= endIndex && end >= startIndex) {
+                    if (start < startIndex && !appendTextRange(start, Math.min(end, startIndex - 1), false)) {
+                        disposeRangeList({ textRanges, rectRanges });
+                        return;
                     }
 
-                    start = tableEnd + 1;
-                }
+                    for (const column of children.filter((child) => child.nodeType === DataStreamTreeNodeType.COLUMN)) {
+                        const columnStart = Math.max(start, column.startIndex + 1);
+                        const columnEnd = Math.min(end, column.endIndex - 1);
+                        if (columnStart <= columnEnd && !appendColumnRanges(column, columnStart, columnEnd)) {
+                            disposeRangeList({ textRanges, rectRanges });
+                            return;
+                        }
+                    }
 
-                if (tableStartPosition && tableEndPosition) {
-                    const ap = direction === RANGE_DIRECTION.FORWARD ? tableStartPosition : tableEndPosition;
-                    const fp = direction === RANGE_DIRECTION.FORWARD ? tableEndPosition : tableStartPosition;
-
-                    rectRanges.push(...convertPositionsToRectRanges(
-                        scene,
-                        document,
-                        skeleton,
-                        ap,
-                        fp,
-                        style,
-                        segmentId,
-                        segmentPage
-                    ));
-                }
-            }
-
-            // TO fix https://github.com/dream-num/univer-pro/issues/3437.
-            if (end === endIndex + 1 && !endInTable && nextParagraph && nextParagraph.children.length) {
-                end = endIndex;
-                endInTable = true;
-            }
-
-            if ((end >= startIndex && end <= endIndex) || endInTable) {
-                const sp = findStartNodePositionByCharIndex(start, true);
-                const ep = findEndNodePositionByCharIndex(end, !endInTable);
-                const ap = direction === RANGE_DIRECTION.FORWARD ? sp : ep;
-                const fp = direction === RANGE_DIRECTION.FORWARD ? ep : sp;
-
-                // Can not create cursor(startOffset === endOffset) and rect range at the same time.
-                if (rectRanges.length && Tools.diffValue(ap, fp)) {
+                    start = endIndex + 1;
                     continue;
                 }
 
-                textRanges.push(new TextRange(scene, document, skeleton, ap, fp, style, segmentId, segmentPage));
+                const paragraphIndex = section.children.indexOf(paragraph);
+                const nextParagraph = section.children[paragraphIndex + 1];
+                const table = children.find((child) => child.nodeType === DataStreamTreeNodeType.TABLE);
+                const nextTable = nextParagraph?.children.find((child) => child.nodeType === DataStreamTreeNodeType.TABLE);
+
+                let endInTable = false;
+
+                if (table) {
+                    const { startIndex: tableStart, endIndex: tableEnd, children } = table;
+                    let tableStartPosition = null;
+                    let tableEndPosition = null;
+
+                    if (startOffset > tableStart && startOffset < tableEnd) {
+                        const startRow = children.find((row) => row.startIndex <= startOffset && row.endIndex >= startOffset);
+                        if (startRow == null) {
+                            disposeRangeList({ textRanges, rectRanges });
+                            return;
+                        }
+
+                        tableStartPosition = skeleton.findNodePositionByCharIndex(startRow.startIndex + 2, true, segmentId, segmentPage);
+                        tableEndPosition = skeleton.findNodePositionByCharIndex(tableEnd - 4, true, segmentId, segmentPage);
+                        start = tableEnd + 1;
+                    } else if (endOffset > tableStart && endOffset < tableEnd) {
+                        const endRow = children.find((row) => row.startIndex <= endOffset && row.endIndex >= endOffset);
+                        if (endRow == null) {
+                            disposeRangeList({ textRanges, rectRanges });
+                            return;
+                        }
+
+                        tableStartPosition = skeleton.findNodePositionByCharIndex(tableStart + 3, true, segmentId, segmentPage);
+                        tableEndPosition = skeleton.findNodePositionByCharIndex(endRow.endIndex - 3, true, segmentId, segmentPage);
+                        end = tableStart - 1;
+
+                        endInTable = true;
+                    } else if (tableStart > startOffset && tableEnd < endOffset) {
+                        tableStartPosition = skeleton.findNodePositionByCharIndex(tableStart + 3, true, segmentId, segmentPage);
+                        tableEndPosition = skeleton.findNodePositionByCharIndex(tableEnd - 4, true, segmentId, segmentPage);
+
+                        if (start <= tableStart - 1) {
+                            const sp = findStartNodePositionByCharIndex(start, true);
+                            const ep = findEndNodePositionByCharIndex(tableStart - 1, false);
+                            const ap = direction === RANGE_DIRECTION.FORWARD ? sp : ep;
+                            const fp = direction === RANGE_DIRECTION.FORWARD ? ep : sp;
+
+                            if (!isCompatibleTextRange(ap, fp)) {
+                                disposeRangeList({ textRanges, rectRanges });
+                                return;
+                            }
+
+                            textRanges.push(new TextRange(scene, document, skeleton, ap, fp, style, segmentId, segmentPage));
+                        }
+
+                        start = tableEnd + 1;
+                    }
+
+                    if (tableStartPosition && tableEndPosition) {
+                        const ap = direction === RANGE_DIRECTION.FORWARD ? tableStartPosition : tableEndPosition;
+                        const fp = direction === RANGE_DIRECTION.FORWARD ? tableEndPosition : tableStartPosition;
+
+                        rectRanges.push(...convertPositionsToRectRanges(
+                            scene,
+                            document,
+                            skeleton,
+                            ap,
+                            fp,
+                            style,
+                            segmentId,
+                            segmentPage
+                        ));
+                    }
+                }
+
+            // TO fix https://github.com/dream-num/univer-pro/issues/3437.
+                if (end === endIndex + 1 && !endInTable && nextTable) {
+                    end = endIndex;
+                    endInTable = true;
+                }
+
+                if ((end >= startIndex && end <= endIndex) || endInTable) {
+                    const sp = findStartNodePositionByCharIndex(start, true);
+                    const ep = findEndNodePositionByCharIndex(end, !endInTable);
+                    const ap = direction === RANGE_DIRECTION.FORWARD ? sp : ep;
+                    const fp = direction === RANGE_DIRECTION.FORWARD ? ep : sp;
+
+                // Can not create cursor(startOffset === endOffset) and rect range at the same time.
+                    if (rectRanges.length && Tools.diffValue(ap, fp)) {
+                        continue;
+                    }
+
+                    if (!isCompatibleTextRange(ap, fp)) {
+                        disposeRangeList({ textRanges, rectRanges });
+                        return;
+                    }
+
+                    textRanges.push(new TextRange(scene, document, skeleton, ap, fp, style, segmentId, segmentPage));
+                }
             }
         }
-    }
 
-    return {
-        textRanges,
-        rectRanges,
-    };
+        return {
+            textRanges,
+            rectRanges,
+        };
+    } catch (error) {
+        disposeRangeList({ textRanges, rectRanges });
+        throw error;
+    }
 }
 
 export function getCanvasOffsetByEngine(engine: Nullable<Engine>) {


### PR DESCRIPTION
## What changed

- split selections at column-group and nested table boundaries
- support progressive select-all from paragraph to column, column group, and document
- dispose partially created ranges when selection conversion fails
- keep drag selection isolated across column pages

## Why

Document selections previously assumed a single render page or table boundary. Column groups introduce nested pages and structural tokens, which could create invalid cross-page text ranges, misclassify child nodes as tables, or leak partially created ranges after an error.

## Impact

Users can select and drag across column groups, including columns containing tables, without invalid range construction or interrupted selection updates.

## Validation

- `pnpm exec vitest run packages/docs-ui/src/commands/commands/__tests__/misc.command.spec.ts packages/docs-ui/src/services/selection/__tests__/selection-utils.spec.ts` (85 tests)
- `pnpm --filter @univerjs/docs-ui typecheck`
- `git diff --check`
