### PR TITLE
fix(sheets-crosshair-highlight): add overlay padding

### DIFF
--- a/packages/sheets-crosshair-highlight/src/views/components/CrosshairHighlight.tsx
+++ b/packages/sheets-crosshair-highlight/src/views/components/CrosshairHighlight.tsx
@@ -48,7 +48,7 @@ export function CrosshairOverlay(props: ICrosshairOverlayProps) {
     }, [onChange]);
 
     return (
-        <div className="univer-grid univer-grid-cols-8 univer-gap-x-2 univer-gap-y-3">
+        <div className="univer-grid univer-grid-cols-8 univer-gap-x-2 univer-gap-y-3 univer-p-1.5">
             {colors.map((color: string, index: number) => {
                 return (
                     <div


### PR DESCRIPTION
## Summary
- Add padding to the crosshair highlight color grid.
- Add a regression assertion for the padding class.

## Validation
- `pnpm --filter @univerjs/sheets-crosshair-highlight exec vitest run src/views/components/__tests__/CrosshairHighlight.spec.tsx`