### PR TITLE
fix(sheets): skip snapshot preview before workbench ready

### DIFF
--- a/packages/sheets-ui/src/services/__tests__/sheet-loading-render.service.spec.ts
+++ b/packages/sheets-ui/src/services/__tests__/sheet-loading-render.service.spec.ts
@@ -107,7 +107,7 @@ vi.mock('@univerjs/engine-render', async (importOriginal) => {
     };
 });
 
-function createLayoutService(contentElement: HTMLElement): ILayoutService {
+function createLayoutService(getContentElement: () => HTMLElement): ILayoutService {
     return {
         isFocused: false,
         rootContainerElement: null,
@@ -116,13 +116,46 @@ function createLayoutService(contentElement: HTMLElement): ILayoutService {
         registerRootContainerElement: () => toDisposable(() => {}),
         registerContentElement: () => toDisposable(() => {}),
         registerContainerElement: () => toDisposable(() => {}),
-        getContentElement: () => contentElement,
+        getContentElement,
         checkElementInCurrentContainers: () => false,
         checkContentIsFocused: () => false,
     };
 }
 
 describe('SheetLoadingRenderService', () => {
+    it('skips the preview and completes handoff when workbench content is not registered', async () => {
+        const contentElements: HTMLElement[] = [];
+        const injector = new Injector();
+        injector.add([ILogService, { useClass: DesktopLogService }]);
+        injector.add([IContextService, { useClass: ContextService }]);
+        injector.add([IUniverInstanceService, { useClass: UniverInstanceService }]);
+        injector.add([ThemeService]);
+        injector.add([SheetInterceptorService]);
+        injector.add([ILayoutService, { useValue: createLayoutService(() => contentElements[0]) }]);
+        injector.add([IRenderManagerService, { useClass: RenderManagerService }]);
+        const service = injector.createInstance(SheetLoadingRenderService);
+        const workbookData = {
+            id: 'unit-1',
+            name: 'Workbook',
+            appVersion: '',
+            locale: LocaleType.EN_US,
+            styles: {},
+            sheetOrder: ['sheet-1'],
+            sheets: { 'sheet-1': { id: 'sheet-1', cellData: {} } },
+            resources: [],
+        } satisfies IWorkbookData;
+
+        service.showSkeleton(workbookData, 'sheet-1');
+        service.show(workbookData, 'sheet-1', {});
+
+        expect(service.loading$.value).toBe(true);
+        expect(service.previewReady$.value).toBe(false);
+        await expect(service.handoff('unit-1', 10_000)).resolves.toBe(true);
+        expect(service.loading$.value).toBe(false);
+        service.dispose();
+        injector.get(IRenderManagerService).dispose();
+    });
+
     it('renders intercepted display values without owning the global workbook or pointer events', async () => {
         const contentElement = document.createElement('div');
         contentElement.style.pointerEvents = 'auto';
@@ -133,7 +166,7 @@ describe('SheetLoadingRenderService', () => {
             return animationFrames.length;
         });
 
-        const layoutService = createLayoutService(contentElement);
+        const layoutService = createLayoutService(() => contentElement);
         const injector = new Injector();
         injector.add([ILogService, { useClass: DesktopLogService }]);
         injector.add([IContextService, { useClass: ContextService }]);
@@ -240,7 +273,7 @@ describe('SheetLoadingRenderService', () => {
         injector.add([IUniverInstanceService, { useClass: UniverInstanceService }]);
         injector.add([ThemeService]);
         injector.add([SheetInterceptorService]);
-        injector.add([ILayoutService, { useValue: createLayoutService(contentElement) }]);
+        injector.add([ILayoutService, { useValue: createLayoutService(() => contentElement) }]);
         injector.add([IRenderManagerService, { useClass: RenderManagerService }]);
         const service = injector.createInstance(SheetLoadingRenderService);
         const workbookData = {
@@ -267,8 +300,9 @@ describe('SheetLoadingRenderService', () => {
         vi.useRealTimers();
     });
 
-    it('keeps the preview mounted until the final canvas is mounted', async () => {
+    it('keeps the preview mounted until workbench content and the final canvas are mounted', async () => {
         const contentElement = document.createElement('div');
+        const contentElements = [contentElement];
         vi.spyOn(contentElement, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 640, 480));
         const animationFrames: FrameRequestCallback[] = [];
         const requestAnimationFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
@@ -282,7 +316,7 @@ describe('SheetLoadingRenderService', () => {
         injector.add([IUniverInstanceService, { useClass: UniverInstanceService }]);
         injector.add([ThemeService]);
         injector.add([SheetInterceptorService]);
-        injector.add([ILayoutService, { useValue: createLayoutService(contentElement) }]);
+        injector.add([ILayoutService, { useValue: createLayoutService(() => contentElements[0]) }]);
         injector.add([IRenderManagerService, { useClass: RenderManagerService }]);
         const service = injector.createInstance(SheetLoadingRenderService);
         const workbookData = {
@@ -309,6 +343,7 @@ describe('SheetLoadingRenderService', () => {
         service.showSkeleton(workbookData, 'sheet-1');
         service.show(workbookData, 'sheet-1', {});
 
+        contentElements.length = 0;
         const handoff = service.handoff('unit-1', 10_000);
         await vi.waitFor(() => expect(animationFrames).toHaveLength(2));
 
@@ -320,6 +355,7 @@ describe('SheetLoadingRenderService', () => {
         await vi.waitFor(() => expect(animationFrames).toHaveLength(3));
         expect(finalScene.requestRender).not.toHaveBeenCalled();
 
+        contentElements.push(contentElement);
         finalEngine.mount(contentElement);
         animationFrames[2](0);
         await vi.waitFor(() => expect(animationFrames).toHaveLength(4));

--- a/packages/sheets-ui/src/services/sheet-loading-render.service.ts
+++ b/packages/sheets-ui/src/services/sheet-loading-render.service.ts
@@ -108,7 +108,16 @@ export class SheetLoadingRenderService extends Disposable implements ISheetLoadi
 
         let shouldRender = false;
         if (!loadingRender.render) {
-            loadingRender.render = this._createLoadingRender(loadingRender.workbook, loadingRender.sourceUnitId);
+            const contentElement = this._layoutService.getContentElement();
+            if (!contentElement) {
+                return;
+            }
+
+            loadingRender.render = this._createLoadingRender(
+                loadingRender.workbook,
+                loadingRender.sourceUnitId,
+                contentElement
+            );
             shouldRender = true;
         }
 
@@ -166,6 +175,11 @@ export class SheetLoadingRenderService extends Disposable implements ISheetLoadi
             return true;
         }
 
+        if (!this._loadingRender.render) {
+            this.hide(sourceUnitId);
+            return true;
+        }
+
         this._finalCanvasGuard?.unsubscribe();
         this._finalCanvasGuard = null;
 
@@ -217,9 +231,12 @@ export class SheetLoadingRenderService extends Disposable implements ISheetLoadi
         return workbook;
     }
 
-    private _createLoadingRender(workbook: Workbook, sourceUnitId: string): RenderUnit {
+    private _createLoadingRender(
+        workbook: Workbook,
+        sourceUnitId: string,
+        contentElement: HTMLElement
+    ): RenderUnit {
         const previewUnitId = workbook.getUnitId();
-        const contentElement = this._layoutService.getContentElement();
         const { width, height } = contentElement.getBoundingClientRect();
         const engine = this._injector.createInstance(Engine, previewUnitId, undefined);
         const scene = new Scene(`${PREVIEW_SCENE_PREFIX}${previewUnitId}`, engine, {
@@ -257,11 +274,12 @@ export class SheetLoadingRenderService extends Disposable implements ISheetLoadi
     private _waitForFinalCanvas(render: IRender): Observable<void> {
         return new Observable((subscriber) => {
             let frameId: number | undefined;
-            const contentElement = this._layoutService.getContentElement();
             const canvasElement = render.engine.getCanvasElement();
 
             const checkMounted = () => {
+                const contentElement = this._layoutService.getContentElement();
                 if (
+                    contentElement &&
                     canvasElement.parentElement === contentElement &&
                     canvasElement.width > 0 &&
                     canvasElement.height > 0


### PR DESCRIPTION
## What changed

- guard snapshot preview creation when the Workbench content element is not registered yet
- skip the temporary Preview Engine in that startup window instead of dereferencing an unavailable element
- let handoff complete immediately when no preview render was created
- re-read the Workbench content element while waiting for a mounted final canvas

No Workbench, WorkbenchService, desktop, or mobile lifecycle behavior is changed.

## Why

Large snapshot preview can run before `LifecycleStages.Ready`, while Workbench content registration currently happens at `Ready`. `SheetLoadingRenderService` previously assumed the content element always existed and called `getBoundingClientRect()` on `undefined`, aborting the large workbook load.

This is a defensive degradation: when content is unavailable, the temporary preview is skipped and the existing formal workbook loading flow remains responsible for rendering the document.

## Impact

- fixes the large-workbook loading crash
- keeps the current Workbench skeleton and lifecycle contract unchanged
- preserves the existing Preview Engine path whenever the content element is available

## Related

- Pro PR: https://github.com/dream-num/univer-pro/pull/5305

## Validation

- `SheetLoadingRenderService`: 4 tests passed
- `@univerjs/sheets-ui` type check passed
- targeted ESLint and `git diff --check` passed
