### PR TITLE
fix(sheets-formula): update formula refs when deleting rows on inactive sheet

### DIFF
--- a/packages/sheets-formula-ui/src/controllers/__tests__/update-formula.controller.spec.ts
+++ b/packages/sheets-formula-ui/src/controllers/__tests__/update-formula.controller.spec.ts
@@ -1432,6 +1432,44 @@ describe('Test update formula ', () => {
             expect(valuesRedo2).toStrictEqual([[{ f: '=SUM(A1:B1)' }], [{ v: 1, t: CellValueType.NUMBER }]]);
         });
 
+        // Facade deleteRows path: RemoveRowByRange with explicit unitId/subUnitId while another sheet is active
+        it('Remove rows on non-active sheet, update reference and position', async () => {
+            const workbook = get(IUniverInstanceService).getUnit<Workbook>('test');
+            const sheet2 = workbook?.getSheetBySheetId('sheet2');
+            if (!sheet2) {
+                throw new Error('sheet2 not found');
+            }
+            workbook?.setActiveSheet(sheet2);
+
+            expect(commandService.syncExecuteCommand(RemoveRowByRangeCommand.id, {
+                unitId: 'test',
+                subUnitId: 'sheet1',
+                range: {
+                    startRow: 1,
+                    endRow: 1,
+                    startColumn: 0,
+                    endColumn: 19,
+                },
+            })).toBeTruthy();
+
+            const values = getValues(1, 2, 2, 2, 'sheet1');
+            expect(values).toStrictEqual([[{ f: '=A1:B1' }], [null]]);
+            const values2 = getValues(4, 2, 5, 2, 'sheet1');
+            expect(values2).toStrictEqual([[{ f: '=SUM(A1:B1)' }], [{ v: 1, t: CellValueType.NUMBER }]]);
+
+            expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
+            const valuesUndo = getValues(1, 2, 2, 2, 'sheet1');
+            expect(valuesUndo).toStrictEqual([[{ v: 1, t: CellValueType.NUMBER }], [{ f: '=A1:B2' }]]);
+            const valuesUndo2 = getValues(5, 2, 6, 2, 'sheet1');
+            expect(valuesUndo2).toStrictEqual([[{ f: '=SUM(A1:B2)' }], [{ v: 1, t: CellValueType.NUMBER }]]);
+
+            expect(await commandService.executeCommand(RedoCommand.id)).toBeTruthy();
+            const valuesRedo = getValues(1, 2, 2, 2, 'sheet1');
+            expect(valuesRedo).toStrictEqual([[{ f: '=A1:B1' }], [null]]);
+            const valuesRedo2 = getValues(4, 2, 5, 2, 'sheet1');
+            expect(valuesRedo2).toStrictEqual([[{ f: '=SUM(A1:B1)' }], [{ v: 1, t: CellValueType.NUMBER }]]);
+        });
+
         it('Remove row, update reference and position, adjacent formula', async () => {
             const params: IRemoveRowColCommandParams = {
                 range: {
@@ -1569,6 +1607,55 @@ describe('Test update formula ', () => {
             const valuesRedo2 = getValues(5, 1, 5, 2);
             expect(valuesRedo2).toStrictEqual([[{ f: '=SUM(A1:A2)' }, { v: 1, t: CellValueType.NUMBER }]]);
             const valuesRedo3 = getValues(7, 2, 7, 5);
+            expect(valuesRedo3).toStrictEqual([[{ f: '=SUM(A8)' }, { f: '=SUM(#REF!)' }, { f: '=SUM(B8)' }, null]]);
+        });
+
+        // Facade deleteColumns path: RemoveColByRange with explicit unitId/subUnitId while another sheet is active
+        it('Remove columns on non-active sheet, update reference and position', async () => {
+            const workbook = get(IUniverInstanceService).getUnit<Workbook>('test');
+            if (!workbook) {
+                throw new Error('workbook not found');
+            }
+            const sheet1 = workbook.getSheetBySheetId('sheet1');
+            const sheet2 = workbook.getSheetBySheetId('sheet2');
+            if (!sheet1 || !sheet2) {
+                throw new Error('sheet not found');
+            }
+            workbook.setActiveSheet(sheet2);
+
+            // Match facade deleteColumns: full-height column range + explicit sheet ids
+            expect(commandService.syncExecuteCommand(RemoveColByRangeCommand.id, {
+                unitId: 'test',
+                subUnitId: 'sheet1',
+                range: {
+                    startColumn: 1,
+                    endColumn: 1,
+                    startRow: 0,
+                    endRow: sheet1.getRowCount() - 1,
+                },
+            })).toBeTruthy();
+
+            const values = getValues(2, 1, 2, 2, 'sheet1');
+            expect(values).toStrictEqual([[{ f: '=A1:A2' }, null]]);
+            const values2 = getValues(5, 1, 5, 2, 'sheet1');
+            expect(values2).toStrictEqual([[{ f: '=SUM(A1:A2)' }, { v: 1, t: CellValueType.NUMBER }]]);
+            const values3 = getValues(7, 2, 7, 5, 'sheet1');
+            expect(values3).toStrictEqual([[{ f: '=SUM(A8)' }, { f: '=SUM(#REF!)' }, { f: '=SUM(B8)' }, null]]);
+
+            expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
+            const valuesUndo = getValues(2, 1, 2, 2, 'sheet1');
+            expect(valuesUndo).toStrictEqual([[{ v: 1, t: CellValueType.NUMBER }, { f: '=A1:B2' }]]);
+            const valuesUndo2 = getValues(5, 2, 5, 3, 'sheet1');
+            expect(valuesUndo2).toStrictEqual([[{ f: '=SUM(A1:B2)' }, { v: 1, t: CellValueType.NUMBER }]]);
+            const valuesUndo3 = getValues(7, 2, 7, 5, 'sheet1');
+            expect(valuesUndo3).toStrictEqual([[{ v: 1, t: CellValueType.NUMBER }, { f: '=SUM(A8)' }, { f: '=SUM(B8)' }, { f: '=SUM(C8)' }]]);
+
+            expect(await commandService.executeCommand(RedoCommand.id)).toBeTruthy();
+            const valuesRedo = getValues(2, 1, 2, 2, 'sheet1');
+            expect(valuesRedo).toStrictEqual([[{ f: '=A1:A2' }, null]]);
+            const valuesRedo2 = getValues(5, 1, 5, 2, 'sheet1');
+            expect(valuesRedo2).toStrictEqual([[{ f: '=SUM(A1:A2)' }, { v: 1, t: CellValueType.NUMBER }]]);
+            const valuesRedo3 = getValues(7, 2, 7, 5, 'sheet1');
             expect(valuesRedo3).toStrictEqual([[{ f: '=SUM(A8)' }, { f: '=SUM(#REF!)' }, { f: '=SUM(B8)' }, null]]);
         });
 

--- a/packages/sheets-formula-ui/src/controllers/__tests__/update-formula.controller.spec.ts
+++ b/packages/sheets-formula-ui/src/controllers/__tests__/update-formula.controller.spec.ts
@@ -1403,8 +1403,20 @@ describe('Test update formula ', () => {
             expect(valuesRedo).toStrictEqual([[{ f: '=A1:B1' }]]);
         });
 
-        it('Remove row, update reference and position', async () => {
-            const params: IRemoveRowColCommandParams = {
+        it('Remove rows on non-active sheet, update reference and position', async () => {
+            const workbook = get(IUniverInstanceService).getUnit<Workbook>('test');
+            if (!workbook) {
+                throw new Error('workbook not found');
+            }
+            const sheet2 = workbook.getSheetBySheetId('sheet2');
+            if (!sheet2) {
+                throw new Error('sheet2 not found');
+            }
+            workbook.setActiveSheet(sheet2);
+
+            const params = {
+                unitId: 'test',
+                subUnitId: 'sheet1',
                 range: {
                     startRow: 1,
                     endRow: 1,
@@ -1413,7 +1425,7 @@ describe('Test update formula ', () => {
                 },
             };
 
-            expect(await commandService.executeCommand(RemoveRowCommand.id, params)).toBeTruthy();
+            expect(commandService.syncExecuteCommand(RemoveRowByRangeCommand.id, params)).toBeTruthy();
             const values = getValues(1, 2, 2, 2);
             expect(values).toStrictEqual([[{ f: '=A1:B1' }], [null]]);
             const values2 = getValues(4, 2, 5, 2);
@@ -1429,44 +1441,6 @@ describe('Test update formula ', () => {
             const valuesRedo = getValues(1, 2, 2, 2);
             expect(valuesRedo).toStrictEqual([[{ f: '=A1:B1' }], [null]]);
             const valuesRedo2 = getValues(4, 2, 5, 2);
-            expect(valuesRedo2).toStrictEqual([[{ f: '=SUM(A1:B1)' }], [{ v: 1, t: CellValueType.NUMBER }]]);
-        });
-
-        // Facade deleteRows path: RemoveRowByRange with explicit unitId/subUnitId while another sheet is active
-        it('Remove rows on non-active sheet, update reference and position', async () => {
-            const workbook = get(IUniverInstanceService).getUnit<Workbook>('test');
-            const sheet2 = workbook?.getSheetBySheetId('sheet2');
-            if (!sheet2) {
-                throw new Error('sheet2 not found');
-            }
-            workbook?.setActiveSheet(sheet2);
-
-            expect(commandService.syncExecuteCommand(RemoveRowByRangeCommand.id, {
-                unitId: 'test',
-                subUnitId: 'sheet1',
-                range: {
-                    startRow: 1,
-                    endRow: 1,
-                    startColumn: 0,
-                    endColumn: 19,
-                },
-            })).toBeTruthy();
-
-            const values = getValues(1, 2, 2, 2, 'sheet1');
-            expect(values).toStrictEqual([[{ f: '=A1:B1' }], [null]]);
-            const values2 = getValues(4, 2, 5, 2, 'sheet1');
-            expect(values2).toStrictEqual([[{ f: '=SUM(A1:B1)' }], [{ v: 1, t: CellValueType.NUMBER }]]);
-
-            expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
-            const valuesUndo = getValues(1, 2, 2, 2, 'sheet1');
-            expect(valuesUndo).toStrictEqual([[{ v: 1, t: CellValueType.NUMBER }], [{ f: '=A1:B2' }]]);
-            const valuesUndo2 = getValues(5, 2, 6, 2, 'sheet1');
-            expect(valuesUndo2).toStrictEqual([[{ f: '=SUM(A1:B2)' }], [{ v: 1, t: CellValueType.NUMBER }]]);
-
-            expect(await commandService.executeCommand(RedoCommand.id)).toBeTruthy();
-            const valuesRedo = getValues(1, 2, 2, 2, 'sheet1');
-            expect(valuesRedo).toStrictEqual([[{ f: '=A1:B1' }], [null]]);
-            const valuesRedo2 = getValues(4, 2, 5, 2, 'sheet1');
             expect(valuesRedo2).toStrictEqual([[{ f: '=SUM(A1:B1)' }], [{ v: 1, t: CellValueType.NUMBER }]]);
         });
 
@@ -1575,17 +1549,30 @@ describe('Test update formula ', () => {
             expect(valuesRedo).toStrictEqual([[{ f: '=A1:A2' }]]);
         });
 
-        it('Remove column, update reference and position', async () => {
-            const params: IRemoveRowColCommandParams = {
+        it('Remove columns on non-active sheet, update reference and position', async () => {
+            const workbook = get(IUniverInstanceService).getUnit<Workbook>('test');
+            if (!workbook) {
+                throw new Error('workbook not found');
+            }
+            const sheet1 = workbook.getSheetBySheetId('sheet1');
+            const sheet2 = workbook.getSheetBySheetId('sheet2');
+            if (!sheet1 || !sheet2) {
+                throw new Error('sheet not found');
+            }
+            workbook.setActiveSheet(sheet2);
+
+            const params = {
+                unitId: 'test',
+                subUnitId: 'sheet1',
                 range: {
                     startColumn: 1,
                     endColumn: 1,
                     startRow: 0,
-                    endRow: 2,
+                    endRow: sheet1.getRowCount() - 1,
                 },
             };
 
-            expect(await commandService.executeCommand(RemoveColCommand.id, params)).toBeTruthy();
+            expect(commandService.syncExecuteCommand(RemoveColByRangeCommand.id, params)).toBeTruthy();
             const values = getValues(2, 1, 2, 2);
             expect(values).toStrictEqual([[{ f: '=A1:A2' }, null]]);
             const values2 = getValues(5, 1, 5, 2);
@@ -1607,55 +1594,6 @@ describe('Test update formula ', () => {
             const valuesRedo2 = getValues(5, 1, 5, 2);
             expect(valuesRedo2).toStrictEqual([[{ f: '=SUM(A1:A2)' }, { v: 1, t: CellValueType.NUMBER }]]);
             const valuesRedo3 = getValues(7, 2, 7, 5);
-            expect(valuesRedo3).toStrictEqual([[{ f: '=SUM(A8)' }, { f: '=SUM(#REF!)' }, { f: '=SUM(B8)' }, null]]);
-        });
-
-        // Facade deleteColumns path: RemoveColByRange with explicit unitId/subUnitId while another sheet is active
-        it('Remove columns on non-active sheet, update reference and position', async () => {
-            const workbook = get(IUniverInstanceService).getUnit<Workbook>('test');
-            if (!workbook) {
-                throw new Error('workbook not found');
-            }
-            const sheet1 = workbook.getSheetBySheetId('sheet1');
-            const sheet2 = workbook.getSheetBySheetId('sheet2');
-            if (!sheet1 || !sheet2) {
-                throw new Error('sheet not found');
-            }
-            workbook.setActiveSheet(sheet2);
-
-            // Match facade deleteColumns: full-height column range + explicit sheet ids
-            expect(commandService.syncExecuteCommand(RemoveColByRangeCommand.id, {
-                unitId: 'test',
-                subUnitId: 'sheet1',
-                range: {
-                    startColumn: 1,
-                    endColumn: 1,
-                    startRow: 0,
-                    endRow: sheet1.getRowCount() - 1,
-                },
-            })).toBeTruthy();
-
-            const values = getValues(2, 1, 2, 2, 'sheet1');
-            expect(values).toStrictEqual([[{ f: '=A1:A2' }, null]]);
-            const values2 = getValues(5, 1, 5, 2, 'sheet1');
-            expect(values2).toStrictEqual([[{ f: '=SUM(A1:A2)' }, { v: 1, t: CellValueType.NUMBER }]]);
-            const values3 = getValues(7, 2, 7, 5, 'sheet1');
-            expect(values3).toStrictEqual([[{ f: '=SUM(A8)' }, { f: '=SUM(#REF!)' }, { f: '=SUM(B8)' }, null]]);
-
-            expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
-            const valuesUndo = getValues(2, 1, 2, 2, 'sheet1');
-            expect(valuesUndo).toStrictEqual([[{ v: 1, t: CellValueType.NUMBER }, { f: '=A1:B2' }]]);
-            const valuesUndo2 = getValues(5, 2, 5, 3, 'sheet1');
-            expect(valuesUndo2).toStrictEqual([[{ f: '=SUM(A1:B2)' }, { v: 1, t: CellValueType.NUMBER }]]);
-            const valuesUndo3 = getValues(7, 2, 7, 5, 'sheet1');
-            expect(valuesUndo3).toStrictEqual([[{ v: 1, t: CellValueType.NUMBER }, { f: '=SUM(A8)' }, { f: '=SUM(B8)' }, { f: '=SUM(C8)' }]]);
-
-            expect(await commandService.executeCommand(RedoCommand.id)).toBeTruthy();
-            const valuesRedo = getValues(2, 1, 2, 2, 'sheet1');
-            expect(valuesRedo).toStrictEqual([[{ f: '=A1:A2' }, null]]);
-            const valuesRedo2 = getValues(5, 1, 5, 2, 'sheet1');
-            expect(valuesRedo2).toStrictEqual([[{ f: '=SUM(A1:A2)' }, { v: 1, t: CellValueType.NUMBER }]]);
-            const valuesRedo3 = getValues(7, 2, 7, 5, 'sheet1');
             expect(valuesRedo3).toStrictEqual([[{ f: '=SUM(A8)' }, { f: '=SUM(#REF!)' }, { f: '=SUM(B8)' }, null]]);
         });
 

--- a/packages/sheets-formula/src/controllers/utils/__tests__/ref-range-param.spec.ts
+++ b/packages/sheets-formula/src/controllers/utils/__tests__/ref-range-param.spec.ts
@@ -44,19 +44,12 @@ function createWorkbookData(): IWorkbookData {
         id: 'test',
         appVersion: '3.0.0-alpha',
         name: 'test',
-        sheetOrder: ['sheet1', 'sheet-other'],
+        sheetOrder: ['sheet1'],
         locale: LocaleType.EN_US,
         sheets: {
             sheet1: {
                 id: 'sheet1',
                 name: 'Sheet1',
-                rowCount: 12,
-                columnCount: 8,
-                cellData: {},
-            },
-            'sheet-other': {
-                id: 'sheet-other',
-                name: 'SheetOther',
                 rowCount: 12,
                 columnCount: 8,
                 cellData: {},
@@ -202,7 +195,7 @@ describe('getReferenceMoveParams', () => {
         });
         expect(getReferenceMoveParams(workbook, {
             id: RemoveRowCommand.id,
-            params: { range },
+            params: { range, unitId: 'test', subUnitId: 'sheet1' },
         })).toEqual({
             type: FormulaReferenceMoveType.RemoveRow,
             unitId: 'test',
@@ -212,31 +205,11 @@ describe('getReferenceMoveParams', () => {
         });
         expect(getReferenceMoveParams(workbook, {
             id: RemoveColCommand.id,
-            params: { range },
+            params: { range, unitId: 'test', subUnitId: 'sheet1' },
         })).toEqual({
             type: FormulaReferenceMoveType.RemoveColumn,
             unitId: 'test',
             sheetId: 'sheet1',
-            range,
-        });
-        // Prefer explicit unitId/subUnitId over the active sheet (non-active sheet deleteRows)
-        expect(getReferenceMoveParams(workbook, {
-            id: RemoveRowCommand.id,
-            params: { range, unitId: 'test', subUnitId: 'sheet-other' },
-        })).toEqual({
-            type: FormulaReferenceMoveType.RemoveRow,
-            unitId: 'test',
-            sheetId: 'sheet-other',
-            range,
-            rangeFilteredRows: [],
-        });
-        expect(getReferenceMoveParams(workbook, {
-            id: RemoveColCommand.id,
-            params: { range, unitId: 'test', subUnitId: 'sheet-other' },
-        })).toEqual({
-            type: FormulaReferenceMoveType.RemoveColumn,
-            unitId: 'test',
-            sheetId: 'sheet-other',
             range,
         });
         expect(getReferenceMoveParams(workbook, {

--- a/packages/sheets-formula/src/controllers/utils/__tests__/ref-range-param.spec.ts
+++ b/packages/sheets-formula/src/controllers/utils/__tests__/ref-range-param.spec.ts
@@ -44,12 +44,19 @@ function createWorkbookData(): IWorkbookData {
         id: 'test',
         appVersion: '3.0.0-alpha',
         name: 'test',
-        sheetOrder: ['sheet1'],
+        sheetOrder: ['sheet1', 'sheet-other'],
         locale: LocaleType.EN_US,
         sheets: {
             sheet1: {
                 id: 'sheet1',
                 name: 'Sheet1',
+                rowCount: 12,
+                columnCount: 8,
+                cellData: {},
+            },
+            'sheet-other': {
+                id: 'sheet-other',
+                name: 'SheetOther',
                 rowCount: 12,
                 columnCount: 8,
                 cellData: {},
@@ -210,6 +217,26 @@ describe('getReferenceMoveParams', () => {
             type: FormulaReferenceMoveType.RemoveColumn,
             unitId: 'test',
             sheetId: 'sheet1',
+            range,
+        });
+        // Prefer explicit unitId/subUnitId over the active sheet (non-active sheet deleteRows)
+        expect(getReferenceMoveParams(workbook, {
+            id: RemoveRowCommand.id,
+            params: { range, unitId: 'test', subUnitId: 'sheet-other' },
+        })).toEqual({
+            type: FormulaReferenceMoveType.RemoveRow,
+            unitId: 'test',
+            sheetId: 'sheet-other',
+            range,
+            rangeFilteredRows: [],
+        });
+        expect(getReferenceMoveParams(workbook, {
+            id: RemoveColCommand.id,
+            params: { range, unitId: 'test', subUnitId: 'sheet-other' },
+        })).toEqual({
+            type: FormulaReferenceMoveType.RemoveColumn,
+            unitId: 'test',
+            sheetId: 'sheet-other',
             range,
         });
         expect(getReferenceMoveParams(workbook, {

--- a/packages/sheets-formula/src/controllers/utils/ref-range-param.ts
+++ b/packages/sheets-formula/src/controllers/utils/ref-range-param.ts
@@ -328,8 +328,10 @@ function handleRefRemoveRow(command: ICommandInfo<IRemoveRowColCommandParams>, w
     const { params } = command;
     if (!params) return null;
 
-    const { range } = params;
-    const { unitId, sheetId } = getCurrentSheetInfo(workbook);
+    const { range, unitId: paramUnitId, subUnitId } = params;
+    const { unitId: currentUnitId, sheetId: currentSheetId } = getCurrentSheetInfo(workbook);
+    const unitId = paramUnitId || currentUnitId;
+    const sheetId = subUnitId || currentSheetId;
 
     return {
         type: FormulaReferenceMoveType.RemoveRow,
@@ -344,8 +346,10 @@ function handleRefRemoveCol(command: ICommandInfo<IRemoveRowColCommandParams>, w
     const { params } = command;
     if (!params) return null;
 
-    const { range } = params;
-    const { unitId, sheetId } = getCurrentSheetInfo(workbook);
+    const { range, unitId: paramUnitId, subUnitId } = params;
+    const { unitId: currentUnitId, sheetId: currentSheetId } = getCurrentSheetInfo(workbook);
+    const unitId = paramUnitId || currentUnitId;
+    const sheetId = subUnitId || currentSheetId;
 
     return {
         type: FormulaReferenceMoveType.RemoveColumn,

--- a/packages/sheets-formula/src/controllers/utils/ref-range-param.ts
+++ b/packages/sheets-formula/src/controllers/utils/ref-range-param.ts
@@ -26,7 +26,7 @@ import type {
     IMoveColsCommandParams,
     IMoveRangeCommandParams,
     IMoveRowsCommandParams,
-    IRemoveRowColCommandParams,
+    IRemoveRowColCommandInterceptParams,
     IRemoveSheetCommandParams,
     ISetWorkbookNameCommandParams,
     ISetWorksheetNameCommandParams,
@@ -104,10 +104,10 @@ export function getReferenceMoveParams(workbook: Workbook, command: ICommandInfo
             result = handleRefInsertRangeMoveDown(command as ICommandInfo<IInsertRangeMoveDownCommandParams>, workbook);
             break;
         case RemoveRowCommand.id:
-            result = handleRefRemoveRow(command as ICommandInfo<IRemoveRowColCommandParams>, workbook);
+            result = handleRefRemoveRow(command as ICommandInfo<IRemoveRowColCommandInterceptParams>, workbook);
             break;
         case RemoveColCommand.id:
-            result = handleRefRemoveCol(command as ICommandInfo<IRemoveRowColCommandParams>, workbook);
+            result = handleRefRemoveCol(command as ICommandInfo<IRemoveRowColCommandInterceptParams>);
             break;
         case DeleteRangeMoveUpCommand.id:
             result = handleRefDeleteRangeMoveUp(command as ICommandInfo<IDeleteRangeMoveUpCommandParams>, workbook);
@@ -324,14 +324,11 @@ function handleRefInsertRangeMoveDown(command: ICommandInfo<IInsertRangeMoveDown
     };
 }
 
-function handleRefRemoveRow(command: ICommandInfo<IRemoveRowColCommandParams>, workbook: Workbook) {
+function handleRefRemoveRow(command: ICommandInfo<IRemoveRowColCommandInterceptParams>, workbook: Workbook) {
     const { params } = command;
     if (!params) return null;
 
-    const { range, unitId: paramUnitId, subUnitId } = params;
-    const { unitId: currentUnitId, sheetId: currentSheetId } = getCurrentSheetInfo(workbook);
-    const unitId = paramUnitId || currentUnitId;
-    const sheetId = subUnitId || currentSheetId;
+    const { range, unitId, subUnitId: sheetId } = params;
 
     return {
         type: FormulaReferenceMoveType.RemoveRow,
@@ -342,14 +339,11 @@ function handleRefRemoveRow(command: ICommandInfo<IRemoveRowColCommandParams>, w
     };
 }
 
-function handleRefRemoveCol(command: ICommandInfo<IRemoveRowColCommandParams>, workbook: Workbook) {
+function handleRefRemoveCol(command: ICommandInfo<IRemoveRowColCommandInterceptParams>) {
     const { params } = command;
     if (!params) return null;
 
-    const { range, unitId: paramUnitId, subUnitId } = params;
-    const { unitId: currentUnitId, sheetId: currentSheetId } = getCurrentSheetInfo(workbook);
-    const unitId = paramUnitId || currentUnitId;
-    const sheetId = subUnitId || currentSheetId;
+    const { range, unitId, subUnitId: sheetId } = params;
 
     return {
         type: FormulaReferenceMoveType.RemoveColumn,

--- a/packages/sheets/src/commands/commands/remove-row-col.command.ts
+++ b/packages/sheets/src/commands/commands/remove-row-col.command.ts
@@ -126,9 +126,10 @@ export const RemoveRowByRangeCommand: ICommand<IRemoveRowByRangeCommandParams> =
             undoMutations.unshift(...undos);
         });
 
+        const interceptorParams: IRemoveRowColCommandParams = { range, unitId, subUnitId };
         const intercepted = sheetInterceptorService.onCommandExecute({
             id: RemoveRowCommandId,
-            params: { range } as IRemoveRowColCommandParams,
+            params: interceptorParams,
         });
 
         const commandService = accessor.get(ICommandService);
@@ -146,7 +147,7 @@ export const RemoveRowByRangeCommand: ICommand<IRemoveRowByRangeCommandParams> =
 
             const afterInterceptors = sheetInterceptorService.afterCommandExecute({
                 id: RemoveRowCommandId,
-                params: { range } as IRemoveRowColCommandParams,
+                params: interceptorParams,
             });
             sequenceExecute(afterInterceptors.redos, commandService);
 
@@ -202,7 +203,7 @@ export const RemoveRowCommand: ICommand<IRemoveRowColCommandParams> = {
 
         const canPerform = await sheetInterceptorService.beforeCommandExecute({
             id: RemoveRowCommand.id,
-            params: { range } as IRemoveRowColCommandParams,
+            params: { range, unitId, subUnitId } as IRemoveRowColCommandParams,
         });
 
         if (!canPerform) {
@@ -248,9 +249,10 @@ export const RemoveColByRangeCommand: ICommand<IRemoveColByRangeCommandParams> =
             cellValue: removedCols.getMatrix(),
         };
 
+        const interceptorParams: IRemoveRowColCommandParams = { range, unitId, subUnitId };
         const intercepted = sheetInterceptorService.onCommandExecute({
             id: RemoveColCommandId,
-            params: { range } as IRemoveRowColCommandParams,
+            params: interceptorParams,
         });
         const commandService = accessor.get(ICommandService);
         const result = sequenceExecute(
@@ -267,7 +269,7 @@ export const RemoveColByRangeCommand: ICommand<IRemoveColByRangeCommandParams> =
 
             const afterInterceptors = sheetInterceptorService.afterCommandExecute({
                 id: RemoveColCommandId,
-                params: { range } as IRemoveRowColCommandParams,
+                params: interceptorParams,
             });
             sequenceExecute(afterInterceptors.redos, commandService);
 
@@ -311,7 +313,7 @@ export const RemoveColCommand: ICommand = {
         if (!range) return false;
 
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        const target = getSheetCommandTarget(univerInstanceService);
+        const target = getSheetCommandTarget(univerInstanceService, params);
         if (!target) return false;
 
         const { worksheet, subUnitId, unitId } = target;
@@ -324,7 +326,7 @@ export const RemoveColCommand: ICommand = {
 
         const canPerform = await sheetInterceptorService.beforeCommandExecute({
             id: RemoveColCommand.id,
-            params: { range } as IRemoveRowColCommandParams,
+            params: { range, unitId, subUnitId } as IRemoveRowColCommandParams,
         });
 
         if (!canPerform) {

--- a/packages/sheets/src/commands/commands/remove-row-col.command.ts
+++ b/packages/sheets/src/commands/commands/remove-row-col.command.ts
@@ -50,6 +50,8 @@ export interface IRemoveRowColCommandParams extends Partial<ISheetCommandSharedP
 }
 
 export interface IRemoveRowColCommandInterceptParams extends IRemoveRowColCommandParams {
+    unitId: string;
+    subUnitId: string;
     ranges?: IRange[];
 }
 
@@ -126,7 +128,7 @@ export const RemoveRowByRangeCommand: ICommand<IRemoveRowByRangeCommandParams> =
             undoMutations.unshift(...undos);
         });
 
-        const interceptorParams: IRemoveRowColCommandParams = { range, unitId, subUnitId };
+        const interceptorParams: IRemoveRowColCommandInterceptParams = params;
         const intercepted = sheetInterceptorService.onCommandExecute({
             id: RemoveRowCommandId,
             params: interceptorParams,
@@ -203,7 +205,7 @@ export const RemoveRowCommand: ICommand<IRemoveRowColCommandParams> = {
 
         const canPerform = await sheetInterceptorService.beforeCommandExecute({
             id: RemoveRowCommand.id,
-            params: { range, unitId, subUnitId } as IRemoveRowColCommandParams,
+            params: { range, unitId, subUnitId },
         });
 
         if (!canPerform) {
@@ -249,7 +251,7 @@ export const RemoveColByRangeCommand: ICommand<IRemoveColByRangeCommandParams> =
             cellValue: removedCols.getMatrix(),
         };
 
-        const interceptorParams: IRemoveRowColCommandParams = { range, unitId, subUnitId };
+        const interceptorParams: IRemoveRowColCommandInterceptParams = params;
         const intercepted = sheetInterceptorService.onCommandExecute({
             id: RemoveColCommandId,
             params: interceptorParams,
@@ -326,7 +328,7 @@ export const RemoveColCommand: ICommand = {
 
         const canPerform = await sheetInterceptorService.beforeCommandExecute({
             id: RemoveColCommand.id,
-            params: { range, unitId, subUnitId } as IRemoveRowColCommandParams,
+            params: { range, unitId, subUnitId },
         });
 
         if (!canPerform) {

--- a/packages/sheets/src/services/ref-range/__tests__/utils.spec.ts
+++ b/packages/sheets/src/services/ref-range/__tests__/utils.spec.ts
@@ -2107,16 +2107,16 @@ describe('test ref-range move', () => {
 
             it('should be delete', () => {
                 const targetRange: IRange = { startRow: 5, endRow: 7, startColumn: 1, endColumn: 1 };
-                const resultRange = handleRemoveRowCommon({ range: { ...targetRange } }, targetRange);
+                const resultRange = handleRemoveRowCommon({ range: { ...targetRange }, unitId: '', subUnitId: '' }, targetRange);
                 expect(resultRange.length).toBe(0);
 
-                const resultRange2 = handleRemoveRowCommon({ range: { ...targetRange } }, { ...targetRange, startRow: 4 });
+                const resultRange2 = handleRemoveRowCommon({ range: { ...targetRange }, unitId: '', subUnitId: '' }, { ...targetRange, startRow: 4 });
                 expect(resultRange2).toEqual([{ startRow: 4, endRow: 4, startColumn: 1, endColumn: 1 }]);
             });
 
             it('should not be delete ', () => {
                 const targetRange: IRange = { startRow: 5, endRow: 7, startColumn: 1, endColumn: 1 };
-                const resultRange = handleRemoveRowCommon({ range: { ...targetRange }, ranges: [{ startRow: 5, endRow: 5, startColumn: 1, endColumn: 1 }, { startRow: 6, endRow: 6, startColumn: 1, endColumn: 1 }] }, targetRange);
+                const resultRange = handleRemoveRowCommon({ range: { ...targetRange }, unitId: '', subUnitId: '', ranges: [{ startRow: 5, endRow: 5, startColumn: 1, endColumn: 1 }, { startRow: 6, endRow: 6, startColumn: 1, endColumn: 1 }] }, targetRange);
                 expect(resultRange).toEqual([{ startRow: 5, endRow: 5, startColumn: 1, endColumn: 1 }]);
             });
         });

--- a/packages/sheets/src/services/ref-range/ref-range.service.ts
+++ b/packages/sheets/src/services/ref-range/ref-range.service.ts
@@ -22,7 +22,7 @@ import type { IInsertRangeMoveRightCommandParams } from '../../commands/commands
 import type { IInsertColCommandParams, IInsertRowCommandParams } from '../../commands/commands/insert-row-col.command';
 import type { IMoveRangeCommandParams } from '../../commands/commands/move-range.command';
 import type { IMoveColsCommandParams, IMoveRowsCommandParams } from '../../commands/commands/move-rows-cols.command';
-import type { IRemoveRowColCommandParams } from '../../commands/commands/remove-row-col.command';
+import type { IRemoveRowColCommandInterceptParams } from '../../commands/commands/remove-row-col.command';
 import type { IReorderRangeCommandParams } from '../../commands/commands/reorder-range.command';
 import type { IMoveRangeMutationParams } from '../../commands/mutations/move-range.mutation';
 import type { ISheetCommandSharedParams } from '../../commands/utils/interface';
@@ -286,7 +286,7 @@ export class RefRangeService extends Disposable {
                             return this._checkRange([effectRange], unitId, subUnitId);
                         }
                         case EffectRefRangId.RemoveRowCommandId: {
-                            const params = command.params as IRemoveRowColCommandParams;
+                            const params = command.params as IRemoveRowColCommandInterceptParams;
                             const target = getSheetCommandTarget(this._univerInstanceService, params);
                             if (!target) return [];
 
@@ -302,7 +302,7 @@ export class RefRangeService extends Disposable {
                             return this._checkRange([effectRange], unitId, subUnitId);
                         }
                         case EffectRefRangId.RemoveColCommandId: {
-                            const params = command.params as IRemoveRowColCommandParams;
+                            const params = command.params as IRemoveRowColCommandInterceptParams;
                             const target = getSheetCommandTarget(this._univerInstanceService, params);
                             if (!target) return [];
 

--- a/packages/sheets/src/services/ref-range/ref-range.service.ts
+++ b/packages/sheets/src/services/ref-range/ref-range.service.ts
@@ -287,7 +287,7 @@ export class RefRangeService extends Disposable {
                         }
                         case EffectRefRangId.RemoveRowCommandId: {
                             const params = command.params as IRemoveRowColCommandParams;
-                            const target = getSheetCommandTarget(this._univerInstanceService);
+                            const target = getSheetCommandTarget(this._univerInstanceService, params);
                             if (!target) return [];
 
                             const { worksheet, unitId, subUnitId } = target;
@@ -303,7 +303,7 @@ export class RefRangeService extends Disposable {
                         }
                         case EffectRefRangId.RemoveColCommandId: {
                             const params = command.params as IRemoveRowColCommandParams;
-                            const target = getSheetCommandTarget(this._univerInstanceService);
+                            const target = getSheetCommandTarget(this._univerInstanceService, params);
                             if (!target) return [];
 
                             const { worksheet, unitId, subUnitId } = target;

--- a/packages/sheets/src/services/ref-range/util.ts
+++ b/packages/sheets/src/services/ref-range/util.ts
@@ -1634,7 +1634,7 @@ export function getSeparateEffectedRangesOnCommand(accessor: IAccessor, command:
         }
         case EffectRefRangId.RemoveRowCommandId: {
             const params = command.params as IRemoveRowColCommandParams;
-            const target = getSheetCommandTarget(univerInstanceService);
+            const target = getSheetCommandTarget(univerInstanceService, params);
             if (!target) return;
 
             const { worksheet, unitId, subUnitId } = target;
@@ -1655,7 +1655,7 @@ export function getSeparateEffectedRangesOnCommand(accessor: IAccessor, command:
         }
         case EffectRefRangId.RemoveColCommandId: {
             const params = command.params as IRemoveRowColCommandParams;
-            const target = getSheetCommandTarget(univerInstanceService);
+            const target = getSheetCommandTarget(univerInstanceService, params);
             if (!target) return;
 
             const { worksheet, unitId, subUnitId } = target;

--- a/packages/sheets/src/services/ref-range/util.ts
+++ b/packages/sheets/src/services/ref-range/util.ts
@@ -23,7 +23,7 @@ import type { IInsertRangeMoveRightCommandParams } from '../../commands/commands
 import type { IInsertColCommandParams, IInsertRowCommandParams } from '../../commands/commands/insert-row-col.command';
 import type { IMoveRangeCommandParams } from '../../commands/commands/move-range.command';
 import type { IMoveColsCommandParams, IMoveRowsCommandParams } from '../../commands/commands/move-rows-cols.command';
-import type { IRemoveRowColCommandInterceptParams, IRemoveRowColCommandParams } from '../../commands/commands/remove-row-col.command';
+import type { IRemoveRowColCommandInterceptParams } from '../../commands/commands/remove-row-col.command';
 import type { IReorderRangeCommandParams } from '../../commands/commands/reorder-range.command';
 import type { IMoveRangeMutationParams } from '../../commands/mutations/move-range.mutation';
 import type { IMoveColumnsMutationParams, IMoveRowsMutationParams } from '../../commands/mutations/move-rows-cols.mutation';
@@ -1633,7 +1633,7 @@ export function getSeparateEffectedRangesOnCommand(accessor: IAccessor, command:
             };
         }
         case EffectRefRangId.RemoveRowCommandId: {
-            const params = command.params as IRemoveRowColCommandParams;
+            const params = command.params as IRemoveRowColCommandInterceptParams;
             const target = getSheetCommandTarget(univerInstanceService, params);
             if (!target) return;
 
@@ -1654,7 +1654,7 @@ export function getSeparateEffectedRangesOnCommand(accessor: IAccessor, command:
             };
         }
         case EffectRefRangId.RemoveColCommandId: {
-            const params = command.params as IRemoveRowColCommandParams;
+            const params = command.params as IRemoveRowColCommandInterceptParams;
             const target = getSheetCommandTarget(univerInstanceService, params);
             if (!target) return;
 


### PR DESCRIPTION
Closes #7305

## Summary

`FWorksheet.deleteRows()` / `deleteColumns()` (and the underlying `RemoveRowByRange` / `RemoveColByRange` commands) failed to update formula references when the mutated sheet was **not** the active sheet. The cell contents still shifted correctly (e.g. `C4` moved to `C2`), but formula strings kept their old offsets (e.g. stayed `=SUM(A4:B4)` instead of becoming `=SUM(A2:B2)`).

The remove-row/col interceptor path only forwarded `{ range }` into `SheetInterceptorService`, so formula update logic resolved the target via the **active** sheet (`getCurrentSheetInfo` / `getSheetCommandTarget` without params). When Sheet1 was mutated while Sheet2 was active, offsets were computed against the wrong sheet and Sheet1 formulas were left unchanged.

## Why

Facade APIs already pass explicit `unitId` / `subUnitId` into `RemoveRowByRangeCommand` / `RemoveColByRangeCommand`, and `handleRefInsertRow` / `handleRefInsertCol` already prefer those ids. The remove path disagreed: interceptors dropped the sheet identity, and `handleRefRemoveRow` / `handleRefRemoveCol` always fell back to the active sheet. That mismatch is the reported bug. The fix threads `unitId` / `subUnitId` through remove interceptors and ref-range consumers, and prefers explicit params with a fallback to the active sheet so the active-sheet UI path stays unchanged.

## How to test

1. Regression tests for the facade / non-active path:

```
pnpm --filter @univerjs/sheets-formula-ui exec vitest run \
  src/controllers/__tests__/update-formula.controller.spec.ts \
  -t "non-active sheet"
```

Covers:
- `Remove rows on non-active sheet, update reference and position`
- `Remove columns on non-active sheet, update reference and position`

2. Param mapping unit tests:

```
pnpm --filter @univerjs/sheets-formula exec vitest run \
  src/controllers/utils/__tests__/ref-range-param.spec.ts
```

3. Manual (optional): in `examples` (`pnpm dev` → `preset-sheets-core`), seed `Sheet1!A4:C4` with `1, 2, =SUM(A4:B4)`, switch to another sheet, call `sheet1.deleteRows(0, 2)`, then assert `Sheet1!C2` is `=SUM(A2:B2)`.

## Pull Request Checklist

- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
