### PR TITLE
fix(core): default Base tables to zero records

### DIFF
--- a/packages/core/src/bases/__tests__/base-data-model.spec.ts
+++ b/packages/core/src/bases/__tests__/base-data-model.spec.ts
@@ -20,6 +20,19 @@ import { BaseDataModel } from '../base-data-model';
 import { BaseFieldType } from '../typedef';
 
 describe('BaseDataModel', () => {
+    it('creates an empty default table without persistent records', () => {
+        const model = new BaseDataModel({ id: 'base-1', name: 'Base' });
+        const snapshot = model.getSnapshot();
+        const table = snapshot.tables['table-1'];
+
+        expect(snapshot.tableOrder).toEqual(['table-1']);
+        expect(table.recordOrder).toEqual([]);
+        expect(table.records).toEqual({});
+        expect(table.rowId).toEqual({});
+        expect(table.rowIndex).toEqual({});
+        expect(table.cellData).toEqual({});
+    });
+
     it('keeps complete recordOrder without sorting all records', () => {
         const throwingOrderKey = {
             localeCompare: () => {

--- a/packages/core/src/bases/empty-snapshot.ts
+++ b/packages/core/src/bases/empty-snapshot.ts
@@ -34,7 +34,7 @@ export function createDefaultBaseTableSnapshot(options: ICreateDefaultBaseTableS
     const now = options.now ?? Date.now();
     const primaryFieldId = options.primaryFieldId ?? generateRandomId(6);
     const gridViewId = options.gridViewId ?? generateRandomId(6);
-    const recordCount = options.recordCount ?? 5;
+    const recordCount = options.recordCount ?? 0;
     const primaryField: IFieldSnapshot = {
         id: primaryFieldId,
         name: options.primaryFieldName ?? 'Name',
@@ -114,7 +114,7 @@ export function getEmptySnapshot(
                 id: tableId,
                 name: 'Table 1',
                 now,
-                recordCount: 5,
+                recordCount: 0,
             }),
         },
         createdAt: now,


### PR DESCRIPTION
Refs dream-num/univer-cli#1022

## What changed

- Make `createDefaultBaseTableSnapshot()` create zero persistent records unless `recordCount` is explicitly provided.
- Make the default `Table 1` in a newly created Base start with zero records.
- Add a regression test covering the empty default Base snapshot.

## Why

The Core Base empty snapshot persisted five blank records with real IDs, order keys, and timestamps. Programmatic Base creation therefore reported five records before any business data was added, and the first added record appeared in row 6.

This PR makes the data-model default neutral. Human-facing UI starter rows are owned explicitly by the Base UI change in the dependent `univer-pro` PR.

## Validation

- `pnpm --filter @univerjs/core test` — 974 passed, 10 skipped.
- `pnpm --filter @univerjs/core typecheck`
- ESLint on the two changed files.
- `git diff --check`

## Pull Request Checklist

- [x] Related issue linked above.
- [x] Naming convention followed.
- [x] Unit tests added.
- [x] No breaking snapshot migration is introduced; existing persisted Base records are preserved.
