### PR TITLE
feat(docs-find-replace): register plugin config and fix dependency order

### DIFF
--- a/packages/docs-find-replace/src/config/config.ts
+++ b/packages/docs-find-replace/src/config/config.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const DOCS_FIND_REPLACE_PLUGIN_CONFIG_KEY = 'docs-find-replace.config';
+
+export const configSymbol = Symbol(DOCS_FIND_REPLACE_PLUGIN_CONFIG_KEY);
+
+export interface IUniverDocsFindReplaceConfig {
+}
+
+export const defaultPluginConfig: IUniverDocsFindReplaceConfig = {};

--- a/packages/docs-find-replace/src/index.ts
+++ b/packages/docs-find-replace/src/index.ts
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-import { DependentOn, Inject, Injector, Plugin, UniverInstanceType } from '@univerjs/core';
+import type { IUniverDocsFindReplaceConfig } from './config/config';
+import { DependentOn, IConfigService, Inject, Injector, merge, Plugin, UniverInstanceType } from '@univerjs/core';
 import { UniverDocsPlugin } from '@univerjs/docs';
 import { UniverDocsUIPlugin } from '@univerjs/docs-ui';
 import { UniverRenderEnginePlugin } from '@univerjs/engine-render';
 import { UniverFindReplacePlugin } from '@univerjs/find-replace';
 import pkg from '../package.json';
+import { defaultPluginConfig, DOCS_FIND_REPLACE_PLUGIN_CONFIG_KEY } from './config/config';
 import { DocsFindReplaceController } from './controllers/docs-find-replace.controller';
 import { DocsFindReplaceProvider } from './services/docs-find-replace.provider';
 
-@DependentOn(UniverDocsPlugin, UniverDocsUIPlugin, UniverRenderEnginePlugin, UniverFindReplacePlugin)
+@DependentOn(UniverDocsPlugin, UniverRenderEnginePlugin, UniverDocsUIPlugin, UniverFindReplacePlugin)
 export class UniverDocsFindReplacePlugin extends Plugin {
     static override pluginName = 'DOCS_FIND_REPLACE_PLUGIN';
     static override packageName = pkg.name;
@@ -31,10 +33,18 @@ export class UniverDocsFindReplacePlugin extends Plugin {
     static override type = UniverInstanceType.UNIVER_DOC;
 
     constructor(
-        _config: undefined,
-        @Inject(Injector) protected override readonly _injector: Injector
+        private readonly _config: Partial<IUniverDocsFindReplaceConfig> = defaultPluginConfig,
+        @Inject(Injector) protected override readonly _injector: Injector,
+        @IConfigService private readonly _configService: IConfigService
     ) {
         super();
+
+        const { ...rest } = merge(
+            {},
+            defaultPluginConfig,
+            this._config
+        );
+        this._configService.setConfig(DOCS_FIND_REPLACE_PLUGIN_CONFIG_KEY, rest);
     }
 
     override onStarting(): void {


### PR DESCRIPTION
## Summary

- Add a typed, overridable configuration for the Docs find/replace plugin and register the merged options through `IConfigService`.
- Order `@DependentOn` prerequisites so the render engine initializes before Docs UI.

## Why

The plugin did not participate in the standard plugin configuration flow, and its dependency list placed Docs UI before its render-engine prerequisite.

## Testing

- `pnpm --filter @univerjs/docs-find-replace typecheck`
- `pnpm --filter @univerjs/docs-find-replace exec vitest run` (16 tests)
- `pnpm --filter @univerjs/core exec vitest run src/services/plugin/__tests__/plugin.service.spec.ts` (10 tests)

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
