### PR TITLE
fix(formula): bound non-sheet other formulas

### DIFF
--- a/packages/engine-formula/src/engine/analysis/__tests__/dependency.spec.ts
+++ b/packages/engine-formula/src/engine/analysis/__tests__/dependency.spec.ts
@@ -189,6 +189,53 @@ describe('Test dependency', () => {
             expect(tree2.refOffsetY).toEqual(2);
         });
 
+        it('limits other formulas without sheet dimensions to one result slot', async () => {
+            const formulaId = 'formula.shape-unit_shape_shape_shape-1_test';
+            formulaCurrentConfigService.load({
+                formulaData: {},
+                arrayFormulaCellData: {},
+                arrayFormulaRange: {},
+                forceCalculate: false,
+                dirtyRanges: [],
+                dirtyNameMap: {},
+                dirtyDefinedNameMap: {},
+                dirtyUnitFeatureMap: {},
+                dirtyUnitOtherFormulaMap: {
+                    'shape-unit': {
+                        shape: {
+                            [formulaId]: true,
+                        },
+                    },
+                },
+                excludedCell: {},
+                allUnitData: {
+                    [testUnitId]: testSheetData,
+                },
+            });
+
+            otherFormulaManagerService.batchRegister({
+                'shape-unit': {
+                    shape: {
+                        [formulaId]: {
+                            f: '=1',
+                            ranges: [{
+                                startRow: 0,
+                                endRow: 2,
+                                startColumn: 0,
+                                endColumn: 2,
+                            }],
+                        },
+                    },
+                },
+            });
+
+            const treeList = await formulaDependencyGenerator.generate();
+            const shapeTrees = treeList.filter((tree) => tree.formulaId === formulaId);
+
+            expect(shapeTrees).toHaveLength(1);
+            expect(shapeTrees[0]).toBeInstanceOf(FormulaDependencyTree);
+        });
+
         it('should generate virtual dependency trees for shared formulas with offsets', async () => {
             formulaCurrentConfigService.load({
                 formulaData: {

--- a/packages/engine-formula/src/engine/dependency/formula-dependency.ts
+++ b/packages/engine-formula/src/engine/dependency/formula-dependency.ts
@@ -296,8 +296,9 @@ export class FormulaDependencyGenerator extends Disposable implements IFormulaDe
                 }
 
                 const sheetSize = this._currentConfigService.getSheetRowColumnCount(unitId, subUnitId);
-                const rowCount = sheetSize.rowCount > 0 ? sheetSize.rowCount : Infinity;
-                const columnCount = sheetSize.columnCount > 0 ? sheetSize.columnCount : Infinity;
+                // A non-sheet other formula uses one virtual result slot at (0, 0).
+                const rowCount = sheetSize.rowCount > 0 ? sheetSize.rowCount : 1;
+                const columnCount = sheetSize.columnCount > 0 ? sheetSize.columnCount : 1;
 
                 const subFormulaDataKeys = Object.keys(subFormulaData);
                 for (const subFormulaDataId of subFormulaDataKeys) {


### PR DESCRIPTION
## Summary

- Treat an Other Formula host without worksheet dimensions as one virtual result slot at `(0, 0)`.
- Keep Sheet-backed conditional-formatting and data-validation expansion bounded by the real worksheet size.
- Add a regression test proving a non-Sheet range cannot expand beyond the single slot.

## Root cause

Shape formulas reuse the Other Formula pipeline but do not own a worksheet. Falling back to `Infinity` allowed an arbitrary supplied range to expand without a host boundary, although Shape needs only one scalar formula instance.

## Validation

- `pnpm --filter @univerjs/engine-formula test` — 560 files / 4054 tests passed.
- `pnpm --filter @univerjs/engine-formula typecheck` — passed.
- Focused ESLint completed with pre-existing warnings only and no errors.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.