### PR TITLE
fix(ui): support dynamic menu command params

### DIFF
--- a/packages/ui/src/services/menu/menu.ts
+++ b/packages/ui/src/services/menu/menu.ts
@@ -63,7 +63,7 @@ interface IMenuItemBase<TLocaleKey extends string, TValue> {
 
     hidden$?: Observable<boolean>;
     disabled$?: Observable<boolean>;
-    params?: IMenuCommandParams;
+    params?: IMenuCommandParams | (() => IMenuCommandParams | undefined);
     /** On observable value that should emit the value of the corresponding selection component. */
     value$?: Observable<TValue>;
 }
@@ -78,7 +78,7 @@ export interface IValueOption<TLocaleKey extends string = string, TValue = undef
     id?: string;
     value?: string | number;
     value$?: Observable<TValue>;
-    params?: IMenuCommandParams | ((value?: string | number) => IMenuCommandParams);
+    params?: IMenuCommandParams | ((value?: string | number) => IMenuCommandParams | undefined);
     slot?: boolean;
     label?: MenuLabel; // custom component, send to CustomLabel label property
     icon?: string;

--- a/packages/ui/src/views/components/ribbon/ToolbarItem.tsx
+++ b/packages/ui/src/views/components/ribbon/ToolbarItem.tsx
@@ -239,8 +239,8 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IDisplayMenuItem<IMenu
                 commandId = option.id;
             }
 
-            const commandParams = typeof option.params === 'function' ? option.params(option.value) : option.params ?? { value: option.value };
-            executeCommand(commandId, commandParams);
+            const commandParams = typeof option.params === 'function' ? option.params(option.value) : option.params;
+            executeCommand(commandId, commandParams ?? { value: option.value });
         }
 
         function handleSelectionsValueChange(value: string | number) {
@@ -252,7 +252,8 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IDisplayMenuItem<IMenu
             if (disabled) return;
 
             if (menuType === MenuItemType.BUTTON_SELECTOR) {
-                executeCommand(bId, params ?? { value });
+                const commandParams = typeof params === 'function' ? params() : params;
+                executeCommand(bId, commandParams ?? { value });
             }
         }
 
@@ -328,8 +329,6 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IDisplayMenuItem<IMenu
     function renderButtonType() {
         const isCustomComponent = componentManager.get(typeof label === 'string' ? label : label?.name ?? '');
 
-        const commandValue = params ?? (typeof value === 'undefined' ? undefined : { value });
-
         return (
             <ToolbarButton
                 data-u-command={id}
@@ -337,7 +336,10 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IDisplayMenuItem<IMenu
                 noIcon={!icon}
                 active={activated}
                 disabled={disabled}
-                onClick={() => executeCommand(props.commandId ?? props.id, commandValue)}
+                onClick={() => {
+                    const commandParams = typeof params === 'function' ? params() : params;
+                    executeCommand(props.commandId ?? props.id, commandParams ?? (typeof value === 'undefined' ? undefined : { value }));
+                }}
                 onDoubleClick={() => props.subId && executeCommand(props.subId)}
             >
                 {isCustomComponent

--- a/packages/ui/src/views/components/ribbon/__tests__/ToolbarItem.spec.tsx
+++ b/packages/ui/src/views/components/ribbon/__tests__/ToolbarItem.spec.tsx
@@ -94,6 +94,26 @@ function renderWithDependencies(element: ReactElement) {
 afterEach(cleanup);
 
 describe('ToolbarItem', () => {
+    it('resolves menu params when clicking a button', () => {
+        const { getByRole, commandService } = renderWithDependencies(
+            <ToolbarItem
+                id="test-button"
+                type={MenuItemType.BUTTON}
+                title="Dynamic params"
+                params={() => ({ unitId: 'unit-1' })}
+            />
+        );
+
+        fireEvent.click(getByRole('button', { name: 'Dynamic params' }));
+
+        expect(commandService.calls).toEqual([
+            {
+                commandId: 'test-button',
+                params: { unitId: 'unit-1' },
+            },
+        ]);
+    });
+
     it('forwards menu params when clicking a button selector main action', () => {
         const rule = { type: 'checkbox' };
         const { container, commandService } = renderWithDependencies(


### PR DESCRIPTION
## Background

The stricter `IMenuCommandParams` typing introduced by #7291 removed support for menu parameter factories, while Pro menu items still derive command parameters from current application state. This caused Pro typecheck failures and would otherwise pass a function to command execution.

## Changes

- allow existing menu items and value options to provide typed parameter factories
- resolve factories at click time before executing commands
- retain the existing value fallback when a factory returns `undefined`
- add a focused toolbar regression test

## Validation

- `pnpm --filter @univerjs/ui typecheck`
- `pnpm --filter @univerjs/ui test -- ToolbarItem.spec.tsx` (62 files, 276 tests passed)
- targeted ESLint (0 errors; 4 pre-existing warnings in menu.ts)