### PR TITLE
fix(engine-render): respect disabled move boundary on resize

### DIFF
--- a/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
+++ b/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
@@ -532,6 +532,9 @@ describe('engine scene viewport extra', () => {
         };
         (transformer as any)._recoverySizeBoundary([recoveryTarget], 0, 0, 100, 80);
         expect(recoveryTarget.transformByState).toHaveBeenCalled();
+        recoveryTarget.transformByState.mockClear();
+        (freeMoveTransformer as any)._recoverySizeBoundary([recoveryTarget], 0, 0, 100, 80);
+        expect(recoveryTarget.transformByState).not.toHaveBeenCalled();
 
         expect((transformer as any)._getRotateAnchorCursor('__SpreadsheetTransformerResizeLM__')).toBe(CURSOR_TYPE.WEST_RESIZE);
         expect((transformer as any)._getRotateAnchorCursor('__SpreadsheetTransformerResizeCB__')).toBe(CURSOR_TYPE.SOUTH_RESIZE);

--- a/packages/engine-render/src/scene.transformer.ts
+++ b/packages/engine-render/src/scene.transformer.ts
@@ -1186,6 +1186,9 @@ export class Transformer extends Disposable implements ITransformerConfig {
     private _recoverySizeBoundary(selectedObjects: BaseObject[], ancestorLeft: number, ancestorTop: number, topSceneWidth: number, topSceneHeight: number) {
         for (let i = 0; i < selectedObjects.length; i++) {
             const moveObject = selectedObjects[i];
+            if (this._getConfig(moveObject).moveBoundaryEnabled === false) {
+                continue;
+            }
             const { left, top, width, height } = moveObject;
 
             const newTransform: ITransformState = {};


### PR DESCRIPTION
## What changed

- Skip resize boundary recovery when the resolved transformer configuration has `moveBoundaryEnabled: false`.
- Add a regression assertion for an object crossing the scene's top-left boundary.

## Why

Move interactions already honor `moveBoundaryEnabled`, but resize mouse-up always called boundary recovery. On free-canvas surfaces such as Board, resizing an element across the scene boundary therefore rewrote its position and dimensions on pointer-up, which appeared as a bounce.

This makes resize recovery consistent with the existing boundary configuration without adding a new API.

## Impact

Transformers with boundary handling enabled keep their existing behavior. Transformers that explicitly disable movement boundaries can now resize across scene boundaries without snapping back.

## Validation

- `pnpm test -- engine-scene-viewport.spec.ts -t "covers transformer geometry and state helper branches" --reporter=verbose`
- 89 test files passed; 770 tests passed, 59 skipped
- `git diff --check`
