### PR TITLE
fix(sheets-numfmt): persist workbook number format locale

### DIFF
--- a/packages/core/src/sheets/__tests__/workbook.spec.ts
+++ b/packages/core/src/sheets/__tests__/workbook.spec.ts
@@ -69,11 +69,17 @@ describe('Test workbook', () => {
             expect(workbook.name).toBe('');
 
             workbook.setName('Renamed');
+            workbook.setNumfmtLocale('de');
             workbook.setRev(5);
             workbook.incrementRev();
             workbook.setCustomMetadata({ owner: 'tester' } as never);
 
             expect(workbook.getSnapshot().name).toBe('Renamed');
+            expect(workbook.getNumfmtLocale()).toBe('de');
+            expect(workbook.save().numfmtLocale).toBe('de');
+            workbook.setNumfmtLocale(null);
+            expect(workbook.getNumfmtLocale()).toBeUndefined();
+            expect(workbook.save()).not.toHaveProperty('numfmtLocale');
             expect(workbook.getRev()).toBe(6);
             expect(workbook.getCustomMetadata()).toEqual({ owner: 'tester' });
             expect(workbook.getConfig()).toBe(workbook.getSnapshot());

--- a/packages/core/src/sheets/typedef.ts
+++ b/packages/core/src/sheets/typedef.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IResources } from '../services/resource-manager/type';
-import type { IObjectArrayPrimitiveType, IObjectMatrixPrimitiveType, Nullable } from '../shared';
+import type { INumfmtLocaleTag, IObjectArrayPrimitiveType, IObjectMatrixPrimitiveType, Nullable } from '../shared';
 import type { BooleanNumber } from '../types/enum';
 import type { LocaleType } from '../types/enum/locale-type';
 import type { IDocumentData } from '../types/interfaces';
@@ -52,6 +52,11 @@ export interface IWorkbookData {
      * Locale of the document.
      */
     locale: LocaleType;
+
+    /**
+     * Locale used to render locale-sensitive number formats.
+     */
+    numfmtLocale?: INumfmtLocaleTag;
 
     /**
      * Style references.

--- a/packages/core/src/sheets/workbook.ts
+++ b/packages/core/src/sheets/workbook.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Observable } from 'rxjs';
-import type { Nullable } from '../shared';
+import type { INumfmtLocaleTag, Nullable } from '../shared';
 import type { IStyleData } from '../types/interfaces';
 import type { CustomData, IRangeType, IWorkbookData, IWorksheetData } from './typedef';
 import { BehaviorSubject, Subject } from 'rxjs';
@@ -147,6 +147,19 @@ export class Workbook extends UnitModel<IWorkbookData, UniverInstanceType.UNIVER
     setName(name: string): void {
         this._name$.next(name);
         this._snapshot.name = name;
+    }
+
+    getNumfmtLocale(): INumfmtLocaleTag | undefined {
+        return this._snapshot.numfmtLocale;
+    }
+
+    setNumfmtLocale(locale: INumfmtLocaleTag | null): void {
+        if (locale === null) {
+            delete this._snapshot.numfmtLocale;
+            return;
+        }
+
+        this._snapshot.numfmtLocale = locale;
     }
 
     getUnitId() {

--- a/packages/sheets-numfmt/src/commands/commands/set-numfmt-locale.command.ts
+++ b/packages/sheets-numfmt/src/commands/commands/set-numfmt-locale.command.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ICommand, INumfmtLocaleTag, Workbook } from '@univerjs/core';
+import { CommandType, ICommandService, IUndoRedoService, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
+import { SetNumfmtLocaleMutation } from '@univerjs/sheets';
+
+export interface ISetNumfmtLocaleCommandParams {
+    unitId: string;
+    locale: INumfmtLocaleTag;
+}
+
+/**
+ * Set the locale used to render number formats for a workbook.
+ */
+export const SetNumfmtLocaleCommand: ICommand<ISetNumfmtLocaleCommandParams> = {
+    id: 'sheet.command.set-numfmt-locale',
+    type: CommandType.COMMAND,
+    handler: (accessor, params) => {
+        if (!params) return false;
+
+        const workbook = accessor.get(IUniverInstanceService).getUnit<Workbook>(params.unitId, UniverInstanceType.UNIVER_SHEET);
+        if (!workbook) return false;
+
+        const currentLocale = workbook.getNumfmtLocale();
+        if (currentLocale === params.locale) return false;
+
+        const redoMutationParams = {
+            unitId: params.unitId,
+            locale: params.locale,
+        };
+        const undoMutationParams = {
+            unitId: params.unitId,
+            locale: currentLocale ?? null,
+        };
+
+        const result = accessor.get(ICommandService).syncExecuteCommand(SetNumfmtLocaleMutation.id, redoMutationParams);
+        if (result) {
+            accessor.get(IUndoRedoService).pushUndoRedo({
+                unitID: params.unitId,
+                undoMutations: [{ id: SetNumfmtLocaleMutation.id, params: undoMutationParams }],
+                redoMutations: [{ id: SetNumfmtLocaleMutation.id, params: redoMutationParams }],
+            });
+        }
+
+        return result;
+    },
+};

--- a/packages/sheets-numfmt/src/controllers/__tests__/numfmt-cell-content.controller.spec.ts
+++ b/packages/sheets-numfmt/src/controllers/__tests__/numfmt-cell-content.controller.spec.ts
@@ -35,11 +35,13 @@ import {
     INTERCEPTOR_POINT,
     INumfmtService,
     NumfmtService,
+    SetNumfmtLocaleMutation,
     SetNumfmtMutation,
     SetRangeValuesMutation,
     SheetInterceptorService,
 } from '@univerjs/sheets';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SetNumfmtLocaleCommand } from '../../commands/commands/set-numfmt-locale.command';
 import { SHEETS_NUMFMT_PLUGIN_CONFIG_KEY } from '../../config/config';
 import * as patternUtils from '../../utils/pattern';
 import { SheetsNumfmtCellContentController } from '../numfmt-cell-content.controller';
@@ -170,6 +172,8 @@ describe('SheetsNumfmtCellContentController', () => {
 
         commandService.registerCommand(SetNumfmtMutation);
         commandService.registerCommand(SetRangeValuesMutation);
+        commandService.registerCommand(SetNumfmtLocaleMutation);
+        commandService.registerCommand(SetNumfmtLocaleCommand);
     });
 
     afterEach(() => {
@@ -294,11 +298,31 @@ describe('SheetsNumfmtCellContentController', () => {
         previewCallCount += 1;
         expect(previewSpy).toHaveBeenCalledTimes(previewCallCount);
 
-        controller.setNumfmtLocal('fr');
+        commandService.syncExecuteCommand(SetNumfmtLocaleCommand.id, {
+            unitId: workbook.getUnitId(),
+            locale: 'fr',
+        });
         expect(controller.locale).toBe('fr');
+        expect(workbook.save().numfmtLocale).toBe('fr');
 
         getInterceptedCell(sheet1, workbook, 1, 1, get);
         previewCallCount += 1;
         expect(previewSpy).toHaveBeenCalledTimes(previewCallCount);
+    });
+
+    it('uses the locale stored on each workbook independently', () => {
+        const defaultWorksheet = workbook.getSheetBySheetId('sheet1')!;
+        numfmtService.setValues('test', 'sheet1', [{ pattern: '#,##0.00', ranges: [cellToRange(1, 1)] }]);
+
+        const germanData = createWorkbookData();
+        germanData.id = 'german';
+        germanData.numfmtLocale = 'de';
+        const germanWorkbook = univer.createUnit<IWorkbookData, Workbook>(UniverInstanceType.UNIVER_SHEET, germanData);
+        const germanWorksheet = germanWorkbook.getSheetBySheetId('sheet1')!;
+        numfmtService.setValues('german', 'sheet1', [{ pattern: '#,##0.00', ranges: [cellToRange(1, 1)] }]);
+
+        expect(getInterceptedCell(defaultWorksheet, workbook, 1, 1, get)).toMatchObject({ v: '1,234.50' });
+        expect(getInterceptedCell(germanWorksheet, germanWorkbook, 1, 1, get)).toMatchObject({ v: '1.234,50' });
+        expect(getInterceptedCell(defaultWorksheet, workbook, 1, 1, get)).toMatchObject({ v: '1,234.50' });
     });
 });

--- a/packages/sheets-numfmt/src/controllers/numfmt-cell-content.controller.ts
+++ b/packages/sheets-numfmt/src/controllers/numfmt-cell-content.controller.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ICellData, ICellDataForSheetInterceptor, INumfmtLocaleTag, Workbook } from '@univerjs/core';
+import type { ICellData, ICellDataForSheetInterceptor, INumfmtLocaleTag, Nullable, Workbook } from '@univerjs/core';
 import type { ISetNumfmtMutationParams, ISetRangeValuesMutationParams } from '@univerjs/sheets';
 import type { IUniverSheetsNumfmtConfig } from '../config/config';
 import {
@@ -39,13 +39,14 @@ import {
     InterceptCellContentPriority,
     INTERCEPTOR_POINT,
     INumfmtService,
+    SetNumfmtLocaleMutation,
     SetNumfmtMutation,
     SetRangeValuesMutation,
     SheetInterceptorService,
 } from '@univerjs/sheets';
 import { BehaviorSubject, merge, of, skip, switchMap } from 'rxjs';
 import { SHEETS_NUMFMT_PLUGIN_CONFIG_KEY } from '../config/config';
-import { getPatternPreviewIgnoreGeneral } from '../utils/pattern';
+import { DEFAULT_NUMFMT_LOCALE, getPatternPreviewIgnoreGeneral } from '../utils/pattern';
 
 const TEXT_FORMAT_MARK = {
     tl: {
@@ -54,7 +55,7 @@ const TEXT_FORMAT_MARK = {
     },
 };
 export class SheetsNumfmtCellContentController extends Disposable {
-    private _locale$ = new BehaviorSubject<INumfmtLocaleTag>('en');
+    private _locale$ = new BehaviorSubject<INumfmtLocaleTag>(DEFAULT_NUMFMT_LOCALE);
     public locale$ = this._locale$.asObservable();
     constructor(
         @IUniverInstanceService private readonly _instanceService: IUniverInstanceService,
@@ -70,9 +71,9 @@ export class SheetsNumfmtCellContentController extends Disposable {
     }
 
     public get locale(): INumfmtLocaleTag {
-        const _locale = this._locale$.getValue();
-        if (_locale) {
-            return _locale;
+        const locale = this._locale$.getValue();
+        if (locale) {
+            return locale;
         }
         const currentLocale = this._localeService.getCurrentLocale();
 
@@ -116,6 +117,13 @@ export class SheetsNumfmtCellContentController extends Disposable {
                 return 'en';
             }
         }
+    }
+
+    private _getWorkbookLocale(workbook?: Nullable<Workbook>): INumfmtLocaleTag {
+        const locale = workbook?.getNumfmtLocale();
+        if (locale) return locale;
+
+        return DEFAULT_NUMFMT_LOCALE;
     }
 
     // eslint-disable-next-line max-lines-per-function
@@ -186,12 +194,14 @@ export class SheetsNumfmtCellContentController extends Disposable {
                 }
 
                 let numfmtRes: string = '';
+                const numfmtLocale = this._getWorkbookLocale(location.workbook);
+                const cacheParameters = `${unitId}_${sheetId}_${numfmtLocale}_${originCellValue.v}_${numfmtValue?.pattern}`;
                 const cache = renderCache.getValue(location.row, location.col);
-                if (cache && cache.parameters === `${originCellValue.v}_${numfmtValue?.pattern}`) {
+                if (cache && cache.parameters === cacheParameters) {
                     return next({ ...cell, ...cache.result });
                 }
 
-                const info = getPatternPreviewIgnoreGeneral(numfmtValue?.pattern as string, Number(originCellValue.v), this.locale);
+                const info = getPatternPreviewIgnoreGeneral(numfmtValue?.pattern as string, Number(originCellValue.v), numfmtLocale);
                 numfmtRes = info.result;
                 if (!numfmtRes) {
                     return next(cell);
@@ -208,7 +218,7 @@ export class SheetsNumfmtCellContentController extends Disposable {
 
                 renderCache.setValue(location.row, location.col, {
                     result: res,
-                    parameters: `${originCellValue.v}_${numfmtValue?.pattern}`,
+                    parameters: cacheParameters,
                 });
                 Object.assign(cell, res);
                 return next(cell);
@@ -217,7 +227,11 @@ export class SheetsNumfmtCellContentController extends Disposable {
         }));
 
         this.disposeWithMe(this._commandService.onCommandExecuted((commandInfo) => {
-            if (commandInfo.id === SetNumfmtMutation.id) {
+            if (commandInfo.id === SetNumfmtLocaleMutation.id) {
+                const currentWorkbook = this._instanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);
+                this._locale$.next(this._getWorkbookLocale(currentWorkbook));
+                renderCache.reset();
+            } else if (commandInfo.id === SetNumfmtMutation.id) {
                 const params = commandInfo.params as ISetNumfmtMutationParams;
                 Object.keys(params.values).forEach((key) => {
                     const v = params.values[key];
@@ -243,9 +257,10 @@ export class SheetsNumfmtCellContentController extends Disposable {
                 )
                 .subscribe(() => renderCache.reset())
         );
-    }
 
-    setNumfmtLocal(locale: INumfmtLocaleTag) {
-        this._locale$.next(locale);
+        this.disposeWithMe(
+            this._instanceService.getCurrentTypeOfUnit$<Workbook>(UniverInstanceType.UNIVER_SHEET)
+                .subscribe((workbook) => this._locale$.next(this._getWorkbookLocale(workbook)))
+        );
     }
 }

--- a/packages/sheets-numfmt/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets-numfmt/src/facade/__tests__/f-range.spec.ts
@@ -15,10 +15,10 @@
  */
 
 import type { FUniver } from '@univerjs/core/facade';
-import { ICommandService } from '@univerjs/core';
-import { RemoveNumfmtMutation, SetNumfmtMutation, SetRangeValuesMutation } from '@univerjs/sheets';
+import { ICommandService, RedoCommand, UndoCommand } from '@univerjs/core';
+import { RemoveNumfmtMutation, SetNumfmtLocaleMutation, SetNumfmtMutation, SetRangeValuesMutation } from '@univerjs/sheets';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { SetNumfmtCommand, SheetsNumfmtCellContentController } from '../../index';
+import { SetNumfmtCommand, SetNumfmtLocaleCommand, SheetsNumfmtCellContentController } from '../../index';
 import { createFacadeTestBed } from './create-test-bed';
 import '../index';
 
@@ -34,6 +34,8 @@ describe('Test FRange', () => {
             SetNumfmtMutation,
             RemoveNumfmtMutation,
             SetNumfmtCommand,
+            SetNumfmtLocaleMutation,
+            SetNumfmtLocaleCommand,
         ].forEach((command) => commandService.registerCommand(command));
         univerAPI = testBed.univerAPI;
     });
@@ -57,8 +59,47 @@ describe('Test FRange', () => {
         ]);
     });
 
-    it('sets workbook number format locale through the facade API', () => {
+    it('sets workbook number format locale through the facade API and supports undo/redo', async () => {
         const workbook = univerAPI.getActiveWorkbook()!;
         expect(workbook.setNumfmtLocal('fr')).toBe(workbook);
+        expect(testBed.sheet.getSnapshot().numfmtLocale).toBe('fr');
+
+        await expect(testBed.injector.get(ICommandService).executeCommand(UndoCommand.id)).resolves.toBe(true);
+        expect(testBed.sheet.getSnapshot().numfmtLocale).toBeUndefined();
+
+        await expect(testBed.injector.get(ICommandService).executeCommand(RedoCommand.id)).resolves.toBe(true);
+        expect(testBed.sheet.getSnapshot().numfmtLocale).toBe('fr');
+    });
+
+    it('restores the number-format locale from a reopened workbook snapshot', () => {
+        const workbook = univerAPI.getActiveWorkbook()!;
+        workbook.setNumfmtLocal('de');
+
+        const snapshot = structuredClone(testBed.sheet.getSnapshot());
+        snapshot.sheetOrder = ['sheet1'];
+        snapshot.styles.german = { n: { pattern: '#,##0.00' } };
+        snapshot.sheets.sheet1.cellData = {
+            0: {
+                0: {
+                    v: 1234.5,
+                    t: 2,
+                    s: 'german',
+                },
+            },
+        };
+
+        const reopened = createFacadeTestBed(snapshot, [[SheetsNumfmtCellContentController]]);
+        try {
+            reopened.injector.get(SheetsNumfmtCellContentController);
+            expect(
+                reopened.univerAPI
+                    .getActiveWorkbook()!
+                    .getSheetBySheetId('sheet1')!
+                    .getRange('A1')
+                    .getDisplayValue()
+            ).toBe('1.234,50');
+        } finally {
+            reopened.univer.dispose();
+        }
     });
 });

--- a/packages/sheets-numfmt/src/facade/f-workbook.ts
+++ b/packages/sheets-numfmt/src/facade/f-workbook.ts
@@ -15,7 +15,7 @@
  */
 
 import type { INumfmtLocaleTag } from '@univerjs/core';
-import { SheetsNumfmtCellContentController } from '@univerjs/sheets-numfmt';
+import { SetNumfmtLocaleCommand } from '@univerjs/sheets-numfmt';
 import { FWorkbook } from '@univerjs/sheets/facade';
 
 export interface IFWorkbookSheetsNumfmtMixin {
@@ -45,8 +45,10 @@ export interface IFWorkbookSheetsNumfmtMixin {
 }
 export class FWorkbookSheetsNumfmtMixin extends FWorkbook implements IFWorkbookSheetsNumfmtMixin {
     override setNumfmtLocal(locale: INumfmtLocaleTag): FWorkbook {
-        const sheetsNumfmtCellContentController = this._injector.get(SheetsNumfmtCellContentController);
-        sheetsNumfmtCellContentController.setNumfmtLocal(locale);
+        this._commandService.syncExecuteCommand(SetNumfmtLocaleCommand.id, {
+            unitId: this.id,
+            locale,
+        });
         return this;
     }
 }

--- a/packages/sheets-numfmt/src/index.ts
+++ b/packages/sheets-numfmt/src/index.ts
@@ -23,6 +23,8 @@ export {
 export { CURRENCYFORMAT, DATEFMTLISG, NUMBERFORMAT } from './base/const/formatdetail';
 export { AddDecimalCommand } from './commands/commands/add-decimal.command';
 export { SetCurrencyCommand } from './commands/commands/set-currency.command';
+export { SetNumfmtLocaleCommand } from './commands/commands/set-numfmt-locale.command';
+export type { ISetNumfmtLocaleCommandParams } from './commands/commands/set-numfmt-locale.command';
 export { SetNumfmtCommand } from './commands/commands/set-numfmt.command';
 export type { ISetNumfmtCommandParams } from './commands/commands/set-numfmt.command';
 export { SetPercentCommand } from './commands/commands/set-percent.command';

--- a/packages/sheets-numfmt/src/plugin.ts
+++ b/packages/sheets-numfmt/src/plugin.ts
@@ -21,6 +21,7 @@ import pkg from '../package.json';
 import { SHEET_NUMFMT_PLUGIN } from './base/const/plugin-name';
 import { AddDecimalCommand } from './commands/commands/add-decimal.command';
 import { SetCurrencyCommand } from './commands/commands/set-currency.command';
+import { SetNumfmtLocaleCommand } from './commands/commands/set-numfmt-locale.command';
 import { SetNumfmtCommand } from './commands/commands/set-numfmt.command';
 import { SetPercentCommand } from './commands/commands/set-percent.command';
 import { SubtractDecimalCommand } from './commands/commands/subtract-decimal.command';
@@ -67,6 +68,7 @@ export class UniverSheetsNumfmtPlugin extends Plugin {
             SetCurrencyCommand,
             SetPercentCommand,
             SetNumfmtCommand,
+            SetNumfmtLocaleCommand,
         ].forEach((config) => {
             this.disposeWithMe(this._commandService.registerCommand(config));
         });

--- a/packages/sheets-numfmt/src/utils/pattern.ts
+++ b/packages/sheets-numfmt/src/utils/pattern.ts
@@ -25,7 +25,9 @@ interface IPatternPreview {
     color?: string;
 }
 
-export const getPatternPreview = (pattern: string, value: number, locale: INumfmtLocaleTag = 'en'): IPatternPreview => {
+export const DEFAULT_NUMFMT_LOCALE: INumfmtLocaleTag = 'en';
+
+export const getPatternPreview = (pattern: string, value: number, locale: INumfmtLocaleTag = DEFAULT_NUMFMT_LOCALE): IPatternPreview => {
     // in the source code of numfmt, the formatColor function will read the the partitions[3]
     try {
         const formatColor = numfmt.formatColor(pattern, value);

--- a/packages/sheets/src/commands/mutations/__tests__/set-numfmt-locale.mutation.spec.ts
+++ b/packages/sheets/src/commands/mutations/__tests__/set-numfmt-locale.mutation.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ICommandService } from '@univerjs/core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SetNumfmtLocaleMutation } from '../set-numfmt-locale.mutation';
+import { createCommandTestBed } from './create-command-test-bed';
+
+describe('SetNumfmtLocaleMutation', () => {
+    const disposables: Array<ReturnType<typeof createCommandTestBed>['univer']> = [];
+
+    afterEach(() => {
+        disposables.splice(0).forEach((univer) => univer.dispose());
+    });
+
+    it('stores the last applied number-format locale in the workbook snapshot', () => {
+        const testBed = createCommandTestBed();
+        disposables.push(testBed.univer);
+        const commandService = testBed.get(ICommandService);
+        commandService.registerCommand(SetNumfmtLocaleMutation);
+
+        expect(commandService.syncExecuteCommand(SetNumfmtLocaleMutation.id, {
+            unitId: testBed.sheet.getUnitId(),
+            locale: 'de',
+        })).toBe(true);
+        expect(testBed.sheet.save().numfmtLocale).toBe('de');
+
+        expect(commandService.syncExecuteCommand(SetNumfmtLocaleMutation.id, {
+            unitId: testBed.sheet.getUnitId(),
+            locale: 'ja',
+        })).toBe(true);
+        expect(testBed.sheet.save().numfmtLocale).toBe('ja');
+    });
+});

--- a/packages/sheets/src/commands/mutations/set-numfmt-locale.mutation.ts
+++ b/packages/sheets/src/commands/mutations/set-numfmt-locale.mutation.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IMutation, INumfmtLocaleTag, Workbook } from '@univerjs/core';
+import { CommandType, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
+
+export interface ISetNumfmtLocaleMutationParams {
+    unitId: string;
+    locale: INumfmtLocaleTag | null;
+}
+
+export const SetNumfmtLocaleMutation: IMutation<ISetNumfmtLocaleMutationParams> = {
+    id: 'sheet.mutation.set-numfmt-locale',
+    type: CommandType.MUTATION,
+    handler: (accessor, params) => {
+        const workbook = accessor.get(IUniverInstanceService).getUnit<Workbook>(params.unitId, UniverInstanceType.UNIVER_SHEET);
+        if (!workbook) return false;
+
+        workbook.setNumfmtLocale(params.locale);
+        return true;
+    },
+};

--- a/packages/sheets/src/controllers/basic-worksheet.controller.ts
+++ b/packages/sheets/src/controllers/basic-worksheet.controller.ts
@@ -145,6 +145,7 @@ import { SetColDataMutation } from '../commands/mutations/set-col-data.mutation'
 import { SetColHiddenMutation, SetColVisibleMutation } from '../commands/mutations/set-col-visible.mutation';
 import { SetFrozenMutation } from '../commands/mutations/set-frozen.mutation';
 import { SetGridlinesColorMutation } from '../commands/mutations/set-gridlines-color.mutation';
+import { SetNumfmtLocaleMutation } from '../commands/mutations/set-numfmt-locale.mutation';
 import { SetRangeProtectionMutation } from '../commands/mutations/set-range-protection.mutation';
 import { SetRangeThemeMutation } from '../commands/mutations/set-range-theme.mutation';
 import { SetRangeValuesMutation } from '../commands/mutations/set-range-values.mutation';
@@ -345,6 +346,7 @@ export class BasicWorksheetController extends Disposable implements IDisposable 
                 ToggleGridlinesMutation,
                 SetGridlinesColorCommand,
                 SetGridlinesColorMutation,
+                SetNumfmtLocaleMutation,
 
                 TextToNumberCommand,
 

--- a/packages/sheets/src/index.ts
+++ b/packages/sheets/src/index.ts
@@ -386,6 +386,8 @@ export { SetFrozenMutation, SetFrozenMutationFactory } from './commands/mutation
 export type { ISetFrozenMutationParams } from './commands/mutations/set-frozen.mutation';
 export { SetGridlinesColorMutation } from './commands/mutations/set-gridlines-color.mutation';
 export type { ISetGridlinesColorMutationParams } from './commands/mutations/set-gridlines-color.mutation';
+export { SetNumfmtLocaleMutation } from './commands/mutations/set-numfmt-locale.mutation';
+export type { ISetNumfmtLocaleMutationParams } from './commands/mutations/set-numfmt-locale.mutation';
 export {
     FactorySetRangeProtectionMutation,
     SetRangeProtectionMutation,


### PR DESCRIPTION
Refs dream-num/univer-cli#1026

## Summary

Persist the number-format locale on `IWorkbookData` so `FWorkbook.setNumfmtLocal()` survives snapshot save/load and collaboration replay.

## Root cause

`setNumfmtLocal()` previously updated only `SheetsNumfmtCellContentController` state. The locale was global to the running instance, was absent from the workbook snapshot, and therefore disappeared in a fresh CLI/runtime session.

## Changes

- add optional `numfmtLocale` metadata to `IWorkbookData` and Workbook model accessors
- add a Sheets mutation plus a Sheets Numfmt command with undo/redo support
- route the Facade API through the command instead of implementing the state change in the controller
- resolve formatting locale from the Workbook being rendered and isolate render-cache entries by unit, sheet, and locale
- register the mutation in `UniverSheetsPlugin`, allowing headless/collaboration runtimes to replay it without a UI plugin
- retain the existing `setNumfmtLocal` Facade API name

No UI, menu, icon, translation, OOXML, resource, or protocol schema changes are introduced. Collaboration snapshot transformers carry the field through workbook `originalMeta`.

## Validation

- Browser Facade flow: English `100,000,000.00` → German `100.000.000,00`; snapshot persistence, undo, redo, and reopened Workbook all passed; no console errors
- `pnpm --filter @univerjs/core test` — 973 passed, 10 skipped
- `pnpm --filter @univerjs/sheets test` — 722 passed
- `pnpm --filter @univerjs/sheets-numfmt test` — 32 passed
- `pnpm --filter @univerjs/core build`
- `pnpm --filter @univerjs/sheets build`
- `pnpm --filter @univerjs/sheets-numfmt build`
- affected-package typechecks passed
- `pnpm lint` — 0 errors (existing repository warnings remain)

Repository-wide `pnpm typecheck` is currently blocked by missing generated mockdata/preset locale modules in this checkout; the affected packages pass their independent typechecks.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
