### PR TITLE
fix(sheets-ui): end selection when pointer is released

### DIFF
--- a/packages/sheets-ui/src/services/selection/__tests__/base-selection-render.service.spec.ts
+++ b/packages/sheets-ui/src/services/selection/__tests__/base-selection-render.service.spec.ts
@@ -441,6 +441,34 @@ describe('BaseSelectionRenderService', () => {
         expect(movingSelections.length).toBeGreaterThan(0);
     });
 
+    it('ends a leaked drag before handling pointer movement with no pressed buttons', () => {
+        const { service } = createSelectionRenderService();
+        const { scene } = service.changeRuntimeForTest();
+        service.resetSelectionsByModelData([selections[0]]);
+        service.listenPointerMoveForTest();
+
+        (scene.onPointerMove$ as unknown as { emit: (evt: unknown) => void }).emit({
+            offsetX: 350,
+            offsetY: 65,
+            buttons: 1,
+        });
+        expect(service.selectionMoving).toBe(true);
+
+        (scene.onPointerMove$ as unknown as { emit: (evt: unknown) => void }).emit({
+            offsetX: 450,
+            offsetY: 85,
+            buttons: 0,
+        });
+
+        expect(service.getActiveRange()).toEqual({
+            startRow: 1,
+            startColumn: 1,
+            endRow: 3,
+            endColumn: 3,
+        });
+        expect(service.selectionMoving).toBe(false);
+    });
+
     it('cancels an in-progress selection when another scene receives a pointer event', () => {
         const { service } = createSelectionRenderService();
         const { scene } = service.changeRuntimeForTest();

--- a/packages/sheets-ui/src/services/selection/base-selection-render.service.ts
+++ b/packages/sheets-ui/src/services/selection/base-selection-render.service.ts
@@ -520,6 +520,11 @@ export class BaseSelectionRenderService extends Disposable implements ISheetSele
         // #region onPointerMove$
         // eslint-disable-next-line max-lines-per-function, complexity
         this._scenePointerMoveSub = scene.onPointerMove$.subscribeEvent((moveEvt: IPointerEvent | IMouseEvent) => {
+            if (moveEvt.buttons === 0) {
+                this.endSelection();
+                return;
+            }
+
             const { offsetX: moveOffsetX, offsetY: moveOffsetY } = moveEvt;
 
             const { x: newMoveOffsetX, y: newMoveOffsetY } = scene.getCoordRelativeToViewport(Vector2.FromArray([moveOffsetX, moveOffsetY]));


### PR DESCRIPTION
## Summary

- End an active selection drag when a pointer-move event reports that no buttons are pressed.
- Add a regression test for a missed pointer-up event.

## Why

If the pointer-up event is lost, the selection service can retain its drag listeners and continue extending the selection after the mouse button has already been released. Checking the native button state on the next pointer move closes that leaked drag before processing more movement.

## Test

- `pnpm --filter @univerjs/sheets-ui test -- src/services/selection/__tests__/base-selection-render.service.spec.ts`
  - 119 test files passed
  - 544 tests passed

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (no related issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
