### PR TITLE
fix(docs): align overflow table interactions

### DIFF
--- a/packages/docs-ui/src/controllers/render-controllers/__tests__/doc-paragraph-placeholder.render-controller.spec.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/__tests__/doc-paragraph-placeholder.render-controller.spec.ts
@@ -17,9 +17,10 @@
 import type { IDocumentBody, IParagraph } from '@univerjs/core';
 import type { IDocumentSkeletonLine, IDocumentSkeletonPage } from '@univerjs/engine-render';
 import { DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY, DocumentFlavor, NamedStyleType } from '@univerjs/core';
-import { DocumentSkeletonPageType, GlyphType, LineType } from '@univerjs/engine-render';
-import { describe, expect, it } from 'vitest';
+import { DocumentSkeletonPageType, GlyphType, LineType, setDocsTableRenderViewportProvider } from '@univerjs/engine-render';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+    drawParagraphPlaceholders,
     getParagraphPlaceholderLayouts,
     shouldRenderParagraphPlaceholder,
 } from '../doc-paragraph-placeholder.render-controller';
@@ -178,6 +179,35 @@ function createPage(lines: IDocumentSkeletonLine[]): IDocumentSkeletonPage {
     return page;
 }
 
+function createPageWithTableCell(lines: IDocumentSkeletonLine[]): IDocumentSkeletonPage {
+    const page = createPage([]);
+    const cell = createPage(lines);
+    Object.assign(cell, {
+        left: 300,
+        marginBottom: 4,
+        marginLeft: 5,
+        marginRight: 5,
+        marginTop: 4,
+        pageHeight: 50,
+        pageWidth: 100,
+    });
+    page.skeTables.set('table-1', {
+        height: 58,
+        left: 80,
+        rows: [{
+            cells: [cell],
+            height: 58,
+            index: 0,
+            top: 0,
+        }],
+        tableId: 'table-1',
+        top: 20,
+        width: 500,
+    } as any);
+
+    return page;
+}
+
 function createBody(dataStream: string, paragraphs: IParagraph[]): IDocumentBody {
     return {
         dataStream,
@@ -194,6 +224,10 @@ function createDocumentModel(documentFlavor: DocumentFlavor) {
         }),
     } as any;
 }
+
+afterEach(() => {
+    setDocsTableRenderViewportProvider(null);
+});
 
 describe('doc paragraph placeholder render controller', () => {
     it('only enables placeholder rendering for modern docs when config is enabled', () => {
@@ -299,5 +333,51 @@ describe('doc paragraph placeholder render controller', () => {
             text: '请输入文字或按"/"启用命令',
             y: 145,
         });
+    });
+
+    it('projects a table-cell placeholder with the table horizontal scroll', () => {
+        const page = createPageWithTableCell([createLine(0)]);
+        const body = createBody('\r\n', [{ startIndex: 0, paragraphId: 'para_placeholder_scrolled_table' }]);
+        setDocsTableRenderViewportProvider(() => ({
+            contentWidth: 500,
+            leadingInsetLeft: 30,
+            scrollLeft: 250,
+            viewportWidth: 220,
+        }));
+
+        const placeholders = getParagraphPlaceholderLayouts(page, body, locale, 10, 0, 0);
+
+        expect(placeholders).toMatchObject([{
+            clipLeft: 206,
+            clipRight: 275,
+            maxWidth: 69,
+            x: 206,
+        }]);
+    });
+
+    it('clips long placeholder text instead of scaling its glyphs to maxWidth', () => {
+        const ctx = {
+            beginPath: vi.fn(),
+            clip: vi.fn(),
+            closePath: vi.fn(),
+            fillText: vi.fn(),
+            rectByPrecision: vi.fn(),
+            restore: vi.fn(),
+            save: vi.fn(),
+        } as any;
+
+        drawParagraphPlaceholders(ctx, [{
+            fontFamily: 'Arial',
+            fontSize: 16,
+            fontWeight: 'normal',
+            maxWidth: 80,
+            text: 'Type text or press "/" for commands',
+            x: 20,
+            y: 40,
+        }]);
+
+        expect(ctx.rectByPrecision).toHaveBeenCalledWith(20, 24, 80, 32);
+        expect(ctx.clip).toHaveBeenCalledOnce();
+        expect(ctx.fillText).toHaveBeenCalledWith('Type text or press "/" for commands', 20, 40);
     });
 });

--- a/packages/docs-ui/src/controllers/render-controllers/__tests__/doc-paragraph-placeholder.render-controller.spec.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/__tests__/doc-paragraph-placeholder.render-controller.spec.ts
@@ -342,15 +342,19 @@ describe('doc paragraph placeholder render controller', () => {
             contentWidth: 500,
             leadingInsetLeft: 30,
             scrollLeft: 250,
+            viewportLeft: 120,
             viewportWidth: 220,
         }));
 
