### PR TITLE
fix(docs-ui): refine embed bleed and Sheet Float DOM scroll

### DIFF
--- a/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
@@ -16,6 +16,7 @@
 
 import { DrawingTypeEnum } from '@univerjs/core';
 import { InsertDocDrawingCommand } from '@univerjs/docs-drawing';
+import { SetDocZoomRatioOperation } from '@univerjs/docs-ui';
 import { Rect } from '@univerjs/engine-render';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
@@ -131,9 +132,9 @@ function createController(options: { drawing?: Record<string, unknown>; rects?: 
 describe('DocFloatDomController', () => {
     it('preserves existing props while adding custom block runtime viewport', () => {
         expect(mergeDocFloatDomRuntimeProps({ keep: true }, {
-            customBlockRenderViewport: { bleedLeft: 96, bleedWidth: 1440, contentHeight: 720, contentWidth: 1280, height: 480, pageContentWidth: 1008, viewportHeight: 320 },
+            customBlockRenderViewport: { bleedLeft: 96, bleedWidth: 1440, contentHeight: 720, contentWidth: 1280, height: 480, pageContentWidth: 1008, viewScale: 1.5, viewportHeight: 320 },
         } as never)).toEqual({
-            customBlockRenderViewport: { bleedLeft: 96, bleedWidth: 1440, contentHeight: 720, contentWidth: 1280, height: 480, pageContentWidth: 1008, viewportHeight: 320 },
+            customBlockRenderViewport: { bleedLeft: 96, bleedWidth: 1440, contentHeight: 720, contentWidth: 1280, height: 480, pageContentWidth: 1008, viewScale: 1.5, viewportHeight: 320 },
             keep: true,
         });
     });
@@ -158,6 +159,73 @@ describe('DocFloatDomController', () => {
             absolute: { left: false, top: false },
             opacity: 0.4,
         });
+    });
+
+    it('updates opted-in runtime view scale when the host doc zoom changes', async () => {
+        const rect = new Rect('dom-rect', {
+            left: 30,
+            top: 50,
+            width: 50,
+            height: 40,
+        });
+        const { add$, canvasFloatDomService, commandHandlers, controller } = createController({
+            rects: [rect],
+            drawing: {
+                customBlockRenderViewport: {
+                    contentHeight: 240,
+                    height: 240,
+                    viewScale: 1,
+                    viewportHeight: 120,
+                },
+            },
+        });
+
+        add$.next([{ unitId: 'doc-1', subUnitId: 'doc-1', drawingId: 'dom-1' }]);
+        await Promise.resolve();
+        commandHandlers.forEach((handler) => handler({
+            id: SetDocZoomRatioOperation.id,
+            params: { unitId: 'doc-1', zoomRatio: 2 },
+        }));
+
+        expect(canvasFloatDomService.updateFloatDom).toHaveBeenCalledWith('dom-1', {
+            props: expect.objectContaining({
+                customBlockRenderViewport: expect.objectContaining({
+                    viewScale: 2,
+                }),
+            }),
+        });
+
+        controller.dispose();
+    });
+
+    it('does not add view scale to other float dom runtimes on host zoom', async () => {
+        const rect = new Rect('dom-rect', {
+            left: 30,
+            top: 50,
+            width: 50,
+            height: 40,
+        });
+        const { add$, canvasFloatDomService, commandHandlers, controller } = createController({
+            rects: [rect],
+            drawing: {
+                customBlockRenderViewport: {
+                    contentHeight: 240,
+                    height: 240,
+                    viewportHeight: 120,
+                },
+            },
+        });
+
+        add$.next([{ unitId: 'doc-1', subUnitId: 'doc-1', drawingId: 'dom-1' }]);
+        await Promise.resolve();
+        commandHandlers.forEach((handler) => handler({
+            id: SetDocZoomRatioOperation.id,
+            params: { unitId: 'doc-1', zoomRatio: 2 },
+        }));
+
+        expect(canvasFloatDomService.updateFloatDom).not.toHaveBeenCalled();
+
+        controller.dispose();
     });
 
     it('adds rendered float doms, updates their position, and removes them with their rect object', async () => {

--- a/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
@@ -131,9 +131,9 @@ function createController(options: { drawing?: Record<string, unknown>; rects?: 
 describe('DocFloatDomController', () => {
     it('preserves existing props while adding custom block runtime viewport', () => {
         expect(mergeDocFloatDomRuntimeProps({ keep: true }, {
-            customBlockRenderViewport: { bleedLeft: 96, bleedWidth: 1440, contentHeight: 720, contentWidth: 1280, height: 480, viewportHeight: 320 },
+            customBlockRenderViewport: { bleedLeft: 96, bleedWidth: 1440, contentHeight: 720, contentWidth: 1280, height: 480, pageContentWidth: 1008, viewportHeight: 320 },
         } as never)).toEqual({
-            customBlockRenderViewport: { bleedLeft: 96, bleedWidth: 1440, contentHeight: 720, contentWidth: 1280, height: 480, viewportHeight: 320 },
+            customBlockRenderViewport: { bleedLeft: 96, bleedWidth: 1440, contentHeight: 720, contentWidth: 1280, height: 480, pageContentWidth: 1008, viewportHeight: 320 },
             keep: true,
         });
     });

--- a/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
@@ -161,7 +161,7 @@ describe('DocFloatDomController', () => {
         });
     });
 
-    it('updates opted-in runtime view scale when the host doc zoom changes', async () => {
+    it('updates float dom position after host doc zoom without rewriting runtime viewport', async () => {
         const rect = new Rect('dom-rect', {
             left: 30,
             top: 50,
@@ -182,6 +182,7 @@ describe('DocFloatDomController', () => {
 
         add$.next([{ unitId: 'doc-1', subUnitId: 'doc-1', drawingId: 'dom-1' }]);
         await Promise.resolve();
+        const position$ = canvasFloatDomService.addFloatDom.mock.calls[0][0].position$ as BehaviorSubject<unknown>;
         scene.getAncestorScale.mockReturnValue({ scaleX: 1, scaleY: 1 });
         commandHandlers.forEach((handler) => handler({
             id: SetDocZoomRatioOperation.id,
@@ -190,42 +191,12 @@ describe('DocFloatDomController', () => {
         scene.getAncestorScale.mockReturnValue({ scaleX: 2, scaleY: 2 });
         await Promise.resolve();
 
-        expect(canvasFloatDomService.updateFloatDom).toHaveBeenCalledWith('dom-1', {
-            props: expect.objectContaining({
-                customBlockRenderViewport: expect.objectContaining({
-                    viewScale: 2,
-                }),
-            }),
+        expect(position$.getValue()).toMatchObject({
+            startX: 40,
+            startY: 60,
+            width: 100,
+            height: 480,
         });
-
-        controller.dispose();
-    });
-
-    it('does not add view scale to other float dom runtimes on host zoom', async () => {
-        const rect = new Rect('dom-rect', {
-            left: 30,
-            top: 50,
-            width: 50,
-            height: 40,
-        });
-        const { add$, canvasFloatDomService, commandHandlers, controller } = createController({
-            rects: [rect],
-            drawing: {
-                customBlockRenderViewport: {
-                    contentHeight: 240,
-                    height: 240,
-                    viewportHeight: 120,
-                },
-            },
-        });
-
-        add$.next([{ unitId: 'doc-1', subUnitId: 'doc-1', drawingId: 'dom-1' }]);
-        await Promise.resolve();
-        commandHandlers.forEach((handler) => handler({
-            id: SetDocZoomRatioOperation.id,
-            params: { unitId: 'doc-1', zoomRatio: 2 },
-        }));
-
         expect(canvasFloatDomService.updateFloatDom).not.toHaveBeenCalled();
 
         controller.dispose();

--- a/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
@@ -168,7 +168,7 @@ describe('DocFloatDomController', () => {
             width: 50,
             height: 40,
         });
-        const { add$, canvasFloatDomService, commandHandlers, controller } = createController({
+        const { add$, canvasFloatDomService, commandHandlers, controller, scene } = createController({
             rects: [rect],
             drawing: {
                 customBlockRenderViewport: {
@@ -182,10 +182,13 @@ describe('DocFloatDomController', () => {
 
         add$.next([{ unitId: 'doc-1', subUnitId: 'doc-1', drawingId: 'dom-1' }]);
         await Promise.resolve();
+        scene.getAncestorScale.mockReturnValue({ scaleX: 1, scaleY: 1 });
         commandHandlers.forEach((handler) => handler({
             id: SetDocZoomRatioOperation.id,
             params: { unitId: 'doc-1', zoomRatio: 2 },
         }));
+        scene.getAncestorScale.mockReturnValue({ scaleX: 2, scaleY: 2 });
+        await Promise.resolve();
 
         expect(canvasFloatDomService.updateFloatDom).toHaveBeenCalledWith('dom-1', {
             props: expect.objectContaining({

--- a/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DrawingTypeEnum } from '@univerjs/core';
+import { DrawingTypeEnum, UniverInstanceType } from '@univerjs/core';
 import { InsertDocDrawingCommand } from '@univerjs/docs-drawing';
 import { SetDocZoomRatioOperation } from '@univerjs/docs-ui';
 import { Rect } from '@univerjs/engine-render';
@@ -374,7 +374,7 @@ describe('DocFloatDomController', () => {
         controller.dispose();
     });
 
-    it('disables host event pass-through for embed float dom runtimes', async () => {
+    it('uses the full content box for sheet-like embed float dom runtimes', async () => {
         const rect = new Rect('dom-rect', {
             left: 30,
             top: 50,
@@ -384,7 +384,12 @@ describe('DocFloatDomController', () => {
         const { controller, add$, canvasFloatDomService } = createController({
             rects: [rect],
             drawing: {
-                data: { version: 1, embedId: 'embed-1', hostAnchorId: 'anchor-1' },
+                data: {
+                    version: 1,
+                    embedId: 'embed-1',
+                    hostAnchorId: 'anchor-1',
+                    childType: UniverInstanceType.UNIVER_SHEET,
+                },
             },
         });
 
@@ -392,6 +397,37 @@ describe('DocFloatDomController', () => {
         await Promise.resolve();
 
         expect(canvasFloatDomService.addFloatDom).toHaveBeenCalledWith(expect.objectContaining({
+            contentBox: { contentInset: 0, wrapperInset: 0 },
+            eventPassThrough: false,
+        }));
+
+        controller.dispose();
+    });
+
+    it('keeps the legacy content box for other embed float dom runtimes', async () => {
+        const rect = new Rect('dom-rect', {
+            left: 30,
+            top: 50,
+            width: 50,
+            height: 40,
+        } as never);
+        const { controller, add$, canvasFloatDomService } = createController({
+            rects: [rect],
+            drawing: {
+                data: {
+                    version: 1,
+                    embedId: 'embed-1',
+                    hostAnchorId: 'anchor-1',
+                    childType: UniverInstanceType.UNIVER_SLIDE,
+                },
+            },
+        });
+
+        add$.next([{ unitId: 'doc-1', subUnitId: 'doc-1', drawingId: 'dom-1' }]);
+        await Promise.resolve();
+
+        expect(canvasFloatDomService.addFloatDom).toHaveBeenCalledWith(expect.objectContaining({
+            contentBox: undefined,
             eventPassThrough: false,
         }));
 

--- a/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/__tests__/doc-float-dom.controller.spec.ts
@@ -299,7 +299,7 @@ describe('DocFloatDomController', () => {
         controller.dispose();
     });
 
-    it('updates rendered float dom bounds from doc drawing transform refreshes', async () => {
+    it('updates rendered float dom bounds only from the owning document unit', async () => {
         const rect = new Rect('dom-rect', {
             left: 30,
             top: 50,
@@ -320,7 +320,16 @@ describe('DocFloatDomController', () => {
         const positions: unknown[] = [];
         const sub = position$.subscribe((position: unknown) => positions.push(position));
 
+        const positionCount = positions.length;
         refreshTransform$.next([{
+            unitId: 'doc-2',
+            drawingId: 'dom-1',
+            transform: { left: 0, top: 0, width: 160, height: 240, angle: 0 },
+        }]);
+        expect(positions).toHaveLength(positionCount);
+
+        refreshTransform$.next([{
+            unitId: 'doc-1',
             drawingId: 'dom-1',
             transform: { left: 40, top: 60, width: 160, height: 240, angle: 0 },
             customBlockRenderViewport: { contentHeight: 240, height: 240, viewportHeight: 120 },
@@ -456,6 +465,7 @@ describe('DocFloatDomController', () => {
         const sub = position$.subscribe((position: unknown) => positions.push(position));
 
         refreshTransform$.next([{
+            unitId: 'doc-1',
             drawingId: 'dom-1',
             customBlockRenderViewport: { contentHeight: 240, height: 240, viewportHeight: 120 },
         }]);
@@ -493,12 +503,14 @@ describe('DocFloatDomController', () => {
         const sub = position$.subscribe((position: unknown) => positions.push(position));
 
         refreshTransform$.next([{
+            unitId: 'doc-1',
             drawingId: 'dom-1',
             transform: { left: 40, top: 60, width: 160, height: 240, angle: 0 },
             customBlockRenderViewport: { contentHeight: 240, height: 240, viewportHeight: 120 },
         }]);
         rect.transformByState({ left: 45, top: 65, width: 160, height: 40, angle: 0 } as never);
         refreshTransform$.next([{
+            unitId: 'doc-1',
             drawingId: 'dom-1',
             transform: { left: 45, top: 65, width: 160, height: 40, angle: 0 },
         }]);
@@ -537,6 +549,7 @@ describe('DocFloatDomController', () => {
 
         rect.transformByState({ left: 30, top: 60, width: 720, height: 405, angle: 0 } as never);
         refreshTransform$.next([{
+            unitId: 'doc-1',
             drawingId: 'dom-1',
             transform: { left: 30, top: 60, width: 720, height: 405, angle: 0 },
         }]);

--- a/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
@@ -314,7 +314,7 @@ export class DocFloatDomController extends Disposable {
             this._drawingManagerService.refreshTransform$.subscribe((params) => {
                 params.forEach((param) => {
                     const floatDomInfo = this._domLayerInfoMap.get(param.drawingId);
-                    if (!floatDomInfo) {
+                    if (!floatDomInfo || floatDomInfo.unitId !== param.unitId) {
                         return;
                     }
 

--- a/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
@@ -35,7 +35,7 @@ import {
     toDisposable,
     UniverInstanceType,
 } from '@univerjs/core';
-import { docDrawingPositionToTransform, DocSkeletonManagerService } from '@univerjs/docs';
+import { docDrawingPositionToTransform, DocSkeletonManagerService, isSheetLikeDocsCustomBlockChildType } from '@univerjs/docs';
 import { InsertDocDrawingCommand } from '@univerjs/docs-drawing';
 import { SetDocZoomRatioOperation, VIEWPORT_KEY } from '@univerjs/docs-ui';
 import { IDrawingManagerService } from '@univerjs/drawing';
@@ -266,6 +266,9 @@ export class DocFloatDomController extends Disposable {
                     position$,
                     id: rectParam.drawingId,
                     componentKey: rectParam.componentKey,
+                    contentBox: isSheetLikeEmbedFloatDomRuntimeParam(runtimeParam)
+                        ? { contentInset: 0, wrapperInset: 0 }
+                        : undefined,
                     eventPassThrough: preserveRuntimeGeometry ? false : undefined,
                     preserveOnFocusChange: preserveRuntimeGeometry,
                     onPointerDown: (evt) => {
@@ -542,6 +545,19 @@ function isEmbedFloatDomRuntimeParam(param: IDocFloatDomRuntimeParam): boolean {
 
     const candidate = data as { embedId?: unknown; hostAnchorId?: unknown; version?: unknown };
     return candidate.version === 1 && typeof candidate.embedId === 'string' && typeof candidate.hostAnchorId === 'string';
+}
+
+function isSheetLikeEmbedFloatDomRuntimeParam(param: IDocFloatDomRuntimeParam): boolean {
+    if (!isEmbedFloatDomRuntimeParam(param)) {
+        return false;
+    }
+
+    const data = param.data;
+    return !!data &&
+        typeof data === 'object' &&
+        'childType' in data &&
+        typeof data.childType === 'number' &&
+        isSheetLikeDocsCustomBlockChildType(data.childType);
 }
 
 function createTransformFromRect(rect: Rect): Partial<ITransformState> {

--- a/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
@@ -381,30 +381,13 @@ export class DocFloatDomController extends Disposable {
     }
 
     private _initScrollAndZoomEvent() {
-        const updateDoc = (unitId: string, updateRuntimeViewScale = false) => {
+        const updateDoc = (unitId: string) => {
             const renderObject = this._getSceneAndTransformerByDrawingSearch(unitId);
             if (!renderObject) {
                 return;
             }
-            const viewScale = renderObject.scene.getAncestorScale().scaleX || 1;
-            this._domLayerInfoMap.forEach((floatDomInfo, drawingId) => {
+            this._domLayerInfoMap.forEach((floatDomInfo) => {
                 if (floatDomInfo.unitId !== unitId) return;
-                if (updateRuntimeViewScale && floatDomInfo.runtimeViewport?.viewScale != null) {
-                    floatDomInfo.runtimeViewport = {
-                        ...floatDomInfo.runtimeViewport,
-                        viewScale,
-                    };
-                    const currentProps = this._canvasFloatDomService.domLayers
-                        .find(([id]) => id === drawingId)
-                        ?.[1]
-                        .props;
-                    this._canvasFloatDomService.updateFloatDom(drawingId, {
-                        props: {
-                            ...currentProps,
-                            customBlockRenderViewport: floatDomInfo.runtimeViewport,
-                        },
-                    });
-                }
                 const position = calcDocFloatDomPosition(floatDomInfo.rect, renderObject.renderUnit);
                 floatDomInfo.position$.next(position);
             });
@@ -436,7 +419,7 @@ export class DocFloatDomController extends Disposable {
                 const params = (commandInfo.params) as ISetDocZoomRatioOperationParams;
                 const { unitId } = params;
                 globalThis.queueMicrotask(() => {
-                    if (!this._disposed) updateDoc(unitId, true);
+                    if (!this._disposed) updateDoc(unitId);
                 });
             }
         }));

--- a/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
@@ -95,7 +95,7 @@ interface ICanvasFloatDomInfo {
 interface IDocFloatDomParams extends IDocFloatDomDataBase {
 }
 
-type IDocFloatDomRuntimeViewport = Partial<Pick<IDocsCustomBlockRenderViewport, 'bleedLeft' | 'bleedWidth' | 'contentHeight' | 'contentWidth' | 'height' | 'pageContentWidth' | 'viewportHeight'>>;
+type IDocFloatDomRuntimeViewport = Partial<Pick<IDocsCustomBlockRenderViewport, 'bleedLeft' | 'bleedWidth' | 'contentHeight' | 'contentWidth' | 'height' | 'pageContentWidth' | 'viewScale' | 'viewportHeight'>>;
 
 interface IDocFloatDomRuntimeParam extends IDocFloatDom {
     customBlockRenderViewport?: IDocFloatDomRuntimeViewport;
@@ -135,6 +135,10 @@ function pickValidCustomBlockRenderViewport(viewport: IDocFloatDomRuntimeViewpor
     }
     if (isPositiveNumber(viewport?.pageContentWidth)) {
         result.pageContentWidth = viewport!.pageContentWidth;
+    }
+    const viewScale = viewport?.viewScale;
+    if (isPositiveNumber(viewScale)) {
+        result.viewScale = viewScale;
     }
     if (isPositiveNumber(viewport?.viewportHeight)) {
         result.viewportHeight = viewport!.viewportHeight;
@@ -377,13 +381,30 @@ export class DocFloatDomController extends Disposable {
     }
 
     private _initScrollAndZoomEvent() {
-        const updateDoc = (unitId: string) => {
+        const updateDoc = (unitId: string, updateRuntimeViewScale = false) => {
             const renderObject = this._getSceneAndTransformerByDrawingSearch(unitId);
             if (!renderObject) {
                 return;
             }
-            this._domLayerInfoMap.forEach((floatDomInfo) => {
+            const viewScale = renderObject.scene.getAncestorScale().scaleX || 1;
+            this._domLayerInfoMap.forEach((floatDomInfo, drawingId) => {
                 if (floatDomInfo.unitId !== unitId) return;
+                if (updateRuntimeViewScale && floatDomInfo.runtimeViewport?.viewScale != null) {
+                    floatDomInfo.runtimeViewport = {
+                        ...floatDomInfo.runtimeViewport,
+                        viewScale,
+                    };
+                    const currentProps = this._canvasFloatDomService.domLayers
+                        .find(([id]) => id === drawingId)
+                        ?.[1]
+                        .props;
+                    this._canvasFloatDomService.updateFloatDom(drawingId, {
+                        props: {
+                            ...currentProps,
+                            customBlockRenderViewport: floatDomInfo.runtimeViewport,
+                        },
+                    });
+                }
                 const position = calcDocFloatDomPosition(floatDomInfo.rect, renderObject.renderUnit);
                 floatDomInfo.position$.next(position);
             });
@@ -414,7 +435,7 @@ export class DocFloatDomController extends Disposable {
             if (commandInfo.id === SetDocZoomRatioOperation.id) {
                 const params = (commandInfo.params) as ISetDocZoomRatioOperationParams;
                 const { unitId } = params;
-                updateDoc(unitId);
+                updateDoc(unitId, true);
             }
         }));
     }

--- a/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
@@ -435,7 +435,9 @@ export class DocFloatDomController extends Disposable {
             if (commandInfo.id === SetDocZoomRatioOperation.id) {
                 const params = (commandInfo.params) as ISetDocZoomRatioOperationParams;
                 const { unitId } = params;
-                updateDoc(unitId, true);
+                globalThis.queueMicrotask(() => {
+                    if (!this._disposed) updateDoc(unitId, true);
+                });
             }
         }));
     }

--- a/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/doc-float-dom.controller.ts
@@ -95,7 +95,7 @@ interface ICanvasFloatDomInfo {
 interface IDocFloatDomParams extends IDocFloatDomDataBase {
 }
 
-type IDocFloatDomRuntimeViewport = Partial<Pick<IDocsCustomBlockRenderViewport, 'bleedLeft' | 'bleedWidth' | 'contentHeight' | 'contentWidth' | 'height' | 'viewportHeight'>>;
+type IDocFloatDomRuntimeViewport = Partial<Pick<IDocsCustomBlockRenderViewport, 'bleedLeft' | 'bleedWidth' | 'contentHeight' | 'contentWidth' | 'height' | 'pageContentWidth' | 'viewportHeight'>>;
 
 interface IDocFloatDomRuntimeParam extends IDocFloatDom {
     customBlockRenderViewport?: IDocFloatDomRuntimeViewport;
@@ -132,6 +132,9 @@ function pickValidCustomBlockRenderViewport(viewport: IDocFloatDomRuntimeViewpor
     }
     if (isPositiveNumber(viewport?.height)) {
         result.height = viewport!.height;
+    }
+    if (isPositiveNumber(viewport?.pageContentWidth)) {
+        result.pageContentWidth = viewport!.pageContentWidth;
     }
     if (isPositiveNumber(viewport?.viewportHeight)) {
         result.viewportHeight = viewport!.viewportHeight;

--- a/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-transform-update.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-transform-update.controller.ts
@@ -47,7 +47,7 @@ interface IDrawingParamsWithBehindText {
     hidden?: boolean;
     transform: ITransformState;
     transforms: ITransformState[];
-    customBlockRenderViewport?: Partial<Pick<IDocsCustomBlockRenderViewport, 'bleedLeft' | 'bleedWidth' | 'contentHeight' | 'contentWidth' | 'height' | 'viewportHeight'>>;
+    customBlockRenderViewport?: Partial<Pick<IDocsCustomBlockRenderViewport, 'bleedLeft' | 'bleedWidth' | 'contentHeight' | 'contentWidth' | 'height' | 'pageContentWidth' | 'viewportHeight'>>;
     // The same drawing render in different place, like image in header and footer.
     // The default value is BooleanNumber.FALSE. if it's true, Please use transforms.
     isMultiTransform: BooleanNumber;

--- a/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-transform-update.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-transform-update.controller.ts
@@ -36,7 +36,7 @@ import { DocSkeletonManagerService, RichTextEditingMutation } from '@univerjs/do
 import { IEditorService, SetDocZoomRatioOperation } from '@univerjs/docs-ui';
 import { IDrawingManagerService } from '@univerjs/drawing';
 import { getDocsTableRenderViewport, getTableIdAndSliceIndex, Liquid, TRANSFORM_CHANGE_OBSERVABLE_TYPE } from '@univerjs/engine-render';
-import { debounceTime, filter } from 'rxjs';
+import { debounceTime, filter, merge } from 'rxjs';
 import { DocRefreshDrawingsService } from '../../services/doc-refresh-drawings.service';
 
 interface IDrawingParamsWithBehindText {
@@ -245,7 +245,7 @@ export class DocDrawingTransformUpdateController extends Disposable implements I
     private _initialize() {
         this._initialRenderRefresh();
         this._drawingInitializeListener();
-        this._initResize();
+        this._initTransformRefresh();
     }
 
     private _initialRenderRefresh() {
@@ -303,10 +303,16 @@ export class DocDrawingTransformUpdateController extends Disposable implements I
         );
     }
 
-    private _initResize() {
+    private _initTransformRefresh() {
         this.disposeWithMe(
-            fromEventSubject(this._context.engine.onTransformChange$).pipe(
-                filter((evt) => evt.type === TRANSFORM_CHANGE_OBSERVABLE_TYPE.resize),
+            merge(
+                fromEventSubject(this._context.engine.onTransformChange$).pipe(
+                    filter((evt) => evt.type === TRANSFORM_CHANGE_OBSERVABLE_TYPE.resize)
+                ),
+                fromEventSubject(this._context.scene.onTransformChange$).pipe(
+                    filter((evt) => evt.type === TRANSFORM_CHANGE_OBSERVABLE_TYPE.scale)
+                )
+            ).pipe(
                 debounceTime(16)
             ).subscribe(() => {
                 const skeleton = this._docSkeletonManagerService.getSkeleton();

--- a/packages/docs-ui/src/__tests__/embed-docs-custom-block-bleed.spec.ts
+++ b/packages/docs-ui/src/__tests__/embed-docs-custom-block-bleed.spec.ts
@@ -87,7 +87,7 @@ describe('resolveDocsTableLikeCustomBlockBleedViewport', () => {
         });
     });
 
-    it('keeps authoritative bleed hints even when runtime content width has not caught up', () => {
+    it('keeps authoritative bleed hints while runtime content width has not caught up', () => {
         const root = createElementWithRect({ left: 220, right: 1180, width: 960 });
 
         expect(resolveDocsTableLikeCustomBlockBleedViewport(root, 960, {
@@ -98,6 +98,37 @@ describe('resolveDocsTableLikeCustomBlockBleedViewport', () => {
             bleedRight: 250,
             bleedWidth: 1420,
             contentWidth: 960,
+            virtualWidth: 1420,
+        });
+    });
+
+    it('does not bleed when authoritative content width fits the block', () => {
+        const root = createElementWithRect({ left: 220, right: 1180, width: 960 });
+
+        expect(resolveDocsTableLikeCustomBlockBleedViewport(root, 960, {
+            authoritativeContentWidth: true,
+            bleedLeft: 210,
+            bleedWidth: 1420,
+        })).toEqual({
+            bleedLeft: 0,
+            bleedRight: 0,
+            bleedWidth: 960,
+            contentWidth: 960,
+            virtualWidth: 960,
+        });
+    });
+
+    it('uses the full visible canvas bleed once content exceeds the page', () => {
+        const root = createElementWithRect({ left: 220, right: 1180, width: 960 });
+
+        expect(resolveDocsTableLikeCustomBlockBleedViewport(root, 1100, {
+            bleedLeft: 210,
+            bleedWidth: 1420,
+        })).toEqual({
+            bleedLeft: 210,
+            bleedRight: 250,
+            bleedWidth: 1420,
+            contentWidth: 1100,
             virtualWidth: 1420,
         });
     });

--- a/packages/docs-ui/src/__tests__/embed-docs-custom-block-bleed.spec.ts
+++ b/packages/docs-ui/src/__tests__/embed-docs-custom-block-bleed.spec.ts
@@ -70,6 +70,22 @@ describe('resolveDocsTableLikeCustomBlockBleedViewport', () => {
         });
     });
 
+    it('converts measured screen geometry back to logical geometry at document scale', () => {
+        const root = createElementWithRect({ left: 440, right: 2360, width: 1920 });
+        document.body.appendChild(root);
+        vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(2880);
+
+        expect(resolveDocsTableLikeCustomBlockBleedViewport(root, 1800, {
+            viewScale: 2,
+        })).toEqual({
+            bleedLeft: 215,
+            bleedRight: 255,
+            bleedWidth: 1430,
+            contentWidth: 1800,
+            virtualWidth: 2015,
+        });
+    });
+
     it('uses authoritative render viewport bleed hints without expanding the layout root', () => {
         const root = createElementWithRect({ left: 220, right: 1180, width: 960 });
         document.body.appendChild(root);

--- a/packages/docs-ui/src/__tests__/embed-host-anchor.spec.ts
+++ b/packages/docs-ui/src/__tests__/embed-host-anchor.spec.ts
@@ -115,6 +115,7 @@ describe('resolveDocsCustomBlockRenderViewport', () => {
             height: 480,
             layoutWidth: 960,
             offsetLeft: 0,
+            pageContentWidth: 1008,
             viewportHeight: 480,
             width: 960,
         });
@@ -221,6 +222,7 @@ describe('resolveDocsCustomBlockRenderViewport', () => {
             height: 480,
             layoutWidth: 600,
             offsetLeft: 0,
+            pageContentWidth: 600,
             viewportHeight: 480,
             width: 600,
         });
@@ -242,6 +244,7 @@ describe('resolveDocsCustomBlockRenderViewport', () => {
             height: 480,
             layoutWidth: 420,
             offsetLeft: 0,
+            pageContentWidth: 600,
             viewportHeight: 480,
             width: 420,
         });

--- a/packages/docs-ui/src/__tests__/embed-host-anchor.spec.ts
+++ b/packages/docs-ui/src/__tests__/embed-host-anchor.spec.ts
@@ -116,9 +116,32 @@ describe('resolveDocsCustomBlockRenderViewport', () => {
             layoutWidth: 960,
             offsetLeft: 0,
             pageContentWidth: 1008,
+            viewScale: 1,
             viewportHeight: 480,
             width: 960,
         });
+    });
+
+    it('keeps document scale separate from logical sheet-like viewport dimensions', () => {
+        expect(resolveDocsCustomBlockRenderViewport({
+            childType: UniverInstanceType.UNIVER_SHEET,
+            docsLeft: 120,
+            documentFlavor: DocumentFlavor.MODERN,
+            fallbackHeight: 480,
+            fallbackWidth: 960,
+            pageMarginLeft: 96,
+            pageMarginRight: 96,
+            pageWidth: 1200,
+            scale: 2,
+            visibleCanvasLeft: 0,
+            visibleCanvasWidth: 1440,
+        })).toEqual(expect.objectContaining({
+            bleedLeft: 211,
+            bleedWidth: 1430,
+            contentHeight: 480,
+            viewScale: 2,
+            width: 960,
+        }));
     });
 
     it('uses actual table height for sheet-like docs blocks so docs owns vertical scrolling', () => {
@@ -223,6 +246,7 @@ describe('resolveDocsCustomBlockRenderViewport', () => {
             layoutWidth: 600,
             offsetLeft: 0,
             pageContentWidth: 600,
+            viewScale: 1,
             viewportHeight: 480,
             width: 600,
         });
@@ -245,6 +269,7 @@ describe('resolveDocsCustomBlockRenderViewport', () => {
             layoutWidth: 420,
             offsetLeft: 0,
             pageContentWidth: 600,
+            viewScale: 1,
             viewportHeight: 480,
             width: 420,
         });

--- a/packages/docs-ui/src/embed-docs-custom-block-bleed.ts
+++ b/packages/docs-ui/src/embed-docs-custom-block-bleed.ts
@@ -25,6 +25,7 @@ export interface IDocsCustomBlockBleedViewport {
 }
 
 export interface IDocsCustomBlockBleedViewportHint {
+    authoritativeContentWidth?: boolean;
     bleedLeft?: number;
     bleedWidth?: number;
 }
@@ -50,7 +51,18 @@ export function resolveDocsTableLikeCustomBlockBleedViewport(root: HTMLElement, 
     const normalizedContentWidth = Math.max(1, contentWidth);
     const hintedBleedLeft = hint?.bleedLeft;
     const hintedBleedWidth = hint?.bleedWidth;
-    if (Number.isFinite(hintedBleedWidth) && (hintedBleedWidth ?? 0) > 0) {
+    const hasBleedHint = Number.isFinite(hintedBleedWidth) && (hintedBleedWidth ?? 0) > 0;
+    if (normalizedContentWidth <= rootWidth && (hint?.authoritativeContentWidth || !hasBleedHint)) {
+        return {
+            bleedLeft: 0,
+            bleedRight: 0,
+            bleedWidth: rootWidth,
+            contentWidth: normalizedContentWidth,
+            virtualWidth: rootWidth,
+        };
+    }
+
+    if (hasBleedHint) {
         const bleedLeft = Math.max(0, hintedBleedLeft ?? 0);
         const bleedWidth = Math.max(1, hintedBleedWidth!);
         return {
@@ -59,16 +71,6 @@ export function resolveDocsTableLikeCustomBlockBleedViewport(root: HTMLElement, 
             bleedWidth,
             contentWidth: normalizedContentWidth,
             virtualWidth: Math.max(bleedWidth, bleedLeft + normalizedContentWidth),
-        };
-    }
-
-    if (normalizedContentWidth <= rootWidth) {
-        return {
-            bleedLeft: 0,
-            bleedRight: 0,
-            bleedWidth: rootWidth,
-            contentWidth: normalizedContentWidth,
-            virtualWidth: rootWidth,
         };
     }
 

--- a/packages/docs-ui/src/embed-docs-custom-block-bleed.ts
+++ b/packages/docs-ui/src/embed-docs-custom-block-bleed.ts
@@ -28,6 +28,7 @@ export interface IDocsCustomBlockBleedViewportHint {
     authoritativeContentWidth?: boolean;
     bleedLeft?: number;
     bleedWidth?: number;
+    viewScale?: number;
 }
 
 export function createDefaultDocsTableLikeCustomBlockBleedViewport(): IDocsCustomBlockBleedViewport {
@@ -47,7 +48,11 @@ export function createDefaultDocsTableLikeCustomBlockBleedViewport(): IDocsCusto
 
 export function resolveDocsTableLikeCustomBlockBleedViewport(root: HTMLElement, contentWidth: number, hint?: IDocsCustomBlockBleedViewportHint): IDocsCustomBlockBleedViewport {
     const rootRect = root.getBoundingClientRect();
-    const rootWidth = Math.max(1, rootRect.width);
+    const hintedViewScale = hint?.viewScale;
+    const viewScale = typeof hintedViewScale === 'number' && Number.isFinite(hintedViewScale) && hintedViewScale > 0
+        ? hintedViewScale
+        : 1;
+    const rootWidth = Math.max(1, rootRect.width / viewScale);
     const normalizedContentWidth = Math.max(1, contentWidth);
     const hintedBleedLeft = hint?.bleedLeft;
     const hintedBleedWidth = hint?.bleedWidth;
@@ -77,15 +82,16 @@ export function resolveDocsTableLikeCustomBlockBleedViewport(root: HTMLElement, 
     const bounds = resolveDocsTableLikeCustomBlockBleedBounds(root);
     const viewportLeft = bounds.left + DOCS_CUSTOM_BLOCK_VIEWPORT_INSET;
     const viewportWidth = Math.max(1, bounds.width - DOCS_CUSTOM_BLOCK_VIEWPORT_INSET * 2);
-    const bleedLeft = Math.max(0, rootRect.left - viewportLeft);
-    const bleedRight = Math.max(0, viewportLeft + viewportWidth - rootRect.right);
+    const bleedLeft = Math.max(0, (rootRect.left - viewportLeft) / viewScale);
+    const bleedRight = Math.max(0, (viewportLeft + viewportWidth - rootRect.right) / viewScale);
+    const logicalViewportWidth = viewportWidth / viewScale;
 
     return {
         bleedLeft,
         bleedRight,
-        bleedWidth: viewportWidth,
+        bleedWidth: logicalViewportWidth,
         contentWidth: normalizedContentWidth,
-        virtualWidth: Math.max(viewportWidth, bleedLeft + normalizedContentWidth),
+        virtualWidth: Math.max(logicalViewportWidth, bleedLeft + normalizedContentWidth),
     };
 }
 

--- a/packages/docs-ui/src/embed-host-anchor.ts
+++ b/packages/docs-ui/src/embed-host-anchor.ts
@@ -46,6 +46,7 @@ export interface IDocsCustomBlockLayoutViewport {
     layoutWidth?: number;
     offsetLeft?: number;
     pageContentWidth?: number;
+    viewScale?: number;
     viewportHeight?: number;
     width: number;
 }
@@ -63,6 +64,7 @@ export function resolveDocsCustomBlockRenderViewport(params: IDocsCustomBlockRen
         : undefined;
     const height = sheetLike ? contentHeight : fallbackHeight;
     const viewportHeight = sheetLike && visibleCanvasHeight != null ? Math.min(contentHeight, visibleCanvasHeight) : height;
+    const viewScale = params.scale && params.scale > 0 ? params.scale : 1;
 
     if (!sheetLike) {
         return {
@@ -90,13 +92,13 @@ export function resolveDocsCustomBlockRenderViewport(params: IDocsCustomBlockRen
             layoutWidth,
             offsetLeft: 0,
             pageContentWidth,
+            viewScale,
             viewportHeight,
             width: layoutWidth,
         };
     }
 
-    const scale = params.scale && params.scale > 0 ? params.scale : 1;
-    const inset = MODERN_DOCS_CUSTOM_BLOCK_VIEWPORT_INSET / scale;
+    const inset = MODERN_DOCS_CUSTOM_BLOCK_VIEWPORT_INSET / viewScale;
     const docsLeft = params.docsLeft ?? 0;
     const fallbackViewportLeft = docsLeft + inset;
     const fallbackViewportWidth = Math.max(0, pageWidth! - inset * 2);
@@ -119,6 +121,7 @@ export function resolveDocsCustomBlockRenderViewport(params: IDocsCustomBlockRen
         layoutWidth,
         offsetLeft: 0,
         pageContentWidth,
+        viewScale,
         viewportHeight,
         width: layoutWidth,
     };

--- a/packages/docs-ui/src/embed-host-anchor.ts
+++ b/packages/docs-ui/src/embed-host-anchor.ts
@@ -45,6 +45,7 @@ export interface IDocsCustomBlockLayoutViewport {
     height: number;
     layoutWidth?: number;
     offsetLeft?: number;
+    pageContentWidth?: number;
     viewportHeight?: number;
     width: number;
 }
@@ -88,6 +89,7 @@ export function resolveDocsCustomBlockRenderViewport(params: IDocsCustomBlockRen
             height,
             layoutWidth,
             offsetLeft: 0,
+            pageContentWidth,
             viewportHeight,
             width: layoutWidth,
         };
@@ -116,6 +118,7 @@ export function resolveDocsCustomBlockRenderViewport(params: IDocsCustomBlockRen
         height,
         layoutWidth,
         offsetLeft: 0,
+        pageContentWidth,
         viewportHeight,
         width: layoutWidth,
     };

--- a/packages/docs/src/services/__tests__/doc-skeleton-manager.service.spec.ts
+++ b/packages/docs/src/services/__tests__/doc-skeleton-manager.service.spec.ts
@@ -88,5 +88,13 @@ describe('DocSkeletonManagerService', () => {
 
         expect(service.getViewModel().getDataModel().getUnitId()).toBe('doc-1');
         expect(service.getSkeleton()).toBeTruthy();
+
+        const publishedSkeletons: unknown[] = [];
+        const subscription = service.currentSkeleton$.subscribe((skeleton) => publishedSkeletons.push(skeleton));
+        const skeleton = service.recalculate();
+
+        expect(skeleton).toBe(service.getSkeleton());
+        expect(publishedSkeletons).toEqual([skeleton, skeleton]);
+        subscription.unsubscribe();
     });
 });

--- a/packages/docs/src/services/doc-skeleton-manager.service.ts
+++ b/packages/docs/src/services/doc-skeleton-manager.service.ts
@@ -77,6 +77,14 @@ export class DocSkeletonManagerService extends RxDisposable implements IRenderMo
         return this._docViewModel;
     }
 
+    recalculate(): DocumentSkeleton {
+        const skeleton = this._skeleton;
+        skeleton.calculate();
+        this._currentSkeletonBefore$.next(skeleton);
+        this._currentSkeleton$.next(skeleton);
+        return skeleton;
+    }
+
     private _init() {
         const documentDataModel = this._context.unit;
         this._update(documentDataModel);
@@ -103,14 +111,7 @@ export class DocSkeletonManagerService extends RxDisposable implements IRenderMo
             this._skeleton = this._buildSkeleton(this._docViewModel);
         }
 
-        const skeleton = this._skeleton;
-        skeleton.calculate();
-
-        // sub: packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
-        this._currentSkeletonBefore$.next(skeleton);
-
-        // sub: packages/docs-ui/src/controllers/render-controllers/text-selection.render-controller.ts
-        this._currentSkeleton$.next(skeleton);
+        this.recalculate();
 
         // sub: packages/docs/src/services/doc-interceptor/doc-interceptor.service.ts
         this._currentViewModel$.next(this._docViewModel);

--- a/packages/engine-render/src/basics/i-document-skeleton-cached.ts
+++ b/packages/engine-render/src/basics/i-document-skeleton-cached.ts
@@ -305,6 +305,7 @@ export interface IDocumentSkeletonDrawing {
         contentWidth?: number;
         height?: number;
         pageContentWidth?: number;
+        viewScale?: number;
         viewportHeight?: number;
     };
 }

--- a/packages/engine-render/src/basics/i-document-skeleton-cached.ts
+++ b/packages/engine-render/src/basics/i-document-skeleton-cached.ts
@@ -304,6 +304,7 @@ export interface IDocumentSkeletonDrawing {
         contentHeight?: number;
         contentWidth?: number;
         height?: number;
+        pageContentWidth?: number;
         viewportHeight?: number;
     };
 }

--- a/packages/engine-render/src/basics/tools.ts
+++ b/packages/engine-render/src/basics/tools.ts
@@ -41,6 +41,11 @@ const PI_OVER_DEG180 = Math.PI / DEG180;
 const DEG180_OVER_PI = DEG180 / Math.PI;
 const RGB_PAREN = 'rgb(';
 const RGBA_PAREN = 'rgba(';
+const SCROLLABLE_OVERFLOW_EPSILON = 0.5;
+
+export function hasScrollableOverflow(contentSize: number, viewportSize: number): boolean {
+    return contentSize - viewportSize > SCROLLABLE_OVERFLOW_EPSILON;
+}
 
 // TODO :move to core @jerry
 export const getColor = (RgbArray: number[], opacity?: number): string => {

--- a/packages/engine-render/src/components/docs/custom-block-render-viewport.ts
+++ b/packages/engine-render/src/components/docs/custom-block-render-viewport.ts
@@ -31,6 +31,7 @@ export interface IDocsCustomBlockRenderViewport {
     height: number;
     layoutWidth?: number;
     offsetLeft?: number;
+    pageContentWidth?: number;
     viewportHeight?: number;
     width: number;
 }

--- a/packages/engine-render/src/components/docs/custom-block-render-viewport.ts
+++ b/packages/engine-render/src/components/docs/custom-block-render-viewport.ts
@@ -32,6 +32,7 @@ export interface IDocsCustomBlockRenderViewport {
     layoutWidth?: number;
     offsetLeft?: number;
     pageContentWidth?: number;
+    viewScale?: number;
     viewportHeight?: number;
     width: number;
 }

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/layout-ruler.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/layout-ruler.spec.ts
@@ -809,6 +809,7 @@ describe('layout-ruler', () => {
             contentWidth: 320,
             height: 80,
             pageContentWidth: 300,
+            viewScale: 1.5,
             viewportHeight: 64,
             layoutWidth: 180,
             width: 180,
@@ -890,6 +891,7 @@ describe('layout-ruler', () => {
         expect(drawing?.customBlockRenderViewport?.contentWidth).toBe(320);
         expect(drawing?.customBlockRenderViewport?.height).toBe(80);
         expect(drawing?.customBlockRenderViewport?.pageContentWidth).toBe(300);
+        expect(drawing?.customBlockRenderViewport?.viewScale).toBe(1.5);
         expect(drawing?.customBlockRenderViewport?.viewportHeight).toBe(64);
         expect(drawing?.aTop).toBe(30);
     });

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/layout-ruler.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/layout-ruler.spec.ts
@@ -808,6 +808,7 @@ describe('layout-ruler', () => {
             contentHeight: 120,
             contentWidth: 320,
             height: 80,
+            pageContentWidth: 300,
             viewportHeight: 64,
             layoutWidth: 180,
             width: 180,
@@ -888,6 +889,7 @@ describe('layout-ruler', () => {
         expect(drawing?.customBlockRenderViewport?.contentHeight).toBe(120);
         expect(drawing?.customBlockRenderViewport?.contentWidth).toBe(320);
         expect(drawing?.customBlockRenderViewport?.height).toBe(80);
+        expect(drawing?.customBlockRenderViewport?.pageContentWidth).toBe(300);
         expect(drawing?.customBlockRenderViewport?.viewportHeight).toBe(64);
         expect(drawing?.aTop).toBe(30);
     });

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/layout-ruler.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/layout-ruler.ts
@@ -1790,6 +1790,7 @@ export function updateInlineDrawingPosition(
                         contentWidth: viewport.contentWidth,
                         height: viewport.height,
                         pageContentWidth: viewport.pageContentWidth,
+                        viewScale: viewport.viewScale,
                         viewportHeight: viewport.viewportHeight,
                     }
                     : undefined;
@@ -1897,6 +1898,7 @@ function __getDrawingPosition(
                 contentWidth: viewport.contentWidth,
                 height: viewport.height,
                 pageContentWidth: viewport.pageContentWidth,
+                viewScale: viewport.viewScale,
                 viewportHeight: viewport.viewportHeight,
             }
             : undefined;

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/layout-ruler.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/layout-ruler.ts
@@ -1789,6 +1789,7 @@ export function updateInlineDrawingPosition(
                         contentHeight: viewport.contentHeight,
                         contentWidth: viewport.contentWidth,
                         height: viewport.height,
+                        pageContentWidth: viewport.pageContentWidth,
                         viewportHeight: viewport.viewportHeight,
                     }
                     : undefined;
@@ -1895,6 +1896,7 @@ function __getDrawingPosition(
                 contentHeight: viewport.contentHeight,
                 contentWidth: viewport.contentWidth,
                 height: viewport.height,
+                pageContentWidth: viewport.pageContentWidth,
                 viewportHeight: viewport.viewportHeight,
             }
             : undefined;

--- a/packages/engine-render/src/shape/__tests__/scroll-bar.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/scroll-bar.spec.ts
@@ -129,6 +129,28 @@ describe('ScrollBar', () => {
         scrollBar.dispose();
     });
 
+    it('optionally hides unscrollable tracks and restores them when content overflows', () => {
+        const scrollBar = ScrollBar.attachTo(viewport, {
+            enableHorizontal: true,
+            enableVertical: true,
+            hideTrackWhenUnscrollable: true,
+        });
+
+        scrollBar.resize(160, 120, 100, 80);
+
+        expect(scrollBar.horizonScrollTrack?.visible).toBe(false);
+        expect(scrollBar.verticalScrollTrack?.visible).toBe(false);
+        expect(scrollBar.placeholderBarRect?.visible).toBe(false);
+
+        scrollBar.resize(160, 120, 640, 480);
+
+        expect(scrollBar.horizonScrollTrack?.visible).toBe(true);
+        expect(scrollBar.verticalScrollTrack?.visible).toBe(true);
+        expect(scrollBar.placeholderBarRect?.visible).toBe(true);
+
+        scrollBar.dispose();
+    });
+
     it('uses track clicks and thumb dragging to update viewport scroll', () => {
         const scrollBar = new ScrollBar(viewport, { mainScene: scene });
         const scrollToBarPos = vi.spyOn(viewport, 'scrollToBarPos');

--- a/packages/engine-render/src/shape/__tests__/scroll-bar.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/scroll-bar.spec.ts
@@ -142,6 +142,11 @@ describe('ScrollBar', () => {
         expect(scrollBar.verticalScrollTrack?.visible).toBe(false);
         expect(scrollBar.placeholderBarRect?.visible).toBe(false);
 
+        scrollBar.resize(160, 120, 160.5, 120.5);
+
+        expect(scrollBar.horizonScrollTrack?.visible).toBe(false);
+        expect(scrollBar.verticalScrollTrack?.visible).toBe(false);
+
         scrollBar.resize(160, 120, 640, 480);
 
         expect(scrollBar.horizonScrollTrack?.visible).toBe(true);

--- a/packages/engine-render/src/shape/scroll-bar.ts
+++ b/packages/engine-render/src/shape/scroll-bar.ts
@@ -48,6 +48,8 @@ export interface IScrollBarProps {
     enableHorizontal?: boolean;
     /** Enable the vertical scroll bar. True by default. */
     enableVertical?: boolean;
+    /** Hide the track when the corresponding content axis does not overflow. False by default. */
+    hideTrackWhenUnscrollable?: boolean;
     /** The min width of horizon thumb. Default is 17 px. */
     minThumbSizeH?: number;
     /** The min height of vertical thumb. Default is 17 px. */
@@ -67,6 +69,7 @@ export class ScrollBar extends Disposable {
 
     _enableHorizontal: boolean = true;
     _enableVertical: boolean = true;
+    private _hideTrackWhenUnscrollable = false;
 
     horizontalThumbSize: number = 0;
     horizontalMinusMiniThumb: number = 0;
@@ -199,6 +202,22 @@ export class ScrollBar extends Disposable {
 
     set enableVertical(val: boolean) {
         this._enableVertical = val;
+    }
+
+    get hideTrackWhenUnscrollable() {
+        return this._hideTrackWhenUnscrollable;
+    }
+
+    set hideTrackWhenUnscrollable(val: boolean) {
+        if (this._hideTrackWhenUnscrollable === val) {
+            return;
+        }
+
+        this._hideTrackWhenUnscrollable = val;
+        this._resizeHorizontal();
+        this._resizeVertical();
+        this._resizeRightBottomCorner();
+        this.makeDirty(true);
     }
 
     get limitX() {
@@ -473,7 +492,11 @@ export class ScrollBar extends Disposable {
         });
 
         // content is smaller than viewport size
-        if (this.horizontalThumbSize >= viewportW - (this._trackThickness + 2)) {
+        const scrollable = this.horizontalThumbSize < viewportW - (this._trackThickness + 2);
+        this.horizonScrollTrack?.setProps({
+            visible: !this._hideTrackWhenUnscrollable || scrollable,
+        });
+        if (!scrollable) {
             this.horizonThumbRect?.setProps({
                 visible: false,
             });
@@ -520,7 +543,11 @@ export class ScrollBar extends Disposable {
         });
 
         // content is smaller than viewport size
-        if (this.verticalThumbSize >= viewportH - this._trackThickness) {
+        const scrollable = this.verticalThumbSize < viewportH - this._trackThickness;
+        this.verticalScrollTrack?.setProps({
+            visible: !this._hideTrackWhenUnscrollable || scrollable,
+        });
+        if (!scrollable) {
             this.verticalThumbRect?.setProps({
                 visible: false,
             });
@@ -543,6 +570,10 @@ export class ScrollBar extends Disposable {
         const viewportH = this._viewportH;
         const viewportW = this._viewportW;
         if (this._enableHorizontal && this._enableVertical) {
+            this.placeholderBarRect?.setProps({
+                visible: !this._hideTrackWhenUnscrollable
+                    || Boolean(this.horizonScrollTrack?.visible && this.verticalScrollTrack?.visible),
+            });
             this.placeholderBarRect?.transformByState({
                 left: viewportW - this._trackThickness,
                 top: viewportH - this._trackThickness,

--- a/packages/engine-render/src/shape/scroll-bar.ts
+++ b/packages/engine-render/src/shape/scroll-bar.ts
@@ -56,12 +56,15 @@ export interface IScrollBarProps {
 
 const MIN_THUMB_SIZE = 17;
 const DEFAULT_TRACK_SIZE = 10;
+const DEFAULT_TRACK_BORDER_SIZE = 1;
 const HOVER_TRACK_SIZE = 10;
 const DEFAULT_THUMB_MARGIN = 2;
 const HOVER_THUMB_MARGIN = 1;
 const BAR_DRAG_SCROLL_THROTTLE_MS = 32;
 
 export class ScrollBar extends Disposable {
+    static readonly DEFAULT_TOTAL_SIZE = DEFAULT_TRACK_SIZE + DEFAULT_TRACK_BORDER_SIZE;
+
     _enableHorizontal: boolean = true;
     _enableVertical: boolean = true;
 
@@ -121,7 +124,7 @@ export class ScrollBar extends Disposable {
     private _hThumbMargin = DEFAULT_THUMB_MARGIN;
 
     // origin: barBorder, used for strokeWidth of scroll track, is draw on the center of the track border, so the visible border thickness is barBorder / 2 at both side of the track, and the visible track thickness is `trackThickness - barBorder`.
-    private _trackBorderThickness = 1;
+    private _trackBorderThickness = DEFAULT_TRACK_BORDER_SIZE;
     private _thumbLengthRatio = 1;
 
     /**

--- a/packages/engine-render/src/shape/scroll-bar.ts
+++ b/packages/engine-render/src/shape/scroll-bar.ts
@@ -22,6 +22,7 @@ import type { Scene } from '../scene';
 import type { Viewport } from '../viewport';
 import { Disposable, Tools } from '@univerjs/core';
 import { Subscription } from 'rxjs';
+import { hasScrollableOverflow } from '../basics/tools';
 import { Transform } from '../basics/transform';
 import { Rect } from './rect';
 
@@ -492,7 +493,7 @@ export class ScrollBar extends Disposable {
         });
 
         // content is smaller than viewport size
-        const scrollable = this.horizontalThumbSize < viewportW - (this._trackThickness + 2);
+        const scrollable = hasScrollableOverflow(contentWidth, viewportW);
         this.horizonScrollTrack?.setProps({
             visible: !this._hideTrackWhenUnscrollable || scrollable,
         });
@@ -543,7 +544,7 @@ export class ScrollBar extends Disposable {
         });
 
         // content is smaller than viewport size
-        const scrollable = this.verticalThumbSize < viewportH - this._trackThickness;
+        const scrollable = hasScrollableOverflow(contentHeight, viewportH);
         this.verticalScrollTrack?.setProps({
             visible: !this._hideTrackWhenUnscrollable || scrollable,
         });

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -25,7 +25,7 @@ import type { ScrollBar } from './shape/scroll-bar';
 import { EventSubject, Tools } from '@univerjs/core';
 import { Subject } from 'rxjs';
 import { RENDER_CLASS_TYPE } from './basics/const';
-import { fixLineWidthByScale, toPx } from './basics/tools';
+import { fixLineWidthByScale, hasScrollableOverflow, toPx } from './basics/tools';
 import { Transform } from './basics/transform';
 import { Vector2 } from './basics/vector2';
 import { subtractViewportRange } from './basics/viewport-subtract';
@@ -1087,10 +1087,10 @@ export class Viewport {
         scrollX = scrollX ?? this.scrollX;
         scrollY = scrollY ?? this.scrollY;
         const { height, width } = this._calcViewPortSize();
-        if (this._sceneWCurrVpAfterScale <= width) {
+        if (!hasScrollableOverflow(this._sceneWCurrVpAfterScale, width)) {
             scrollX = 0;
         }
-        if (this._sceneHCurrVpAfterScale <= height) {
+        if (!hasScrollableOverflow(this._sceneHCurrVpAfterScale, height)) {
             scrollY = 0;
         }
 

--- a/packages/sheets-drawing-ui/src/services/__tests__/canvas-float-dom-manager.service.spec.ts
+++ b/packages/sheets-drawing-ui/src/services/__tests__/canvas-float-dom-manager.service.spec.ts
@@ -25,6 +25,7 @@ import {
     Disposable,
     DrawingTypeEnum,
     EventSubject,
+    IUniverInstanceService,
     LifecycleService,
     LifecycleStages,
     LocaleType,
@@ -35,7 +36,7 @@ import { IRenderManagerService, Rect, SHEET_VIEWPORT_KEY, SpreadsheetSkeleton } 
 import { DrawingApplyType, InsertSheetDrawingCommand, ISheetDrawingService, RemoveSheetDrawingCommand, SetDrawingApplyMutation, SetSheetDrawingCommand } from '@univerjs/sheets-drawing';
 import { ISheetSelectionRenderService, SheetSkeletonManagerService } from '@univerjs/sheets-ui';
 import { CanvasFloatDomService } from '@univerjs/ui';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createSheetsDrawingUiTestBed } from '../../__tests__/create-sheets-drawing-ui-test-bed';
 import {
@@ -1998,9 +1999,10 @@ describe('SheetCanvasFloatDomManagerService', () => {
         }));
     });
 
-    it('refreshes float dom position when the sheet viewport scrolls', () => {
+    it('refreshes float dom position when a non-current sheet renderer scrolls', () => {
         const fixture = setup();
         disposables.push(fixture);
+        vi.spyOn(fixture.get(IUniverInstanceService), 'getCurrentTypeOfUnit$').mockReturnValue(of(null));
         fixture.get(LifecycleService).stage = LifecycleStages.Rendered;
         const canvasFloatDomService = fixture.get(CanvasFloatDomService);
 

--- a/packages/sheets-drawing-ui/src/services/canvas-float-dom-manager.service.ts
+++ b/packages/sheets-drawing-ui/src/services/canvas-float-dom-manager.service.ts
@@ -1483,6 +1483,7 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
                         }
                     });
                     listener && disposableCollection.add(listener);
+                    this._bindFloatDomScroll(disposableCollection, info, renderObject.renderUnit.scene, skeleton.skeleton, target.worksheet);
                     this._domLayerInfoMap.set(drawingId, info);
                 });
             })
@@ -1546,32 +1547,6 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
             })
         );
 
-        // #region scroll
-        this.disposeWithMe(
-            this._univerInstanceService.getCurrentTypeOfUnit$<Workbook>(UniverInstanceType.UNIVER_SHEET).pipe(
-                switchMap((workbook) => workbook ? workbook.activeSheet$ : of(null)),
-                map((worksheet) => {
-                    if (!worksheet) return null;
-                    const unitId = worksheet.getUnitId();
-                    const render = this._renderManagerService.getRenderUnitById(unitId);
-                    return render ? { render, unitId, subUnitId: worksheet.getSheetId() } : null;
-                }),
-                switchMap((render) =>
-                    render
-                        ? fromEventSubject(render.render.scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_MAIN)!.onScrollAfter$)
-                            .pipe(map(() => ({ unitId: render.unitId, subUnitId: render.subUnitId })))
-                        : of(null)
-                )
-            ).subscribe((value) => {
-                if (!value) return; // TODO@weird94: maybe we should throw an error here and do some cleaning work?
-
-                const { unitId, subUnitId } = value;
-                updateSheet(unitId, subUnitId);
-            })
-        );
-
-        //#endregion
-
         // #region zoom
         this.disposeWithMe(this._commandService.onCommandExecuted((commandInfo) => {
             if (commandInfo.id === SetZoomRatioOperation.id) {
@@ -1590,6 +1565,23 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
             }
         }));
         //# endregion
+    }
+
+    private _bindFloatDomScroll(
+        disposableCollection: DisposableCollection,
+        info: ICanvasFloatDomInfo,
+        scene: Scene,
+        skeleton: SpreadsheetSkeleton,
+        worksheet: Worksheet
+    ): void {
+        const viewport = scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_MAIN);
+        if (!viewport) {
+            return;
+        }
+
+        disposableCollection.add(fromEventSubject(viewport.onScrollAfter$).subscribe(() => {
+            info.position$.next(calcSheetFloatDomPosition(info.rect, scene, skeleton, worksheet, info));
+        }));
     }
 
     updateFloatDomProps(unitId: string, subUnitId: string, id: string, props: Record<string, any>) {
@@ -2112,6 +2104,7 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
                 this._canvasFloatDomService.removeFloatDom(drawingId);
             });
             listener && disposableCollection.add(listener);
+            this._bindFloatDomScroll(disposableCollection, floatDomInfo, renderObject.renderUnit.scene, skeletonParam.skeleton, target.worksheet);
             this._domLayerInfoMap.set(drawingId, floatDomInfo);
         }
 
@@ -2352,6 +2345,7 @@ export class SheetCanvasFloatDomManagerService extends Disposable {
                 this._canvasFloatDomService.removeFloatDom(drawingId);
             });
             listener && disposableCollection.add(listener);
+            this._bindFloatDomScroll(disposableCollection, floatDomInfo, renderObject.renderUnit.scene, skeleton.skeleton, target.worksheet);
             this._domLayerInfoMap.set(drawingId, floatDomInfo);
         }
 

--- a/packages/ui/src/services/dom/canvas-dom-layer.service.ts
+++ b/packages/ui/src/services/dom/canvas-dom-layer.service.ts
@@ -16,7 +16,7 @@
 
 import type { IPosition, Serializable } from '@univerjs/core';
 import type { Observable } from 'rxjs';
-import { Disposable } from '@univerjs/core';
+import { Disposable, toDisposable } from '@univerjs/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 
 export interface IFloatDomLayout extends IPosition {
@@ -78,6 +78,7 @@ export function shouldRenderFloatDomLayer(layer: Pick<IFloatDom, 'unitId' | 'pre
 
 export class CanvasFloatDomService extends Disposable {
     private _domLayerMap = new Map<string, IFloatDom>();
+    private _scopedRenderRootCount = new Map<string, number>();
     private _domLayers$ = new BehaviorSubject<[string, IFloatDom][]>([]);
 
     domLayers$ = this._domLayers$.asObservable();
@@ -108,6 +109,29 @@ export class CanvasFloatDomService extends Disposable {
         this._notice();
     }
 
+    hasScopedRenderRoot(unitId: string): boolean {
+        return this._scopedRenderRootCount.has(unitId);
+    }
+
+    registerScopedRenderRoot(unitId: string) {
+        this._scopedRenderRootCount.set(unitId, (this._scopedRenderRootCount.get(unitId) ?? 0) + 1);
+        this._notice();
+
+        return toDisposable(() => {
+            const count = this._scopedRenderRootCount.get(unitId);
+            if (count == null) {
+                return;
+            }
+
+            if (count === 1) {
+                this._scopedRenderRootCount.delete(unitId);
+            } else {
+                this._scopedRenderRootCount.set(unitId, count - 1);
+            }
+            this._notice();
+        });
+    }
+
     removeFloatDom(id: string): void {
         if (this._domLayerMap.delete(id)) {
             this._notice();
@@ -121,6 +145,7 @@ export class CanvasFloatDomService extends Disposable {
 
     override dispose(): void {
         this._domLayerMap.clear();
+        this._scopedRenderRootCount.clear();
         this._domLayers$.next([]);
         this._domLayers$.complete();
         super.dispose();

--- a/packages/ui/src/views/components/dom/FloatDom.tsx
+++ b/packages/ui/src/views/components/dom/FloatDom.tsx
@@ -159,8 +159,11 @@ export const FloatDom = ({ unitId }: { unitId?: string }) => {
     const layers = useObservable(domLayerService.domLayers$);
     const focusUnit = useObservable(instanceService.focused$);
     const currentUnitId = resolveFloatDomCurrentUnitId(unitId, focusUnit);
+    const visibleLayers = typeof unitId === 'string'
+        ? layers?.filter((layer) => layer[1].unitId === unitId)
+        : layers?.filter((layer) => shouldRenderFloatDomLayer(layer[1], currentUnitId));
 
-    return layers?.filter((layer) => shouldRenderFloatDomLayer(layer[1], currentUnitId))?.map((layer) => (
+    return visibleLayers?.map((layer) => (
         <FloatDomSingle
             id={layer[1].domId ?? layer[0]}
             layer={layer[1]}

--- a/packages/ui/src/views/components/dom/FloatDom.tsx
+++ b/packages/ui/src/views/components/dom/FloatDom.tsx
@@ -159,9 +159,22 @@ export const FloatDom = ({ unitId }: { unitId?: string }) => {
     const layers = useObservable(domLayerService.domLayers$);
     const focusUnit = useObservable(instanceService.focused$);
     const currentUnitId = resolveFloatDomCurrentUnitId(unitId, focusUnit);
+
+    useEffect(() => {
+        if (typeof unitId !== 'string') {
+            return;
+        }
+
+        const disposable = domLayerService.registerScopedRenderRoot(unitId);
+        return () => disposable.dispose();
+    }, [domLayerService, unitId]);
+
     const visibleLayers = typeof unitId === 'string'
         ? layers?.filter((layer) => layer[1].unitId === unitId)
-        : layers?.filter((layer) => shouldRenderFloatDomLayer(layer[1], currentUnitId));
+        : layers?.filter((layer) =>
+            !domLayerService.hasScopedRenderRoot(layer[1].unitId) &&
+            shouldRenderFloatDomLayer(layer[1], currentUnitId)
+        );
 
     return visibleLayers?.map((layer) => (
         <FloatDomSingle

--- a/packages/ui/src/views/components/dom/__tests__/FloatDom.spec.tsx
+++ b/packages/ui/src/views/components/dom/__tests__/FloatDom.spec.tsx
@@ -239,6 +239,21 @@ describe('FloatDom', () => {
         expect(document.getElementById('float-1')).toBeNull();
     });
 
+    it('renders a unit only in its explicit root when the same unit is focused globally', async () => {
+        const rendered = renderWithDependencies(
+            <>
+                <div data-testid="global-root"><FloatDom /></div>
+                <div data-testid="scoped-root"><FloatDom unitId="doc-1" /></div>
+            </>,
+            { getUnitId: () => 'doc-1' }
+        );
+
+        act(() => rendered.injector.get(CanvasFloatDomService).addFloatDom(createFloatDom()));
+
+        await waitFor(() => expect(screen.getByTestId('scoped-root').textContent).toBe('float content'));
+        expect(screen.getByTestId('global-root').textContent).toBe('');
+    });
+
     it('updates content box insets at runtime through CanvasFloatDomService', async () => {
         const rendered = renderWithDependencies(<FloatDom unitId="doc-1" />);
         const service = rendered.injector.get(CanvasFloatDomService);

--- a/packages/ui/src/views/components/dom/__tests__/FloatDom.spec.tsx
+++ b/packages/ui/src/views/components/dom/__tests__/FloatDom.spec.tsx
@@ -227,6 +227,18 @@ describe('FloatDom', () => {
         expect(document.getElementById('float-1')).not.toBeNull();
     });
 
+    it('does not render preserved layers from another unit in an explicitly scoped root', () => {
+        const rendered = renderWithDependencies(<FloatDom unitId="sheet-1" />);
+
+        act(() => rendered.injector.get(CanvasFloatDomService).addFloatDom({
+            ...createFloatDom(),
+            preserveOnFocusChange: true,
+        }));
+
+        expect(screen.queryByText('float content')).toBeNull();
+        expect(document.getElementById('float-1')).toBeNull();
+    });
+
     it('updates content box insets at runtime through CanvasFloatDomService', async () => {
         const rendered = renderWithDependencies(<FloatDom unitId="doc-1" />);
         const service = rendered.injector.get(CanvasFloatDomService);


### PR DESCRIPTION
## What changed

- honor authoritative embedded content width when resolving Docs custom-block bleed
- bind each Sheet Float DOM layer to the viewport of the renderer that created it
- refresh Float DOM position from that renderer's own scroll event
- let an explicit unit-scoped Float DOM root claim its unit so the global root does not render the same layer a second time
- reference-count scoped roots so mounting and unmounting multiple renderers remains safe
- add focused regression coverage for authoritative width, per-renderer scrolling, and duplicate scoped/global roots

## Why

Docs bleed hints could keep a block expanded after its authoritative content width fit the page. Sheet Float DOM updates also listened to the globally current workbook/renderer, and an embedded Sheet could be rendered by both its scoped root and the global root when it became focused.

## Impact

Embedded Sheet Float DOM content follows its owning Sheet viewport and renders once. Standalone Sheet still uses the global root and keeps its existing behavior. No embed-specific portal or cross-plugin routing is added.

## Validation

- post-rebase `@univerjs/ui` Float DOM suite: 13 tests passed
- earlier focused UI, Sheets Drawing UI, and Docs UI regression run: 4 suites, 69 tests passed
- commit hooks passed
- `docs-embed-local`: one Sheet Float DOM image in both inactive and editing states
- unrelated OSS clipboard changes were kept unstaged and excluded from this PR
