### PR TITLE
fix(formula): start Other Formula calculation without Sheets

### DIFF
--- a/packages/engine-formula/src/controllers/__tests__/formula.controller.spec.ts
+++ b/packages/engine-formula/src/controllers/__tests__/formula.controller.spec.ts
@@ -27,6 +27,7 @@ import {
     toDisposable,
 } from '@univerjs/core';
 import { describe, expect, it, vi } from 'vitest';
+import { OtherFormulaMarkDirty } from '../../commands/mutations/formula.mutation';
 import { ActiveDirtyManagerService, IActiveDirtyManagerService } from '../../services/active-dirty-manager.service';
 import { FunctionService, IFunctionService } from '../../services/function.service';
 import { RegisterOtherFormulaService } from '../../services/register-other-formula.service';
@@ -38,6 +39,7 @@ type FormulaDataSyncController = Pick<
 >;
 
 function createController(dataSyncPrimaryController?: FormulaDataSyncController): {
+    commandService: ICommandService;
     controller: FormulaController;
     registerOtherFormulaService: RegisterOtherFormulaService;
 } {
@@ -49,10 +51,12 @@ function createController(dataSyncPrimaryController?: FormulaDataSyncController)
     injector.add([IActiveDirtyManagerService, { useClass: ActiveDirtyManagerService }]);
     injector.add([LifecycleService]);
     injector.add([RegisterOtherFormulaService]);
+    const commandService = injector.get(ICommandService);
     const registerOtherFormulaService = injector.get(RegisterOtherFormulaService);
     return {
+        commandService,
         controller: new FormulaController(
-            injector.get(ICommandService),
+            commandService,
             injector.get(IFunctionService),
             injector.get(IConfigService),
             dataSyncPrimaryController,
@@ -63,6 +67,21 @@ function createController(dataSyncPrimaryController?: FormulaDataSyncController)
 }
 
 describe('FormulaController', () => {
+    it('registers the generic Other Formula dirty mutation', async () => {
+        const { commandService, controller } = createController();
+
+        expect(commandService.hasCommand(OtherFormulaMarkDirty.id)).toBe(true);
+        await expect(commandService.executeCommand(OtherFormulaMarkDirty.id, {
+            'doc-1': {
+                'shape-1': {
+                    'formula-1': true,
+                },
+            },
+        })).resolves.toBe(true);
+
+        controller.dispose();
+    });
+
     it('registers mutation-only synchronization once per other-formula host', () => {
         const dispose = vi.fn();
         const dataSyncPrimaryController = {

--- a/packages/engine-formula/src/controllers/formula.controller.ts
+++ b/packages/engine-formula/src/controllers/formula.controller.ts
@@ -20,6 +20,7 @@ import type { IUniverEngineFormulaConfig } from '../config/config';
 import type { BaseFunction } from '../functions/base-function';
 import { Disposable, ICommandService, IConfigService, Inject, Optional } from '@univerjs/core';
 import { DataSyncPrimaryController } from '@univerjs/rpc';
+import { OtherFormulaMarkDirty } from '../commands/mutations/formula.mutation';
 import { RegisterFunctionMutation } from '../commands/mutations/register-function.mutation';
 import { SetArrayFormulaDataMutation } from '../commands/mutations/set-array-formula-data.mutation';
 import { RemoveDefinedNameMutation, SetDefinedNameMutation } from '../commands/mutations/set-defined-name.mutation';
@@ -119,6 +120,7 @@ export class FormulaController extends Disposable {
             SetFeatureCalculationMutation,
             RemoveFeatureCalculationMutation,
 
+            OtherFormulaMarkDirty,
             SetOtherFormulaMutation,
             RemoveOtherFormulaMutation,
             SetSuperTableMutation,

--- a/packages/engine-formula/src/services/__tests__/current-data.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/current-data.service.spec.ts
@@ -33,9 +33,15 @@ function createService() {
     };
 
     const workbookById = new Map<string, unknown>();
+    const unitTypeById = new Map<string, UniverInstanceType>();
     const univerInstanceService = {
         getCurrentUnitOfType: vi.fn(() => workbookForCurrentType),
-        getUnit: vi.fn((unitId: string) => workbookById.get(unitId)),
+        getUnit: vi.fn((unitId: string, unitType?: UniverInstanceType) => {
+            if (unitType != null && unitTypeById.get(unitId) !== unitType) {
+                return undefined;
+            }
+            return workbookById.get(unitId);
+        }),
     };
     const localeService = {
         getCurrentLocale: vi.fn(() => 'zhCN'),
@@ -86,6 +92,7 @@ function createService() {
     return {
         service,
         workbookById,
+        unitTypeById,
         univerInstanceService,
         localeService,
         formulaDataModel,
@@ -204,8 +211,9 @@ describe('FormulaCurrentConfigService', () => {
     });
 
     it('should resolve sheet size, filtered rows and lightweight data loading', () => {
-        const { service, workbookById, formulaDataModel } = createService();
+        const { service, workbookById, unitTypeById, formulaDataModel } = createService();
 
+        unitTypeById.set('unit-size', UniverInstanceType.UNIVER_SHEET);
         workbookById.set('unit-size', {
             getSheetBySheetId: (sheetId: string) => {
                 if (sheetId === 'sheet-size') {
@@ -219,6 +227,9 @@ describe('FormulaCurrentConfigService', () => {
 
         expect(service.getSheetRowColumnCount('unit-size', 'sheet-size')).toEqual({ rowCount: 22, columnCount: 8 });
         expect(service.getSheetRowColumnCount('unit-size', 'missing')).toEqual({ rowCount: 0, columnCount: 0 });
+        unitTypeById.set('doc-unit', UniverInstanceType.UNIVER_DOC);
+        workbookById.set('doc-unit', {});
+        expect(service.getSheetRowColumnCount('doc-unit', 'doc-unit')).toEqual({ rowCount: 0, columnCount: 0 });
         expect(service.getFilteredOutRows('unit-size', 'sheet-size', 1, 5)).toEqual([2, 4]);
 
         formulaDataModel.getCalculateData.mockReturnValue({

--- a/packages/engine-formula/src/services/__tests__/formula-calculation-trigger.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/formula-calculation-trigger.service.spec.ts
@@ -29,6 +29,7 @@ function createTestBed(start = true) {
     let listener: ((command: ICommandInfo, options?: IExecutionOptions) => void) | undefined;
     const executed: Array<{ id: string; params: unknown; options: unknown }> = [];
     const conversions = new Map<string, { commandId: string; shouldTrigger?: () => boolean; getDirtyData: (command: ICommandInfo) => object }>();
+    const calculateStartedNext = vi.fn();
     const commandService = {
         onCommandExecuted: vi.fn((callback: typeof listener) => {
             listener = callback;
@@ -42,8 +43,15 @@ function createTestBed(start = true) {
     } as unknown as ICommandService;
     const activeDirtyManagerService = {
         get: (id: string) => conversions.get(id),
+        register: (id: string, conversion: { commandId: string; shouldTrigger?: () => boolean; getDirtyData: (command: ICommandInfo) => object }) => {
+            conversions.set(id, conversion);
+        },
     };
-    const service = new FormulaCalculationTriggerService(commandService, activeDirtyManagerService as never);
+    const service = new FormulaCalculationTriggerService(
+        commandService,
+        activeDirtyManagerService as never,
+        { calculateStarted$: { next: calculateStartedNext } } as never
+    );
     if (start) {
         service.start();
     }
@@ -52,6 +60,7 @@ function createTestBed(start = true) {
         service,
         executed,
         conversions,
+        calculateStartedNext,
         emit: (command: ICommandInfo, options?: IExecutionOptions) => listener?.(command, options),
     };
 }
@@ -61,6 +70,53 @@ describe('FormulaCalculationTriggerService', () => {
     afterEach(() => {
         vi.useRealTimers();
         vi.restoreAllMocks();
+    });
+
+    it('enables Other Formula registration when global calculation scheduling starts', () => {
+        const testBed = createTestBed(false);
+
+        expect(testBed.calculateStartedNext).not.toHaveBeenCalled();
+        testBed.service.start();
+        expect(testBed.calculateStartedNext).toHaveBeenCalledExactlyOnceWith(true);
+
+        testBed.service.start();
+        expect(testBed.calculateStartedNext).toHaveBeenCalledOnce();
+        testBed.service.dispose();
+    });
+
+    it('owns explicit recalculation dirty conversion without a Sheet plugin', async () => {
+        const testBed = createTestBed();
+
+        testBed.emit({
+            id: SetTriggerFormulaCalculationStartMutation.id,
+            params: {
+                forceCalculation: true,
+                dirtyUnitOtherFormulaMap: {
+                    'doc-unit': {
+                        'shape-unit': {
+                            'formula-id': true,
+                        },
+                    },
+                },
+            },
+        } as ICommandInfo);
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect(testBed.executed).toHaveLength(1);
+        expect(testBed.executed[0]).toMatchObject({
+            id: SetFormulaCalculationStartMutation.id,
+            params: {
+                forceCalculation: true,
+                dirtyUnitOtherFormulaMap: {
+                    'doc-unit': {
+                        'shape-unit': {
+                            'formula-id': true,
+                        },
+                    },
+                },
+            },
+        });
+        testBed.service.dispose();
     });
 
     it('collects changeset dirty data before start and merges it with the initial trigger', async () => {

--- a/packages/engine-formula/src/services/current-data.service.ts
+++ b/packages/engine-formula/src/services/current-data.service.ts
@@ -327,7 +327,7 @@ export class FormulaCurrentConfigService extends Disposable implements IFormulaC
     }
 
     getSheetRowColumnCount(unitId: string, sheetId: string) {
-        const workbook = this._univerInstanceService.getUnit<Workbook>(unitId);
+        const workbook = this._univerInstanceService.getUnit<Workbook>(unitId, UniverInstanceType.UNIVER_SHEET);
         const worksheet = workbook?.getSheetBySheetId(sheetId);
         const snapshot = worksheet?.getSnapshot();
 

--- a/packages/engine-formula/src/services/formula-calculation-trigger.service.ts
+++ b/packages/engine-formula/src/services/formula-calculation-trigger.service.ts
@@ -18,7 +18,7 @@ import type { ICommandInfo, IUnitRange, Nullable } from '@univerjs/core';
 import type { IDirtyUnitFeatureMap } from '../basics/common';
 import type { ISetFormulaCalculationNotificationMutation } from '../commands/mutations/set-formula-calculation.mutation';
 import type { IFormulaDirtyData } from './current-data.service';
-import { Disposable, ICommandService, Rectangle } from '@univerjs/core';
+import { Disposable, ICommandService, Inject, Rectangle } from '@univerjs/core';
 import {
     SetFormulaCalculationNotificationMutation,
     SetFormulaCalculationStartMutation,
@@ -26,6 +26,7 @@ import {
     SetTriggerFormulaCalculationStartMutation,
 } from '../commands/mutations/set-formula-calculation.mutation';
 import { IActiveDirtyManagerService } from './active-dirty-manager.service';
+import { RegisterOtherFormulaService } from './register-other-formula.service';
 import { FormulaExecutedStateType } from './runtime.service';
 
 const LOCAL_ONLY = { onlyLocal: true };
@@ -50,9 +51,16 @@ export class FormulaCalculationTriggerService extends Disposable {
 
     constructor(
         @ICommandService private readonly _commandService: ICommandService,
-        @IActiveDirtyManagerService private readonly _activeDirtyManagerService: IActiveDirtyManagerService
+        @IActiveDirtyManagerService private readonly _activeDirtyManagerService: IActiveDirtyManagerService,
+        @Inject(RegisterOtherFormulaService) private readonly _registerOtherFormulaService: RegisterOtherFormulaService
     ) {
         super();
+        this._activeDirtyManagerService.register(SetTriggerFormulaCalculationStartMutation.id, {
+            commandId: SetTriggerFormulaCalculationStartMutation.id,
+            getDirtyData: (command) => ({
+                ...(command.params as IFormulaDirtyData),
+            }),
+        });
         this._initialize();
     }
 
@@ -62,6 +70,7 @@ export class FormulaCalculationTriggerService extends Disposable {
         }
 
         this._started = true;
+        this._registerOtherFormulaService.calculateStarted$.next(true);
         this._scheduleFlush();
     }
 

--- a/packages/sheets-formula/src/controllers/__tests__/active-dirty.controller.spec.ts
+++ b/packages/sheets-formula/src/controllers/__tests__/active-dirty.controller.spec.ts
@@ -25,7 +25,6 @@ import {
     IActiveDirtyManagerService,
     RemoveDefinedNameMutation,
     SetDefinedNameMutation,
-    SetTriggerFormulaCalculationStartMutation,
 } from '@univerjs/engine-formula';
 import {
     InsertSheetMutation,
@@ -338,27 +337,6 @@ describe('ActiveDirtyController', () => {
                 name: 'Added Sheet',
             },
         } as IInsertSheetMutationParams;
-
-        expect(getDirtyData(testBed, {
-            id: SetTriggerFormulaCalculationStartMutation.id,
-            params: {
-                forceCalculation: true,
-                dirtyRanges: [],
-                dirtyNameMap: { test: { sheet1: 'Sheet1' } },
-                dirtyDefinedNameMap: {},
-                dirtyUnitFeatureMap: {},
-                dirtyUnitOtherFormulaMap: {},
-                clearDependencyTreeCache: {},
-            },
-        } as ICommandInfo)).toEqual({
-            forceCalculation: true,
-            dirtyRanges: [],
-            dirtyNameMap: { test: { sheet1: 'Sheet1' } },
-            dirtyDefinedNameMap: {},
-            dirtyUnitFeatureMap: {},
-            dirtyUnitOtherFormulaMap: {},
-            clearDependencyTreeCache: {},
-        });
 
         expect(getDirtyData(testBed, {
             id: RemoveSheetMutation.id,

--- a/packages/sheets-formula/src/controllers/__tests__/formula.controller.spec.ts
+++ b/packages/sheets-formula/src/controllers/__tests__/formula.controller.spec.ts
@@ -15,7 +15,6 @@
  */
 
 import { ICommandService } from '@univerjs/core';
-import { OtherFormulaMarkDirty } from '@univerjs/engine-formula';
 import { afterEach, describe, expect, it } from 'vitest';
 import { InsertFunctionCommand } from '../../commands/commands/insert-function.command';
 import { QuickSumCommand } from '../../commands/commands/quick-sum.command';
@@ -33,13 +32,11 @@ describe('FormulaController', () => {
 
         expect(commandService.hasCommand(InsertFunctionCommand.id)).toBe(false);
         expect(commandService.hasCommand(QuickSumCommand.id)).toBe(false);
-        expect(commandService.hasCommand(OtherFormulaMarkDirty.id)).toBe(false);
 
         testBed.injector.get(FormulaController);
 
         expect(commandService.hasCommand(InsertFunctionCommand.id)).toBe(true);
         expect(commandService.hasCommand(QuickSumCommand.id)).toBe(true);
-        expect(commandService.hasCommand(OtherFormulaMarkDirty.id)).toBe(true);
 
         testBed.univer.dispose();
     });

--- a/packages/sheets-formula/src/controllers/__tests__/trigger-calculation.controller.spec.ts
+++ b/packages/sheets-formula/src/controllers/__tests__/trigger-calculation.controller.spec.ts
@@ -136,7 +136,6 @@ function createControllerTestBed(initialFormulaComputing = CalculationMode.WHEN_
         commandService,
         formulaDataModel: injector.get(FormulaDataModel),
         activeDirtyManagerService: injector.get(IActiveDirtyManagerService),
-        registerOtherFormulaService: injector.get(RegisterOtherFormulaService),
         executedCommands,
         executedDisposable,
     };
@@ -156,8 +155,6 @@ describe('TriggerCalculationController', () => {
         const testBed = createControllerTestBed();
 
         await Promise.resolve();
-
-        expect(testBed.registerOtherFormulaService.calculateStarted$.getValue()).toBe(true);
 
         testBed.executedCommands.length = 0;
 
@@ -189,7 +186,6 @@ describe('TriggerCalculationController', () => {
 
         await Promise.resolve();
 
-        expect(testBed.registerOtherFormulaService.calculateStarted$.getValue()).toBe(true);
         expect(testBed.executedCommands.some(({ id }) => id === SetTriggerFormulaCalculationStartMutation.id)).toBe(false);
 
         testBed.executedDisposable.dispose();
@@ -197,7 +193,7 @@ describe('TriggerCalculationController', () => {
     });
 
     it('should merge dirty data from real active-dirty registrations and skip style-triggered range updates', async () => {
-        const testBed = createControllerTestBed();
+        const testBed = createControllerTestBed(CalculationMode.NO_CALCULATION);
 
         testBed.activeDirtyManagerService.register('formula.test-dirty-1', {
             commandId: 'formula.test-dirty-1',
@@ -265,7 +261,7 @@ describe('TriggerCalculationController', () => {
     });
 
     it('should stop and restart calculation through real notification flow', async () => {
-        const testBed = createControllerTestBed();
+        const testBed = createControllerTestBed(CalculationMode.NO_CALCULATION);
 
         testBed.activeDirtyManagerService.register('formula.test-dirty-restart', {
             commandId: 'formula.test-dirty-restart',

--- a/packages/sheets-formula/src/controllers/active-dirty.controller.ts
+++ b/packages/sheets-formula/src/controllers/active-dirty.controller.ts
@@ -15,7 +15,7 @@
  */
 
 import type { ICellData, ICommandInfo, IObjectMatrixPrimitiveType, IRange, IUnitRange, Nullable, Workbook } from '@univerjs/core';
-import type { IDirtyUnitDefinedNameMap, IDirtyUnitSheetNameMap, IFormulaDirtyData, ISetDefinedNameMutationParam } from '@univerjs/engine-formula';
+import type { IDirtyUnitDefinedNameMap, IDirtyUnitSheetNameMap, ISetDefinedNameMutationParam } from '@univerjs/engine-formula';
 import type {
     IInsertColMutationParams,
     IInsertRowMutationParams,
@@ -38,7 +38,7 @@ import {
     ObjectMatrix,
     UniverInstanceType,
 } from '@univerjs/core';
-import { FormulaDataModel, IActiveDirtyManagerService, RemoveDefinedNameMutation, SetDefinedNameMutation, SetTriggerFormulaCalculationStartMutation } from '@univerjs/engine-formula';
+import { FormulaDataModel, IActiveDirtyManagerService, RemoveDefinedNameMutation, SetDefinedNameMutation } from '@univerjs/engine-formula';
 import {
     ClearSelectionFormatCommand,
     InsertColMutation,
@@ -257,16 +257,6 @@ export class ActiveDirtyController extends Disposable {
     }
 
     private _initialSheet() {
-        this._activeDirtyManagerService.register(SetTriggerFormulaCalculationStartMutation.id, {
-            commandId: SetTriggerFormulaCalculationStartMutation.id,
-            getDirtyData: (command: ICommandInfo) => {
-                const params = command.params as IFormulaDirtyData;
-                return {
-                    ...params,
-                };
-            },
-        });
-
         this._activeDirtyManagerService.register(RemoveSheetMutation.id, {
             commandId: RemoveSheetMutation.id,
             getDirtyData: (command: ICommandInfo) => {

--- a/packages/sheets-formula/src/controllers/formula.controller.ts
+++ b/packages/sheets-formula/src/controllers/formula.controller.ts
@@ -15,7 +15,6 @@
  */
 
 import { Disposable, ICommandService } from '@univerjs/core';
-import { OtherFormulaMarkDirty } from '@univerjs/engine-formula';
 import { InsertFunctionCommand } from '../commands/commands/insert-function.command';
 import { QuickSumCommand } from '../commands/commands/quick-sum.command';
 
@@ -28,7 +27,6 @@ export class FormulaController extends Disposable {
         [
             InsertFunctionCommand,
             QuickSumCommand,
-            OtherFormulaMarkDirty,
         ].forEach((c) => this._commandService.registerCommand(c));
     }
 }

--- a/packages/sheets-formula/src/controllers/trigger-calculation.controller.ts
+++ b/packages/sheets-formula/src/controllers/trigger-calculation.controller.ts
@@ -44,7 +44,6 @@ import {
     FormulaDataModel,
     FormulaExecutedStateType,
     FormulaExecuteStageType,
-    RegisterOtherFormulaService,
     SetFormulaCalculationNotificationMutation,
     SetFormulaCalculationStartMutation,
     SetFormulaCalculationStopMutation,
@@ -133,8 +132,7 @@ export class TriggerCalculationController extends Disposable {
         @ILogService private readonly _logService: ILogService,
         @IConfigService private readonly _configService: IConfigService,
         @Inject(FormulaDataModel) private readonly _formulaDataModel: FormulaDataModel,
-        @Inject(LocaleService) private readonly _localeService: LocaleService,
-        @Inject(RegisterOtherFormulaService) private readonly _registerOtherFormulaService: RegisterOtherFormulaService
+        @Inject(LocaleService) private readonly _localeService: LocaleService
     ) {
         super();
 
@@ -306,8 +304,6 @@ export class TriggerCalculationController extends Disposable {
             const params = this._getDirtyDataByCalculationMode(calculationMode);
             this._commandService.executeCommand(SetTriggerFormulaCalculationStartMutation.id, params, lo);
         }
-
-        this._registerOtherFormulaService.calculateStarted$.next(true);
     }
 
     private _getDirtyDataByCalculationMode(calculationMode: CalculationMode): IFormulaDirtyData {


### PR DESCRIPTION
Closes dream-num/univer-pro#5286
Closes dream-num/univer-pro#5296

## What changed

- make the global formula calculation trigger own explicit recalculation dirty conversion and Other Formula readiness
- register `OtherFormulaMarkDirty` in the engine Formula controller and remove the Sheet-owned duplicate
- resolve sheet dimensions through a Sheet-typed Unit lookup
- remove generic formula-engine responsibilities from Sheet controllers

## Why

Doc, Slide, and Board Formula Shapes can exist in a runtime with no Sheet Unit. In that state, Other Formula registrations remained buffered, explicit recalculation had no dirty conversion, and dependency generation could call Workbook APIs on a non-Sheet host.

## Canonical path

`Other Formula registration -> global calculation trigger -> external-reference provider -> formula result`

The change keeps one provider-driven path. It does not preload Source Units or parse formulas in host applications.

## Validation

- `pnpm vitest run packages/engine-formula/src/services/__tests__/formula-calculation-trigger.service.spec.ts` — 8 passed
- `pnpm vitest run packages/engine-formula/src/controllers/__tests__/formula.controller.spec.ts` — 3 passed
- `pnpm vitest run packages/engine-formula/src/services/__tests__/current-data.service.spec.ts` — 4 passed
- `pnpm vitest run packages/engine-formula/src/controllers/__tests__/formula-calculation-trigger.controller.spec.ts` — 2 passed
- `pnpm vitest run packages/engine-formula/src/services/__tests__/register-other-formula.service.spec.ts` — 8 passed
- `pnpm vitest run packages/sheets-formula/src/controllers/__tests__/formula.controller.spec.ts` — 1 passed
- `pnpm vitest run packages/sheets-formula/src/controllers/__tests__/trigger-calculation.controller.spec.ts` — 5 passed
- `pnpm vitest run packages/sheets-formula/src/controllers/__tests__/active-dirty.controller.spec.ts` — 4 passed
- `pnpm --filter @univerjs/engine-formula typecheck`
- `pnpm --filter @univerjs/sheets-formula typecheck`
- downstream Pro zero-Sheet persisted Doc Formula Shape integration — 1 passed with value 45, provider reads, and explicit recalculation
- downstream existing Sheet Formula Shape integration — 2 passed

Full repository CI is left to the Draft PR checks.