### PR TITLE
fix(engine-render): load opentype through its default export

### DIFF
--- a/packages/engine-render/src/components/docs/layout/shaping-engine/__tests__/text-shaping-engine.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/shaping-engine/__tests__/text-shaping-engine.spec.ts
@@ -57,7 +57,9 @@ const h = vi.hoisted(() => {
 });
 
 vi.mock('opentype.js', () => ({
-    parse: h.parse,
+    default: {
+        parse: h.parse,
+    },
 }));
 
 vi.mock('../font-library', () => ({

--- a/packages/engine-render/src/components/docs/layout/shaping-engine/text-shaping.ts
+++ b/packages/engine-render/src/components/docs/layout/shaping-engine/text-shaping.ts
@@ -15,9 +15,8 @@
  */
 
 import type { IDocumentBody, IStyleBase, Nullable } from '@univerjs/core';
-import type Opentype from 'opentype.js';
 import { BooleanNumber } from '@univerjs/core';
-import { parse } from 'opentype.js';
+import Opentype from 'opentype.js';
 import { DEFAULT_FONTFACE_PLANE } from '../../../../basics/const';
 import { getFirstGrapheme, isEmojiGrapheme } from '../../../../basics/tools';
 import { fontLibrary } from './font-library';
@@ -126,7 +125,7 @@ function shapeChunk(
 
     let font = fontCache.get(fontInfo.fullName);
     if (!font) {
-        font = parse(fontBuffer) as Opentype.Font;
+        font = Opentype.parse(fontBuffer) as Opentype.Font;
         fontCache.set(fontInfo.fullName, font);
     }
 


### PR DESCRIPTION
## Necessity

`opentype.js@2` exposes its package root through a CommonJS entry. Native Node ESM cannot reliably resolve `parse` as a named export from that entry, which prevents clean ESM consumers of `@univerjs/engine-render` from loading.

## Correctness

Load the package through its default CommonJS interop export and call `Opentype.parse`. The package build now emits the matching contracts for both formats: ESM uses a default import and CommonJS uses `require` with default interop. The existing shaping mock follows the same public module shape.

## Long-term correctness

The source consumes the documented package root and works with both emitted module formats, without a version-specific deep import. The text-shaping test exercises the same default-export contract.

## Verification

- `pnpm --filter @univerjs/engine-render exec vitest run src/components/docs/layout/shaping-engine/__tests__/text-shaping-engine.spec.ts` — 4/4 passed
- `pnpm --filter @univerjs/engine-render typecheck` — passed
- `pnpm --filter @univerjs/engine-render build` — ESM, CommonJS, UMD, and declarations built successfully
- targeted ESLint — 0 errors
- `git diff --check` — passed