### PR TITLE
perf(engine-render): skip invisible drawing effects

### DIFF
--- a/packages/engine-render/src/basics/__tests__/drawing-effect.spec.ts
+++ b/packages/engine-render/src/basics/__tests__/drawing-effect.spec.ts
@@ -56,6 +56,17 @@ describe('drawing effect', () => {
         });
     });
 
+    it('skips effects that cannot paint visible pixels', () => {
+        expect(resolveGlowEffect({ color: '#5b9bd5', radius: 0 })).toBeUndefined();
+        expect(resolveGlowEffect({ color: 'rgba(91, 155, 213, 0)', radius: 4 })).toBeUndefined();
+        expect(resolveOuterShadowEffect({
+            color: '#000000',
+            opacity: 0,
+            blurRadius: 4,
+            distance: 2,
+        })).toBeUndefined();
+    });
+
     it('creates one filter chain for glow and shadow without duplicating the source draw', () => {
         expect(createDrawingEffectFilter(
             { color: '#5b9bd5', radius: 4 },

--- a/packages/engine-render/src/basics/drawing-effect.ts
+++ b/packages/engine-render/src/basics/drawing-effect.ts
@@ -47,6 +47,11 @@ function colorWithOpacity(color: string, opacity: number | undefined): string {
     return parsedColor.setAlpha(parsedColor.getAlpha() * clamp(opacity, 0, 1)).toRgbString();
 }
 
+function isTransparentColor(color: string): boolean {
+    const parsedColor = new ColorKit(color);
+    return parsedColor.isValid && parsedColor.getAlpha() <= 0;
+}
+
 function cssPixels(value: number): string {
     return `${Math.abs(value) < Number.EPSILON ? 0 : value}px`;
 }
@@ -56,7 +61,7 @@ function toDropShadowFilter(effect: IResolvedDrawingShadow): string {
 }
 
 export function resolveOuterShadowEffect(effect: IShadowEffect | undefined): IResolvedDrawingShadow | undefined {
-    if (!effect?.color) {
+    if (!effect?.color || (effect.opacity !== undefined && effect.opacity <= 0)) {
         return undefined;
     }
 
@@ -64,8 +69,13 @@ export function resolveOuterShadowEffect(effect: IShadowEffect | undefined): IRe
     const direction = ((effect.direction ?? 0) * Math.PI) / 180;
     const sizeScale = ((effect.sx ?? 1) + (effect.sy ?? 1)) / 2;
 
+    const color = colorWithOpacity(effect.color, effect.opacity);
+    if (isTransparentColor(color)) {
+        return undefined;
+    }
+
     return {
-        color: colorWithOpacity(effect.color, effect.opacity),
+        color,
         blurRadius: Math.max(0, effect.blurRadius ?? 0) * sizeScale,
         offsetX: Math.cos(direction) * distance * sizeScale,
         offsetY: Math.sin(direction) * distance * sizeScale,
@@ -73,7 +83,7 @@ export function resolveOuterShadowEffect(effect: IShadowEffect | undefined): IRe
 }
 
 export function resolveGlowEffect(effect: IGlowEffect | undefined): IResolvedDrawingShadow | undefined {
-    if (!effect?.color) {
+    if (!effect?.color || (effect.radius ?? 0) <= 0 || isTransparentColor(effect.color)) {
         return undefined;
     }
 


### PR DESCRIPTION
## What

- Skip glow effects with a zero radius or transparent color.
- Skip outer shadows whose effective opacity is zero.
- Cover the no-visible-pixels cases with focused unit tests.

## Why

Slide thumbnails can render many text glyphs across multiple pages. Building CSS filter chains for effects that cannot paint any visible pixels adds avoidable per-glyph rendering work. This keeps the existing rendering path and visual output while removing only provably invisible effects.

## Validation

- `pnpm exec vitest run src/basics/__tests__/drawing-effect.spec.ts` (6 tests passed)
- `pnpm --filter @univerjs/engine-render typecheck`
- ESLint passed through the pre-commit hook
- `git diff --check`

## Pull Request Checklist

- [x] No related issue was provided.
- [x] Naming convention is followed; no new plugins, commands, or resources are introduced.
- [x] Focused unit tests cover the change.
- [x] No breaking changes are introduced.
