### PR TITLE
fix(docs-drawing): expose TextWrappingStyle through Facade

### DIFF
--- a/packages/docs-drawing/src/facade/__tests__/f-document-image.spec.ts
+++ b/packages/docs-drawing/src/facade/__tests__/f-document-image.spec.ts
@@ -24,6 +24,7 @@ import {
     ObjectRelativeFromV,
     PositionedObjectLayoutType,
 } from '@univerjs/core';
+import { FEnum } from '@univerjs/core/facade';
 import { DocSelectionManagerService } from '@univerjs/docs';
 import { IDocDrawingService, TextWrappingStyle, UpdateDocDrawingWrappingStyleCommand } from '@univerjs/docs-drawing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -59,6 +60,11 @@ describe('FDocument image facade', () => {
         testBed.univer.dispose();
         vi.unstubAllGlobals();
         vi.restoreAllMocks();
+    });
+
+    it('exposes TextWrappingStyle under its Facade signature name', () => {
+        expect(FEnum.get().TextWrappingStyle).toBe(TextWrappingStyle);
+        expect(FEnum.get()).not.toHaveProperty('DocsImageWrappingStyle');
     });
 
     it('inserts an image with optional transform and text range options', async () => {

--- a/packages/docs-drawing/src/facade/f-document-image.ts
+++ b/packages/docs-drawing/src/facade/f-document-image.ts
@@ -301,7 +301,7 @@ export class FDocumentImage {
      *
      * if (image) {
      *   // Float the image beside body text without covering it.
-     *   const success = image.setWrappingStyle(univerAPI.Enum.DocsImageWrappingStyle.WRAP_SQUARE);
+     *   const success = image.setWrappingStyle(univerAPI.Enum.TextWrappingStyle.WRAP_SQUARE);
      *   console.log(success);
      * }
      * ```

--- a/packages/docs-drawing/src/facade/f-document.ts
+++ b/packages/docs-drawing/src/facade/f-document.ts
@@ -90,7 +90,7 @@ export interface IFDocumentImageMixin {
      *   imageSourceType: univerAPI.Enum.ImageSourceType.URL,
      *   width: 320,
      *   // Keep the image in the text flow so it cannot cover surrounding text.
-     *   wrappingStyle: univerAPI.Enum.DocsImageWrappingStyle.INLINE,
+     *   wrappingStyle: univerAPI.Enum.TextWrappingStyle.INLINE,
      *   textRange: {
      *     startOffset: 30,
      *   },
@@ -106,7 +106,7 @@ export interface IFDocumentImageMixin {
      *   imageSourceType: univerAPI.Enum.ImageSourceType.URL,
      *   width: 320,
      *   // Float the image and let body text flow beside its rectangular bounds.
-     *   wrappingStyle: univerAPI.Enum.DocsImageWrappingStyle.WRAP_SQUARE,
+     *   wrappingStyle: univerAPI.Enum.TextWrappingStyle.WRAP_SQUARE,
      *   textRange: {
      *     startOffset: 30,
      *   },

--- a/packages/docs-drawing/src/facade/f-enum.ts
+++ b/packages/docs-drawing/src/facade/f-enum.ts
@@ -23,10 +23,11 @@ import { TextWrappingStyle } from '@univerjs/docs-drawing';
  */
 export interface IFDocumentImageEnumMixin {
     /**
-     * Represents the wrapping styles used by docs image operations.
+     * Represents the text wrapping styles used by document drawings, including images and Shapes.
      *
      * Prefer `INLINE`, `WRAP_SQUARE`, or `WRAP_TOP_AND_BOTTOM` for ordinary document content.
      * `BEHIND_TEXT` and `IN_FRONT_OF_TEXT` are overlay styles that do not cause text to reflow.
+     * Use this property whenever a Facade signature references `TextWrappingStyle`.
      * @example
      * ```ts
      * const fDocument = univerAPI.getActiveDocument();
@@ -35,7 +36,7 @@ export interface IFDocumentImageEnumMixin {
      *   imageSourceType: univerAPI.Enum.ImageSourceType.URL,
      *   width: 320,
      *   // Float the image and wrap body text around its rectangular bounds.
-     *   wrappingStyle: univerAPI.Enum.DocsImageWrappingStyle.WRAP_SQUARE,
+     *   wrappingStyle: univerAPI.Enum.TextWrappingStyle.WRAP_SQUARE,
      *   textRange: {
      *     startOffset: 30,
      *   },
@@ -43,7 +44,7 @@ export interface IFDocumentImageEnumMixin {
      * console.log(image);
      * ```
      */
-    DocsImageWrappingStyle: typeof TextWrappingStyle;
+    TextWrappingStyle: typeof TextWrappingStyle;
 
     /**
      * Represents the horizontal position types used by docs image operations.
@@ -83,7 +84,7 @@ export interface IFDocumentImageEnumMixin {
 }
 
 export class FDocumentImageEnumMixin extends FEnum implements IFDocumentImageEnumMixin {
-    override get DocsImageWrappingStyle(): typeof TextWrappingStyle {
+    override get TextWrappingStyle(): typeof TextWrappingStyle {
         return TextWrappingStyle;
     }
 


### PR DESCRIPTION
Refs dream-num/univer-cli#1079

## Summary

- Expose the document drawing wrapping enum as `univerAPI.Enum.TextWrappingStyle`, matching the public Facade signatures.
- Remove the contextual `DocsImageWrappingStyle` name.
- Update examples and comments so agents receive one unambiguous API name.
- Add a regression assertion for the canonical runtime enum.

The enum members and serialized wrapping values are unchanged, so workbook snapshots are unaffected.

## Validation

- `pnpm --filter @univerjs/docs-drawing exec vitest run src/facade/__tests__/f-document-image.spec.ts`
- `pnpm --filter @univerjs/docs-drawing typecheck`
- `pnpm exec eslint packages/docs-drawing/src/facade/f-enum.ts packages/docs-drawing/src/facade/f-document.ts packages/docs-drawing/src/facade/f-document-image.ts packages/docs-drawing/src/facade/__tests__/f-document-image.spec.ts --max-warnings=0`

BREAKING CHANGE:
Before: document image examples exposed wrapping values through `univerAPI.Enum.DocsImageWrappingStyle`.

After: document images and Shapes use the signature-aligned `univerAPI.Enum.TextWrappingStyle` name.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