-        const placeholders = getParagraphPlaceholderLayouts(page, body, locale, 10, 0, 0);
+        const placeholders = getParagraphPlaceholderLayouts(page, body, locale, 10, 0, 0, {
+            docsLeft: 100,
+            unitId: 'doc-1',
+        });
 
         expect(placeholders).toMatchObject([{
             clipLeft: 206,
-            clipRight: 275,
-            maxWidth: 69,
+            clipRight: 240,
+            maxWidth: 34,
             x: 206,
         }]);
     });

--- a/packages/docs-ui/src/controllers/render-controllers/doc-paragraph-placeholder.render-controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc-paragraph-placeholder.render-controller.ts
@@ -40,6 +40,7 @@ import {
     NamedStyleType,
 } from '@univerjs/core';
 import { DocSelectionManagerService } from '@univerjs/docs';
+import { getDocsTableRenderViewport, getTableIdAndSliceIndex } from '@univerjs/engine-render';
 import { DOCS_UI_PLUGIN_CONFIG_KEY } from '../../config/config';
 
 const PLACEHOLDER_COLOR = 'rgba(0, 0, 0, 0.35)';
@@ -49,6 +50,10 @@ const DEFAULT_PLACEHOLDER_FONT_FAMILY = 'Arial';
 const LIST_PLACEHOLDER_GAP = 4;
 
 export interface IParagraphPlaceholderLayout {
+    clipBottom?: number;
+    clipLeft?: number;
+    clipRight?: number;
+    clipTop?: number;
     fontFamily: string;
     fontSize: number;
     fontWeight: string;
@@ -66,6 +71,15 @@ interface IParagraphPlaceholderLocale {
     heading5: string;
     listItem: string;
     normalText: string;
+}
+
+interface IParagraphPlaceholderLayoutOptions {
+    unitId?: string;
+}
+
+interface IParagraphPlaceholderClip {
+    left: number;
+    right: number;
 }
 
 export class DocParagraphPlaceholderRenderController extends Disposable implements IRenderModule {
@@ -105,7 +119,15 @@ export class DocParagraphPlaceholderRenderController extends Disposable implemen
             return;
         }
 
-        const placeholders = getParagraphPlaceholderLayouts(page, body, this._getLocale(), pageLeft, pageTop, activeRange.startOffset);
+        const placeholders = getParagraphPlaceholderLayouts(
+            page,
+            body,
+            this._getLocale(),
+            pageLeft,
+            pageTop,
+            activeRange.startOffset,
+            { unitId: this._context.unitId }
+        );
         if (!placeholders.length) {
             return;
         }
@@ -148,14 +170,30 @@ export function getParagraphPlaceholderLayouts(
     locale: IParagraphPlaceholderLocale,
     pageLeft = 0,
     pageTop = 0,
-    activeOffset?: number
+    activeOffset?: number,
+    options?: IParagraphPlaceholderLayoutOptions
 ): IParagraphPlaceholderLayout[] {
     const paragraphs = new Map((body.paragraphs ?? []).map((paragraph) => [paragraph.startIndex, paragraph]));
     const layouts: IParagraphPlaceholderLayout[] = [];
 
-    const visitSection = (section: IDocumentSkeletonSection, originLeft: number, originTop: number) => {
+    const visitSection = (
+        section: IDocumentSkeletonSection,
+        originLeft: number,
+        originTop: number,
+        clip?: IParagraphPlaceholderClip
+    ) => {
         for (const column of section.columns) {
-            visitColumn(column, body, paragraphs, locale, layouts, originLeft + column.left, originTop + section.top, activeOffset);
+            visitColumn(
+                column,
+                body,
+                paragraphs,
+                locale,
+                layouts,
+                originLeft + column.left,
+                originTop + section.top,
+                activeOffset,
+                clip
+            );
         }
     };
 
@@ -163,14 +201,38 @@ export function getParagraphPlaceholderLayouts(
         visitSection(section, pageLeft + page.marginLeft, pageTop + page.marginTop);
     }
 
-    page.skeTables?.forEach((table) => {
+    page.skeTables?.forEach((table, tableId) => {
+        const sourceTableId = getTableIdAndSliceIndex(table.tableId ?? tableId).tableId;
+        const viewport = getDocsTableRenderViewport(options?.unitId ?? '', sourceTableId);
+        const hasHorizontalViewport = viewport != null &&
+            (viewport.leadingInsetLeft ?? 0) +
+            viewport.contentWidth +
+            (viewport.trailingInsetRight ?? 0) > viewport.viewportWidth;
+        const tableLeft = pageLeft + page.marginLeft + table.left;
+        const tableViewportLeft = hasHorizontalViewport
+            ? tableLeft - (viewport.leadingInsetLeft ?? 0)
+            : tableLeft;
+        const tableViewportRight = tableViewportLeft +
+            (hasHorizontalViewport ? viewport.viewportWidth : table.width);
+        const tableScrollLeft = hasHorizontalViewport ? viewport.scrollLeft : 0;
+
         for (const row of table.rows) {
             for (const cell of row.cells) {
+                const cellLeft = tableLeft + cell.left - tableScrollLeft;
+                const cellContentLeft = cellLeft + cell.marginLeft;
+                const cellContentRight = cellLeft + cell.pageWidth - cell.marginRight;
+                const clipLeft = Math.max(cellContentLeft, tableViewportLeft);
+                const clipRight = Math.min(cellContentRight, tableViewportRight);
+                if (clipRight <= clipLeft) {
+                    continue;
+                }
+
                 for (const section of cell.sections) {
                     visitSection(
                         section,
-                        pageLeft + page.marginLeft + table.left + cell.left + cell.marginLeft,
-                        pageTop + page.marginTop + table.top + row.top + cell.marginTop
+                        cellContentLeft,
+                        pageTop + page.marginTop + table.top + row.top + cell.marginTop,
+                        { left: clipLeft, right: clipRight }
                     );
                 }
             }
@@ -188,7 +250,8 @@ function visitColumn(
     layouts: IParagraphPlaceholderLayout[],
     originLeft: number,
     originTop: number,
-    activeOffset?: number
+    activeOffset?: number,
+    clip?: IParagraphPlaceholderClip
 ): void {
     for (const line of column.lines) {
         if (!line.paragraphStart) {
@@ -211,7 +274,7 @@ function visitColumn(
             continue;
         }
 
-        layouts.push(getLinePlaceholderLayout(line, paragraph, text, originLeft, originTop));
+        layouts.push(getLinePlaceholderLayout(line, paragraph, text, originLeft, originTop, clip));
     }
 }
 
@@ -245,7 +308,8 @@ function getLinePlaceholderLayout(
     paragraph: IParagraph,
     text: string,
     originLeft: number,
-    originTop: number
+    originTop: number,
+    clip?: IParagraphPlaceholderClip
 ): IParagraphPlaceholderLayout {
     const divide = line.divides[0];
     const glyphs = divide?.glyphGroup ?? [];
@@ -257,14 +321,23 @@ function getLinePlaceholderLayout(
     const fontWeight = textStyle?.bl ? 'bold' : 'normal';
     const lineStartX = originLeft + (divide?.left ?? 0) + (divide?.paddingLeft ?? 0);
     const listOffset = paragraph.bullet && firstGlyph ? firstGlyph.left + firstGlyph.width + LIST_PLACEHOLDER_GAP : 0;
+    const x = lineStartX + listOffset;
+    const naturalMaxWidth = Math.max(0, (divide?.width ?? line.width ?? 0) - listOffset);
+    const clipLeft = Math.max(x, clip?.left ?? x);
+    const clipRight = Math.min(x + naturalMaxWidth, clip?.right ?? x + naturalMaxWidth);
+    const clipTop = originTop + line.top;
 
     return {
+        clipBottom: clipTop + line.lineHeight,
+        clipLeft,
+        clipRight,
+        clipTop,
         fontFamily,
         fontSize,
         fontWeight,
-        maxWidth: Math.max(0, (divide?.width ?? line.width ?? 0) - listOffset),
+        maxWidth: Math.max(0, clipRight - clipLeft),
         text,
-        x: lineStartX + listOffset,
+        x,
         y: originTop + line.top + line.marginTop + line.paddingTop + line.asc,
     };
 }
@@ -319,14 +392,28 @@ function getLineFontFamily(line: IDocumentSkeletonLine): Nullable<string> {
     return null;
 }
 
-function drawParagraphPlaceholders(ctx: UniverRenderingContext, placeholders: IParagraphPlaceholderLayout[]): void {
+export function drawParagraphPlaceholders(ctx: UniverRenderingContext, placeholders: IParagraphPlaceholderLayout[]): void {
     ctx.save();
     ctx.fillStyle = PLACEHOLDER_COLOR;
     ctx.textBaseline = 'alphabetic';
 
     for (const placeholder of placeholders) {
+        const clipLeft = placeholder.clipLeft ?? placeholder.x;
+        const clipRight = placeholder.clipRight ?? placeholder.x + placeholder.maxWidth;
+        const clipTop = placeholder.clipTop ?? placeholder.y - placeholder.fontSize;
+        const clipBottom = placeholder.clipBottom ?? placeholder.y + placeholder.fontSize;
+        if (clipRight <= clipLeft || clipBottom <= clipTop) {
+            continue;
+        }
+
+        ctx.save();
+        ctx.beginPath();
+        ctx.rectByPrecision(clipLeft, clipTop, clipRight - clipLeft, clipBottom - clipTop);
+        ctx.closePath();
+        ctx.clip();
         ctx.font = `${placeholder.fontWeight} ${placeholder.fontSize}px ${placeholder.fontFamily}`;
-        ctx.fillText(placeholder.text, placeholder.x, placeholder.y, placeholder.maxWidth || undefined);
+        ctx.fillText(placeholder.text, placeholder.x, placeholder.y);
+        ctx.restore();
     }
 
     ctx.restore();

--- a/packages/docs-ui/src/controllers/render-controllers/doc-paragraph-placeholder.render-controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc-paragraph-placeholder.render-controller.ts
@@ -40,7 +40,7 @@ import {
     NamedStyleType,
 } from '@univerjs/core';
 import { DocSelectionManagerService } from '@univerjs/docs';
-import { getDocsTableRenderViewport, getTableIdAndSliceIndex } from '@univerjs/engine-render';
+import { getDocsTableRenderViewport, getDocsTableViewportLeft, getTableIdAndSliceIndex } from '@univerjs/engine-render';
 import { DOCS_UI_PLUGIN_CONFIG_KEY } from '../../config/config';
 
 const PLACEHOLDER_COLOR = 'rgba(0, 0, 0, 0.35)';
@@ -74,6 +74,7 @@ interface IParagraphPlaceholderLocale {
 }
 
 interface IParagraphPlaceholderLayoutOptions {
+    docsLeft?: number;
     unitId?: string;
 }
 
@@ -126,7 +127,10 @@ export class DocParagraphPlaceholderRenderController extends Disposable implemen
             pageLeft,
             pageTop,
             activeRange.startOffset,
-            { unitId: this._context.unitId }
+            {
+                docsLeft: (this._context.mainComponent as Documents | undefined)?.getOffsetConfig().docsLeft,
+                unitId: this._context.unitId,
+            }
         );
         if (!placeholders.length) {
             return;
@@ -210,7 +214,11 @@ export function getParagraphPlaceholderLayouts(
             (viewport.trailingInsetRight ?? 0) > viewport.viewportWidth;
         const tableLeft = pageLeft + page.marginLeft + table.left;
         const tableViewportLeft = hasHorizontalViewport
-            ? tableLeft - (viewport.leadingInsetLeft ?? 0)
+            ? getDocsTableViewportLeft(
+                viewport,
+                tableLeft - (viewport.leadingInsetLeft ?? 0),
+                options?.docsLeft
+            )
             : tableLeft;
         const tableViewportRight = tableViewportLeft +
             (hasHorizontalViewport ? viewport.viewportWidth : table.width);

--- a/packages/engine-render/src/components/docs/__tests__/document.spec.ts
+++ b/packages/engine-render/src/components/docs/__tests__/document.spec.ts
@@ -361,6 +361,80 @@ describe('documents render', () => {
         setDocsTableRenderViewportProvider(null);
     });
 
+    it('hit tests table content and controls that overflow the document bounds', () => {
+        const bodyPage = createPage(DocumentSkeletonPageType.BODY, '');
+        attachTable(bodyPage);
+        const table = bodyPage.skeTables.get('table-1')!;
+        table.width = 260;
+        table.rows[0].cells[0].pageWidth = 260;
+        const skeletonData = {
+            pages: [bodyPage],
+            skeHeaders: new Map(),
+            skeFooters: new Map(),
+        };
+        const documents = new Documents('docs-overflow-hit', {
+            getSkeletonData: () => skeletonData,
+        } as any, {
+            pageLayoutType: PageLayoutType.VERTICAL,
+            pageMarginLeft: 0,
+            pageMarginTop: 0,
+        });
+        documents.transformByState({
+            left: 0,
+            top: 0,
+            width: 200,
+            height: 420,
+        });
+        scene.addObject(documents, 1);
+
+        expect(documents.isHit(Vector2.create(250, 50))).toBe(true);
+        expect(documents.isHit(Vector2.create(250, 12))).toBe(true);
+        expect(documents.isHit(Vector2.create(250, 130))).toBe(false);
+
+        documents.dispose();
+    });
+
+    it('hit tests a horizontally projected table to the left of the document bounds', () => {
+        const bodyPage = createPage(DocumentSkeletonPageType.BODY, '');
+        attachTable(bodyPage);
+        const table = bodyPage.skeTables.get('table-1')!;
+        table.width = 260;
+        table.rows[0].cells[0].pageWidth = 260;
+        const skeletonData = {
+            pages: [bodyPage],
+            skeHeaders: new Map(),
+            skeFooters: new Map(),
+        };
+        const documents = new Documents('docs-left-overflow-hit', {
+            getSkeletonData: () => skeletonData,
+        } as any, {
+            pageLayoutType: PageLayoutType.VERTICAL,
+            pageMarginLeft: 0,
+            pageMarginTop: 0,
+        });
+        documents.transformByState({
+            left: 0,
+            top: 0,
+            width: 200,
+            height: 420,
+        });
+        scene.addObject(documents, 1);
+        setDocsTableRenderViewportProvider((unitId, tableId) => unitId === 'docs-left-overflow-hit' && tableId === 'table-1'
+            ? {
+                contentWidth: 260,
+                leadingInsetLeft: 80,
+                scrollLeft: 0,
+                viewportWidth: 200,
+            }
+            : null);
+
+        expect(documents.isHit(Vector2.create(-40, 50))).toBe(true);
+        expect(documents.isHit(Vector2.create(-40, 12))).toBe(true);
+        expect(documents.isHit(Vector2.create(-90, 50))).toBe(false);
+
+        documents.dispose();
+    });
+
     it('uses explicit table cell border width inside table render path', () => {
         const skeleton = { getSkeletonData: () => ({ pages: [] }) } as any;
         const documents = new Documents('docs-border', skeleton, {

--- a/packages/engine-render/src/components/docs/__tests__/document.spec.ts
+++ b/packages/engine-render/src/components/docs/__tests__/document.spec.ts
@@ -424,13 +424,14 @@ describe('documents render', () => {
                 contentWidth: 260,
                 leadingInsetLeft: 80,
                 scrollLeft: 0,
+                viewportLeft: -20,
                 viewportWidth: 200,
             }
             : null);
 
         expect(documents.isHit(Vector2.create(-40, 50))).toBe(true);
         expect(documents.isHit(Vector2.create(-40, 12))).toBe(true);
-        expect(documents.isHit(Vector2.create(-90, 50))).toBe(false);
+        expect(documents.isHit(Vector2.create(-70, 50))).toBe(false);
 
         documents.dispose();
     });

--- a/packages/engine-render/src/components/docs/document.ts
+++ b/packages/engine-render/src/components/docs/document.ts
@@ -49,7 +49,7 @@ import { collectBackgroundGlyphRuns } from './extensions/background-runs';
 import { getTableIdAndSliceIndex } from './layout/block/table';
 import { documentSkeletonTableIterator } from './layout/tools';
 import { Liquid } from './liquid';
-import { getDocsTableRenderViewport, hasDocsTableHorizontalViewport } from './table-render-viewport';
+import { getDocsTableRenderViewport, getDocsTableViewportLeft, hasDocsTableHorizontalViewport } from './table-render-viewport';
 import './extensions';
 
 const DEFAULT_BORDER_COLOR: ITableCellBorder = {
@@ -167,6 +167,7 @@ export class Documents extends DocComponent {
         const localCoord = this.getInverseCoord(coord);
         const { pages, skeHeaders, skeFooters } = skeletonData;
         const unitId = this._getRenderUnitId();
+        const { docsLeft } = this.getOffsetConfig();
         return documentSkeletonTableIterator(pages, {
             includeCells: false,
             pageMarginTop: this.pageMarginTop,
@@ -178,7 +179,11 @@ export class Documents extends DocComponent {
             const sourceTableId = getTableIdAndSliceIndex(tableId).tableId;
             const viewport = getDocsTableRenderViewport(unitId, sourceTableId);
             const projectedLeft = hasDocsTableHorizontalViewport(viewport)
-                ? tableRect.left - (viewport.leadingInsetLeft ?? 0)
+                ? getDocsTableViewportLeft(
+                    viewport,
+                    tableRect.left - (viewport.leadingInsetLeft ?? 0),
+                    docsLeft
+                )
                 : tableRect.left;
             const projectedRight = hasDocsTableHorizontalViewport(viewport)
                 ? projectedLeft + viewport.viewportWidth

--- a/packages/engine-render/src/components/docs/document.ts
+++ b/packages/engine-render/src/components/docs/document.ts
@@ -47,6 +47,7 @@ import { DOCS_EXTENSION_TYPE } from './doc-extension';
 import { getDocumentCompatibilityPolicy, shouldAllowImportedTableMarginOverflow } from './document-compatibility';
 import { collectBackgroundGlyphRuns } from './extensions/background-runs';
 import { getTableIdAndSliceIndex } from './layout/block/table';
+import { documentSkeletonTableIterator } from './layout/tools';
 import { Liquid } from './liquid';
 import { getDocsTableRenderViewport, hasDocsTableHorizontalViewport } from './table-render-viewport';
 import './extensions';
@@ -57,6 +58,7 @@ const DEFAULT_BORDER_COLOR: ITableCellBorder = {
     },
 };
 const TABLE_VIEWPORT_BORDER_CLIP_PADDING = 2;
+const TABLE_OVERFLOW_INTERACTION_PADDING = 24;
 
 export interface IPageRenderConfig {
     page: IDocumentSkeletonPage;
@@ -150,6 +152,43 @@ export class Documents extends DocComponent {
 
     override getEngine() {
         return (this.getScene() as Scene).getEngine();
+    }
+
+    override isHit(coord: Vector2): boolean {
+        if (super.isHit(coord)) {
+            return true;
+        }
+
+        const skeletonData = this.getSkeleton()?.getSkeletonData();
+        if (!skeletonData) {
+            return false;
+        }
+
+        const localCoord = this.getInverseCoord(coord);
+        const { pages, skeHeaders, skeFooters } = skeletonData;
+        const unitId = this._getRenderUnitId();
+        return documentSkeletonTableIterator(pages, {
+            includeCells: false,
+            pageMarginTop: this.pageMarginTop,
+            resolveViewport: false,
+            skeFooters,
+            skeHeaders,
+            unitId,
+        }).some(({ tableId, tableRect }) => {
+            const sourceTableId = getTableIdAndSliceIndex(tableId).tableId;
+            const viewport = getDocsTableRenderViewport(unitId, sourceTableId);
+            const projectedLeft = hasDocsTableHorizontalViewport(viewport)
+                ? tableRect.left - (viewport.leadingInsetLeft ?? 0)
+                : tableRect.left;
+            const projectedRight = hasDocsTableHorizontalViewport(viewport)
+                ? projectedLeft + viewport.viewportWidth
+                : tableRect.right;
+
+            return localCoord.x >= projectedLeft - TABLE_OVERFLOW_INTERACTION_PADDING &&
+                localCoord.x <= projectedRight + TABLE_OVERFLOW_INTERACTION_PADDING &&
+                localCoord.y >= tableRect.top - TABLE_OVERFLOW_INTERACTION_PADDING &&
+                localCoord.y <= tableRect.bottom + TABLE_OVERFLOW_INTERACTION_PADDING;
+        });
     }
 
     changeSkeleton(newSkeleton: DocumentSkeleton) {

--- a/packages/engine-render/src/components/docs/layout/tools.ts
+++ b/packages/engine-render/src/components/docs/layout/tools.ts
@@ -718,6 +718,7 @@ export interface IDocumentSkeletonTableContext {
 }
 
 export interface IDocumentSkeletonTableIteratorOptions {
+    includeCells?: boolean;
     docsLeft?: number;
     docsTop?: number;
     pageMarginTop?: number;
@@ -735,6 +736,7 @@ export function documentSkeletonTableIterator(
     const {
         docsLeft = 0,
         docsTop = 0,
+        includeCells = true,
         pageMarginTop = 0,
         resolveViewport = true,
         skeFooters,
@@ -752,6 +754,7 @@ export function documentSkeletonTableIterator(
         collectPageTables({
             contexts,
             docsLeft,
+            includeCells,
             page: rootPage,
             pageIndex,
             pageLeft: rootPageLeft,
@@ -770,6 +773,7 @@ export function documentSkeletonTableIterator(
             collectPageTables({
                 contexts,
                 docsLeft,
+                includeCells,
                 page: headerPage,
                 pageIndex,
                 pageLeft: rootPageDocumentLeft,
@@ -787,6 +791,7 @@ export function documentSkeletonTableIterator(
             collectPageTables({
                 contexts,
                 docsLeft,
+                includeCells,
                 page: footerPage,
                 pageIndex,
                 pageLeft: rootPageDocumentLeft,
@@ -808,6 +813,7 @@ export function documentSkeletonTableIterator(
                 collectPageTables({
                     contexts,
                     docsLeft,
+                    includeCells,
                     page: nestedPage,
                     pageIndex,
                     pageLeft: nestedPageLeft,
@@ -1053,6 +1059,7 @@ function getPageLineBounds(
 interface ICollectPageTablesOptions {
     contexts: IDocumentSkeletonTableContext[];
     docsLeft: number;
+    includeCells: boolean;
     page: IDocumentSkeletonPage;
     pageIndex: number;
     pageLeft: number;
@@ -1068,6 +1075,7 @@ function collectPageTables(options: ICollectPageTablesOptions): void {
     const {
         contexts,
         docsLeft,
+        includeCells,
         page,
         pageIndex,
         pageLeft,
@@ -1091,51 +1099,53 @@ function collectPageTables(options: ICollectPageTablesOptions): void {
         const tableScrollLeft = hasHorizontalViewport ? viewport.scrollLeft : 0;
         const cells: IDocumentSkeletonTableCellGeometry[] = [];
 
-        table.rows.forEach((row, rowIndex) => {
-            row.cells.forEach((cell, columnIndex) => {
-                if ((cell as IDocumentSkeletonPage & { isMergedCellCovered?: boolean }).isMergedCellCovered) {
-                    return;
-                }
+        if (includeCells) {
+            table.rows.forEach((row, rowIndex) => {
+                row.cells.forEach((cell, columnIndex) => {
+                    if ((cell as IDocumentSkeletonPage & { isMergedCellCovered?: boolean }).isMergedCellCovered) {
+                        return;
+                    }
 
-                const cellMarginLeft = cell.marginLeft ?? 0;
-                const cellMarginRight = cell.marginRight ?? 0;
-                const cellMarginTop = cell.marginTop ?? 0;
-                const cellMarginBottom = cell.marginBottom ?? 0;
-                const cellPageWidth = cell.pageWidth ?? 0;
-                const cellPageHeight = cell.pageHeight ?? 0;
-                const cellTop = tableTop + (row.top ?? 0) + cellMarginTop;
-                const cellLeft = tableLeft + (cell.left ?? 0) - tableScrollLeft + cellMarginLeft;
-                const cellContentRight = cellLeft + cellPageWidth - cellMarginLeft - cellMarginRight;
-                const visualLeft = cellLeft + tableCellInsetX;
-                const visualRight = cellContentRight - tableCellInsetX;
-                const visualWidth = Math.max(0, visualRight - visualLeft);
-                const clipLeft = tableViewportLeft;
-                const clipRight = Math.min(cellContentRight, tableViewportRight);
+                    const cellMarginLeft = cell.marginLeft ?? 0;
+                    const cellMarginRight = cell.marginRight ?? 0;
+                    const cellMarginTop = cell.marginTop ?? 0;
+                    const cellMarginBottom = cell.marginBottom ?? 0;
+                    const cellPageWidth = cell.pageWidth ?? 0;
+                    const cellPageHeight = cell.pageHeight ?? 0;
+                    const cellTop = tableTop + (row.top ?? 0) + cellMarginTop;
+                    const cellLeft = tableLeft + (cell.left ?? 0) - tableScrollLeft + cellMarginLeft;
+                    const cellContentRight = cellLeft + cellPageWidth - cellMarginLeft - cellMarginRight;
+                    const visualLeft = cellLeft + tableCellInsetX;
+                    const visualRight = cellContentRight - tableCellInsetX;
+                    const visualWidth = Math.max(0, visualRight - visualLeft);
+                    const clipLeft = tableViewportLeft;
+                    const clipRight = Math.min(cellContentRight, tableViewportRight);
 
-                if (visualWidth <= 0 || Math.min(visualRight, clipRight) <= Math.max(visualLeft, clipLeft)) {
-                    return;
-                }
+                    if (visualWidth <= 0 || Math.min(visualRight, clipRight) <= Math.max(visualLeft, clipLeft)) {
+                        return;
+                    }
 
-                cells.push({
-                    cell,
-                    cellRect: {
-                        bottom: cellTop + cellPageHeight - cellMarginBottom - cellMarginTop,
-                        left: Math.max(cellLeft, tableViewportLeft),
-                        right: Math.min(cellContentRight, tableViewportRight),
-                        top: cellTop,
-                    },
-                    clipLeft,
-                    clipRight,
-                    columnIndex,
-                    pageLeft: cellLeft,
-                    pageTop: cellTop,
-                    row,
-                    rowIndex,
-                    visualLeft,
-                    visualWidth,
+                    cells.push({
+                        cell,
+                        cellRect: {
+                            bottom: cellTop + cellPageHeight - cellMarginBottom - cellMarginTop,
+                            left: Math.max(cellLeft, tableViewportLeft),
+                            right: Math.min(cellContentRight, tableViewportRight),
+                            top: cellTop,
+                        },
+                        clipLeft,
+                        clipRight,
+                        columnIndex,
+                        pageLeft: cellLeft,
+                        pageTop: cellTop,
+                        row,
+                        rowIndex,
+                        visualLeft,
+                        visualWidth,
+                    });
                 });
             });
-        });
+        }
 
         contexts.push({
             cells,

--- a/packages/engine-render/src/components/docs/layout/tools.ts
+++ b/packages/engine-render/src/components/docs/layout/tools.ts
@@ -78,7 +78,7 @@ import { DEFAULT_DOCUMENT_FONTSIZE } from '../../../basics/const';
 import { GlyphType, LineType } from '../../../basics/i-document-skeleton-cached';
 import { getFontStyleString, isFunction, ptToPixel } from '../../../basics/tools';
 import { getDocumentCompatibilityPolicy } from '../document-compatibility';
-import { getDocsTableRenderViewport, hasDocsTableHorizontalViewport } from '../table-render-viewport';
+import { getDocsTableRenderViewport, getDocsTableViewportLeft, hasDocsTableHorizontalViewport } from '../table-render-viewport';
 import { updateInlineDrawingPosition } from './block/paragraph/layout-ruler';
 import { getCustomDecorationStyle } from './style/custom-decoration';
 import { getCustomRangeStyle } from './style/custom-range';
@@ -860,7 +860,7 @@ export function documentSkeletonLineIterator(
             const sourceTableId = getSourceTableId(table.tableId);
             const viewport = getDocsTableRenderViewport(unitId, sourceTableId);
             const hasHorizontalViewport = hasDocsTableHorizontalViewport(viewport);
-            const tableViewportLeft = getTableViewportLeft(pageLeft, table.left, viewport, docsLeft);
+            const tableViewportLeft = getDocsTableViewportLeft(viewport, pageLeft + table.left, docsLeft);
             const tableViewportRight = tableViewportLeft + (hasHorizontalViewport ? viewport.viewportWidth : table.width);
             const tableScrollLeft = hasHorizontalViewport ? viewport.scrollLeft : 0;
 
@@ -1094,7 +1094,7 @@ function collectPageTables(options: ICollectPageTablesOptions): void {
         const sourceTableId = getSourceTableId(effectiveTableId);
         const viewport = resolveViewport ? getDocsTableRenderViewport(unitId, sourceTableId) : null;
         const hasHorizontalViewport = hasDocsTableHorizontalViewport(viewport);
-        const tableViewportLeft = getTableViewportLeft(pageLeft, table.left, viewport, docsLeft);
+        const tableViewportLeft = getDocsTableViewportLeft(viewport, pageLeft + table.left, docsLeft);
         const tableViewportRight = tableViewportLeft + (hasHorizontalViewport ? viewport.viewportWidth : table.width);
         const tableScrollLeft = hasHorizontalViewport ? viewport.scrollLeft : 0;
         const cells: IDocumentSkeletonTableCellGeometry[] = [];
@@ -1165,13 +1165,6 @@ function collectPageTables(options: ICollectPageTablesOptions): void {
             },
         });
     });
-}
-
-function getTableViewportLeft(pageLeft: number, tableLeft: number, viewport: unknown, docsLeft: number): number {
-    const viewportLeft = (viewport as Nullable<{ viewportLeft?: number }>)?.viewportLeft;
-    return viewportLeft != null
-        ? viewportLeft - docsLeft
-        : pageLeft + tableLeft;
 }
 
 function getSourceTableId(tableId: string): string {

--- a/packages/engine-render/src/components/docs/table-render-viewport.ts
+++ b/packages/engine-render/src/components/docs/table-render-viewport.ts
@@ -19,6 +19,7 @@ export interface IDocsTableRenderViewport {
     leadingInsetLeft?: number;
     scrollLeft: number;
     trailingInsetRight?: number;
+    viewportLeft?: number;
     viewportWidth: number;
 }
 
@@ -36,6 +37,16 @@ export function getDocsTableRenderViewport(unitId: string, tableId: string): IDo
 
 export function getDocsTableVirtualContentWidth(viewport: IDocsTableRenderViewport): number {
     return (viewport.leadingInsetLeft ?? 0) + viewport.contentWidth + (viewport.trailingInsetRight ?? 0);
+}
+
+export function getDocsTableViewportLeft(
+    viewport: IDocsTableRenderViewport | null | undefined,
+    fallbackLeft: number,
+    docsLeft = 0
+): number {
+    return viewport?.viewportLeft != null
+        ? viewport.viewportLeft - docsLeft
+        : fallbackLeft;
 }
 
 export function hasDocsTableHorizontalViewport(viewport: IDocsTableRenderViewport | null | undefined): viewport is IDocsTableRenderViewport {

--- a/packages/engine-render/src/index.ts
+++ b/packages/engine-render/src/index.ts
@@ -64,6 +64,7 @@ export type {
 } from './components/docs/table-render-viewport';
 export {
     getDocsTableRenderViewport,
+    getDocsTableViewportLeft,
     setDocsTableRenderViewportProvider,
 } from './components/docs/table-render-viewport';
 export { DataStreamTreeNode } from './components/docs/view-model/data-stream-tree-node';


### PR DESCRIPTION
## What changed

- project modern Docs table hit testing to the visible horizontal viewport so overflow cells remain interactive
- keep paragraph placeholders aligned with horizontally scrolled table cells
- render placeholder text at its original font metrics and clip it to the visible cell instead of compressing glyphs
- add focused regression coverage for viewport hit testing and placeholder projection/clipping

## Root cause

Wide modern Docs tables are rendered through a horizontal viewport transform, but document hit testing and paragraph placeholder layout still used the unprojected skeleton coordinates. Placeholder rendering also passed `maxWidth` to Canvas `fillText`, which scales glyphs horizontally when text exceeds the available width.

## Impact

Overflow table cells can be selected on both sides of the page, and placeholders stay attached to the selected cell while preserving readable text proportions.

## Validation

- `packages/engine-render`: document regression spec, 31 tests passed
- `packages/engine-render`: TypeScript typecheck passed
- `packages/docs-ui`: placeholder regression spec, 10 tests passed
- `packages/docs-ui`: TypeScript typecheck passed
- browser verification against the local `docs-local` demo
