### PR TITLE
fix(formula): preserve dirty data across restarts

### DIFF
--- a/packages/engine-formula/src/services/__tests__/calculate-formula.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/calculate-formula.service.spec.ts
@@ -25,7 +25,7 @@ import { Interpreter } from '../../engine/interpreter/interpreter';
 import { FORMULA_REF_TO_ARRAY_CACHE } from '../../engine/reference-object/base-reference-object';
 import { CalculateFormulaService, ICalculateFormulaService } from '../calculate-formula.service';
 import { IFormulaCurrentConfigService } from '../current-data.service';
-import { FormulaExecuteStageType, IFormulaRuntimeService } from '../runtime.service';
+import { FormulaExecutedStateType, FormulaExecuteStageType, IFormulaRuntimeService } from '../runtime.service';
 
 function createService() {
     const configService = {
@@ -483,7 +483,38 @@ describe('CalculateFormulaService', () => {
 
         expect(mocks.runtimeService.setFormulaExecuteStage).toHaveBeenCalledWith(FormulaExecuteStageType.IDLE);
         expect(mocks.runtimeService.markedAsStopFunctionsExecuted).toHaveBeenCalledTimes(1);
-        expect(completed.length).toBe(1);
+        expect(completed).toEqual([]);
+    });
+
+    it('should emit one terminal notification when execution stops', async () => {
+        const { service, mocks } = createService();
+        mocks.formulaDependencyGenerator.generate.mockResolvedValueOnce([
+            {
+                row: 1,
+                column: 1,
+                rowCount: 10,
+                columnCount: 10,
+                subUnitId: 's',
+                unitId: 'u',
+                nodeData: null,
+                getDirtyData: null,
+                featureId: null,
+                formulaId: null,
+                refOffsetX: 0,
+                refOffsetY: 0,
+            },
+        ] as never);
+        mocks.runtimeService.isStopExecution.mockReturnValue(true);
+        mocks.runtimeService.getAllRuntimeData.mockReturnValue({
+            functionsExecutedState: FormulaExecutedStateType.STOP_EXECUTION,
+        } as never);
+        const completed: unknown[] = [];
+        service.executionCompleteListener$.subscribe((item) => completed.push(item));
+
+        await service.execute({ maxIteration: 3 } as never);
+        await vi.waitFor(() => expect(mocks.runtimeService.reset).toHaveBeenCalledTimes(2));
+
+        expect(completed).toHaveLength(1);
     });
 
     it('should mark no-functions-executed when tree list is empty', async () => {

--- a/packages/engine-formula/src/services/__tests__/formula-calculation-trigger.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/formula-calculation-trigger.service.spec.ts
@@ -77,12 +77,12 @@ describe('FormulaCalculationTriggerService', () => {
         });
 
         testBed.emit({ id: 'sheet-dirty' } as ICommandInfo, { fromChangeset: true });
-        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(10);
         expect(testBed.executed).toEqual([]);
 
         testBed.service.start();
         testBed.emit({ id: SetTriggerFormulaCalculationStartMutation.id } as ICommandInfo);
-        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(10);
 
         expect(testBed.executed).toHaveLength(1);
         expect(testBed.executed[0]).toMatchObject({
@@ -112,7 +112,7 @@ describe('FormulaCalculationTriggerService', () => {
 
         testBed.emit({ id: 'sheet-dirty' } as ICommandInfo);
         testBed.emit({ id: 'base-dirty' } as ICommandInfo);
-        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(10);
 
         expect(testBed.executed).toHaveLength(1);
         expect(testBed.executed[0]).toMatchObject({
@@ -128,27 +128,89 @@ describe('FormulaCalculationTriggerService', () => {
         testBed.service.dispose();
     });
 
-    it('keeps all pending dirty data when an active calculation is stopped and restarted', async () => {
+    it('stops once and requeues running dirty data when ranges intersect', async () => {
         const testBed = createTestBed();
-        testBed.conversions.set('base-dirty', {
-            commandId: 'base-dirty',
-            getDirtyData: () => ({ dirtySuperTableMap: { 'base-unit': { Pricing: '1' } } }),
+        testBed.conversions.set('initial-dirty', {
+            commandId: 'initial-dirty',
+            getDirtyData: () => ({
+                dirtyRanges: [{ unitId: 'unit', sheetId: 'sheet', range: { startRow: 0, startColumn: 0, endRow: 1, endColumn: 1 } }],
+            }),
+        });
+        testBed.conversions.set('overlapping-dirty', {
+            commandId: 'overlapping-dirty',
+            getDirtyData: () => ({
+                dirtyRanges: [{ unitId: 'unit', sheetId: 'sheet', range: { startRow: 1, startColumn: 1, endRow: 2, endColumn: 2 } }],
+            }),
         });
 
-        testBed.emit({ id: SetFormulaCalculationStartMutation.id, params: {} } as ICommandInfo);
-        testBed.emit({ id: 'base-dirty' } as ICommandInfo);
-        await vi.advanceTimersByTimeAsync(100);
+        testBed.emit({ id: 'initial-dirty' } as ICommandInfo);
+        await vi.advanceTimersByTimeAsync(10);
+        testBed.executed.length = 0;
+
+        testBed.emit({ id: 'overlapping-dirty' } as ICommandInfo);
+        await vi.advanceTimersByTimeAsync(10);
 
         expect(testBed.executed[0]).toMatchObject({ id: SetFormulaCalculationStopMutation.id });
+
+        testBed.emit({ id: 'overlapping-dirty' } as ICommandInfo);
+        await vi.advanceTimersByTimeAsync(10);
+        expect(testBed.executed).toHaveLength(1);
 
         testBed.emit({
             id: SetFormulaCalculationNotificationMutation.id,
             params: { functionsExecutedState: FormulaExecutedStateType.STOP_EXECUTION },
         } as ICommandInfo);
 
+        expect(testBed.executed).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(10);
         expect(testBed.executed[1]).toMatchObject({
             id: SetFormulaCalculationStartMutation.id,
-            params: { dirtySuperTableMap: { 'base-unit': { Pricing: '1' } } },
+            params: {
+                dirtyRanges: [
+                    { unitId: 'unit', sheetId: 'sheet', range: { startRow: 0, startColumn: 0, endRow: 1, endColumn: 1 } },
+                    { unitId: 'unit', sheetId: 'sheet', range: { startRow: 1, startColumn: 1, endRow: 2, endColumn: 2 } },
+                ],
+            },
+        });
+        testBed.service.dispose();
+    });
+
+    it('waits for success when dirty data does not intersect and only starts pending data', async () => {
+        const testBed = createTestBed();
+        testBed.conversions.set('initial-dirty', {
+            commandId: 'initial-dirty',
+            getDirtyData: () => ({
+                dirtyRanges: [{ unitId: 'unit', sheetId: 'sheet', range: { startRow: 0, startColumn: 0, endRow: 0, endColumn: 0 } }],
+            }),
+        });
+        testBed.conversions.set('non-overlapping-dirty', {
+            commandId: 'non-overlapping-dirty',
+            getDirtyData: () => ({
+                dirtyRanges: [{ unitId: 'unit', sheetId: 'sheet', range: { startRow: 10, startColumn: 10, endRow: 10, endColumn: 10 } }],
+            }),
+        });
+
+        testBed.emit({ id: 'initial-dirty' } as ICommandInfo);
+        await vi.advanceTimersByTimeAsync(10);
+        testBed.executed.length = 0;
+
+        testBed.emit({ id: 'non-overlapping-dirty' } as ICommandInfo);
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect(testBed.executed).toEqual([]);
+
+        testBed.emit({
+            id: SetFormulaCalculationNotificationMutation.id,
+            params: { functionsExecutedState: FormulaExecutedStateType.SUCCESS },
+        } as ICommandInfo);
+
+        expect(testBed.executed).toEqual([]);
+        await vi.advanceTimersByTimeAsync(10);
+        expect(testBed.executed[0]).toMatchObject({
+            id: SetFormulaCalculationStartMutation.id,
+            params: {
+                dirtyRanges: [{ unitId: 'unit', sheetId: 'sheet', range: { startRow: 10, startColumn: 10, endRow: 10, endColumn: 10 } }],
+            },
         });
         testBed.service.dispose();
     });
@@ -162,7 +224,7 @@ describe('FormulaCalculationTriggerService', () => {
         });
 
         testBed.emit({ id: 'local-result' } as ICommandInfo);
-        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(10);
 
         expect(testBed.executed).toEqual([]);
         testBed.service.dispose();
@@ -180,11 +242,11 @@ describe('FormulaCalculationTriggerService', () => {
         });
 
         testBed.emit({ id: 'empty-dirty' } as ICommandInfo);
-        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(10);
         expect(testBed.executed).toEqual([]);
 
         testBed.emit({ id: SetTriggerFormulaCalculationStartMutation.id } as ICommandInfo);
-        await vi.advanceTimersByTimeAsync(100);
+        await vi.advanceTimersByTimeAsync(10);
 
         expect(testBed.executed).toHaveLength(1);
         expect(testBed.executed[0]).toMatchObject({ id: SetFormulaCalculationStartMutation.id });

--- a/packages/engine-formula/src/services/calculate-formula.service.ts
+++ b/packages/engine-formula/src/services/calculate-formula.service.ts
@@ -157,12 +157,12 @@ export class CalculateFormulaService extends Disposable implements ICalculateFor
         this._executeLock.acquire('FORMULA_EXECUTION_LOCK', async () => {
             for (let i = 0; i < cycleReferenceCount; i++) {
                 this._runtimeService.setFormulaCycleIndex(i);
-                await this._executeStep();
+                const executed = await this._executeStep();
 
                 FORMULA_REF_TO_ARRAY_CACHE.clear();
 
                 const isCycleDependency = this._runtimeService.isCycleDependency();
-                if (!isCycleDependency) {
+                if (!executed || !isCycleDependency) {
                     break;
                 }
             }
@@ -343,7 +343,6 @@ export class CalculateFormulaService extends Disposable implements ICalculateFor
                 if (this._runtimeService.isStopExecution() || (nodeData == null && getDirtyData == null)) {
                     this._runtimeService.setFormulaExecuteStage(FormulaExecuteStageType.IDLE);
                     this._runtimeService.markedAsStopFunctionsExecuted();
-                    this._executionCompleteListener$.next(this._runtimeService.getAllRuntimeData());
                     return;
                 }
             }

--- a/packages/engine-formula/src/services/formula-calculation-trigger.service.ts
+++ b/packages/engine-formula/src/services/formula-calculation-trigger.service.ts
@@ -18,7 +18,7 @@ import type { ICommandInfo, IUnitRange, Nullable } from '@univerjs/core';
 import type { IDirtyUnitFeatureMap } from '../basics/common';
 import type { ISetFormulaCalculationNotificationMutation } from '../commands/mutations/set-formula-calculation.mutation';
 import type { IFormulaDirtyData } from './current-data.service';
-import { Disposable, ICommandService } from '@univerjs/core';
+import { Disposable, ICommandService, Rectangle } from '@univerjs/core';
 import {
     SetFormulaCalculationNotificationMutation,
     SetFormulaCalculationStartMutation,
@@ -29,7 +29,7 @@ import { IActiveDirtyManagerService } from './active-dirty-manager.service';
 import { FormulaExecutedStateType } from './runtime.service';
 
 const LOCAL_ONLY = { onlyLocal: true };
-const CALCULATION_DEBOUNCE_TIME = 100;
+const CALCULATION_DEBOUNCE_TIME = 10;
 
 type IDirtyUnitStringMap = Record<string, Nullable<Record<string, string>>>;
 
@@ -40,11 +40,13 @@ type IDirtyUnitStringMap = Record<string, Nullable<Record<string, string>>>;
  */
 export class FormulaCalculationTriggerService extends Disposable {
     private _waitingCommandQueue: ICommandInfo[] = [];
-    private _executingDirtyData = createEmptyDirtyData();
+    private _pendingDirtyData = createEmptyDirtyData();
+    private _runningDirtyData = createEmptyDirtyData();
     private _timer: ReturnType<typeof setTimeout> | undefined;
     private _started = false;
     private _executionInProgress = false;
-    private _restartCalculation = false;
+    private _hasPendingCalculation = false;
+    private _stopRequested = false;
 
     constructor(
         @ICommandService private readonly _commandService: ICommandService,
@@ -66,7 +68,8 @@ export class FormulaCalculationTriggerService extends Disposable {
     override dispose(): void {
         clearTimeout(this._timer);
         this._waitingCommandQueue = [];
-        this._executingDirtyData = createEmptyDirtyData();
+        this._pendingDirtyData = createEmptyDirtyData();
+        this._runningDirtyData = createEmptyDirtyData();
         super.dispose();
     }
 
@@ -96,7 +99,7 @@ export class FormulaCalculationTriggerService extends Disposable {
     }
 
     private _scheduleFlush(): void {
-        if (!this._started || this._waitingCommandQueue.length === 0) {
+        if (!this._started || (this._waitingCommandQueue.length === 0 && !this._hasPendingCalculation)) {
             return;
         }
 
@@ -109,14 +112,20 @@ export class FormulaCalculationTriggerService extends Disposable {
         const dirtyData = this._generateDirty(commands);
         this._waitingCommandQueue = [];
         this._timer = undefined;
-        if (!hasDirtyData(dirtyData) && !commands.some(({ id }) => id === SetTriggerFormulaCalculationStartMutation.id)) {
+        if (hasDirtyData(dirtyData) || commands.some(({ id }) => id === SetTriggerFormulaCalculationStartMutation.id)) {
+            this._pendingDirtyData = mergeDirtyData(this._pendingDirtyData, dirtyData);
+            this._hasPendingCalculation = true;
+        }
+
+        if (!this._hasPendingCalculation) {
             return;
         }
 
-        this._executingDirtyData = mergeDirtyData(this._executingDirtyData, dirtyData);
         if (this._executionInProgress) {
-            this._restartCalculation = true;
-            this._commandService.executeCommand(SetFormulaCalculationStopMutation.id, {}, LOCAL_ONLY);
+            if (!this._stopRequested && dirtyDataIntersects(this._runningDirtyData, this._pendingDirtyData)) {
+                this._stopRequested = true;
+                this._commandService.executeCommand(SetFormulaCalculationStopMutation.id, {}, LOCAL_ONLY);
+            }
             return;
         }
 
@@ -124,10 +133,14 @@ export class FormulaCalculationTriggerService extends Disposable {
     }
 
     private _startCalculation(): void {
+        this._runningDirtyData = this._pendingDirtyData;
+        this._pendingDirtyData = createEmptyDirtyData();
+        this._hasPendingCalculation = false;
         this._executionInProgress = true;
+        this._stopRequested = false;
         this._commandService.executeCommand(
             SetFormulaCalculationStartMutation.id,
-            { ...this._executingDirtyData },
+            { ...this._runningDirtyData },
             LOCAL_ONLY
         );
     }
@@ -143,15 +156,23 @@ export class FormulaCalculationTriggerService extends Disposable {
             return;
         }
 
-        this._executionInProgress = false;
-        if (state === FormulaExecutedStateType.STOP_EXECUTION && this._restartCalculation) {
-            this._restartCalculation = false;
-            this._startCalculation();
+        const calculationCompleted = state === FormulaExecutedStateType.STOP_EXECUTION ||
+            state === FormulaExecutedStateType.SUCCESS ||
+            state === FormulaExecutedStateType.NOT_EXECUTED;
+        if (!calculationCompleted || !this._executionInProgress) {
             return;
         }
 
-        this._restartCalculation = false;
-        this._executingDirtyData = createEmptyDirtyData();
+        this._executionInProgress = false;
+        this._stopRequested = false;
+        if (state === FormulaExecutedStateType.STOP_EXECUTION) {
+            this._pendingDirtyData = mergeDirtyData(this._runningDirtyData, this._pendingDirtyData);
+        }
+        this._runningDirtyData = createEmptyDirtyData();
+
+        if (this._hasPendingCalculation || this._waitingCommandQueue.length > 0) {
+            this._scheduleFlush();
+        }
     }
 
     private _generateDirty(commands: ICommandInfo[]): IFormulaDirtyData {
@@ -191,19 +212,18 @@ function mergeDirtyData(left: IFormulaDirtyData, right: Partial<IFormulaDirtyDat
 }
 
 function mergeDirtyRanges(target: IUnitRange[], source: IUnitRange[]): void {
+    const keys = new Set(target.map(getDirtyRangeKey));
     source.forEach((range) => {
-        const duplicate = target.some((item) =>
-            item.unitId === range.unitId &&
-            item.sheetId === range.sheetId &&
-            item.range.startRow === range.range.startRow &&
-            item.range.startColumn === range.range.startColumn &&
-            item.range.endRow === range.range.endRow &&
-            item.range.endColumn === range.range.endColumn
-        );
-        if (!duplicate) {
+        const key = getDirtyRangeKey(range);
+        if (!keys.has(key)) {
+            keys.add(key);
             target.push(range);
         }
     });
+}
+
+function getDirtyRangeKey({ unitId, sheetId, range }: IUnitRange): string {
+    return JSON.stringify([unitId, sheetId, range.startRow, range.startColumn, range.endRow, range.endColumn, range.rangeType]);
 }
 
 function mergeDirtyUnitStringMap(left: IDirtyUnitStringMap, right?: IDirtyUnitStringMap): IDirtyUnitStringMap {
@@ -245,4 +265,50 @@ function hasNestedValue(value: unknown): boolean {
         return true;
     }
     return Object.values(value as Record<string, unknown>).some(hasNestedValue);
+}
+
+function dirtyDataIntersects(left: IFormulaDirtyData, right: IFormulaDirtyData): boolean {
+    if (left.forceCalculation || right.forceCalculation) {
+        return true;
+    }
+
+    const rangesIntersect = left.dirtyRanges.some((leftRange) => right.dirtyRanges.some((rightRange) =>
+        leftRange.unitId === rightRange.unitId &&
+        leftRange.sheetId === rightRange.sheetId &&
+        Rectangle.intersects(leftRange.range, rightRange.range)
+    ));
+    if (rangesIntersect || clearedSheetIntersects(left, right) || clearedSheetIntersects(right, left)) {
+        return true;
+    }
+
+    return [
+        [left.dirtyNameMap, right.dirtyNameMap],
+        [left.dirtyDefinedNameMap, right.dirtyDefinedNameMap],
+        [left.dirtySuperTableMap, right.dirtySuperTableMap],
+        [left.dirtyUnitFeatureMap, right.dirtyUnitFeatureMap],
+        [left.dirtyUnitOtherFormulaMap, right.dirtyUnitOtherFormulaMap],
+        [left.clearDependencyTreeCache, right.clearDependencyTreeCache],
+    ].some(([leftMap, rightMap]) => hasSameNestedKey(leftMap, rightMap));
+}
+
+function clearedSheetIntersects(cleared: IFormulaDirtyData, dirty: IFormulaDirtyData): boolean {
+    return Object.entries(cleared.clearDependencyTreeCache).some(([unitId, sheets]) =>
+        Object.keys(sheets ?? {}).some((sheetId) =>
+            dirty.dirtyRanges.some((range) => range.unitId === unitId && range.sheetId === sheetId) ||
+            dirty.dirtyNameMap[unitId]?.[sheetId] != null ||
+            dirty.dirtyUnitFeatureMap[unitId]?.[sheetId] != null ||
+            dirty.dirtyUnitOtherFormulaMap[unitId]?.[sheetId] != null
+        )
+    );
+}
+
+function hasSameNestedKey(left: unknown, right: unknown): boolean {
+    if (left == null || right == null || typeof left !== 'object' || typeof right !== 'object') {
+        return left != null && right != null;
+    }
+
+    const rightRecord = right as Record<string, unknown>;
+    return Object.entries(left as Record<string, unknown>).some(([key, value]) =>
+        Object.prototype.hasOwnProperty.call(rightRecord, key) && hasSameNestedKey(value, rightRecord[key])
+    );
 }

--- a/packages/sheets-formula/src/controllers/__tests__/trigger-calculation.controller.spec.ts
+++ b/packages/sheets-formula/src/controllers/__tests__/trigger-calculation.controller.spec.ts
@@ -256,6 +256,7 @@ describe('TriggerCalculationController', () => {
         testBed.activeDirtyManagerService.register('formula.test-dirty-restart', {
             commandId: 'formula.test-dirty-restart',
             getDirtyData: () => ({
+                forceCalculation: true,
                 dirtyRanges: [{ unitId: 'test', sheetId: 'sheet1', range: { startRow: 4, startColumn: 0, endRow: 4, endColumn: 1 } }],
             }),
         });
@@ -282,7 +283,7 @@ describe('TriggerCalculationController', () => {
             functionsExecutedState: FormulaExecutedStateType.STOP_EXECUTION,
         });
 
-        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(10);
 
         expect(testBed.executedCommands.findLast((command) => command.id === SetFormulaCalculationStartMutation.id)).toMatchObject({
             options: { onlyLocal: true },


### PR DESCRIPTION
## Summary

- keep running and pending formula dirty data separate behind one 10 ms trailing debounce
- interrupt only when pending dirty data intersects the running calculation; otherwise wait for success
- requeue running dirty data after a stop and emit the stop terminal only once

## Root cause

Interrupted calculations lost their running dirty data, while a duplicate STOP terminal could clear or stall the restarted calculation. The scheduler also stopped every running calculation without considering whether the new dirty data overlapped it.

## Impact

Formula recalculation now preserves all dirty inputs across interruptions, avoids unnecessary restarts for non-overlapping changes, and starts the next calculation after the current result has synchronously completed its success path.

## Validation

- `pnpm vitest run packages/engine-formula/src/services/__tests__/formula-calculation-trigger.service.spec.ts packages/engine-formula/src/services/__tests__/calculate-formula.service.spec.ts packages/sheets-formula/src/controllers/__tests__/trigger-calculation.controller.spec.ts` (24 tests)
- `pnpm --filter @univerjs/engine-formula typecheck`
- `pnpm --filter @univerjs/sheets-formula typecheck`
- ESLint on all changed files (0 errors)

Supersedes #7281 with a branch rebased onto the latest `dev`.
