### PR TITLE
fix(sheets-numfmt): preserve empty format results

### DIFF
--- a/packages/sheets-numfmt/src/controllers/__tests__/numfmt-cell-content.controller.spec.ts
+++ b/packages/sheets-numfmt/src/controllers/__tests__/numfmt-cell-content.controller.spec.ts
@@ -269,6 +269,24 @@ describe('SheetsNumfmtCellContentController', () => {
         expect(previewSpy).toHaveBeenCalledTimes(previewCallsAfterFirstRender + 2);
     });
 
+    it('applies and caches a legitimate empty number-format result', () => {
+        const worksheet = workbook.getSheetBySheetId('sheet1')!;
+        const previewSpy = vi.spyOn(patternUtils, 'getPatternPreviewIgnoreGeneral');
+
+        numfmtService.setValues('test', 'sheet1', [{ pattern: ';;;', ranges: [cellToRange(1, 1)] }]);
+
+        expect(getInterceptedCell(worksheet, workbook, 1, 1, get)).toMatchObject({
+            v: '',
+            t: CellValueType.NUMBER,
+            coverable: false,
+        });
+        expect(worksheet.getCellRaw(1, 1)).toMatchObject({ v: '1234.5', t: CellValueType.STRING });
+
+        const previewCallsAfterFirstRender = previewSpy.mock.calls.length;
+        getInterceptedCell(worksheet, workbook, 1, 1, get);
+        expect(previewSpy).toHaveBeenCalledTimes(previewCallsAfterFirstRender);
+    });
+
     it('resets cached rendering when active sheet changes and supports locale override', () => {
         const sheet1 = workbook.getSheetBySheetId('sheet1')!;
         const sheet2 = workbook.getSheetBySheetId('sheet2')!;

--- a/packages/sheets-numfmt/src/controllers/numfmt-cell-content.controller.ts
+++ b/packages/sheets-numfmt/src/controllers/numfmt-cell-content.controller.ts
@@ -185,19 +185,17 @@ export class SheetsNumfmtCellContentController extends Disposable {
                     return next(cell);
                 }
 
-                let numfmtRes: string = '';
                 const cache = renderCache.getValue(location.row, location.col);
                 if (cache && cache.parameters === `${originCellValue.v}_${numfmtValue?.pattern}`) {
                     return next({ ...cell, ...cache.result });
                 }
 
                 const info = getPatternPreviewIgnoreGeneral(numfmtValue?.pattern as string, Number(originCellValue.v), this.locale);
-                numfmtRes = info.result;
-                if (!numfmtRes) {
-                    return next(cell);
-                }
-
+                const numfmtRes = info.result;
                 const res: ICellDataForSheetInterceptor = { v: numfmtRes, t: CellValueType.NUMBER };
+                if (numfmtRes === '') {
+                    res.coverable = false;
+                }
                 if (info.color) {
                     const color = this._themeService.getColorFromTheme(`${info.color}.500`) ?? info.color;
 

--- a/packages/sheets-numfmt/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets-numfmt/src/facade/__tests__/f-range.spec.ts
@@ -16,7 +16,7 @@
 
 import type { FUniver } from '@univerjs/core/facade';
 import { ICommandService } from '@univerjs/core';
-import { RemoveNumfmtMutation, SetNumfmtMutation, SetRangeValuesMutation } from '@univerjs/sheets';
+import { RemoveNumfmtMutation, SetNumfmtMutation, SetRangeValuesCommand, SetRangeValuesMutation } from '@univerjs/sheets';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SetNumfmtCommand, SheetsNumfmtCellContentController } from '../../index';
 import { createFacadeTestBed } from './create-test-bed';
@@ -31,10 +31,12 @@ describe('Test FRange', () => {
         const commandService = testBed.injector.get(ICommandService);
         [
             SetRangeValuesMutation,
+            SetRangeValuesCommand,
             SetNumfmtMutation,
             RemoveNumfmtMutation,
             SetNumfmtCommand,
         ].forEach((command) => commandService.registerCommand(command));
+        testBed.injector.get(SheetsNumfmtCellContentController);
         univerAPI = testBed.univerAPI;
     });
 
@@ -60,5 +62,17 @@ describe('Test FRange', () => {
     it('sets workbook number format locale through the facade API', () => {
         const workbook = univerAPI.getActiveWorkbook()!;
         expect(workbook.setNumfmtLocal('fr')).toBe(workbook);
+    });
+
+    it('hides a formatted value without changing its raw value', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
+        const cell = activeSheet.getRange('A1');
+
+        cell.setValue(233628);
+        cell.setNumberFormat(';;;');
+
+        expect(cell.getDisplayValue()).toBe('');
+        expect(cell.getRawValue()).toBe(233628);
+        expect(cell.getNumberFormat()).toBe(';;;');
     });
 });


### PR DESCRIPTION
## What changed

- Preserve legitimate empty results from the number-format formatter instead of falling back to the raw cell value.
- Mark hidden display cells as non-coverable so neighboring text cannot overflow into them.
- Add controller and facade regression coverage for the Excel-compatible `;;;` format, including cache reuse and raw-value preservation.

## Root cause

The sheets number-format cell-content interceptor treated an empty formatted string as a failed formatting result. Formats such as `;;;` intentionally return an empty string, so the interceptor discarded the result and exposed the raw number.

## Impact

Cells formatted with `;;;` now display nothing while retaining their raw numeric value for formulas and conditional-formatting data bars.

Closes dream-num/univer-cli#1080.

## Validation

- `pnpm exec vitest run packages/sheets-numfmt/src --reporter=dot` (32 tests passed)
- `pnpm --filter @univerjs/sheets-numfmt typecheck`
- ESLint pre-commit hook passed