### PR TITLE
docs(base): document RecordLink field configuration

### DIFF
--- a/packages/core/src/bases/typedef.ts
+++ b/packages/core/src/bases/typedef.ts
@@ -124,12 +124,30 @@ export enum BaseFieldType {
     Summary = 'summary',
 }
 
+/**
+ * Configuration for a RecordLink field.
+ *
+ * A RecordLink points to records in another table in the same Base. The cell
+ * stores target record IDs, while the UI resolves those IDs to the configured
+ * display field. Prefer the dedicated RecordLink Facade methods instead of
+ * reading or writing the canonical cell string directly.
+ */
 export interface IRecordLinkFieldConfig extends Record<string, unknown> {
+    /** ID of the target table. The table must belong to the same Base. */
     targetTableId: TableId;
+    /** `false` allows one linked record; `true` allows an ordered list of linked records. */
     multiple: boolean;
-    /** Field used as the single visible RecordLink label. Defaults to the target table primary field. */
+    /**
+     * Target-table field used as the visible label in cells, cards, and record details.
+     * Defaults to the target table's primary field. The field must exist and must not
+     * be a system field such as `record-id`.
+     */
     displayFieldId?: FieldId;
-    /** Ordered target-table fields rendered as secondary context in the record picker. */
+    /**
+     * Ordered target-table fields shown as secondary context in the record picker.
+     * These fields help users distinguish records; they do not change the stored link
+     * or add more labels to the cell. IDs must be unique, existing, non-system fields.
+     */
     pickerFieldIds?: FieldId[];
 }
 


### PR DESCRIPTION
## 变更

- 补充 `IRecordLinkFieldConfig` 的用途说明。
- 明确同一 Base 内的目标表约束，以及单选、多选的有序关系语义。
- 说明 `displayFieldId` 与 `pickerFieldIds` 的展示职责、默认值和字段约束。
- 提醒 SDK 调用方优先使用 RecordLink Facade 方法，而不是直接读写底层字符串。

## 影响

仅补充 SDK TSDoc，不改变运行时行为、序列化格式或公共类型结构。

## 验证

- `pnpm --filter @univerjs/core typecheck`
- `pnpm --filter @univerjs/core test -- packages/core/src/bases/__tests__/base-data-model.spec.ts`（976 passed，10 skipped）
- `pnpm exec eslint packages/core/src/bases/typedef.ts`

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes (not applicable: documentation-only change; existing tests passed).
- [x] Breaking changes have been documented (no breaking changes introduced).
