### PR TITLE
refactor: replace manual subscriptions with useObservable

### DIFF
--- a/packages/docs-drawing-ui/src/views/doc-image-panel/DocDrawingPanel.tsx
+++ b/packages/docs-drawing-ui/src/views/doc-image-panel/DocDrawingPanel.tsx
@@ -14,29 +14,20 @@
  * limitations under the License.
  */
 
-import type { IDrawingParam } from '@univerjs/core';
 import { IDrawingManagerService } from '@univerjs/drawing';
 import { DrawingCommonPanel } from '@univerjs/drawing-ui';
-import { useDependency } from '@univerjs/ui';
-import { useEffect, useState } from 'react';
+import { useDependency, useObservable } from '@univerjs/ui';
 import { DocDrawingPosition } from './DocDrawingPosition';
 import { DocDrawingTextWrap } from './DocDrawingTextWrap';
 
 export const DocDrawingPanel = () => {
     const drawingManagerService = useDependency(IDrawingManagerService);
-    const focusDrawings = drawingManagerService.getFocusDrawings();
-
-    const [drawings, setDrawings] = useState<IDrawingParam[]>(focusDrawings);
-
-    useEffect(() => {
-        const focusDispose = drawingManagerService.focus$.subscribe((drawings) => {
-            setDrawings(drawings);
-        });
-
-        return () => {
-            focusDispose.unsubscribe();
-        };
-    }, []);
+    const drawings = useObservable(
+        () => drawingManagerService.focus$,
+        drawingManagerService.getFocusDrawings(),
+        false,
+        [drawingManagerService]
+    );
 
     return !!drawings?.length && (
         <div className="univer-text-sm">

--- a/packages/docs-thread-comment-ui/src/views/DocThreadCommentPanel.tsx
+++ b/packages/docs-thread-comment-ui/src/views/DocThreadCommentPanel.tsx
@@ -22,7 +22,7 @@ import { DocSelectionManagerService, RichTextEditingMutation } from '@univerjs/d
 import { ThreadCommentPanel } from '@univerjs/thread-comment-ui';
 import { useDependency, useObservable } from '@univerjs/ui';
 import { useEffect, useMemo, useState } from 'react';
-import { debounceTime, filter, Observable } from 'rxjs';
+import { debounceTime, filter, map, Observable } from 'rxjs';
 import { AddDocCommentComment } from '../commands/commands/add-doc-comment.command';
 import { DeleteDocCommentComment } from '../commands/commands/delete-doc-comment.command';
 import { StartAddCommentOperation } from '../commands/operations/show-comment-panel.operation';
@@ -41,7 +41,12 @@ export const DocThreadCommentPanel = () => {
         () => docSelectionManagerService.textSelection$.pipe(debounceTime(16)),
         [docSelectionManagerService.textSelection$]
     );
-    useObservable(selectionChange$);
+    const disableAdd = useObservable(
+        () => selectionChange$.pipe(map(() => shouldDisableAddComment(injector))),
+        shouldDisableAddComment(injector),
+        false,
+        [injector, selectionChange$]
+    );
     const commandService = useDependency(ICommandService);
     const docCommentService = useDependency(DocThreadCommentService);
     const tempComment = useObservable(docCommentService.addingComment$);
@@ -76,8 +81,6 @@ export const DocThreadCommentPanel = () => {
         return null;
     }
 
-    const isInValidSelection = shouldDisableAddComment(injector);
-
     const unitId = doc.getUnitId();
 
     return (
@@ -89,7 +92,7 @@ export const DocThreadCommentPanel = () => {
                 commandService.executeCommand(StartAddCommentOperation.id);
             }}
             getSubUnitName={() => ''}
-            disableAdd={isInValidSelection}
+            disableAdd={disableAdd}
             tempComment={tempComment}
             onAddComment={(comment) => {
                 // attach an comment to an custom-range

--- a/packages/docs-ui/src/views/DocSideMenu.tsx
+++ b/packages/docs-ui/src/views/DocSideMenu.tsx
@@ -15,25 +15,21 @@
  */
 
 import type { DocumentDataModel, IParagraph } from '@univerjs/core';
-import type { IRichTextEditingMutationParams } from '@univerjs/docs';
 import type { IUniverDocsUIConfig } from '../config/config';
 import type { IMutiPageParagraphBound } from '../services/doc-event-manager.service';
 import type { ISideMenuItem } from './SideMenu';
 import {
-    debounce,
     fromEventSubject,
     getPlainText,
-    ICommandService,
     isInternalEditorID,
     IUniverInstanceService,
     NamedStyleType,
     UniverInstanceType,
 } from '@univerjs/core';
-import { RichTextEditingMutation } from '@univerjs/docs';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { useConfigValue, useDependency, useEvent, useObservable } from '@univerjs/ui';
 import { useEffect, useMemo, useState } from 'react';
-import { of, throttleTime } from 'rxjs';
+import { debounceTime, map, startWith, throttleTime } from 'rxjs';
 import { VIEWPORT_KEY } from '../basics/docs-view-key';
 import { DOCS_UI_PLUGIN_CONFIG_KEY } from '../config/config';
 import { DocEventManagerService } from '../services/doc-event-manager.service';
@@ -98,23 +94,47 @@ export function DocSideMenu() {
 }
 
 function DocSideMenuContent() {
-    const commandService = useDependency(ICommandService);
     const instanceService = useDependency(IUniverInstanceService);
     const currentDoc = useObservable(useMemo(() => instanceService.getCurrentTypeOfUnit$<DocumentDataModel>(UniverInstanceType.UNIVER_DOC), []));
     const renderManagerService = useDependency(IRenderManagerService);
-    const fullDataStream = currentDoc?.getBody()?.dataStream ?? '';
-    const [_updateKey, setUpdateKey] = useState(0);
+    const documentData = useObservable(
+        currentDoc
+            ? () => currentDoc.change$.pipe(
+                debounceTime(100),
+                map(() => currentDoc.getSnapshot())
+            )
+            : null,
+        currentDoc?.getSnapshot(),
+        false,
+        [currentDoc]
+    );
+    const fullDataStream = documentData?.body?.dataStream ?? '';
     const [activeId, setActiveId] = useState<string | undefined>(undefined);
     const unitId = currentDoc?.getUnitId() ?? '';
     const renderer = renderManagerService.getRenderById(unitId);
-    const title = currentDoc?.getTitle();
+    const title = documentData?.title;
     const docEventManagerService = renderer?.with(DocEventManagerService);
     const paragraphBounds = docEventManagerService?.paragraphBounds;
-    const left = renderer?.mainComponent?.left ?? 0;
-    const canvasHeight = renderer?.engine.height ?? 0;
-    const scaleY = renderer?.scene.scaleY ?? 1;
+    const readLayout = () => ({
+        left: renderer?.mainComponent?.left ?? 0,
+        canvasHeight: renderer?.engine.height ?? 0,
+        scaleY: renderer?.scene.scaleY ?? 1,
+    });
+    const layout = useObservable(
+        renderer?.engine.onTransformChange$
+            ? () => fromEventSubject(renderer.engine.onTransformChange$).pipe(
+                throttleTime(33),
+                map(readLayout),
+                startWith(readLayout())
+            )
+            : null,
+        readLayout(),
+        false,
+        [renderer]
+    );
+    const { left, canvasHeight, scaleY } = layout;
 
-    const paragraphs = currentDoc?.getBody()?.paragraphs ?? [];
+    const paragraphs = documentData?.body?.paragraphs ?? [];
     const paragraphMap = useMemo(() => {
         const map = new Map<number, IParagraph>();
         paragraphs.forEach((p) => {
@@ -122,7 +142,6 @@ function DocSideMenuContent() {
         });
         return map;
     }, [paragraphs]);
-    useObservable(useMemo(() => (renderer?.engine.onTransformChange$ ? fromEventSubject(renderer?.engine.onTransformChange$).pipe(throttleTime(33)) : of(null)), [renderer?.engine.onTransformChange$]));
     const mode = left < 180 ? 'float' : 'side-bar';
     let minLevel = Infinity;
 
@@ -172,22 +191,6 @@ function DocSideMenuContent() {
         ].filter(Boolean) as ISideMenuItem[];
 
     const [open, setOpen] = useState(true);
-
-    useEffect(() => {
-        const debounceUpdater = debounce(setUpdateKey, 100);
-
-        const sub = commandService.onCommandExecuted((commandInfo) => {
-            if (commandInfo.id === RichTextEditingMutation.id) {
-                const params = commandInfo.params as IRichTextEditingMutationParams;
-                if (params.unitId === currentDoc?.getUnitId()) {
-                    debounceUpdater((prev) => prev + 1);
-                }
-            }
-        });
-        return () => {
-            sub.dispose();
-        };
-    }, [commandService, currentDoc]);
 
     useEffect(() => {
         const viewport = renderer?.scene.getViewport(VIEWPORT_KEY.VIEW_MAIN);

--- a/packages/docs-ui/src/views/Icon.tsx
+++ b/packages/docs-ui/src/views/Icon.tsx
@@ -17,6 +17,7 @@
 import type { IconType, IIconProps } from '@univerjs/ui';
 import { ThemeService } from '@univerjs/core';
 import { useDependency, useObservable } from '@univerjs/ui';
+import { map } from 'rxjs';
 import { getHighlightBackgroundColor } from './paragraph-menu/theme-color';
 
 type ColorSwatchIconProps = IIconProps & {
@@ -175,8 +176,12 @@ function createTextColorSwatchIcon(color: string): IconType {
 function createBackgroundColorSwatchIcon(index: number): IconType {
     return function DocParagraphBackgroundColorSwatchIcon(props: IIconProps) {
         const themeService = useDependency(ThemeService);
-        useObservable(themeService.currentTheme$);
-        const color = getHighlightBackgroundColor(themeService, index);
+        const color = useObservable(
+            () => themeService.currentTheme$.pipe(map(() => getHighlightBackgroundColor(themeService, index))),
+            getHighlightBackgroundColor(themeService, index),
+            false,
+            [index, themeService]
+        );
 
         return <BackgroundColorSwatchIcon {...props} color={color} />;
     };

--- a/packages/docs-ui/src/views/RichTextEditor.tsx
+++ b/packages/docs-ui/src/views/RichTextEditor.tsx
@@ -24,7 +24,9 @@ import { DocSkeletonManagerService } from '@univerjs/docs';
 import { IRenderManagerService } from '@univerjs/engine-render';
 import { useDependency, useEvent, useObservable } from '@univerjs/ui';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { map, merge, startWith } from 'rxjs';
 import { IEditorService } from '../services/editor/editor-manager.service';
+import { DocSelectionRenderService } from '../services/selection/doc-selection-render.service';
 import { createEditorUndoRedoKeyboardConfig, useEditorClickOutside, useIsFocusing, useKeyboardEvent, useResize } from './rich-text-editor/hooks';
 import { useEditor } from './rich-text-editor/hooks/use-editor';
 import { useLeftAndRightArrow } from './rich-text-editor/hooks/use-left-and-right-arrow';
@@ -89,9 +91,33 @@ export const RichTextEditor = (props: IRichTextEditorProps) => {
     });
     const renderManagerService = useDependency(IRenderManagerService);
     const renderer = renderManagerService.getRenderById(editorId);
-    const isFocusing = useIsFocusing(editorId);
+    const selectionIsFocusing = useIsFocusing(editorId);
+    const docSelectionRenderService = renderer?.with(DocSelectionRenderService);
+    const editorFocused = useObservable(
+        editor
+            ? () => merge(
+                editor.focus$,
+                editor.blur$
+            ).pipe(
+                map(() => docSelectionRenderService?.isFocusing ?? false),
+                startWith(docSelectionRenderService?.isFocusing ?? false)
+            )
+            : null,
+        docSelectionRenderService?.isFocusing ?? false,
+        false,
+        [docSelectionRenderService, editor]
+    );
+    const isFocusing = selectionIsFocusing && editorFocused;
     const sheetEmbeddingRef = useRef<HTMLDivElement>(null);
-    const [showPlaceholder, setShowPlaceholder] = useState(() => !BuildTextUtils.transform.getPlainText(editor?.getDocumentData().body?.dataStream ?? ''));
+    const resolveShowPlaceholder = () => !BuildTextUtils.transform.getPlainText(editor?.getDocumentData().body?.dataStream ?? '');
+    const showPlaceholder = useObservable(
+        editor
+            ? () => editor.selectionChange$.pipe(map(resolveShowPlaceholder), startWith(resolveShowPlaceholder()))
+            : null,
+        resolveShowPlaceholder(),
+        false,
+        [editor]
+    );
     const { checkScrollBar } = useResize(editor, isSingle, true, true);
 
     useLayoutEffect(() => {
@@ -113,19 +139,6 @@ export const RichTextEditor = (props: IRichTextEditorProps) => {
         _onChange?.(data, getPlainText(data.body?.dataStream ?? ''));
         checkScrollBar();
     });
-
-    useEffect(() => {
-        setShowPlaceholder(!BuildTextUtils.transform.getPlainText(editor?.getDocumentData().body?.dataStream ?? ''));
-
-        const sub = editor?.selectionChange$.subscribe(() => {
-            setShowPlaceholder(!BuildTextUtils.transform.getPlainText(editor?.getDocumentData().body?.dataStream ?? ''));
-        });
-
-        return () => sub?.unsubscribe();
-    }, [editor]);
-
-    useObservable(editor?.blur$);
-    useObservable(editor?.focus$);
 
     useEffect(() => {
         const data = editor?.getDocumentData();

--- a/packages/docs-ui/src/views/count-bar/ZoomSlider.tsx
+++ b/packages/docs-ui/src/views/count-bar/ZoomSlider.tsx
@@ -16,8 +16,9 @@
 
 import type { DocumentDataModel } from '@univerjs/core';
 import { ICommandService, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
-import { Slider, useDependency } from '@univerjs/ui';
+import { Slider, useDependency, useObservable } from '@univerjs/ui';
 import { useCallback, useEffect, useState } from 'react';
+import { filter } from 'rxjs';
 import { SetDocZoomRatioOperation } from '../../commands/operations/set-doc-zoom-ratio.operation';
 import { getDocEffectiveZoomRatio } from '../../services/doc-zoom';
 
@@ -27,38 +28,28 @@ const DOC_ZOOM_RANGE = [10, 400];
 export function ZoomSlider() {
     const commandService = useDependency(ICommandService);
     const univerInstanceService = useDependency(IUniverInstanceService);
-    const [documentDataModel, setDocumentDataModel] = useState<DocumentDataModel | null>(null);
-    const [zoom, setZoom] = useState<number>(100);
-
+    const documentDataModel = useObservable(
+        () => univerInstanceService.getCurrentTypeOfUnit$<DocumentDataModel>(UniverInstanceType.UNIVER_DOC).pipe(
+            filter((documentDataModel): documentDataModel is DocumentDataModel => documentDataModel != null)
+        ),
+        null,
+        false,
+        [univerInstanceService]
+    );
     const getCurrentZoom = useCallback((docModel: DocumentDataModel | null = documentDataModel) => {
         if (!docModel) return 100;
-
         return Math.round(getDocEffectiveZoomRatio(docModel) * 100);
     }, [documentDataModel]);
+    const [zoom, setZoom] = useState(100);
 
-    useEffect(() => {
-        const currentDoc$ = univerInstanceService.getCurrentTypeOfUnit$<DocumentDataModel>(UniverInstanceType.UNIVER_DOC);
-
-        const subscription = currentDoc$.subscribe((doc) => {
-            if (doc) {
-                setDocumentDataModel(doc);
-                setZoom(getCurrentZoom(doc));
-            }
-        });
-
-        return () => {
-            subscription.unsubscribe();
-        };
-    }, [univerInstanceService, getCurrentZoom]);
+    useEffect(() => setZoom(getCurrentZoom(documentDataModel)), [documentDataModel, getCurrentZoom]);
 
     useEffect(() => {
         const disposable = commandService.onCommandExecuted((commandInfo) => {
             if (commandInfo.id === SetDocZoomRatioOperation.id) {
-                const currentZoom = getCurrentZoom();
-                setZoom(currentZoom);
+                setZoom(getCurrentZoom());
             }
         });
-
         return disposable.dispose;
     }, [commandService, getCurrentZoom]);
 

--- a/packages/docs-ui/src/views/header-footer/panel/DocHeaderFooterPanel.tsx
+++ b/packages/docs-ui/src/views/header-footer/panel/DocHeaderFooterPanel.tsx
@@ -19,8 +19,8 @@ import type { LocaleKey } from '../../../locale/types';
 import { IUniverInstanceService, LocaleService, UniverInstanceType } from '@univerjs/core';
 import { DocSkeletonManagerService } from '@univerjs/docs';
 import { DocumentEditArea, IRenderManagerService } from '@univerjs/engine-render';
-import { useDependency } from '@univerjs/ui';
-import { useEffect, useState } from 'react';
+import { useDependency, useObservable } from '@univerjs/ui';
+import { filter, map } from 'rxjs';
 import { DocHeaderFooterOptions } from './DocHeaderFooterOptions';
 
 export const DocHeaderFooterPanel = () => {
@@ -32,23 +32,15 @@ export const DocHeaderFooterPanel = () => {
     const docSkeletonManagerService = renderManagerService.getRenderUnitById(unitId)?.with(DocSkeletonManagerService);
 
     const viewModel = docSkeletonManagerService!.getViewModel();
-    const [isEditHeaderFooter, setIsEditHeaderFooter] = useState(true);
-
-    useEffect(() => {
-        const editArea = viewModel.getEditArea();
-        setIsEditHeaderFooter(editArea !== DocumentEditArea.BODY);
-
-        const subscription = viewModel.editAreaChange$.subscribe((editArea) => {
-            if (editArea == null) {
-                return;
-            }
-            setIsEditHeaderFooter(editArea !== DocumentEditArea.BODY);
-        });
-
-        return () => {
-            subscription.unsubscribe();
-        };
-    }, []);
+    const isEditHeaderFooter = useObservable(
+        () => viewModel.editAreaChange$.pipe(
+            filter((editArea) => editArea != null),
+            map((editArea) => editArea !== DocumentEditArea.BODY)
+        ),
+        viewModel.getEditArea() !== DocumentEditArea.BODY,
+        false,
+        [viewModel]
+    );
 
     return (
         <div className="univer-text-sm">

--- a/packages/docs-ui/src/views/section-setting/Setting.tsx
+++ b/packages/docs-ui/src/views/section-setting/Setting.tsx
@@ -18,8 +18,8 @@ import type { ReactNode } from 'react';
 import type { LocaleKey } from '../../locale/types';
 import { ColumnSeparatorType, LocaleService, SectionType } from '@univerjs/core';
 import { InputNumber, Select } from '@univerjs/design';
-import { useDependency } from '@univerjs/ui';
-import { useEffect } from 'react';
+import { useDependency, useObservable } from '@univerjs/ui';
+import { useEffect, useMemo } from 'react';
 import { DocSectionSettingController } from '../../controllers/doc-section-setting.controller';
 import { useSectionSetting } from './use-section-setting';
 
@@ -43,6 +43,21 @@ export function SectionSetting() {
     const localeService = useDependency(LocaleService);
     const controller = useDependency(DocSectionSettingController);
     const setting = useSectionSetting();
+    const locale = useObservable(localeService.currentLocale$);
+    const labels = useMemo(() => ({
+        selectedSections: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.selectedSections', String(setting.selectedCount)),
+        columnCount: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.columnCount'),
+        columnGap: `${localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.columnGap')}(px)`,
+        columnSeparator: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.columnSeparator'),
+        none: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.none'),
+        betweenColumns: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.betweenColumns'),
+        sectionStart: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.sectionStart'),
+        unspecified: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.unspecified'),
+        continuous: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.continuous'),
+        nextPage: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.nextPage'),
+        evenPage: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.evenPage'),
+        oddPage: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.oddPage'),
+    }), [locale, localeService, setting.selectedCount]);
 
     useEffect(() => {
         if (!setting.valid) {
@@ -63,37 +78,37 @@ export function SectionSetting() {
                       dark:!univer-text-gray-300
                     "
                 >
-                    {localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.selectedSections', String(setting.selectedCount))}
+                    {labels.selectedSections}
                 </div>
             )}
             <div className="univer-grid univer-gap-3">
-                <SettingRow label={localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.columnCount')}>
+                <SettingRow label={labels.columnCount}>
                     <InputNumber className="univer-w-full" min={1} max={12} step={1} precision={0} value={setting.columnCount} onChange={(value) => value != null && setting.setColumnCount(value)} />
                 </SettingRow>
-                <SettingRow label={`${localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.columnGap')}(px)`}>
+                <SettingRow label={labels.columnGap}>
                     <InputNumber className="univer-w-full" min={0} max={1000} step={1} precision={1} value={setting.columnGap} onChange={(value) => value != null && setting.setColumnGap(value)} />
                 </SettingRow>
-                <SettingRow label={localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.columnSeparator')}>
+                <SettingRow label={labels.columnSeparator}>
                     <Select
                         className="univer-w-full"
                         value={setting.separatorType == null ? '' : String(setting.separatorType)}
                         options={[
-                            { label: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.none'), value: String(ColumnSeparatorType.NONE) },
-                            { label: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.betweenColumns'), value: String(ColumnSeparatorType.BETWEEN_EACH_COLUMN) },
+                            { label: labels.none, value: String(ColumnSeparatorType.NONE) },
+                            { label: labels.betweenColumns, value: String(ColumnSeparatorType.BETWEEN_EACH_COLUMN) },
                         ]}
                         onChange={(value) => setting.setSeparatorType(Number(value))}
                     />
                 </SettingRow>
-                <SettingRow label={localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.sectionStart')}>
+                <SettingRow label={labels.sectionStart}>
                     <Select
                         className="univer-w-full"
                         value={setting.sectionType == null ? '' : String(setting.sectionType)}
                         options={[
-                            { label: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.unspecified'), value: String(SectionType.SECTION_TYPE_UNSPECIFIED) },
-                            { label: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.continuous'), value: String(SectionType.CONTINUOUS) },
-                            { label: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.nextPage'), value: String(SectionType.NEXT_PAGE) },
-                            { label: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.evenPage'), value: String(SectionType.EVEN_PAGE) },
-                            { label: localeService.t<LocaleKey>('docs-ui.doc.sectionSetting.oddPage'), value: String(SectionType.ODD_PAGE) },
+                            { label: labels.unspecified, value: String(SectionType.SECTION_TYPE_UNSPECIFIED) },
+                            { label: labels.continuous, value: String(SectionType.CONTINUOUS) },
+                            { label: labels.nextPage, value: String(SectionType.NEXT_PAGE) },
+                            { label: labels.evenPage, value: String(SectionType.EVEN_PAGE) },
+                            { label: labels.oddPage, value: String(SectionType.ODD_PAGE) },
                         ]}
                         onChange={(value) => setting.setSectionType(Number(value))}
                     />

--- a/packages/docs-ui/src/views/section-setting/index.tsx
+++ b/packages/docs-ui/src/views/section-setting/index.tsx
@@ -15,16 +15,14 @@
  */
 
 import type { ISetTextSelectionsOperationParams } from '@univerjs/docs';
-import { generateRandomId, ICommandService, LocaleService } from '@univerjs/core';
+import { generateRandomId, ICommandService } from '@univerjs/core';
 import { RichTextEditingMutation, SetTextSelectionsOperation } from '@univerjs/docs';
-import { useDependency, useObservable } from '@univerjs/ui';
+import { useDependency } from '@univerjs/ui';
 import { useEffect, useState } from 'react';
 import { SectionSetting } from './Setting';
 
 export function SectionSettingIndex() {
     const commandService = useDependency(ICommandService);
-    const localeService = useDependency(LocaleService);
-    useObservable(localeService.currentLocale$);
     const [key, setKey] = useState(() => generateRandomId(4));
 
     useEffect(() => {

--- a/packages/docs-ui/src/views/section-setting/use-section-setting.ts
+++ b/packages/docs-ui/src/views/section-setting/use-section-setting.ts
@@ -32,6 +32,7 @@ import {
 } from '@univerjs/docs';
 import { useDependency, useObservable } from '@univerjs/ui';
 import { useMemo } from 'react';
+import { combineLatest, map, startWith } from 'rxjs';
 
 const DEFAULT_SECTION_COLUMN_GAP = 18;
 
@@ -106,12 +107,20 @@ export function useSectionSetting() {
         () => instanceService.getCurrentTypeOfUnit$<DocumentDataModel>(UniverInstanceType.UNIVER_DOC),
         [instanceService]
     ));
-    useObservable(selectionManager.textSelection$);
-    useObservable(documentDataModel?.change$);
-    const ranges = selectionManager.getDocRanges();
-    const sections = documentDataModel?.getDocumentStyle().documentFlavor === DocumentFlavor.TRADITIONAL
-        ? getSelectedSections(documentDataModel, ranges)
+    const resolveSections = () => documentDataModel?.getDocumentStyle().documentFlavor === DocumentFlavor.TRADITIONAL
+        ? getSelectedSections(documentDataModel, selectionManager.getDocRanges())
         : [];
+    const sections = useObservable(
+        documentDataModel
+            ? () => combineLatest([
+                selectionManager.textSelection$.pipe(startWith(undefined)),
+                documentDataModel.change$.pipe(startWith(undefined)),
+            ]).pipe(map(resolveSections))
+            : null,
+        resolveSections(),
+        false,
+        [documentDataModel, selectionManager]
+    );
     const values = getSectionSettingValues(sections);
 
     const update = (updates: IDocumentSectionUpdate[]) => {

--- a/packages/drawing-ui/src/views/panel/DrawingArrange.tsx
+++ b/packages/drawing-ui/src/views/panel/DrawingArrange.tsx
@@ -19,8 +19,7 @@ import type { LocaleKey } from '../../locale/types';
 import { ArrangeTypeEnum, ICommandService, LocaleService } from '@univerjs/core';
 import { Button, clsx } from '@univerjs/design';
 import { IDrawingManagerService } from '@univerjs/drawing';
-import { IconManager, useDependency } from '@univerjs/ui';
-import { useEffect, useState } from 'react';
+import { IconManager, useDependency, useObservable } from '@univerjs/ui';
 import { SetDrawingArrangeOperation } from '../../commands/operations/drawing-arrange.operation';
 
 export interface IDrawingArrangeProps {
@@ -41,17 +40,12 @@ export const DrawingArrange = (props: IDrawingArrangeProps) => {
     const TopmostIcon = iconManager.get('TopmostIcon');
     const BottomIcon = iconManager.get('BottomIcon');
 
-    const [drawings, setDrawings] = useState<IDrawingParam[]>(focusDrawings);
-
-    useEffect(() => {
-        const focusDispose = drawingManagerService.focus$.subscribe((drawings) => {
-            setDrawings(drawings);
-        });
-
-        return () => {
-            focusDispose.unsubscribe();
-        };
-    }, []);
+    const drawings = useObservable(
+        () => drawingManagerService.focus$,
+        focusDrawings,
+        false,
+        [drawingManagerService]
+    );
 
     const onArrangeBtnClick = (arrangeType: ArrangeTypeEnum) => {
         commandService.syncExecuteCommand(SetDrawingArrangeOperation.id, { arrangeType, drawings });

--- a/packages/drawing-ui/src/views/panel/DrawingCommonPanel.tsx
+++ b/packages/drawing-ui/src/views/panel/DrawingCommonPanel.tsx
@@ -20,8 +20,8 @@ import { LocaleService } from '@univerjs/core';
 import { clsx } from '@univerjs/design';
 import { IDrawingManagerService } from '@univerjs/drawing';
 import { IRenderManagerService } from '@univerjs/engine-render';
-import { useDependency } from '@univerjs/ui';
-import { useEffect, useState } from 'react';
+import { useDependency, useObservable } from '@univerjs/ui';
+import { filter, map, merge } from 'rxjs';
 import { getUpdateParams } from '../../utils/get-update-params';
 import { DrawingAlign } from './DrawingAlign';
 import { DrawingArrange } from './DrawingArrange';
@@ -80,80 +80,28 @@ export const DrawingCommonPanel = (props: IDrawingCommonPanelProps) => {
     const scene = renderObject?.scene;
     const transformer = scene?.getTransformerByCreate();
 
-    const initialShowState = getPanelShowState(drawings);
-
-    const [arrangeShow, setArrangeShow] = useState(initialShowState.arrangeShow);
-    const [transformShow, setTransformShow] = useState(initialShowState.transformShow);
-    const [alignShow, setAlignShow] = useState(initialShowState.alignShow);
-    const [cropperShow, setCropperShow] = useState(initialShowState.cropperShow);
-    const [nullShow, setNullShow] = useState(initialShowState.nullShow);
-    // const [groupShow, setGroupShow] = useState(false);
-
-    useEffect(() => {
-        if (!transformer) return;
-        const clearControlSub = transformer.clearControl$.subscribe((changeSelf) => {
-            if (changeSelf === true) {
-                setArrangeShow(false);
-                setTransformShow(false);
-                setAlignShow(false);
-                setCropperShow(false);
-                setNullShow(true);
-            }
-        });
-
-        const changeStartSub = transformer.changeStart$.subscribe((state) => {
-            const { objects } = state;
-            const params = getUpdateParams(objects, drawingManagerService);
-
-            if (params.length === 0) {
-                setArrangeShow(false);
-                setTransformShow(false);
-                setAlignShow(false);
-                setCropperShow(false);
-                setNullShow(true);
-            } else if (params.length === 1) {
-                setArrangeShow(true);
-                setTransformShow(true);
-                setAlignShow(false);
-                setCropperShow(true);
-                setNullShow(false);
-            } else {
-                setArrangeShow(true);
-                setTransformShow(false);
-                setAlignShow(true);
-                setCropperShow(false);
-                setNullShow(false);
-            }
-        });
-
-        const focusSub = drawingManagerService.focus$.subscribe((drawings) => {
-            if (drawings.length === 0) {
-                setArrangeShow(false);
-                setTransformShow(false);
-                setAlignShow(false);
-                setCropperShow(false);
-                setNullShow(true);
-            } else if (drawings.length === 1) {
-                setArrangeShow(true);
-                setTransformShow(true);
-                setAlignShow(false);
-                setCropperShow(true);
-                setNullShow(false);
-            } else {
-                setArrangeShow(true);
-                setTransformShow(false);
-                setAlignShow(true);
-                setCropperShow(false);
-                setNullShow(false);
-            }
-        });
-
-        return () => {
-            changeStartSub.unsubscribe();
-            clearControlSub.unsubscribe();
-            focusSub.unsubscribe();
-        };
-    }, [drawingManagerService, transformer]);
+    const panelState = useObservable(
+        () => merge(
+            drawingManagerService.focus$.pipe(map(getPanelShowState)),
+            ...(transformer
+                ? [
+                    transformer.clearControl$.pipe(
+                        filter((changeSelf) => changeSelf === true),
+                        map(() => getPanelShowState([]))
+                    ),
+                    transformer.changeStart$.pipe(
+                        map((state) => getPanelShowState(
+                            getUpdateParams(state.objects, drawingManagerService) as IDrawingParam[]
+                        ))
+                    ),
+                ]
+                : [])
+        ),
+        getPanelShowState(drawings),
+        false,
+        [drawingManagerService, transformer]
+    );
+    const { arrangeShow, transformShow, alignShow, cropperShow, nullShow } = panelState;
 
     if (!drawingParam || !scene || !transformer) {
         return null;

--- a/packages/drawing-ui/src/views/panel/DrawingGroup.tsx
+++ b/packages/drawing-ui/src/views/panel/DrawingGroup.tsx
@@ -20,8 +20,8 @@ import { DrawingTypeEnum, ICommandService, LocaleService } from '@univerjs/core'
 import { Button, clsx } from '@univerjs/design';
 import { IDrawingManagerService } from '@univerjs/drawing';
 import { IRenderManagerService } from '@univerjs/engine-render';
-import { IconManager, useDependency } from '@univerjs/ui';
-import { useEffect, useState } from 'react';
+import { IconManager, useDependency, useObservable } from '@univerjs/ui';
+import { filter, map, merge } from 'rxjs';
 import {
     CancelDrawingGroupOperation,
     SetDrawingGroupOperation,
@@ -44,9 +44,34 @@ export const DrawingGroup = (props: IDrawingGroupProps) => {
     const GroupIcon = iconManager.get('GroupIcon');
     const UngroupIcon = iconManager.get('UngroupIcon');
 
-    const [groupShow, setGroupShow] = useState(false);
-    const [groupBtnShow, setGroupBtnShow] = useState(true);
-    const [ungroupBtnShow, setUngroupBtnShow] = useState(true);
+    const drawingParam = drawings[0];
+    const transformer = drawingParam
+        ? renderManagerService.getRenderById(drawingParam.unitId)?.scene?.getTransformerByCreate()
+        : undefined;
+    const groupState = useObservable(
+        transformer
+            ? () => merge(
+                transformer.clearControl$.pipe(
+                    filter((changeSelf) => changeSelf === true),
+                    map(() => ({ groupShow: false, groupBtnShow: false, ungroupBtnShow: false }))
+                ),
+                transformer.changeStart$.pipe(map((state) => {
+                    const params = getUpdateParams(state.objects, drawingManagerService);
+                    const groupBtnShow = params.length > 1;
+                    const ungroupBtnShow = params.some((item) => item?.drawingType === DrawingTypeEnum.DRAWING_GROUP);
+                    return {
+                        groupShow: groupBtnShow || ungroupBtnShow,
+                        groupBtnShow,
+                        ungroupBtnShow,
+                    };
+                }))
+            )
+            : null,
+        { groupShow: false, groupBtnShow: true, ungroupBtnShow: true },
+        false,
+        [drawingManagerService, transformer]
+    );
+    const { groupShow, groupBtnShow, ungroupBtnShow } = groupState;
 
     const onGroupBtnClick = () => {
         commandService.syncExecuteCommand(SetDrawingGroupOperation.id, { drawings });
@@ -55,57 +80,6 @@ export const DrawingGroup = (props: IDrawingGroupProps) => {
     const onUngroupBtnClick = () => {
         commandService.syncExecuteCommand(CancelDrawingGroupOperation.id, { drawings });
     };
-
-    useEffect(() => {
-        const drawingParam = drawings[0];
-
-        if (drawingParam == null) {
-            return;
-        }
-
-        const { unitId } = drawingParam;
-
-        const renderObject = renderManagerService.getRenderById(unitId);
-        const scene = renderObject?.scene;
-        if (scene == null) {
-            return;
-        }
-        const transformer = scene.getTransformerByCreate();
-
-        const onClearControlObserver = transformer.clearControl$.subscribe((changeSelf) => {
-            if (changeSelf === true) {
-                setGroupShow(false);
-            }
-        });
-
-        const onChangeStartObserver = transformer.changeStart$.subscribe((state) => {
-            const { objects } = state;
-            const params = getUpdateParams(objects, drawingManagerService);
-            const groupParams = params.filter((o) => o?.drawingType === DrawingTypeEnum.DRAWING_GROUP) as IDrawingParam[];
-
-            let groupBtnShow = false;
-            let ungroupBtnShow = false;
-
-            if (params.length > 1) {
-                groupBtnShow = true;
-            }
-
-            if (groupParams.length > 0) {
-                ungroupBtnShow = true;
-            }
-
-            const groupShow = groupBtnShow || ungroupBtnShow;
-
-            setGroupShow(groupShow);
-            setGroupBtnShow(groupBtnShow);
-            setUngroupBtnShow(ungroupBtnShow);
-        });
-
-        return () => {
-            onChangeStartObserver.unsubscribe();
-            onClearControlObserver.unsubscribe();
-        };
-    }, []);
 
     return (
         <div

--- a/packages/sheets-conditional-formatting-ui/src/views/panel/RuleList.tsx
+++ b/packages/sheets-conditional-formatting-ui/src/views/panel/RuleList.tsx
@@ -52,8 +52,8 @@ import {
 } from '@univerjs/sheets-conditional-formatting';
 import { useHighlightRange } from '@univerjs/sheets-ui';
 import { useDependency, useObservable } from '@univerjs/ui';
-import { useEffect, useMemo, useState } from 'react';
-import { debounceTime, Observable } from 'rxjs';
+import { useMemo, useState } from 'react';
+import { debounceTime, filter, map, merge, Observable, share, startWith } from 'rxjs';
 import { ConditionalFormattingI18nController } from '../../controllers/cf.i18n.controller';
 import { Preview } from '../Preview';
 
@@ -145,7 +145,6 @@ export function RuleList(props: IRuleListProps) {
 
     const [currentRuleRanges, setCurrentRuleRanges] = useState<IRange[]>([]);
     const [selectValue, setSelectValue] = useState('2');
-    const [fetchRuleListId, setFetchRuleListId] = useState(0);
     const [draggingId, setDraggingId] = useState<string>('');
 
     const selectOption = [
@@ -174,52 +173,48 @@ export function RuleList(props: IRuleListProps) {
         return [];
     };
 
-    const [ruleList, setRuleList] = useState(getRuleList);
-
-    useHighlightRange(currentRuleRanges);
-
-    useEffect(() => {
-        const disposable = commandService.onCommandExecuted((commandInfo) => {
-            if (commandInfo.id === SetWorksheetActiveOperation.id) {
-                setFetchRuleListId(Math.random());
-            }
-        });
-        return () => disposable.dispose();
-    });
-
-    useEffect(() => {
-        setRuleList(getRuleList);
-    }, [selectValue, fetchRuleListId, unitId, subUnitId]);
-
-    useEffect(() => {
-        if (selectValue === '2') {
-            return;
-        }
-        const subscription =
-            new Observable<null>((commandSubscribe) => {
-                const commandList = [SetSelectionsOperation.id, AddConditionalRuleMutation.id, SetConditionalRuleMutation.id, DeleteConditionalRuleMutation.id, MoveConditionalRuleMutation.id];
+    const ruleList = useObservable(
+        () => {
+            const commandEvent$ = new Observable<'immediate' | 'debounced'>((subscriber) => {
+                const commandList = [
+                    SetSelectionsOperation.id,
+                    AddConditionalRuleMutation.id,
+                    SetConditionalRuleMutation.id,
+                    DeleteConditionalRuleMutation.id,
+                    MoveConditionalRuleMutation.id,
+                ];
                 const disposable = commandService.onCommandExecuted((commandInfo) => {
-                    const { id, params } = commandInfo;
-                    const unitId = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();
-                    if (commandList.includes(id) && (params as { unitId: string }).unitId === unitId) {
-                        commandSubscribe.next(null);
+                    if (commandInfo.id === SetWorksheetActiveOperation.id) {
+                        subscriber.next('immediate');
+                        return;
+                    }
+
+                    const commandUnitId = (commandInfo.params as { unitId?: string } | undefined)?.unitId;
+                    if (selectValue === '1' && commandList.includes(commandInfo.id) && commandUnitId === unitId) {
+                        subscriber.next('debounced');
                     }
                 });
                 return () => disposable.dispose();
-            }).pipe(debounceTime(16)).subscribe(() => {
-                setRuleList(getRuleList);
-            });
-        return () => {
-            subscription.unsubscribe();
-        };
-    }, [univerInstanceService, selectValue, unitId, subUnitId]);
+            }).pipe(share());
 
-    useEffect(() => {
-        const dispose = conditionalFormattingRuleModel.$ruleChange.subscribe(() => {
-            setFetchRuleListId(Math.random());
-        });
-        return () => dispose.unsubscribe();
-    }, [conditionalFormattingRuleModel]);
+            return merge(
+                conditionalFormattingRuleModel.$ruleChange,
+                commandEvent$.pipe(filter((event) => event === 'immediate')),
+                commandEvent$.pipe(
+                    filter((event) => event === 'debounced'),
+                    debounceTime(16)
+                )
+            ).pipe(
+                map(getRuleList),
+                startWith(getRuleList())
+            );
+        },
+        [],
+        false,
+        [commandService, conditionalFormattingRuleModel, selectValue, subUnitId, unitId]
+    );
+
+    useHighlightRange(currentRuleRanges);
 
     const handleDelete = (rule: IConditionFormattingRule) => {
         const unitId = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!.getUnitId();

--- a/packages/sheets-crosshair-highlight/src/views/components/CrosshairHighlight.tsx
+++ b/packages/sheets-crosshair-highlight/src/views/components/CrosshairHighlight.tsx
@@ -18,6 +18,7 @@ import { ThemeService } from '@univerjs/core';
 import { borderClassName, clsx } from '@univerjs/design';
 import { useDependency, useObservable } from '@univerjs/ui';
 import { useCallback } from 'react';
+import { map } from 'rxjs';
 import {
     CROSSHAIR_HIGHLIGHT_COLOR_THEME_PATHS,
     resolveCrosshairHighlightColors,
@@ -35,9 +36,12 @@ export function CrosshairOverlay(props: ICrosshairOverlayProps) {
     const themeService = useDependency(ThemeService);
 
     const currentColor = useObservable(crosshairSrv.color$);
-    useObservable(themeService.currentTheme$);
-
-    const colors = resolveCrosshairHighlightColors(themeService);
+    const colors = useObservable(
+        () => themeService.currentTheme$.pipe(map(() => resolveCrosshairHighlightColors(themeService))),
+        resolveCrosshairHighlightColors(themeService),
+        false,
+        [themeService]
+    );
 
     const handleColorPicked = useCallback((tokenPath: string) => {
         onChange?.(tokenPath);

--- a/packages/sheets-data-validation-ui/src/views/components/DataValidationList.tsx
+++ b/packages/sheets-data-validation-ui/src/views/components/DataValidationList.tsx
@@ -27,7 +27,7 @@ import {
     SheetDataValidationModel,
 } from '@univerjs/sheets-data-validation';
 import { useDependency, useObservable } from '@univerjs/ui';
-import { useEffect, useState } from 'react';
+import { filter, map, startWith } from 'rxjs';
 import { DataValidationPanelService } from '../../services/data-validation-panel.service';
 import { DataValidationItem } from './DataValidationItem';
 
@@ -38,26 +38,21 @@ export function DataValidationList(props: { workbook: Workbook }) {
     const injector = useDependency(Injector);
     const dataValidationPanelService = useDependency(DataValidationPanelService);
     const localeService = useDependency(LocaleService);
-    const [rules, setRules] = useState<ISheetDataValidationRule[]>([]);
-
     const { workbook } = props;
     const worksheet = useObservable(workbook.activeSheet$, undefined, true)!;
     const unitId = workbook.getUnitId();
     const subUnitId = worksheet?.getSheetId();
 
-    useEffect(() => {
-        setRules(sheetDataValidationModel.getRules(unitId, subUnitId));
-
-        const subscription = sheetDataValidationModel.ruleChange$.subscribe((change) => {
-            if (change.unitId === unitId && change.subUnitId === subUnitId) {
-                setRules(sheetDataValidationModel.getRules(unitId, subUnitId));
-            }
-        });
-
-        return () => {
-            subscription.unsubscribe();
-        };
-    }, [unitId, subUnitId, sheetDataValidationModel]);
+    const rules = useObservable(
+        () => sheetDataValidationModel.ruleChange$.pipe(
+            filter((change) => change.unitId === unitId && change.subUnitId === subUnitId),
+            map(() => sheetDataValidationModel.getRules(unitId, subUnitId)),
+            startWith(sheetDataValidationModel.getRules(unitId, subUnitId))
+        ),
+        [],
+        false,
+        [sheetDataValidationModel, subUnitId, unitId]
+    );
 
     const handleAddRule = async () => {
         const rule = createDefaultNewRule(injector);

--- a/packages/sheets-drawing-ui/src/views/sheet-image-panel/SheetDrawingPanel.tsx
+++ b/packages/sheets-drawing-ui/src/views/sheet-image-panel/SheetDrawingPanel.tsx
@@ -14,28 +14,19 @@
  * limitations under the License.
  */
 
-import type { IDrawingParam } from '@univerjs/core';
 import { IDrawingManagerService } from '@univerjs/drawing';
 import { DrawingCommonPanel } from '@univerjs/drawing-ui';
-import { useDependency } from '@univerjs/ui';
-import { useEffect, useState } from 'react';
+import { useDependency, useObservable } from '@univerjs/ui';
 import { SheetDrawingAnchor } from './SheetDrawingAnchor';
 
 export const SheetDrawingPanel = () => {
     const drawingManagerService = useDependency(IDrawingManagerService);
-    const focusDrawings = drawingManagerService.getFocusDrawings();
-
-    const [drawings, setDrawings] = useState<IDrawingParam[]>(focusDrawings);
-
-    useEffect(() => {
-        const focusDispose = drawingManagerService.focus$.subscribe((drawings) => {
-            setDrawings(drawings);
-        });
-
-        return () => {
-            focusDispose.unsubscribe();
-        };
-    }, []);
+    const drawings = useObservable(
+        () => drawingManagerService.focus$,
+        drawingManagerService.getFocusDrawings(),
+        false,
+        [drawingManagerService]
+    );
 
     return !!drawings?.length && (
         <div className="univer-text-sm">

--- a/packages/sheets-formula-ui/src/views/formula-editor/index.tsx
+++ b/packages/sheets-formula-ui/src/views/formula-editor/index.tsx
@@ -51,6 +51,7 @@ import { IRenderManagerService } from '@univerjs/engine-render';
 import { EMBEDDING_FORMULA_EDITOR } from '@univerjs/sheets-ui';
 import { useDependency, useEvent, useObservable, useUpdateEffect } from '@univerjs/ui';
 import { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { map } from 'rxjs';
 import { PLUGIN_CONFIG_KEY_BASE } from '../../config/config';
 import { findIndexFromSequenceNodes, findRefSequenceIndex } from '../range-selector/utils/find-index-from-sequence-nodes';
 import {
@@ -201,9 +202,15 @@ export const FormulaEditor = forwardRef((props: IFormulaEditorProps, ref: Ref<IF
     const isError = errorText !== undefined;
     const univerInstanceService = useDependency(IUniverInstanceService);
     const document = univerInstanceService.getUnit<DocumentDataModel>(editorId);
-    useObservable(document?.change$);
     const getFormulaToken = useFormulaToken();
-    const formulaText = BuildTextUtils.transform.getPlainText(document?.getBody()?.dataStream ?? '');
+    const formulaText = useObservable(
+        document
+            ? () => document.change$.pipe(map(() => BuildTextUtils.transform.getPlainText(document.getBody()?.dataStream ?? '')))
+            : null,
+        BuildTextUtils.transform.getPlainText(document?.getBody()?.dataStream ?? ''),
+        false,
+        [document]
+    );
     const formulaTextRef = useStateRef(formulaText);
     const formulaWithoutEqualSymbol = useMemo(() => getFormulaText(formulaText), [formulaText]);
     const sequenceNodes = useMemo(() => getFormulaToken(formulaWithoutEqualSymbol), [formulaWithoutEqualSymbol, getFormulaToken]);

--- a/packages/sheets-hyper-link-ui/src/views/CellLinkPopup.tsx
+++ b/packages/sheets-hyper-link-ui/src/views/CellLinkPopup.tsx
@@ -16,7 +16,6 @@
 
 import type { ICustomRange, Nullable, Workbook } from '@univerjs/core';
 import type { LocaleKey } from '../locale/types';
-import type { IHyperLinkPopup } from '../services/popup.service';
 import { ICommandService, IUniverInstanceService, LocaleService, UniverInstanceType } from '@univerjs/core';
 import { borderClassName, clsx, MessageType, Tooltip } from '@univerjs/design';
 import { AllBorderIcon, CopyIcon, LinkIcon, SheetsMultiIcon, UnlinkIcon, WriteIcon } from '@univerjs/icons';
@@ -27,8 +26,7 @@ import {
     SheetsHyperLinkParserService,
 } from '@univerjs/sheets-hyper-link';
 import { IEditorBridgeService } from '@univerjs/sheets-ui';
-import { IMessageService, useDependency } from '@univerjs/ui';
-import { useEffect, useState } from 'react';
+import { IMessageService, useDependency, useObservable } from '@univerjs/ui';
 import { OpenHyperLinkEditPanelOperation } from '../commands/operations/popup.operations';
 import { SheetsHyperLinkPopupService } from '../services/popup.service';
 import { SheetsHyperLinkResolverService } from '../services/resolver.service';
@@ -200,18 +198,8 @@ export const CellLinkPopupPure = (props: ICellLinkPopupPureProps) => {
 
 export const CellLinkPopup = () => {
     const popupService = useDependency(SheetsHyperLinkPopupService);
-    const [currentPopup, setCurrentPopup] = useState<IHyperLinkPopup | null>(null);
+    const currentPopup = useObservable(popupService.currentPopup$, popupService.currentPopup);
     const univerInstanceService = useDependency(IUniverInstanceService);
-
-    useEffect(() => {
-        setCurrentPopup(popupService.currentPopup);
-        const ob = popupService.currentPopup$.subscribe((popup) => {
-            setCurrentPopup(popup);
-        });
-        return () => {
-            ob.unsubscribe();
-        };
-    }, [popupService.currentPopup, popupService.currentPopup$]);
 
     if (!currentPopup) {
         return null;

--- a/packages/sheets-thread-comment-ui/src/views/SheetsThreadCommentCell.tsx
+++ b/packages/sheets-thread-comment-ui/src/views/SheetsThreadCommentCell.tsx
@@ -19,6 +19,7 @@ import { IUniverInstanceService, Tools, UniverInstanceType } from '@univerjs/cor
 import { SheetsThreadCommentModel } from '@univerjs/sheets-thread-comment';
 import { ThreadCommentTree, ThreadCommentTreeLocation } from '@univerjs/thread-comment-ui';
 import { useDependency, useObservable } from '@univerjs/ui';
+import { map, startWith } from 'rxjs';
 import { SheetsThreadCommentPopupService } from '../services/sheets-thread-comment-popup.service';
 
 export const SheetsThreadCommentCell = () => {
@@ -26,12 +27,21 @@ export const SheetsThreadCommentCell = () => {
     const sheetsThreadCommentPopupService = useDependency(SheetsThreadCommentPopupService);
     const activePopup = useObservable(sheetsThreadCommentPopupService.activePopup$);
     const sheetThreadCommentModel = useDependency(SheetsThreadCommentModel);
-    useObservable(sheetThreadCommentModel.commentUpdate$);
+    const rootId = useObservable(
+        activePopup
+            ? () => sheetThreadCommentModel.commentUpdate$.pipe(
+                map(() => sheetThreadCommentModel.getByLocation(activePopup.unitId, activePopup.subUnitId, activePopup.row, activePopup.col)),
+                startWith(sheetThreadCommentModel.getByLocation(activePopup.unitId, activePopup.subUnitId, activePopup.row, activePopup.col))
+            )
+            : null,
+        undefined,
+        false,
+        [activePopup, sheetThreadCommentModel]
+    );
     if (!activePopup) {
         return null;
     }
     const { row, col, unitId, subUnitId, trigger } = activePopup;
-    const rootId = sheetThreadCommentModel.getByLocation(unitId, subUnitId, row, col);
     const ref = `${Tools.chatAtABC(col)}${row + 1}`;
     const onClose = () => {
         sheetsThreadCommentPopupService.hidePopup();

--- a/packages/sheets-ui/src/views/CellPopup.tsx
+++ b/packages/sheets-ui/src/views/CellPopup.tsx
@@ -18,7 +18,7 @@ import type { ISheetLocationBase } from '@univerjs/sheets';
 import type { IPopupWithExtraProps } from '@univerjs/ui';
 import { ComponentManager, useDependency, useObservable } from '@univerjs/ui';
 import { useMemo } from 'react';
-import { filter } from 'rxjs';
+import { filter, map } from 'rxjs';
 import { CellPopupManagerService } from '../services/cell-popup-manager.service';
 
 export const CellPopup = (props: { popup: IPopupWithExtraProps<ISheetLocationBase & { direction: 'horizontal' | 'vertical' }> }) => {
@@ -26,12 +26,13 @@ export const CellPopup = (props: { popup: IPopupWithExtraProps<ISheetLocationBas
     const location = popup.extraProps;
     const { row, col, direction, unitId, subUnitId } = location;
     const cellPopupManagerService = useDependency(CellPopupManagerService);
-    useObservable(
+    const popups = useObservable(
         useMemo(() => cellPopupManagerService.change$.pipe(
-            filter((change) => change.row === row && change.col === col && change.direction === direction)
-        ), [cellPopupManagerService, row, col, direction])
+            filter((change) => change.row === row && change.col === col && change.direction === direction),
+            map(() => cellPopupManagerService.getPopups(unitId, subUnitId, row, col, direction))
+        ), [cellPopupManagerService, col, direction, row, subUnitId, unitId]),
+        cellPopupManagerService.getPopups(unitId, subUnitId, row, col, direction)
     );
-    const popups = cellPopupManagerService.getPopups(unitId, subUnitId, row, col, direction);
     const componentManager = useDependency(ComponentManager);
 
     return (

--- a/packages/sheets-ui/src/views/auto-fill-popup-menu/AutoFillPopupMenu.tsx
+++ b/packages/sheets-ui/src/views/auto-fill-popup-menu/AutoFillPopupMenu.tsx
@@ -20,8 +20,9 @@ import { borderClassName, clsx, DropdownMenu } from '@univerjs/design';
 import { convertTransformToOffsetX, convertTransformToOffsetY, IRenderManagerService } from '@univerjs/engine-render';
 import { AutofillDoubleIcon, MoreDownIcon } from '@univerjs/icons';
 import { AUTO_FILL_APPLY_TYPE, IAutoFillService, RefillCommand } from '@univerjs/sheets';
-import { useDependency } from '@univerjs/ui';
+import { useDependency, useObservable } from '@univerjs/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { map } from 'rxjs';
 import { SetScrollOperation } from '../../commands/operations/scroll.operation';
 import { getSheetObject } from '../../controllers/utils/component-tools';
 import { ISheetSelectionRenderService } from '../../services/selection/base-selection-render.service';
@@ -51,10 +52,33 @@ export function AutoFillPopupMenu() {
     const renderManagerService = useDependency(IRenderManagerService);
     const autoFillService = useDependency(IAutoFillService);
     const localeService = useDependency(LocaleService);
-    const [menu, setMenu] = useState<IAutoFillPopupMenuItem[]>([]);
+    const menu = useObservable(
+        () => autoFillService.menu$.pipe(map((items) => items.map((item) => ({
+            ...item,
+            index: items.indexOf(item),
+        })))),
+        [],
+        false,
+        [autoFillService]
+    );
     const [visible, setVisible] = useState(false);
-    const [anchor, setAnchor] = useState<IAnchorPoint>({ row: -1, col: -1 });
-    const [selected, setSelected] = useState<AUTO_FILL_APPLY_TYPE>(AUTO_FILL_APPLY_TYPE.SERIES);
+    const anchor = useObservable(
+        () => autoFillService.showMenu$.pipe(map((show) => {
+            const { source, target } = autoFillService.autoFillLocation || { source: null, target: null };
+            if (!show || !source || !target) {
+                return { row: -1, col: -1 };
+            }
+
+            return {
+                row: Math.max(source.rows[source.rows.length - 1], target.rows[target.rows.length - 1]),
+                col: Math.max(source.cols[source.cols.length - 1], target.cols[target.cols.length - 1]),
+            };
+        })),
+        { row: -1, col: -1 },
+        false,
+        [autoFillService]
+    );
+    const selected = useObservable(autoFillService.applyType$, AUTO_FILL_APPLY_TYPE.SERIES);
     const [isHovered, setHovered] = useState(false);
     const workbook = useActiveWorkbook();
     const { sheetSkeletonManagerService, selectionRenderService } = useMemo(() => {
@@ -97,40 +121,6 @@ export function AutoFillPopupMenu() {
         );
         return disposable?.dispose;
     }, [sheetSkeletonManagerService, forceUpdate]);
-
-    useEffect(() => {
-        const disposable = toDisposable(
-            autoFillService.menu$.subscribe((menu) => {
-                setMenu(menu.map((i) => ({ ...i, index: menu.indexOf(i) })));
-            })
-        );
-        return disposable.dispose;
-    }, [autoFillService]);
-
-    useEffect(() => {
-        const disposable = toDisposable(
-            autoFillService.showMenu$.subscribe((show) => {
-                const { source, target } = autoFillService.autoFillLocation || { source: null, target: null };
-                if (show && source && target) {
-                    const lastRow = Math.max(source.rows[source.rows.length - 1], target.rows[target.rows.length - 1]);
-                    const lastCol = Math.max(source.cols[source.cols.length - 1], target.cols[target.cols.length - 1]);
-                    setAnchor({ row: lastRow, col: lastCol });
-                } else {
-                    setAnchor({ row: -1, col: -1 });
-                }
-            })
-        );
-        return disposable.dispose;
-    }, [autoFillService]);
-
-    useEffect(() => {
-        const disposable = toDisposable(
-            autoFillService.applyType$.subscribe((type) => {
-                setSelected(type);
-            })
-        );
-        return disposable.dispose;
-    }, [autoFillService]);
 
     useEffect(() => {
         function handleClose() {

--- a/packages/sheets-ui/src/views/defined-name/DefinedName.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedName.tsx
@@ -45,8 +45,9 @@ import {
     SheetsSelectionsService,
     WorkbookEditablePermission,
 } from '@univerjs/sheets';
-import { ILayoutService, useDependency } from '@univerjs/ui';
+import { ILayoutService, useDependency, useObservable } from '@univerjs/ui';
 import { useEffect, useRef, useState } from 'react';
+import { map, startWith } from 'rxjs';
 import { ScrollToCellCommand } from '../../commands/commands/set-scroll.command';
 import { genNormalSelectionStyle } from '../../services/selection/const';
 import {
@@ -122,17 +123,12 @@ export function DefinedName({ disable }: { disable: boolean }) {
         });
     };
 
-    const [definedNames, setDefinedNames] = useState<IDefinedNamesServiceParam[]>(() => getDefinedNameMap());
-
-    useEffect(() => {
-        const definedNamesSubscription = definedNamesService.update$.subscribe(() => {
-            setDefinedNames(getDefinedNameMap());
-        });
-
-        return () => {
-            definedNamesSubscription.unsubscribe();
-        };
-    }, []);
+    const definedNames = useObservable(
+        () => definedNamesService.update$.pipe(map(getDefinedNameMap), startWith(getDefinedNameMap())),
+        getDefinedNameMap(),
+        false,
+        [definedNamesService, unitId]
+    );
 
     useEffect(() => {
         const subscription = definedNamesService.currentRange$.subscribe(() => {

--- a/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameContainer.tsx
@@ -32,8 +32,9 @@ import {
     WorkbookEditablePermission,
     WorksheetEditPermission,
 } from '@univerjs/sheets';
-import { useDependency, useVirtualList } from '@univerjs/ui';
-import { useEffect, useRef, useState } from 'react';
+import { useDependency, useObservable, useVirtualList } from '@univerjs/ui';
+import { useRef, useState } from 'react';
+import { map, startWith } from 'rxjs';
 import { DefinedNameInput } from './DefinedNameInput';
 
 export const DefinedNameContainer = () => {
@@ -59,10 +60,14 @@ export const DefinedNameContainer = () => {
     };
 
     const [editState, setEditState] = useState(false);
-    const [definedNames, setDefinedNames] = useState<IDefinedNamesServiceParam[]>([]);
+    const definedNames = useObservable(
+        () => definedNamesService.update$.pipe(map(getDefinedNameMap), startWith(getDefinedNameMap())),
+        getDefinedNameMap(),
+        false,
+        [definedNamesService, unitId]
+    );
     const [editorKey, setEditorKey] = useState<Nullable<string>>(null);
     const [deleteConformKey, setDeleteConformKey] = useState<Nullable<string>>();
-    const [permissionCheckVersion, setPermissionCheckVersion] = useState(0);
 
     const listContainerRef = useRef<HTMLDivElement>(undefined!);
     const [virtualDefinedNames, virtualActions] = useVirtualList(definedNames, {
@@ -76,54 +81,49 @@ export const DefinedNameContainer = () => {
         overscan: 6,
     });
 
-    useEffect(() => {
-        setDefinedNames(getDefinedNameMap());
+    const resolvePermissionState = () => {
+        if (!unitId) {
+            return { workbook: false, worksheets: new Map<string, boolean>() };
+        }
 
-        const definedNamesSubscription = definedNamesService.update$.subscribe(() => {
-            setDefinedNames(getDefinedNameMap());
-        });
-
-        return () => {
-            definedNamesSubscription.unsubscribe();
+        return {
+            workbook: sheetPermissionCheckController.permissionCheckWithoutRange(
+                { workbookTypes: [WorkbookEditablePermission] },
+                unitId
+            ),
+            worksheets: new Map(definedNames.map((definedName) => [
+                definedName.id,
+                !definedName.localSheetId || definedName.localSheetId === SCOPE_WORKBOOK_VALUE_DEFINED_NAME
+                    ? sheetPermissionCheckController.permissionCheckWithoutRange(
+                        { workbookTypes: [WorkbookEditablePermission] },
+                        unitId
+                    )
+                    : sheetPermissionCheckController.permissionCheckWithoutRange(
+                        { worksheetTypes: [WorksheetEditPermission] },
+                        unitId,
+                        definedName.localSheetId
+                    ),
+            ])),
         };
-    }, []);
-
-    // permission point update may cause the permission check result to change, so we need to update the component when permission point update happens
-    useEffect(() => {
-        const permissionSubscription = permissionService.permissionPointUpdate$.subscribe(() => {
-            setPermissionCheckVersion((v) => v + 1);
-        });
-
-        return () => {
-            permissionSubscription.unsubscribe();
-        };
-    }, [permissionService]);
+    };
+    const permissionState = useObservable(
+        () => permissionService.permissionPointUpdate$.pipe(
+            map(resolvePermissionState),
+            startWith(resolvePermissionState())
+        ),
+        resolvePermissionState(),
+        false,
+        [definedNames, permissionService, sheetPermissionCheckController, unitId]
+    );
 
     if (!workbook || !unitId) {
         return;
     }
 
     // check defined name permission
-    const checkWorkbookPermission = sheetPermissionCheckController.permissionCheckWithoutRange(
-        {
-            workbookTypes: [WorkbookEditablePermission],
-        },
-        unitId
-    );
+    const checkWorkbookPermission = permissionState.workbook;
     const checkDefinedNamePermission = (definedName: IDefinedNamesServiceParam): boolean => {
-        const { localSheetId } = definedName;
-
-        if (!localSheetId || localSheetId === SCOPE_WORKBOOK_VALUE_DEFINED_NAME) {
-            return checkWorkbookPermission;
-        }
-
-        return sheetPermissionCheckController.permissionCheckWithoutRange(
-            {
-                worksheetTypes: [WorksheetEditPermission],
-            },
-            unitId,
-            localSheetId
-        );
+        return permissionState.worksheets.get(definedName.id) ?? checkWorkbookPermission;
     };
 
     const insertConfirm = (param: IDefinedNamesServiceParam) => {

--- a/packages/sheets-ui/src/views/defined-name/DefinedNameOverlay.tsx
+++ b/packages/sheets-ui/src/views/defined-name/DefinedNameOverlay.tsx
@@ -21,8 +21,9 @@ import { ICommandService, IUniverInstanceService, LocaleService, UniverInstanceT
 import { borderBottomClassName, clsx, scrollbarClassName } from '@univerjs/design';
 import { IDefinedNamesService } from '@univerjs/engine-formula';
 import { SetWorksheetShowCommand } from '@univerjs/sheets';
-import { ISidebarService, useDependency, useVirtualList } from '@univerjs/ui';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { ISidebarService, useDependency, useObservable, useVirtualList } from '@univerjs/ui';
+import { useEffect, useMemo, useRef } from 'react';
+import { map, startWith } from 'rxjs';
 import { SidebarDefinedNameOperation } from '../../commands/operations/sidebar-defined-name.operation';
 import { DEFINED_NAME_CONTAINER } from './component-name';
 
@@ -45,17 +46,12 @@ export function DefinedNameOverlay({ search, isInputEvent }: { search: string; i
         return [];
     };
 
-    const [definedNames, setDefinedNames] = useState<IDefinedNamesServiceParam[]>(() => getDefinedNameMap());
-
-    useEffect(() => {
-        const definedNamesSubscription = definedNamesService.update$.subscribe(() => {
-            setDefinedNames(getDefinedNameMap());
-        });
-
-        return () => {
-            definedNamesSubscription.unsubscribe();
-        };
-    }, []); // Empty dependency array means this effect runs once on mount and clean up on unmount
+    const definedNames = useObservable(
+        () => definedNamesService.update$.pipe(map(getDefinedNameMap), startWith(getDefinedNameMap())),
+        getDefinedNameMap(),
+        false,
+        [definedNamesService, unitId]
+    );
 
     // When closing the panel, clear the react cache
     useEffect(() => {

--- a/packages/sheets-ui/src/views/editor-container/EditorContainer.tsx
+++ b/packages/sheets-ui/src/views/editor-container/EditorContainer.tsx
@@ -41,6 +41,7 @@ import {
     useSidebarClick,
 } from '@univerjs/ui';
 import { useEffect, useRef, useState } from 'react';
+import { map, startWith } from 'rxjs';
 import {
     SetCellEditVisibleArrowOperation,
     SetCellEditVisibleOperation,
@@ -215,7 +216,6 @@ export function EditorContainer() {
     const rootRef = useRef<HTMLDivElement>(null);
     const pointerRefocusTimerRef = useRef<number | undefined>(undefined);
     const visible = useObservable(editorBridgeService.visible$);
-    const [runtimeFocusRevision, setRuntimeFocusRevision] = useState(0);
     const commandService = useDependency(ICommandService);
     const disableAutoFocus = useObservable(
         () => contextService.subscribeContextValue$(DISABLE_AUTO_FOCUS_KEY),
@@ -226,9 +226,29 @@ export function EditorContainer() {
     const FormulaEditor = componentManager.get(EMBEDDING_FORMULA_EDITOR_COMPONENT_KEY);
     const editState = useObservable(editorBridgeService.currentEditCellState$);
     const darkMode = useObservable(themeService.darkMode$, themeService.darkMode);
+    const focusCoordinator = injector.has(ISheetEmbedRuntimeFocusCoordinator)
+        ? injector.get(ISheetEmbedRuntimeFocusCoordinator)
+        : undefined;
+    const resolveRuntimeFocusState = () => ({
+        activeSessionScope: focusCoordinator?.resolveActiveChildSessionRuntimeScope(),
+        editUnitScope: focusCoordinator?.resolveRuntimeScopeByChildUnitId(editState?.unitId),
+        visibleUnitScope: focusCoordinator?.resolveRuntimeScopeByChildUnitId(visible?.unitId),
+        focusedUnitScope: focusCoordinator?.resolveRuntimeScopeByChildUnitId(instanceService.getFocusedUnit()?.getUnitId()),
+    });
+    const runtimeFocusState = useObservable(
+        focusCoordinator
+            ? () => focusCoordinator.runtimeSessionChanged$.pipe(
+                map(resolveRuntimeFocusState),
+                startWith(resolveRuntimeFocusState())
+            )
+            : null,
+        resolveRuntimeFocusState(),
+        false,
+        [editState?.unitId, focusCoordinator, instanceService, visible?.unitId]
+    );
 
     useEffect(() => {
-        const sub = cellEditorManagerService.state$.subscribe((param) => {
+        const subscription = cellEditorManagerService.state$.subscribe((param) => {
             if (param == null) {
                 return;
             }
@@ -254,20 +274,17 @@ export function EditorContainer() {
                 });
 
                 const editor = editorService.getEditor(DOCS_NORMAL_EDITOR_UNIT_ID_KEY);
-
                 if (editor == null) {
                     return;
                 }
 
                 const { left, top, width, height } = editor.getBoundingClientRect();
-
                 cellEditorManagerService.setRect({ left, top, width, height });
             }
         });
-        return () => {
-            sub.unsubscribe();
-        };
-    }, []); // Empty dependency array means this effect runs once on mount and clean up on unmount
+
+        return () => subscription.unsubscribe();
+    }, [cellEditorManagerService, editorService]);
 
     useEffect(() => {
         if (!injector.has(ISheetEmbedFloatingGeometryService)) {
@@ -281,18 +298,6 @@ export function EditorContainer() {
 
         return () => subscription.unsubscribe();
     }, [cellEditorResizeService, injector]);
-
-    useEffect(() => {
-        if (!injector.has(ISheetEmbedRuntimeFocusCoordinator)) {
-            return undefined;
-        }
-
-        const subscription = injector.get(ISheetEmbedRuntimeFocusCoordinator).runtimeSessionChanged$.subscribe(() => {
-            setRuntimeFocusRevision((revision) => revision + 1);
-        });
-
-        return () => subscription.unsubscribe();
-    }, [injector]);
 
     useEffect(() => {
         if (!disableAutoFocus) {
@@ -373,21 +378,22 @@ export function EditorContainer() {
     }, [cellEditorResizeService, editorService, visible?.visible]);
 
     useEffect(() => {
-        if (!visible?.visible || !rootRef.current || !injector.has(ISheetEmbedRuntimeFocusCoordinator)) {
+        if (!visible?.visible || !rootRef.current || !focusCoordinator) {
             return undefined;
         }
 
-        const focusCoordinator = injector.get(ISheetEmbedRuntimeFocusCoordinator);
-        const focusedUnitId = instanceService.getFocusedUnit()?.getUnitId();
         const rootRuntimeScope = resolveSheetEmbedRuntimeDomScope(rootRef.current);
-        const unitRuntimeScope = [editState?.unitId, visible.unitId, focusedUnitId]
-            .map((unitId) => focusCoordinator.resolveRuntimeScopeByChildUnitId(unitId))
+        const unitRuntimeScope = [
+            runtimeFocusState.editUnitScope,
+            runtimeFocusState.visibleUnitScope,
+            runtimeFocusState.focusedUnitScope,
+        ]
             .find((resolvedScope) => resolvedScope != null);
         if (rootRuntimeScope && unitRuntimeScope && rootRuntimeScope.embedId !== unitRuntimeScope.embedId) {
             return undefined;
         }
 
-        const activeSessionScope = focusCoordinator.resolveActiveChildSessionRuntimeScope();
+        const activeSessionScope = runtimeFocusState.activeSessionScope;
         const explicitRuntimeScope = unitRuntimeScope ?? rootRuntimeScope;
         if (activeSessionScope && rootRuntimeScope && !unitRuntimeScope && rootRuntimeScope.embedId !== activeSessionScope.embedId) {
             return undefined;
@@ -464,15 +470,14 @@ export function EditorContainer() {
         }
 
         return () => collection.dispose();
-    }, [contextService, editState?.unitId, editorService, injector, instanceService, runtimeFocusRevision, visible?.unitId, visible?.visible]);
+    }, [contextService, editorService, focusCoordinator, injector, runtimeFocusState, visible?.visible]);
 
     useEffect(() => {
-        if (visible?.visible || !injector.has(ISheetEmbedRuntimeFocusCoordinator)) {
+        if (visible?.visible || !focusCoordinator) {
             return undefined;
         }
 
-        const focusCoordinator = injector.get(ISheetEmbedRuntimeFocusCoordinator);
-        const activeSessionScope = focusCoordinator.resolveActiveChildSessionRuntimeScope();
+        const activeSessionScope = runtimeFocusState.activeSessionScope;
         const childUnitId = activeSessionScope?.childUnitId;
         if (
             !activeSessionScope ||
@@ -558,7 +563,7 @@ export function EditorContainer() {
             ownerDocument.removeEventListener('click', refocusHiddenEditorAfterRuntimePointer, true);
             portalRegistration.dispose();
         };
-    }, [editorService, injector, instanceService, runtimeFocusRevision, visible?.visible]);
+    }, [editorService, focusCoordinator, injector, instanceService, runtimeFocusState, visible?.visible]);
 
     useEffect(() => {
         return () => {

--- a/packages/sheets-ui/src/views/editor-container/hooks.ts
+++ b/packages/sheets-ui/src/views/editor-container/hooks.ts
@@ -19,6 +19,7 @@ import { DocSelectionRenderService } from '@univerjs/docs-ui';
 import { DeviceInputEventType, IRenderManagerService } from '@univerjs/engine-render';
 import { KeyCode, useDependency, useObservable } from '@univerjs/ui';
 import { useMemo } from 'react';
+import { map, merge } from 'rxjs';
 import { SetCellEditVisibleOperation } from '../../commands/operations/cell-edit.operation';
 import { IEditorBridgeService } from '../../services/editor-bridge.service';
 
@@ -55,8 +56,15 @@ export function useKeyEventConfig(unitId?: string) {
 export function useIsFocusing(editorId: string) {
     const renderManagerService = useDependency(IRenderManagerService);
     const docSelectionRenderService = renderManagerService.getRenderById(editorId)?.with(DocSelectionRenderService);
-    useObservable(docSelectionRenderService?.onBlur$);
-    useObservable(docSelectionRenderService?.onFocus$);
-
-    return docSelectionRenderService?.isFocusing;
+    return useObservable(
+        docSelectionRenderService
+            ? () => merge(
+                docSelectionRenderService.onBlur$.pipe(map(() => false)),
+                docSelectionRenderService.onFocus$.pipe(map(() => true))
+            )
+            : null,
+        docSelectionRenderService?.isFocusing,
+        false,
+        [docSelectionRenderService]
+    );
 }

--- a/packages/sheets-ui/src/views/formula-bar/FormulaBar.tsx
+++ b/packages/sheets-ui/src/views/formula-bar/FormulaBar.tsx
@@ -49,8 +49,8 @@ import {
     useDependency,
     useObservable,
 } from '@univerjs/ui';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { EMPTY, merge, of, switchMap } from 'rxjs';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { EMPTY, map, merge, of, switchMap } from 'rxjs';
 import { SetCellEditVisibleOperation } from '../../commands/operations/cell-edit.operation';
 import { EMBEDDING_FORMULA_EDITOR_COMPONENT_KEY } from '../../common/keys';
 import { SHEETS_UI_PLUGIN_CONFIG_KEY } from '../../config/config';
@@ -72,10 +72,15 @@ interface IProps {
 
 export function FormulaBar(props: IProps) {
     const { className, disableDefinedName } = props;
-    const [iconActivated, setIconActivated] = useState<boolean>(false);
+    const editorBridgeService = useDependency(IEditorBridgeService);
+    const iconActivated = useObservable(
+        () => editorBridgeService.visible$.pipe(map((visibleInfo) => visibleInfo.visible)),
+        false,
+        false,
+        [editorBridgeService]
+    );
     const [arrowDirection, setArrowDirection] = useState<ArrowDirection>(ArrowDirection.Down);
     const formulaEditorManagerService = useDependency(IFormulaEditorManagerService);
-    const editorBridgeService = useDependency(IEditorBridgeService);
     const worksheetProtectionRuleModel = useDependency(WorksheetProtectionRuleModel);
     const rangeProtectionRuleModel = useDependency(RangeProtectionRuleModel);
     const univerInstanceService = useDependency(IUniverInstanceService);
@@ -83,11 +88,14 @@ export function FormulaBar(props: IProps) {
     const permissionService = useDependency(IPermissionService);
     const rangeProtectionCache = useDependency(RangeProtectionCache);
     const commandService = useDependency(ICommandService);
-    const [disableInfo, setDisableInfo] = useState<{ editDisable: boolean; viewDisable: boolean }>({
-        editDisable: false,
-        viewDisable: false,
-    });
-    const [imageDisable, setImageDisable] = useState<boolean>(false);
+    const imageDisable = useObservable(
+        () => editorBridgeService.currentEditCellState$.pipe(map((state) => Boolean(
+            state?.documentLayoutObject.documentModel?.getBody()?.customBlocks?.length
+        ))),
+        false,
+        false,
+        [editorBridgeService]
+    );
     const componentManager = useDependency(ComponentManager);
     const workbook = useObservable(() => univerInstanceService.getCurrentTypeOfUnit$<Workbook>(UniverInstanceType.UNIVER_SHEET), undefined, undefined, [])!;
     const editState = useObservable(editorBridgeService.currentEditCellState$);
@@ -95,8 +103,10 @@ export function FormulaBar(props: IProps) {
     const FormulaEditor = componentManager.get(EMBEDDING_FORMULA_EDITOR_COMPONENT_KEY);
     const formulaAuxUIParts = useComponentsOfPart(SheetsUIPart.FORMULA_AUX);
     const contextService = useDependency(IContextService);
-    useObservable(useMemo(() => contextService.subscribeContextValue$(FOCUSING_FX_BAR_EDITOR), [contextService]));
-    const isFocusFxBar = contextService.getContextValue(FOCUSING_FX_BAR_EDITOR);
+    const isFocusFxBar = useObservable(
+        useMemo(() => contextService.subscribeContextValue$(FOCUSING_FX_BAR_EDITOR), [contextService]),
+        contextService.getContextValue(FOCUSING_FX_BAR_EDITOR)
+    );
     const workbookEditablePermission = useObservable(useMemo(() => {
         if (!workbook) {
             return undefined;
@@ -109,8 +119,8 @@ export function FormulaBar(props: IProps) {
     const config = useConfigValue<IUniverSheetsUIConfig>(SHEETS_UI_PLUGIN_CONFIG_KEY);
     const disableEdit = config?.disableEdit;
 
-    useLayoutEffect(() => {
-        const subscription = workbook.activeSheet$.pipe(
+    const disableInfo = useObservable(
+        () => workbook.activeSheet$.pipe(
             switchMap((worksheet) => {
                 if (!worksheet) {
                     return EMPTY;
@@ -138,57 +148,39 @@ export function FormulaBar(props: IProps) {
                         });
                     })
                 );
-            })
-        ).subscribe((cellInfo) => {
-            if (cellInfo) {
-                const { unitId, subUnitId, primary } = cellInfo;
-                if (worksheetProtectionRuleModel.getRule(unitId, subUnitId)) {
-                    const editDisable = !(permissionService.getPermissionPoint(new WorksheetEditPermission(unitId, subUnitId).id)?.value ?? true);
-                    const viewDisable = !(permissionService.getPermissionPoint(new WorksheetViewPermission(unitId, subUnitId).id)?.value ?? true);
-                    setDisableInfo({
-                        viewDisable,
-                        editDisable,
-                    });
-                    return;
+            }),
+            map((cellInfo) => {
+                if (cellInfo) {
+                    const { unitId, subUnitId, primary } = cellInfo;
+                    if (worksheetProtectionRuleModel.getRule(unitId, subUnitId)) {
+                        const editDisable = !(permissionService.getPermissionPoint(new WorksheetEditPermission(unitId, subUnitId).id)?.value ?? true);
+                        const viewDisable = !(permissionService.getPermissionPoint(new WorksheetViewPermission(unitId, subUnitId).id)?.value ?? true);
+                        return {
+                            viewDisable,
+                            editDisable,
+                        };
+                    }
+                    const { actualRow, actualColumn } = primary;
+                    const cellInfoWithPermission = rangeProtectionCache.getCellInfo(unitId, subUnitId, actualRow, actualColumn);
+                    return {
+                        editDisable: !(cellInfoWithPermission?.[UnitAction.Edit] ?? true),
+                        viewDisable: !(cellInfoWithPermission?.[UnitAction.View] ?? true),
+                    };
                 }
-                const { actualRow, actualColumn } = primary;
-                const cellInfoWithPermission = rangeProtectionCache.getCellInfo(unitId, subUnitId, actualRow, actualColumn);
-                setDisableInfo({
-                    editDisable: !(cellInfoWithPermission?.[UnitAction.Edit] ?? true),
-                    viewDisable: !(cellInfoWithPermission?.[UnitAction.View] ?? true),
-                });
-            } else {
-                setDisableInfo({
-                    viewDisable: false,
-                    editDisable: false,
-                });
-            }
-        });
-
-        return () => {
-            subscription.unsubscribe();
-        };
-    }, [workbook]);
-
-    useEffect(() => {
-        const subscription = editorBridgeService.visible$.subscribe((visibleInfo) => {
-            setIconActivated(visibleInfo.visible);
-        });
-
-        return () => subscription.unsubscribe();
-    }, [editorBridgeService.visible$]);
-
-    useEffect(() => {
-        const subscription = editorBridgeService.currentEditCellState$.subscribe((state) => {
-            if (state?.documentLayoutObject.documentModel?.getBody()?.customBlocks?.length) {
-                setImageDisable(true);
-            } else {
-                setImageDisable(false);
-            }
-        });
-
-        return () => subscription.unsubscribe();
-    }, [editorBridgeService.currentEditCellState$]);
+                return { viewDisable: false, editDisable: false };
+            })
+        ),
+        { editDisable: false, viewDisable: false },
+        false,
+        [
+            permissionService,
+            rangeProtectionCache,
+            rangeProtectionRuleModel,
+            selectionManager,
+            workbook,
+            worksheetProtectionRuleModel,
+        ]
+    );
 
     useEffect(() => {
         const handleResize = () => {

--- a/packages/sheets-ui/src/views/menu-item-input/MenuItemInput.tsx
+++ b/packages/sheets-ui/src/views/menu-item-input/MenuItemInput.tsx
@@ -18,7 +18,7 @@ import type { KeyboardEvent } from 'react';
 import type { IMenuItemInputProps } from './interface';
 import { LocaleService } from '@univerjs/core';
 import { InputNumber } from '@univerjs/design';
-import { IContextMenuService, useDependency } from '@univerjs/ui';
+import { IContextMenuService, useDependency, useObservable } from '@univerjs/ui';
 import { useEffect, useState } from 'react';
 
 export const MenuItemInput = (props: IMenuItemInputProps) => {
@@ -34,7 +34,7 @@ export const MenuItemInput = (props: IMenuItemInputProps) => {
 
     const localeService = useDependency(LocaleService);
     const contextMenuService = useDependency(IContextMenuService);
-    const [disabled, setDisabled] = useState<boolean>(false);
+    const disabled = useObservable(disabled$ ?? null, false);
     const [inputValue, setInputValue] = useState<string>(); // Initialized to an empty string
 
     const handleChange = (value: number | null) => {
@@ -47,18 +47,6 @@ export const MenuItemInput = (props: IMenuItemInputProps) => {
         setInputValue(inputValue);
         onChange(inputValue);
     };
-
-    useEffect(() => {
-        if (!disabled$) {
-            return;
-        }
-        const subscription = disabled$.subscribe((value) => {
-            setDisabled(value);
-        });
-        return () => {
-            subscription.unsubscribe();
-        };
-    }, []);
 
     useEffect(() => {
         if (!contextMenuService.visible) {

--- a/packages/sheets-ui/src/views/permission/SheetPermissionPanelList.tsx
+++ b/packages/sheets-ui/src/views/permission/SheetPermissionPanelList.tsx
@@ -44,7 +44,7 @@ import {
 } from '@univerjs/sheets';
 import { ISidebarService, useDependency, useObservable } from '@univerjs/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { distinctUntilChanged, merge } from 'rxjs';
+import { distinctUntilChanged, from, merge, startWith, switchMap } from 'rxjs';
 import { UNIVER_SHEET_PERMISSION_PANEL } from '../../consts/permission';
 import { useHighlightRange } from '../../hooks/use-highlight-range';
 import { SheetPermissionUserManagerService } from '../../services/permission/sheet-permission-user-list.service';
@@ -61,7 +61,6 @@ export function SheetPermissionPanelList() {
 
 function SheetPermissionPanelListContent() {
     const [isCurrentSheet, setIsCurrentSheet] = useState(true);
-    const [forceUpdateFlag, setForceUpdateFlag] = useState(false);
     const [currentRuleRanges, setCurrentRuleRanges] = useState<IRange[]>([]);
 
     const localeService = useDependency(LocaleService);
@@ -75,9 +74,6 @@ function SheetPermissionPanelListContent() {
     const usesManagerService = useDependency(UserManagerService);
     const currentUser = usesManagerService.getCurrentUser();
     const sheetPermissionUserManagerService = useDependency(SheetPermissionUserManagerService);
-
-    const sheetRuleRefresh = useObservable(worksheetProtectionModel.ruleRefresh$, '');
-    const rangeRuleRefresh = useObservable(rangeProtectionRuleModel.ruleRefresh$, '');
 
     const workbook = univerInstanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
 
@@ -125,58 +121,23 @@ function SheetPermissionPanelListContent() {
         return isCurrentSheet ? subUnitRuleList : allPermissionRule;
     }, [authzIoService, rangeProtectionRuleModel, workbook, worksheetProtectionModel]);
 
-    const [ruleList, setRuleList] = useState<IPermissionPoint[]>([]);
-
-    useEffect(() => {
-        let active = true;
-        const subscription = merge(
+    const ruleList = useObservable<IPermissionPoint[]>(
+        () => merge(
             rangeProtectionRuleModel.ruleChange$,
-            worksheetProtectionModel.ruleChange$
-        ).subscribe(() => {
-            void getRuleList(isCurrentSheet).then((ruleList) => {
-                if (active) {
-                    setRuleList(ruleList);
-                }
-            });
-        });
-        return () => {
-            active = false;
-            subscription.unsubscribe();
-        };
-    }, [getRuleList, isCurrentSheet, rangeProtectionRuleModel.ruleChange$, worksheetProtectionModel.ruleChange$]);
-
-    useEffect(() => {
-        let active = true;
-        const subscribe = workbook.activeSheet$.pipe(
-            distinctUntilChanged((prevSheet, currSheet) => prevSheet?.getSheetId() === currSheet?.getSheetId())
-        ).subscribe(() => {
-            void getRuleList(isCurrentSheet).then((ruleList) => {
-                if (active) {
-                    setRuleList(ruleList);
-                }
-            });
-        });
-        return () => {
-            active = false;
-            subscribe.unsubscribe();
-        };
-    }, [getRuleList, isCurrentSheet, workbook.activeSheet$]);
-
-    useEffect(() => {
-        let cancelled = false;
-
-        if (sheetRuleRefresh || rangeRuleRefresh) {
-            void getRuleList(true).then((ruleList) => {
-                if (!cancelled) {
-                    setRuleList(ruleList);
-                }
-            });
-        }
-
-        return () => {
-            cancelled = true;
-        };
-    }, [getRuleList, sheetRuleRefresh, rangeRuleRefresh]);
+            worksheetProtectionModel.ruleChange$,
+            rangeProtectionRuleModel.ruleRefresh$,
+            worksheetProtectionModel.ruleRefresh$,
+            workbook.activeSheet$.pipe(
+                distinctUntilChanged((prevSheet, currSheet) => prevSheet?.getSheetId() === currSheet?.getSheetId())
+            )
+        ).pipe(
+            startWith(undefined),
+            switchMap(() => from(getRuleList(isCurrentSheet)))
+        ),
+        [],
+        false,
+        [getRuleList, isCurrentSheet, rangeProtectionRuleModel, workbook, worksheetProtectionModel]
+    );
 
     function handleDelete(rule: IRuleItem) {
         const { unitId, subUnitId, unitType } = rule;
@@ -188,7 +149,6 @@ function SheetPermissionPanelListContent() {
         }
 
         if (res) {
-            setForceUpdateFlag(!forceUpdateFlag);
             if ((rule as IRangeProtectionRule).ranges === currentRuleRanges) {
                 setCurrentRuleRanges([]);
             }

--- a/packages/slides-ui/src/views/slide-bar/SlideBar.tsx
+++ b/packages/slides-ui/src/views/slide-bar/SlideBar.tsx
@@ -19,8 +19,9 @@ import type { LocaleKey } from '../../locale/types';
 import { ICommandService, IUniverInstanceService, LocaleService, UniverInstanceType } from '@univerjs/core';
 import { borderClassName, clsx, scrollbarClassName } from '@univerjs/design';
 import { IRenderManagerService } from '@univerjs/engine-render';
-import { useDependency } from '@univerjs/ui';
-import { createRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDependency, useObservable } from '@univerjs/ui';
+import { createRef, useCallback, useEffect, useMemo, useRef } from 'react';
+import { scan } from 'rxjs';
 import { ActivateSlidePageOperation } from '../../commands/operations/activate.operation';
 import { AppendSlideOperation } from '../../commands/operations/append-slide.operation';
 import { SetSlidePageThumbOperation } from '../../commands/operations/set-thumb.operation';
@@ -36,33 +37,29 @@ export function SlideSideBar() {
     const localeService = useDependency(LocaleService);
 
     const slideBarRef = useRef<HTMLDivElement>(null);
-    const currentSlide = univerInstanceService.getCurrentUnitOfType<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE);
-
-    // const currentSlide = useObservable(
-    //     () => univerInstanceService.getCurrentTypeOfUnit$<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE),
-    //     undefined,
-    //     undefined,
-    //     []
-    // );
+    const currentSlide = useObservable(
+        () => univerInstanceService.getCurrentTypeOfUnit$<SlideDataModel>(UniverInstanceType.UNIVER_SLIDE),
+        undefined,
+        false,
+        [univerInstanceService]
+    );
     const pages = currentSlide?.getPages();
     const pageOrder = currentSlide?.getPageOrder();
     const slideList = useMemo(() => pages && pageOrder ? pageOrder.map((id) => pages[id]) : [], [pageOrder, pages]);
 
-    const [activatePageId, setActivatePageId] = useState<string | null>(currentSlide?.getActivePage()?.id ?? null);
+    const initialActivePageId = currentSlide?.getActivePage()?.id ?? null;
+    const activatePageId = useObservable(
+        currentSlide
+            ? () => currentSlide.activePage$.pipe(
+                scan((previousId, page) => page?.id ?? previousId, initialActivePageId)
+            )
+            : null,
+        initialActivePageId,
+        false,
+        [currentSlide, initialActivePageId]
+    );
 
     const divRefs = useMemo(() => slideList.map(() => createRef<HTMLDivElement>()), [slideList]);
-
-    useEffect(() => {
-        const subscriber = currentSlide?.activePage$.subscribe((page) => {
-            const id = page?.id ?? null;
-
-            id && setActivatePageId(id);
-        });
-
-        return () => {
-            subscriber?.unsubscribe();
-        };
-    }, []);
 
     useEffect(() => {
         divRefs.forEach((ref, index) => {

--- a/packages/thread-comment-ui/src/views/ThreadCommentEditor.tsx
+++ b/packages/thread-comment-ui/src/views/ThreadCommentEditor.tsx
@@ -65,16 +65,9 @@ export const ThreadCommentEditor = forwardRef<IThreadCommentEditorInstance, IThr
     const editorService = useDependency(IEditorService);
     const editor = useRef<Editor>(null);
     const rootEditorId = type === UniverInstanceType.UNIVER_DOC ? DOCS_NORMAL_EDITOR_UNIT_ID_KEY : unitId;
-    const [canSubmit, setCanSubmit] = useState(() => BuildTextUtils.transform.getPlainText(editor.current?.getDocumentData().body?.dataStream ?? ''));
-    useEffect(() => {
-        setCanSubmit(BuildTextUtils.transform.getPlainText(editor.current?.getDocumentData().body?.dataStream ?? ''));
-
-        const sub = editor.current?.selectionChange$.subscribe(() => {
-            setCanSubmit(BuildTextUtils.transform.getPlainText(editor.current?.getDocumentData().body?.dataStream ?? ''));
-        });
-
-        return () => sub?.unsubscribe();
-    }, [editor.current?.selectionChange$]);
+    const [canSubmit, setCanSubmit] = useState(() => (
+        BuildTextUtils.transform.getPlainText(comment?.text?.dataStream ?? '')
+    ));
 
     const keyboardEventConfig: IKeyboardEventConfig = useMemo(() => (
         {
@@ -150,6 +143,7 @@ export const ThreadCommentEditor = forwardRef<IThreadCommentEditorInstance, IThr
                     keyboardEventConfig={keyboardEventConfig}
                     placeholder={localeService.t<LocaleKey>('thread-comment-ui.editor.placeholder')}
                     initialValue={comment?.text && getSnapshot(comment.text)}
+                    onChange={(data) => setCanSubmit(BuildTextUtils.transform.getPlainText(data.body?.dataStream ?? ''))}
                     onFocusChange={(isFocus) => isFocus && setEditing(isFocus)}
                     isSingle={false}
                     maxHeight={64}

--- a/packages/thread-comment-ui/src/views/ThreadCommentTree.tsx
+++ b/packages/thread-comment-ui/src/views/ThreadCommentTree.tsx
@@ -33,7 +33,7 @@ import {
 } from '@univerjs/thread-comment';
 import { UI_PLUGIN_CONFIG_KEY, useConfigValue, useDependency, useObservable } from '@univerjs/ui';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { debounceTime, map } from 'rxjs';
+import { debounceTime, map, of, startWith } from 'rxjs';
 import { SetActiveCommentOperation } from '../commands/operations/comment.operations';
 import { transformDocument2TextNodes, transformTextNodes2Document } from './thread-comment-editor/util';
 import { getThreadCommentEditorId } from './thread-comment-tree/util';
@@ -326,10 +326,13 @@ export const ThreadCommentTree = (props: IThreadCommentTreeProps) => {
     const [editingId, setEditingId] = useState('');
     const updte$ = useMemo(() => threadCommentModel.commentUpdate$.pipe(debounceTime(16)), [threadCommentModel]);
     const comments = useObservable(
-        id
-            ? () => updte$.pipe(map(() => threadCommentModel.getCommentWithChildren(unitId, subUnitId, id)))
-            : null,
-        id ? threadCommentModel.getCommentWithChildren(unitId, subUnitId, id) : null,
+        () => id
+            ? updte$.pipe(
+                map(() => threadCommentModel.getCommentWithChildren(unitId, subUnitId, id)),
+                startWith(threadCommentModel.getCommentWithChildren(unitId, subUnitId, id))
+            )
+            : of(null),
+        null,
         false,
         [id, subUnitId, threadCommentModel, unitId, updte$]
     );

--- a/packages/thread-comment-ui/src/views/ThreadCommentTree.tsx
+++ b/packages/thread-comment-ui/src/views/ThreadCommentTree.tsx
@@ -33,7 +33,7 @@ import {
 } from '@univerjs/thread-comment';
 import { UI_PLUGIN_CONFIG_KEY, useConfigValue, useDependency, useObservable } from '@univerjs/ui';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { debounceTime } from 'rxjs';
+import { debounceTime, map } from 'rxjs';
 import { SetActiveCommentOperation } from '../commands/operations/comment.operations';
 import { transformDocument2TextNodes, transformTextNodes2Document } from './thread-comment-editor/util';
 import { getThreadCommentEditorId } from './thread-comment-tree/util';
@@ -325,8 +325,14 @@ export const ThreadCommentTree = (props: IThreadCommentTreeProps) => {
     const [isHover, setIsHover] = useState(false);
     const [editingId, setEditingId] = useState('');
     const updte$ = useMemo(() => threadCommentModel.commentUpdate$.pipe(debounceTime(16)), [threadCommentModel]);
-    useObservable(updte$);
-    const comments = id ? threadCommentModel.getCommentWithChildren(unitId, subUnitId, id) : null;
+    const comments = useObservable(
+        id
+            ? () => updte$.pipe(map(() => threadCommentModel.getCommentWithChildren(unitId, subUnitId, id)))
+            : null,
+        id ? threadCommentModel.getCommentWithChildren(unitId, subUnitId, id) : null,
+        false,
+        [id, subUnitId, threadCommentModel, unitId, updte$]
+    );
     const commandService = useDependency(ICommandService);
     const userManagerService = useDependency(UserManagerService);
     const resolved = comments?.root.resolved;

--- a/packages/ui/src/views/components/confirm-part/ConfirmPart.tsx
+++ b/packages/ui/src/views/components/confirm-part/ConfirmPart.tsx
@@ -18,8 +18,8 @@ import type { IConfirmProps } from '@univerjs/design';
 import type { IConfirmChildrenProps, IConfirmPartMethodOptions, IContextConfirmProps } from './interface';
 import { IConfirmService } from '@univerjs/core';
 import { Confirm } from '@univerjs/design';
-import { cloneElement, useEffect, useState } from 'react';
-import { useDependency } from '../../../utils/di';
+import { cloneElement, useState } from 'react';
+import { useDependency, useObservable } from '../../../utils/di';
 import { CustomLabel } from '../../custom-label/CustomLabel';
 
 const ContextConfirm = (props: IContextConfirmProps) => {
@@ -67,17 +67,7 @@ const ContextConfirm = (props: IContextConfirmProps) => {
 export function ConfirmPart() {
     const confirmService = useDependency(IConfirmService) as IConfirmService<IConfirmPartMethodOptions>;
 
-    const [confirmOptions, setConfirmOptions] = useState<IConfirmPartMethodOptions[]>([]);
-
-    useEffect(() => {
-        const subscription = confirmService.confirmOptions$.subscribe((options: IConfirmPartMethodOptions[]) => {
-            setConfirmOptions(options);
-        });
-
-        return () => {
-            subscription.unsubscribe();
-        };
-    }, []);
+    const confirmOptions = useObservable(confirmService.confirmOptions$, []);
 
     const props = confirmOptions.map((options) => {
         const { children, title, ...restProps } = options;

--- a/packages/ui/src/views/components/context-menu/ContextMenuPanel.tsx
+++ b/packages/ui/src/views/components/context-menu/ContextMenuPanel.tsx
@@ -29,7 +29,7 @@ import { borderBottomClassName, borderClassName, clsx, cva, scrollbarClassName }
 import { CheckMarkIcon, MoreLeftIcon, MoreRightIcon } from '@univerjs/icons';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { combineLatest, isObservable, of, scan, startWith } from 'rxjs';
+import { combineLatest, isObservable, map, merge, of, scan, startWith } from 'rxjs';
 import { ILayoutService } from '../../../services/layout/layout.service';
 import { MenuItemType } from '../../../services/menu/menu';
 import { IMenuManagerService } from '../../../services/menu/menu-manager.service';
@@ -1565,29 +1565,21 @@ function ContextMenuMenuItem(props: IContextMenuMenuItemProps) {
 }
 
 function useContextGroupHiddenStates(menuSchemas: IMenuSchema[]) {
-    const [hiddenStates, setHiddenStates] = useState<Record<string, boolean>>({});
-
-    useEffect(() => {
-        const subscriptions = menuSchemas.map((menuSchema) => {
-            if (!menuSchema.children?.length) {
-                return null;
-            }
-
-            const hiddenObservables = menuSchema.children.map((childSchema) => childSchema.item?.hidden$ ?? of(false));
-            return combineLatest(hiddenObservables).subscribe((hiddenValues) => {
-                const isAllHidden = hiddenValues.every((hidden) => hidden === true);
-                setHiddenStates((state) => ({
-                    ...state,
-                    [menuSchema.key]: isAllHidden,
-                }));
-            });
+    const hiddenStates$ = useMemo(() => {
+        const groupStates = menuSchemas.flatMap((menuSchema) => {
+            const hiddenObservables = menuSchema.children?.map((childSchema) => childSchema.item?.hidden$ ?? of(false)) ?? [];
+            return hiddenObservables.length
+                ? [combineLatest(hiddenObservables).pipe(map((values) => [menuSchema.key, values.every(Boolean)] as const))]
+                : [];
         });
 
-        return () => {
-            subscriptions.forEach((subscription) => subscription?.unsubscribe());
-            setHiddenStates({});
-        };
+        return groupStates.length
+            ? merge(...groupStates).pipe(
+                scan((states, [key, hidden]) => ({ ...states, [key]: hidden }), {} as Record<string, boolean>),
+                startWith({})
+            )
+            : of({});
     }, [menuSchemas]);
 
-    return hiddenStates;
+    return useObservable<Record<string, boolean>>(hiddenStates$, {});
 }

--- a/packages/ui/src/views/components/dialog-part/DialogPart.tsx
+++ b/packages/ui/src/views/components/dialog-part/DialogPart.tsx
@@ -17,24 +17,15 @@
 import type { IDialogProps } from '@univerjs/design';
 import type { IDialogPartMethodOptions } from './interface';
 import { Dialog } from '@univerjs/design';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { IDialogService } from '../../../services/dialog/dialog.service';
-import { useDependency } from '../../../utils/di';
+import { useDependency, useObservable } from '../../../utils/di';
 import { CustomLabel } from '../../custom-label/CustomLabel';
 
 export function DialogPart() {
     const dialogService = useDependency(IDialogService);
 
-    const [dialogOptions, setDialogOptions] = useState<IDialogPartMethodOptions[]>([]);
-
-    useEffect(() => {
-        const dialog$ = dialogService.getDialogs$();
-        const subscription = dialog$.subscribe((options: IDialogPartMethodOptions[]) => {
-            setDialogOptions(options);
-        });
-
-        return () => subscription.unsubscribe();
-    }, []);
+    const dialogOptions = useObservable(dialogService.getDialogs$(), []);
 
     const attrs = useMemo(() => dialogOptions.map((options) => {
         const { children, title, footer, ...restProps } = options;

--- a/packages/ui/src/views/components/popup/CanvasPopup.tsx
+++ b/packages/ui/src/views/components/popup/CanvasPopup.tsx
@@ -16,7 +16,7 @@
 
 import type { ReactNode } from 'react';
 import type { IPopup } from '../../../services/popup/canvas-popup.service';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { animationFrameScheduler, combineLatest, map, of, throttleTime } from 'rxjs';
 import { ComponentManager } from '../../../common';
 import { ICanvasPopupService } from '../../../services/popup/canvas-popup.service';
@@ -29,7 +29,6 @@ interface ISingleCanvasPopupProps {
 }
 
 export const SingleCanvasPopup = ({ popup, children }: ISingleCanvasPopupProps) => {
-    const [hidden, setHidden] = useState(false);
     const anchorRect$ = useMemo(() => popup.anchorRect$.pipe(
         throttleTime(0, animationFrameScheduler),
         map((anchorRect) => {
@@ -48,35 +47,31 @@ export const SingleCanvasPopup = ({ popup, children }: ISingleCanvasPopupProps) 
     const excludeRectsRef = useObservableRef(excludeRects$, popup.excludeRects);
     const { canvasElement, hideOnInvisible = true, hiddenType = 'destroy' } = popup;
 
-    useEffect(() => {
-        if (!hideOnInvisible) {
-            return;
-        }
+    const hidden = useObservable(
+        hideOnInvisible
+            ? () => combineLatest([anchorRect$, hiddenRects$]).pipe(map(([rectWithOffset, hiddenRects]) => {
+                const rect = canvasElement.getBoundingClientRect();
+                const { top, left, bottom, right } = rect;
+                const rectHeight = rectWithOffset.bottom - rectWithOffset.top;
+                const rectWidth = rectWithOffset.right - rectWithOffset.left;
 
-        const anchorRectSub = combineLatest([anchorRect$, hiddenRects$]).subscribe(([rectWithOffset, hiddenRects]) => {
-            const rect = canvasElement.getBoundingClientRect();
-            const { top, left, bottom, right } = rect;
-            const rectHeight = rectWithOffset.bottom - rectWithOffset.top;
-            const rectWidth = rectWithOffset.right - rectWithOffset.left;
+                const isInHiddenRect = hiddenRects.some((hiddenRect) => {
+                    const bufferY = Math.min(0.5 * rectHeight, 10);
+                    const bufferX = Math.min(0.5 * rectWidth, 10);
+                    return rectWithOffset.top >= (hiddenRect.top - bufferY) &&
+                        rectWithOffset.bottom <= (hiddenRect.bottom + bufferY) &&
+                        rectWithOffset.left >= (hiddenRect.left - bufferX) &&
+                        rectWithOffset.right <= (hiddenRect.right + bufferX);
+                });
 
-            const isInHiddenRect = hiddenRects.some((hiddenRect) => {
-                const bufferY = Math.min(0.5 * rectHeight, 10);
-                const bufferX = Math.min(0.5 * rectWidth, 10);
-                return rectWithOffset.top >= (hiddenRect.top - bufferY) &&
-                    rectWithOffset.bottom <= (hiddenRect.bottom + bufferY) &&
-                    rectWithOffset.left >= (hiddenRect.left - bufferX) &&
-                    rectWithOffset.right <= (hiddenRect.right + bufferX);
-            });
-
-            if (rectWithOffset.bottom < top || rectWithOffset.top > bottom || rectWithOffset.right < left || rectWithOffset.left > right || isInHiddenRect) {
-                setHidden(true);
-            } else {
-                setHidden(false);
-            }
-        });
-
-        return () => anchorRectSub.unsubscribe();
-    }, [canvasElement, hideOnInvisible, anchorRect$, hiddenRects$]);
+                return rectWithOffset.bottom < top || rectWithOffset.top > bottom ||
+                    rectWithOffset.right < left || rectWithOffset.left > right || isInHiddenRect;
+            }))
+            : null,
+        false,
+        false,
+        [anchorRect$, canvasElement, hiddenRects$, hideOnInvisible]
+    );
 
     if ((hidden && hiddenType === 'destroy')) {
         return null;

--- a/packages/ui/src/views/components/ribbon/TooltipButtonWrapper.tsx
+++ b/packages/ui/src/views/components/ribbon/TooltipButtonWrapper.tsx
@@ -16,7 +16,6 @@
 
 import type { IDropdownMenuProps, IDropdownProps, ITooltipProps } from '@univerjs/design';
 import type { ReactNode } from 'react';
-import type { Subscription } from 'rxjs';
 import type { IMenuItem, IValueOption } from '../../../services/menu/menu';
 import { clsx, Dropdown, DropdownMenu, Tooltip } from '@univerjs/design';
 import { CheckMarkIcon } from '@univerjs/icons';
@@ -25,15 +24,14 @@ import {
     forwardRef,
     useCallback,
     useContext,
-    useEffect,
     useImperativeHandle,
     useMemo,
     useRef,
     useState,
 } from 'react';
-import { combineLatest, of } from 'rxjs';
+import { combineLatest, map, merge, of, scan, startWith } from 'rxjs';
 import { IMenuManagerService } from '../../../services/menu/menu-manager.service';
-import { useDependency } from '../../../utils/di';
+import { useDependency, useObservable } from '../../../utils/di';
 import { keepInteractionInsideSameEmbedBoundary } from '../../../utils/embed-boundary';
 import { CustomLabel } from '../../custom-label/CustomLabel';
 
@@ -212,20 +210,30 @@ export function DropdownMenuWrapper({
     const { dropdownVisible, setDropdownVisible } = useContext(TooltipWrapperContext);
 
     const menuManagerService = useDependency(IMenuManagerService);
-    const [hiddenStates, setHiddenStates] = useState<Record<string, boolean>>({});
-    const [_, setMenuVersion] = useState(0);
-
-    useEffect(() => {
-        const subscription = menuManagerService.menuChanged$.subscribe(() => {
-            setMenuVersion((version) => version + 1);
+    const resolveMenuItems = () => menuId ? menuManagerService.getMenuByPositionKey(menuId) : [];
+    const menuItems = useObservable(
+        () => menuManagerService.menuChanged$.pipe(map(resolveMenuItems), startWith(resolveMenuItems())),
+        resolveMenuItems(),
+        false,
+        [menuId, menuManagerService]
+    );
+    const hiddenStates$ = useMemo(() => {
+        const itemStates = menuItems.map((item) => {
+            const hidden$ = item.children
+                ? combineLatest(item.children.map((subItem) => subItem.item?.hidden$ ?? of(false))).pipe(
+                    map((hiddenValues) => hiddenValues.every(Boolean))
+                )
+                : item.item?.hidden$ ?? of(false);
+            return hidden$.pipe(map((hidden) => [String(item.key), hidden] as const));
         });
-
-        return () => subscription.unsubscribe();
-    }, [menuManagerService]);
-
-    const menuItems = useMemo(() => {
-        return menuId ? menuManagerService.getMenuByPositionKey(menuId) : [];
-    }, [menuId, menuManagerService]);
+        return itemStates.length
+            ? merge(...itemStates).pipe(
+                scan((states, [key, hidden]) => ({ ...states, [key]: hidden }), {} as Record<string, boolean>),
+                startWith({})
+            )
+            : of({});
+    }, [menuItems]);
+    const hiddenStates = useObservable<Record<string, boolean>>(hiddenStates$, {});
 
     const filteredMenuItems = useMemo(() => {
         return menuItems.filter((item) => {
@@ -250,41 +258,6 @@ export function DropdownMenuWrapper({
         onOptionSelect(option);
         setDropdownVisible(false);
     }
-
-    useEffect(() => {
-        const subscriptions: Subscription[] = [];
-
-        menuItems.forEach((item) => {
-            if (!item.children) {
-                if (item.item?.hidden$) {
-                    const sub = item.item.hidden$.subscribe((hidden) => {
-                        setHiddenStates((prev) => ({
-                            ...prev,
-                            [item.key]: hidden,
-                        }));
-                    });
-                    subscriptions.push(sub);
-                }
-            } else {
-                const hiddenObservables = item.children.map((subItem) => subItem.item?.hidden$ ?? of(false));
-
-                const sub = combineLatest(hiddenObservables).subscribe((hiddenValues) => {
-                    const isAllHidden = hiddenValues.every((hidden) => hidden === true);
-                    setHiddenStates((prev) => ({
-                        ...prev,
-                        [item.key]: isAllHidden,
-                    }));
-                });
-
-                subscriptions.push(sub);
-            }
-        });
-
-        return () => {
-            subscriptions.forEach((sub) => sub?.unsubscribe());
-            setHiddenStates({});
-        };
-    }, [menuItems]);
 
     if (slot) {
         return (

--- a/packages/ui/src/views/components/ribbon/hook.ts
+++ b/packages/ui/src/views/components/ribbon/hook.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import type { Observable, Subscription } from 'rxjs';
+import type { Observable } from 'rxjs';
 import type { IDisplayMenuItem, IMenuItem } from '../../../services/menu/menu';
-import { useEffect, useMemo, useState } from 'react';
-import { map, of, startWith } from 'rxjs';
+import { useMemo } from 'react';
+import { EMPTY, map, merge, of, startWith } from 'rxjs';
 import { isMenuButtonSelectorItem } from '../../../services/menu/menu';
 import { IShortcutService } from '../../../services/shortcut/shortcut.service';
 import { useDependency, useObservable } from '../../../utils/di';
@@ -31,8 +31,6 @@ export interface IToolbarItemStatus {
     // eslint-disable-next-line ts/no-explicit-any
     selectionsValue: any;
 }
-
-// TODO@wzhudev: maybe we should use `useObservable` here.
 
 /**
  * Subscribe to a menu item's status change and return the latest status.
@@ -53,29 +51,15 @@ export function useToolbarItemStatus(menuItem: IDisplayMenuItem<IMenuItem>): ITo
         }
     }
 
-    // eslint-disable-next-line ts/no-explicit-any
-    const [value, setValue] = useState<any>();
-    const [disabled, setDisabled] = useState(false);
-    const [activated, setActivated] = useState(false);
-    const [hidden, setHidden] = useState(false);
-    // eslint-disable-next-line ts/no-explicit-any
-    const [selectionsValue, setSelectionsValue] = useState<any>();
-
-    useEffect(() => {
-        const subscriptions: Subscription[] = [];
-        disabled$ && subscriptions.push(disabled$.subscribe((disabled) => setDisabled(disabled)));
-        hidden$ && subscriptions.push(hidden$.subscribe((hidden) => setHidden(hidden)));
-        activated$ && subscriptions.push(activated$.subscribe((activated) => setActivated(activated)));
-        value$ && subscriptions.push(value$.subscribe((value) => {
-            setValue(value);
-        }));
-        selectionsValue$ && subscriptions.push(selectionsValue$.subscribe((value) => {
-            setSelectionsValue(value);
-            setValue(value);
-        }));
-
-        return () => subscriptions.forEach((subscription) => subscription.unsubscribe());
-    }, [activated$, disabled$, hidden$, value$, selectionsValue$]);
+    const disabled = useObservable(disabled$ ?? null, false);
+    const activated = useObservable(activated$ ?? null, false);
+    const hidden = useObservable(hidden$ ?? null, false);
+    const valueObservable = useMemo(
+        () => merge(value$ ?? EMPTY, selectionsValue$ ?? EMPTY),
+        [selectionsValue$, value$]
+    );
+    const value = useObservable(valueObservable);
+    const selectionsValue = useObservable(selectionsValue$ ?? null);
 
     return { disabled, value, activated, hidden, selectionsValue };
 }

--- a/packages/ui/src/views/custom-label/CustomLabel.tsx
+++ b/packages/ui/src/views/custom-label/CustomLabel.tsx
@@ -18,10 +18,10 @@ import type { ReactNode } from 'react';
 import type { Observable } from 'rxjs';
 import type { IMenuSelectorItem } from '../../services/menu/menu';
 import { ColorKit, LocaleService } from '@univerjs/core';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { isObservable } from 'rxjs';
 import { ComponentManager, IconManager } from '../../common';
-import { useDependency } from '../../utils/di';
+import { useDependency, useObservable } from '../../utils/di';
 
 export type ICustomLabelProps<T = undefined> = {
     className?: string;
@@ -44,42 +44,17 @@ export function CustomLabel(props: ICustomLabelProps) {
     const localeService = useDependency(LocaleService);
     const componentManager = useDependency(ComponentManager);
     const iconManager = useDependency(IconManager);
-    const [subscribedValue, setSubscribedValue] = useState(value);
-    const [realIcon, setRealIcon] = useState('');
+    const subscribedValue = useObservable(value$ ?? null, value);
+    const observableIcon = isObservable(icon) ? icon : null;
+    const subscribedIcon = useObservable(observableIcon, '');
+    const realIcon = isObservable(icon) ? subscribedIcon : icon ?? '';
 
     const nodes = [];
     let index = 0;
 
-    useEffect(() => {
-        if (value$) {
-            const subscription = value$.subscribe((v) => {
-                setSubscribedValue(v);
-            });
-
-            return () => {
-                subscription.unsubscribe();
-            };
-        }
-    }, [value$]);
-
     const realValue = useMemo(() => {
         return value ?? subscribedValue;
     }, [subscribedValue, value]);
-
-    useEffect(() => {
-        let subscription = null;
-        if (isObservable(icon)) {
-            subscription = icon.subscribe((v) => {
-                setRealIcon(v);
-            });
-        } else {
-            setRealIcon(icon ?? '');
-        }
-
-        return () => {
-            subscription?.unsubscribe();
-        };
-    }, [icon]);
 
     // if value is not valid, use primary color
     const isValid = useMemo(() => {

--- a/packages/ui/src/views/font-family/use-font-list.ts
+++ b/packages/ui/src/views/font-family/use-font-list.ts
@@ -15,23 +15,12 @@
  */
 
 import type { IFontConfig } from '../../services/font.service';
-import { useEffect, useState } from 'react';
 import { IFontService } from '../../services/font.service';
-import { useDependency } from '../../utils/di';
+import { useDependency, useObservable } from '../../utils/di';
 
 export function useFontList() {
     const fontService = useDependency(IFontService);
-    const [fonts, setFonts] = useState<IFontConfig[]>(() => fontService.getFonts());
-
-    useEffect(() => {
-        const subscription = fontService.fonts$.subscribe((fonts) => {
-            setFonts(fonts);
-        });
-
-        return () => {
-            subscription.unsubscribe();
-        };
-    }, [fontService]);
+    const fonts = useObservable<IFontConfig[]>(fontService.fonts$, fontService.getFonts());
 
     return { fonts, fontService };
 }

--- a/packages/ui/src/views/menu/desktop/TinyMenuGroup.tsx
+++ b/packages/ui/src/views/menu/desktop/TinyMenuGroup.tsx
@@ -17,10 +17,10 @@
 import type { IDisplayMenuItem, IMenuItem, IValueOption, MenuItemDefaultValueType } from '../../../services/menu/menu';
 import type { IMenuSchema } from '../../../services/menu/menu-manager.service';
 import type { TinyMenuLayoutVariant, TinyMenuSizeVariant } from './DesignTinyMenuGroup';
-import { convertObservableToBehaviorSubject, LocaleService } from '@univerjs/core';
+import { LocaleService } from '@univerjs/core';
 import { cva } from '@univerjs/design';
-import { useEffect, useMemo, useState } from 'react';
-import { combineLatest, of } from 'rxjs';
+import { useMemo } from 'react';
+import { combineLatest, map, of, startWith } from 'rxjs';
 import { IconManager } from '../../../common';
 import { useDependency, useObservable } from '../../../utils/di';
 import { DesignTinyMenuGroup } from './DesignTinyMenuGroup';
@@ -43,6 +43,7 @@ interface IUIQuickTileMenuItemProps {
 }
 
 const EMPTY_HIDDEN_ITEM_IDS: string[] = [];
+const EMPTY_TINY_MENU_CHILDREN: IMenuSchema[] = [];
 
 type TinyMenuDisplayItem = IDisplayMenuItem<IMenuItem> & {
     value?: MenuItemDefaultValueType;
@@ -151,56 +152,21 @@ function QuickTileMenuItem(props: IUIQuickTileMenuItemProps) {
 
 export function UITinyMenuGroup(props: IUIQuickMenuGroupProps) {
     const { item, activeItemIds, hiddenItemIds = EMPTY_HIDDEN_ITEM_IDS, hoverSuppressed, columns, sizeVariant = 'default', layoutVariant = 'default', onOptionSelect } = props;
-    const [activeItems, setActiveItems] = useState<string[]>([]);
-    const [hiddenItems, setHiddenItems] = useState<string[]>([]);
     const iconManager = useDependency(IconManager);
     const localeService = useDependency(LocaleService);
-
-    useEffect(() => {
-        const { children } = item;
-        if (!children) return;
-
-        const observables = children.map((child) => convertObservableToBehaviorSubject(child.item?.activated$ ?? of(false), false));
-        const subscription = combineLatest(observables).subscribe((activedArr) => {
-            const activeItems: string[] = [];
-            for (let index = 0; index < activedArr.length; index++) {
-                if (activedArr[index]) {
-                    activeItems.push(getTinyMenuChildStateKey(children[index]));
-                }
-            }
-            setActiveItems(activeItems);
-        });
-
-        return () => {
-            subscription.unsubscribe();
-            observables.forEach((observable) => {
-                observable.complete();
-            });
-        };
-    }, [item]);
-
-    useEffect(() => {
-        const { children } = item;
-        if (!children) return;
-
-        const observables = children.map((child) => convertObservableToBehaviorSubject(child.item?.hidden$ ?? of(false), false));
-        const subscription = combineLatest(observables).subscribe((hiddenArr) => {
-            const hiddenItems: string[] = [];
-            for (let index = 0; index < hiddenArr.length; index++) {
-                if (hiddenArr[index]) {
-                    hiddenItems.push(getTinyMenuChildStateKey(children[index]));
-                }
-            }
-            setHiddenItems(hiddenItems);
-        });
-
-        return () => {
-            subscription.unsubscribe();
-            observables.forEach((observable) => {
-                observable.complete();
-            });
-        };
-    }, [item]);
+    const children = item.children ?? EMPTY_TINY_MENU_CHILDREN;
+    const activeItems$ = useMemo(() => children.length
+        ? combineLatest(children.map((child) => (child.item?.activated$ ?? of(false)).pipe(startWith(false)))).pipe(
+            map((states) => children.flatMap((child, index) => states[index] ? [getTinyMenuChildStateKey(child)] : []))
+        )
+        : of([] as string[]), [children]);
+    const hiddenItems$ = useMemo(() => children.length
+        ? combineLatest(children.map((child) => (child.item?.hidden$ ?? of(false)).pipe(startWith(false)))).pipe(
+            map((states) => children.flatMap((child, index) => states[index] ? [getTinyMenuChildStateKey(child)] : []))
+        )
+        : of([] as string[]), [children]);
+    const activeItems = useObservable(activeItems$, []);
+    const hiddenItems = useObservable(hiddenItems$, []);
 
     const visibleChildren = useMemo(
         () => getVisibleTinyMenuChildren(item.children ?? [], [...hiddenItems, ...hiddenItemIds]),

--- a/packages/ui/src/views/menu/mobile/MobileMenu.tsx
+++ b/packages/ui/src/views/menu/mobile/MobileMenu.tsx
@@ -29,7 +29,7 @@ import { LocaleService } from '@univerjs/core';
 import { borderBottomClassName, clsx } from '@univerjs/design';
 import { CheckMarkIcon, MoreLeftIcon, MoreRightIcon } from '@univerjs/icons';
 import { useEffect, useMemo, useState } from 'react';
-import { combineLatest, isObservable, of } from 'rxjs';
+import { combineLatest, isObservable, map, merge, of } from 'rxjs';
 import { scan, startWith } from 'rxjs/operators';
 import { MenuItemType } from '../../../services/menu/menu';
 import { IMenuManagerService } from '../../../services/menu/menu-manager.service';
@@ -492,35 +492,25 @@ function getMenuSchemaTitle(schema: IMenuSchema, localeService: LocaleService) {
 }
 
 function useContextGroupHiddenStates(menuSchemas: IMenuSchema[]) {
-    const [hiddenStates, setHiddenStates] = useState<Record<string, boolean>>({});
-
-    useEffect(() => {
-        const subscriptions = menuSchemas.map((menuSchema) => {
-            if (!menuSchema.children?.length) {
-                return null;
-            }
-
-            const hiddenObservables = getLeafItemSchemas(menuSchema.children).map((childSchema) => childSchema.item?.hidden$ ?? of(false));
-            if (!hiddenObservables.length) {
-                return null;
-            }
-
-            return combineLatest(hiddenObservables).subscribe((hiddenValues) => {
-                const isAllHidden = hiddenValues.every((hidden) => hidden === true);
-                setHiddenStates((state) => ({
-                    ...state,
-                    [menuSchema.key]: isAllHidden,
-                }));
-            });
+    const hiddenStates$ = useMemo(() => {
+        const groupStates = menuSchemas.flatMap((menuSchema) => {
+            const hiddenObservables = menuSchema.children?.length
+                ? getLeafItemSchemas(menuSchema.children).map((childSchema) => childSchema.item?.hidden$ ?? of(false))
+                : [];
+            return hiddenObservables.length
+                ? [combineLatest(hiddenObservables).pipe(map((values) => [menuSchema.key, values.every(Boolean)] as const))]
+                : [];
         });
 
-        return () => {
-            subscriptions.forEach((subscription) => subscription?.unsubscribe());
-            setHiddenStates({});
-        };
+        return groupStates.length
+            ? merge(...groupStates).pipe(
+                scan((states, [key, hidden]) => ({ ...states, [key]: hidden }), {} as Record<string, boolean>),
+                startWith({})
+            )
+            : of({});
     }, [menuSchemas]);
 
-    return hiddenStates;
+    return useObservable<Record<string, boolean>>(hiddenStates$, {});
 }
 
 function getLeafItemSchemas(schemas: IMenuSchema[]): IMenuSchema[] {

--- a/packages/ui/src/views/mobile-workbench/MobileWorkbench.tsx
+++ b/packages/ui/src/views/mobile-workbench/MobileWorkbench.tsx
@@ -19,10 +19,11 @@ import type { ComponentType } from 'react';
 import type { IWorkbenchOptions } from '../../controllers/ui/ui.controller';
 import { LocaleService, ThemeService } from '@univerjs/core';
 import { borderBottomClassName, clsx, ConfigProvider, render } from '@univerjs/design';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { map } from 'rxjs';
 import { BuiltInUIPart } from '../../services/parts/parts.service';
 import { ThemeSwitcherService } from '../../services/theme-switcher/theme-switcher.service';
-import { connectInjector, useDependency } from '../../utils/di';
+import { connectInjector, useDependency, useObservable } from '../../utils/di';
 import { ComponentContainer, useComponentsOfPart } from '../components/ComponentContainer';
 import { MobileContextMenu } from '../components/context-menu/MobileContextMenu';
 import { Sidebar } from '../components/sidebar/Sidebar';
@@ -77,16 +78,7 @@ export function MobileWorkbench(props: IUniverAppProps) {
     const globalComponents = useComponentsOfPart(BuiltInUIPart.GLOBAL);
     const toolbarComponents = useComponentsOfPart(BuiltInUIPart.TOOLBAR);
 
-    const [darkMode, setDarkMode] = useState<boolean>(false);
-    useEffect(() => {
-        const sub = themeService.darkMode$.subscribe((darkMode) => {
-            setDarkMode(darkMode);
-        });
-
-        return () => {
-            sub.unsubscribe();
-        };
-    }, []);
+    const darkMode = useObservable(themeService.darkMode$, themeService.darkMode);
 
     useEffect(() => {
         if (contentRef.current) {
@@ -94,8 +86,13 @@ export function MobileWorkbench(props: IUniverAppProps) {
         }
     }, [onRendered]);
 
-    const [locale, setLocale] = useState(() => localeService.getLocales());
-    const [direction, setDirection] = useState(() => localeService.getDirection());
+    const locale = useObservable(
+        () => localeService.localeChanged$.pipe(map(() => localeService.getLocales())),
+        localeService.getLocales(),
+        false,
+        [localeService]
+    );
+    const direction = useObservable(localeService.direction$, localeService.getDirection());
 
     // Create a portal container for injecting global component themes.
     const portalContainer = useMemo<HTMLElement>(() => document.createElement('div'), []);
@@ -113,23 +110,10 @@ export function MobileWorkbench(props: IUniverAppProps) {
     useEffect(() => {
         document.body.appendChild(portalContainer);
 
-        const subscriptions = [
-            localeService.localeChanged$.subscribe(() => {
-                setLocale(localeService.getLocales());
-            }),
-            localeService.direction$.subscribe(() => {
-                setDirection(localeService.getDirection());
-            }),
-        ];
-
         return () => {
-            // batch unsubscribe
-            subscriptions.forEach((subscription) => subscription.unsubscribe());
-
-            // cleanup
             document.body.removeChild(portalContainer);
         };
-    }, [localeService, mountContainer, portalContainer]);
+    }, [mountContainer, portalContainer]);
 
     useEffect(() => {
         portalContainer.dir = direction;

--- a/packages/ui/src/views/workbench/Workbench.tsx
+++ b/packages/ui/src/views/workbench/Workbench.tsx
@@ -20,12 +20,13 @@ import type { IUniverUIConfig } from '../../config/config';
 import type { IWorkbenchOptions } from '../../controllers/ui/ui.controller';
 import { IConfigService, LocaleService, ThemeService } from '@univerjs/core';
 import { borderBottomClassName, clsx, ConfigContext, ConfigProvider, render } from '@univerjs/design';
-import { useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { map } from 'rxjs';
 import { UI_PLUGIN_CONFIG_KEY } from '../../config/config';
 import { BuiltInUIPart } from '../../services/parts/parts.service';
 import { ThemeSwitcherService } from '../../services/theme-switcher/theme-switcher.service';
-import { connectInjector, useDependency } from '../../utils/di';
+import { connectInjector, useDependency, useObservable } from '../../utils/di';
 import { ComponentContainer, useComponentsOfPart } from '../components/ComponentContainer';
 import { DesktopContextMenu } from '../components/context-menu/ContextMenu';
 import { Sidebar } from '../components/sidebar/Sidebar';
@@ -99,22 +100,14 @@ export function DesktopWorkbenchContent(props: IUniverWorkbenchProps) {
         };
     }, []);
 
-    const [darkMode, setDarkMode] = useState<boolean>(false);
+    const darkMode = useObservable(themeService.darkMode$, themeService.darkMode);
     useLayoutEffect(() => {
-        const sub = themeService.darkMode$.subscribe((darkMode) => {
-            setDarkMode(darkMode);
-
-            if (darkMode) {
-                document.documentElement.classList.add('univer-dark');
-            } else {
-                document.documentElement.classList.remove('univer-dark');
-            }
-        });
-
-        return () => {
-            sub.unsubscribe();
-        };
-    }, []);
+        if (darkMode) {
+            document.documentElement.classList.add('univer-dark');
+        } else {
+            document.documentElement.classList.remove('univer-dark');
+        }
+    }, [darkMode]);
 
     useEffect(() => {
         if (contentRef.current) {
@@ -122,8 +115,13 @@ export function DesktopWorkbenchContent(props: IUniverWorkbenchProps) {
         }
     }, [onRendered]);
 
-    const [locale, setLocale] = useState(() => localeService.getLocales());
-    const [direction, setDirection] = useState(() => localeService.getDirection());
+    const locale = useObservable(
+        () => localeService.localeChanged$.pipe(map(() => localeService.getLocales())),
+        localeService.getLocales(),
+        false,
+        [localeService]
+    );
+    const direction = useObservable(localeService.direction$, localeService.getDirection());
 
     // Create a portal container for injecting global component themes.
     const portalContainer = useMemo<HTMLElement>(() => document.createElement('div'), []);
@@ -131,23 +129,10 @@ export function DesktopWorkbenchContent(props: IUniverWorkbenchProps) {
     useEffect(() => {
         document.body.appendChild(portalContainer);
 
-        const subscriptions = [
-            localeService.localeChanged$.subscribe(() => {
-                setLocale(localeService.getLocales());
-            }),
-            localeService.direction$.subscribe(() => {
-                setDirection(localeService.getDirection());
-            }),
-        ];
-
         return () => {
-            // batch unsubscribe
-            subscriptions.forEach((subscription) => subscription.unsubscribe());
-
-            // cleanup
             document.body.removeChild(portalContainer);
         };
-    }, [localeService, mountContainer, portalContainer]);
+    }, [mountContainer, portalContainer]);
 
     useEffect(() => {
         portalContainer.dir = direction;


### PR DESCRIPTION
## Summary

- Replace manual React and RxJS subscription bookkeeping with useObservable across core UI packages.
- Derive docs, drawing, sheets, slides, and workbench state directly from existing observables.
- Remove duplicated cleanup and force-refresh state.

## Testing

- eslint --fix via the pre-commit hook (45 files)
- git diff --cached --check

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (missing issue).
- [x] Naming convention is followed.
- [x] Unit tests are not applicable to this behavior-preserving refactor.
- [x] No breaking changes are introduced.