### PR TITLE
fix(docs-ui): move custom range chrome test

### DIFF
--- a/packages/docs-ui/src/basics/__tests__/doc-custom-range-chrome.spec.ts
+++ b/packages/docs-ui/src/basics/__tests__/doc-custom-range-chrome.spec.ts
@@ -22,7 +22,7 @@ import {
     DOC_CUSTOM_RANGE_CHROME_RADIUS,
     drawDocCustomRangeChrome,
     resolveDocCustomRangeChromeTheme,
-} from './doc-custom-range-chrome';
+} from '../doc-custom-range-chrome';
 
 describe('Doc custom range chrome', () => {
     it('derives a subtle background and border from the current primary theme token', () => {


### PR DESCRIPTION
## Summary

Move the Doc custom-range chrome unit test into the source file’s `__tests__` directory so repository naming conventions pass when Univer is consumed as the Pro submodule.

## Validation

- `pnpm --filter @univerjs/docs-ui typecheck`
- `pnpm --filter @univerjs/docs-ui exec vitest run src/basics/__tests__/doc-custom-range-chrome.spec.ts`
- Pro repository `node scripts/check-conventions.mjs`

## Pull Request Checklist

- [x] No related issue.
- [x] Naming convention is followed.
- [x] Existing unit tests cover the change.
- [x] No breaking changes introduced.