### PR TITLE
fix(render): skip invalid shape stroke widths

### DIFF
--- a/packages/engine-render/src/shape/__tests__/basic-shapes-extra.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/basic-shapes-extra.spec.ts
@@ -141,6 +141,23 @@ describe('basic shape and position helpers', () => {
         expect(ctx.restore).toHaveBeenCalled();
     });
 
+    it('skips non-positive and non-finite stroke widths', () => {
+        for (const strokeWidth of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+            const ctx = createShapeCtx();
+
+            Rect.drawWith(ctx, {
+                width: 80,
+                height: 32,
+                fill: '#ffffff',
+                stroke: '#ff0000',
+                strokeWidth,
+            });
+
+            expect(ctx.fill).toHaveBeenCalled();
+            expect(ctx.stroke).not.toHaveBeenCalled();
+        }
+    });
+
     it('draws a rounded visual rect centered in the interaction bounds', () => {
         const rect = new Rect('rect-visual', {
             width: 80,

--- a/packages/engine-render/src/shape/shape.ts
+++ b/packages/engine-render/src/shape/shape.ts
@@ -283,7 +283,7 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
 
         // let { scaleX, scaleY } = props;
         // const { scaleX = 1, scaleY = 1 } = ctx.getScale();
-        if (!stroke || strokeWidth === 0) {
+        if (!stroke || strokeWidth === undefined || !Number.isFinite(strokeWidth) || strokeWidth <= 0) {
             return;
         }
 


### PR DESCRIPTION
## What changed

- Skip Canvas stroke rendering when a Shape stroke width is missing, non-finite, or non-positive.
- Add focused regression coverage for zero, negative, `NaN`, and infinite widths while confirming fill rendering remains intact.

## Why

Canvas 2D ignores invalid `lineWidth` assignments and keeps the previous positive width. Calling `stroke()` afterward can therefore produce an unexpected hairline border.

## Impact

Shapes with invisible stroke widths no longer inherit a visible Canvas line width.

## Validation

- `pnpm --filter @univerjs/engine-render test` — 93 files passed, 836 tests passed, 59 skipped
- `pnpm --filter @univerjs/engine-render typecheck`

Related to https://github.com/dream-num/univer-cli/issues/1041
