### PR TITLE
fix(docs): preserve drawing drag positions across layouts

### DIFF
--- a/packages/docs-drawing-ui/src/controllers/__tests__/doc-drawing-transformer-update.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/__tests__/doc-drawing-transformer-update.controller.spec.ts
@@ -14,8 +14,17 @@
  * limitations under the License.
  */
 
+import type {
+    IDocumentSkeletonColumn,
+    IDocumentSkeletonDivide,
+    IDocumentSkeletonGlyph,
+    IDocumentSkeletonLine,
+    IDocumentSkeletonSection,
+} from '@univerjs/engine-render';
 import { ObjectRelativeFromH, ObjectRelativeFromV, PositionedObjectLayoutType } from '@univerjs/core';
 import { UpdateDrawingDocTransformCommand } from '@univerjs/docs-drawing';
+import { NodePositionConvertToCursor } from '@univerjs/docs-ui';
+import { DocumentSkeletonPageType } from '@univerjs/engine-render';
 import { Subject } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -198,6 +207,125 @@ describe('DocDrawingTransformerController business methods', () => {
             width: 90,
             height: 70,
         }]]));
+    });
+
+    it('uses the outer page origin only for WRAP_NONE page-relative positions', () => {
+        const controller = createController();
+        const previousPage = {
+            type: DocumentSkeletonPageType.BODY,
+            marginLeft: 30,
+            marginTop: 40,
+        };
+        const anchorPage = {
+            type: DocumentSkeletonPageType.BODY,
+            marginLeft: 48,
+            marginTop: 64,
+        };
+        const glyph = {} as IDocumentSkeletonGlyph;
+        const divide = { glyphGroup: [glyph] } as IDocumentSkeletonDivide;
+        const line = {
+            divides: [divide],
+            paragraphIndex: 0,
+            paragraphStart: true,
+            top: 0,
+        } as IDocumentSkeletonLine;
+        const section = { parent: anchorPage, top: 0 } as unknown as IDocumentSkeletonSection;
+        const column = { left: 0, lines: [line], parent: section } as IDocumentSkeletonColumn;
+        Object.assign(glyph, { parent: divide });
+        Object.assign(divide, { parent: line });
+        Object.assign(line, { parent: column });
+
+        const skeleton = {
+            findNodeByCoord: vi.fn(() => ({
+                node: glyph,
+                segmentId: '',
+                segmentPage: 1,
+            })),
+            findPositionByGlyph: vi.fn(() => ({})),
+            getSkeletonData: vi.fn(() => ({
+                pages: [previousPage, anchorPage],
+                skeFooters: new Map(),
+                skeHeaders: new Map(),
+            })),
+        };
+        const renderDependency = {
+            getSegment: vi.fn(() => ''),
+            getSegmentPage: vi.fn(() => 1),
+            getSkeleton: vi.fn(() => skeleton),
+        };
+        const mainComponent = {
+            getOffsetConfig: vi.fn(() => ({
+                docsLeft: 5,
+                docsTop: 7,
+                pageLayoutType: 0,
+                pageMarginLeft: 0,
+                pageMarginTop: 20,
+            })),
+        };
+        controller._renderManagerService.getRenderUnitById.mockReturnValue({
+            components: new Map(),
+            engine: {},
+            mainComponent,
+            scene: {
+                getViewports: vi.fn(() => [{}]),
+                getViewportScrollXY: vi.fn(() => ({ x: 0, y: 0 })),
+            },
+            with: vi.fn(() => renderDependency),
+        });
+        controller._getPageContentSize = vi.fn(() => ({ width: 1000, height: 1000 }));
+        controller._getTransformCoordForDocumentOffset = vi.fn(() => ({}));
+        controller._liquid = {
+            x: 0,
+            y: 0,
+            reset: vi.fn(() => {
+                controller._liquid.x = 0;
+                controller._liquid.y = 0;
+            }),
+            restorePagePadding: vi.fn((page: { marginLeft: number; marginTop: number }) => {
+                controller._liquid.x -= page.marginLeft;
+                controller._liquid.y -= page.marginTop;
+            }),
+            translatePage: vi.fn(() => {
+                controller._liquid.x += 300;
+                controller._liquid.y += 400;
+            }),
+            translatePagePadding: vi.fn((page: { marginLeft: number; marginTop: number }) => {
+                controller._liquid.x += page.marginLeft;
+                controller._liquid.y += page.marginTop;
+            }),
+        };
+        const rangeSpy = vi.spyOn(NodePositionConvertToCursor.prototype, 'getRangePointData').mockReturnValue({
+            borderBoxPointGroup: [],
+            contentBoxPointGroup: [],
+            cursorList: [{ collapsed: true, endOffset: 0, startOffset: 0 }],
+        } as ReturnType<NodePositionConvertToCursor['getRangePointData']>);
+        const overlayDrawing = {
+            ...drawing(),
+            layoutType: PositionedObjectLayoutType.WRAP_NONE,
+        };
+        const object = {
+            angle: 0,
+            height: 60,
+            left: 395,
+            top: 527,
+            width: 80,
+        };
+
+        const anchor = controller._getDrawingAnchor(overlayDrawing, object);
+
+        expect(anchor?.docTransform.positionH).toEqual({
+            relativeFrom: ObjectRelativeFromH.PAGE,
+            posOffset: 90,
+        });
+        expect(anchor?.docTransform.positionV).toEqual({
+            relativeFrom: ObjectRelativeFromV.PAGE,
+            posOffset: 120,
+        });
+
+        const wrappedAnchor = controller._getDrawingAnchor(drawing(), object);
+        expect(wrappedAnchor?.docTransform.positionH.posOffset).toBe(42);
+        expect(wrappedAnchor?.docTransform.positionV.posOffset).toBe(-8);
+        rangeSpy.mockRestore();
     });
 
     it('limits a drawing away from the gap between document pages while preserving drawings already on one page', () => {

--- a/packages/docs-drawing-ui/src/controllers/__tests__/doc-drawing-transformer-update.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/__tests__/doc-drawing-transformer-update.controller.spec.ts
@@ -19,9 +19,10 @@ import type {
     IDocumentSkeletonDivide,
     IDocumentSkeletonGlyph,
     IDocumentSkeletonLine,
+    IDocumentSkeletonPage,
     IDocumentSkeletonSection,
 } from '@univerjs/engine-render';
-import { ObjectRelativeFromH, ObjectRelativeFromV, PositionedObjectLayoutType } from '@univerjs/core';
+import { BooleanNumber, ObjectRelativeFromH, ObjectRelativeFromV, PositionedObjectLayoutType } from '@univerjs/core';
 import { UpdateDrawingDocTransformCommand } from '@univerjs/docs-drawing';
 import { NodePositionConvertToCursor } from '@univerjs/docs-ui';
 import { DocumentSkeletonPageType } from '@univerjs/engine-render';
@@ -31,7 +32,11 @@ import {
     IMoveInlineDrawingCommand,
     ITransformNonInlineDrawingCommand,
 } from '../../commands/commands/update-doc-drawing.command';
-import { DocDrawingTransformerController, getDocsTableCellAnchorContext } from '../doc-drawing-transformer-update.controller';
+import {
+    DocDrawingTransformerController,
+    getDocsTableCellAnchorContext,
+    shouldUseDocsDrawingOuterPageOrigin,
+} from '../doc-drawing-transformer-update.controller';
 
 function createController() {
     const controller = Object.create(DocDrawingTransformerController.prototype) as any;
@@ -324,8 +329,62 @@ describe('DocDrawingTransformerController business methods', () => {
 
         const wrappedAnchor = controller._getDrawingAnchor(drawing(), object);
         expect(wrappedAnchor?.docTransform.positionH.posOffset).toBe(42);
-        expect(wrappedAnchor?.docTransform.positionV.posOffset).toBe(-8);
+        expect(wrappedAnchor?.docTransform.positionV.posOffset).toBe(120);
+
+        const topAndBottomAnchor = controller._getDrawingAnchor({
+            ...drawing(),
+            layoutType: PositionedObjectLayoutType.WRAP_TOP_AND_BOTTOM,
+        }, object);
+        expect(topAndBottomAnchor?.docTransform.positionH.posOffset).toBe(42);
+        expect(topAndBottomAnchor?.docTransform.positionV.posOffset).toBe(120);
         rangeSpy.mockRestore();
+    });
+
+    it('matches the render-side page origin for body and header/footer drawings', () => {
+        const bodyPage = {
+            type: DocumentSkeletonPageType.BODY,
+            pageWidth: 816,
+            pageHeight: 1056,
+        } as IDocumentSkeletonPage;
+        const headerPage = {
+            type: DocumentSkeletonPageType.HEADER,
+            pageWidth: 816,
+            pageHeight: 120,
+        } as IDocumentSkeletonPage;
+        const overlayDrawing = {
+            layoutType: PositionedObjectLayoutType.WRAP_NONE,
+            behindDoc: BooleanNumber.FALSE,
+        };
+
+        expect(shouldUseDocsDrawingOuterPageOrigin({
+            drawing: overlayDrawing,
+            height: 60,
+            page: bodyPage,
+            width: 80,
+        })).toBe(true);
+        expect(shouldUseDocsDrawingOuterPageOrigin({
+            drawing: overlayDrawing,
+            height: 60,
+            hostPage: bodyPage,
+            page: headerPage,
+            width: 80,
+        })).toBe(false);
+        expect(shouldUseDocsDrawingOuterPageOrigin({
+            drawing: overlayDrawing,
+            height: 1055,
+            hostPage: bodyPage,
+            page: headerPage,
+            width: 815,
+        })).toBe(true);
+        expect(shouldUseDocsDrawingOuterPageOrigin({
+            drawing: {
+                ...overlayDrawing,
+                layoutType: PositionedObjectLayoutType.WRAP_SQUARE,
+            },
+            height: 60,
+            page: bodyPage,
+            width: 80,
+        })).toBe(false);
     });
 
     it('limits a drawing away from the gap between document pages while preserving drawings already on one page', () => {

--- a/packages/docs-drawing-ui/src/controllers/doc-drawing-transformer-update.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/doc-drawing-transformer-update.controller.ts
@@ -559,12 +559,17 @@ export class DocDrawingTransformerController extends Disposable {
         const tableCellContext = page.type === DocumentSkeletonPageType.CELL ? getDocsTableCellAnchorContext(drawing.unitId, page) : null;
         const anchorPage = tableCellContext?.hostPage ?? page;
         const pageType = anchorPage.type;
+        let pageOffsetLeft = this._liquid.x;
+        let pageOffsetTop = this._liquid.y;
 
         for (const p of pages) {
             const { headerId, footerId, pageHeight, pageWidth, marginLeft, marginBottom } = p;
             const pIndex = pages.indexOf(p);
 
             if (segmentPage > -1 && pIndex === segmentPage) {
+                pageOffsetLeft = this._liquid.x;
+                pageOffsetTop = this._liquid.y;
+
                 switch (pageType) {
                     case DocumentSkeletonPageType.HEADER: {
                         const headerSke = skeHeaders.get(headerId)?.get(pageWidth);
@@ -605,6 +610,11 @@ export class DocDrawingTransformerController extends Disposable {
                 break;
             }
 
+            if (p === anchorPage) {
+                pageOffsetLeft = this._liquid.x;
+                pageOffsetTop = this._liquid.y;
+            }
+
             this._liquid.translatePagePadding(p);
             if (p === anchorPage) {
                 break;
@@ -630,6 +640,12 @@ export class DocDrawingTransformerController extends Disposable {
         };
 
         switch (positionH.relativeFrom) {
+            case ObjectRelativeFromH.PAGE: {
+                if (drawing.layoutType === PositionedObjectLayoutType.WRAP_NONE) {
+                    docTransform.positionH.posOffset = left - pageOffsetLeft - docsLeft;
+                }
+                break;
+            }
             case ObjectRelativeFromH.MARGIN: {
                 docTransform.positionH.posOffset = left - this._liquid.x - docsLeft - page.marginLeft;
                 break;
@@ -647,7 +663,9 @@ export class DocDrawingTransformerController extends Disposable {
 
         switch (positionV.relativeFrom) {
             case ObjectRelativeFromV.PAGE: {
-                docTransform.positionV.posOffset = top - this._liquid.y - docsTop - page.marginTop;
+                docTransform.positionV.posOffset = drawing.layoutType === PositionedObjectLayoutType.WRAP_NONE
+                    ? top - pageOffsetTop - docsTop
+                    : top - this._liquid.y - docsTop - page.marginTop;
                 break;
             }
             case ObjectRelativeFromV.LINE: {

--- a/packages/docs-drawing-ui/src/controllers/doc-drawing-transformer-update.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/doc-drawing-transformer-update.controller.ts
@@ -38,7 +38,12 @@ import { DocSelectionRenderService, getAnchorBounding, getOneTextSelectionRange,
 import { IDrawingManagerService } from '@univerjs/drawing';
 import { DocumentSkeletonPageType, getColor, IRenderManagerService, Liquid, PageLayoutType, Rect, Vector2 } from '@univerjs/engine-render';
 import { IMoveInlineDrawingCommand, ITransformNonInlineDrawingCommand } from '../commands/commands/update-doc-drawing.command';
-import { getDocsTableCellDrawingOffset } from './render-controllers/doc-drawing-transform-update.controller';
+import {
+    getDocsDrawingBehindText,
+    getDocsDrawingClipPage,
+    getDocsPageRelativeDrawingAnchorPage,
+    getDocsTableCellDrawingOffset,
+} from './render-controllers/doc-drawing-transform-update.controller';
 
 const INLINE_DRAWING_ANCHOR_KEY_PREFIX = '__InlineDrawingAnchor__';
 
@@ -86,6 +91,31 @@ export function getDocsTableCellAnchorContext(unitId: string, cell: IDocumentSke
         row,
         table,
     };
+}
+
+export function shouldUseDocsDrawingOuterPageOrigin(config: {
+    drawing: Pick<IDocDrawingBase, 'behindDoc' | 'layoutType'>;
+    height: number;
+    hostPage?: IDocumentSkeletonPage;
+    page: IDocumentSkeletonPage;
+    width: number;
+}): boolean {
+    const { drawing, height, hostPage, page, width } = config;
+    if (drawing.layoutType !== PositionedObjectLayoutType.WRAP_NONE) {
+        return false;
+    }
+
+    const behindText = getDocsDrawingBehindText({ drawingOrigin: drawing, hostPage });
+    const clipPage = getDocsDrawingClipPage({
+        drawing: {
+            behindText,
+            transform: { width, height },
+        },
+        hostPage,
+        page,
+    });
+
+    return getDocsPageRelativeDrawingAnchorPage({ page, clipPage, hostPage }) != null;
 }
 
 // Listen doc drawing transformer change, and update drawing data.
@@ -559,6 +589,16 @@ export class DocDrawingTransformerController extends Disposable {
         const tableCellContext = page.type === DocumentSkeletonPageType.CELL ? getDocsTableCellAnchorContext(drawing.unitId, page) : null;
         const anchorPage = tableCellContext?.hostPage ?? page;
         const pageType = anchorPage.type;
+        const drawingHostPage = (page.type === DocumentSkeletonPageType.HEADER || page.type === DocumentSkeletonPageType.FOOTER) && segmentPage > -1
+            ? pages[segmentPage]
+            : undefined;
+        const useOuterPageOrigin = shouldUseDocsDrawingOuterPageOrigin({
+            drawing,
+            height: object.height,
+            hostPage: drawingHostPage,
+            page,
+            width: object.width,
+        });
         let pageOffsetLeft = this._liquid.x;
         let pageOffsetTop = this._liquid.y;
 
@@ -641,7 +681,7 @@ export class DocDrawingTransformerController extends Disposable {
 
         switch (positionH.relativeFrom) {
             case ObjectRelativeFromH.PAGE: {
-                if (drawing.layoutType === PositionedObjectLayoutType.WRAP_NONE) {
+                if (useOuterPageOrigin) {
                     docTransform.positionH.posOffset = left - pageOffsetLeft - docsLeft;
                 }
                 break;
@@ -663,9 +703,9 @@ export class DocDrawingTransformerController extends Disposable {
 
         switch (positionV.relativeFrom) {
             case ObjectRelativeFromV.PAGE: {
-                docTransform.positionV.posOffset = drawing.layoutType === PositionedObjectLayoutType.WRAP_NONE
+                docTransform.positionV.posOffset = useOuterPageOrigin
                     ? top - pageOffsetTop - docsTop
-                    : top - this._liquid.y - docsTop - page.marginTop;
+                    : top - this._liquid.y - docsTop + page.marginTop;
                 break;
             }
             case ObjectRelativeFromV.LINE: {


### PR DESCRIPTION
## What changed

- Capture the outer document page origin before applying page padding during drawing drag persistence.
- Use the same clip/anchor decision as rendering before applying the outer origin to `WRAP_NONE` drawings, including header and footer edge cases.
- Restore wrapped `PAGE` vertical offsets by adding back the page margin that the layout engine subtracts.
- Add regression coverage for front/behind, square, top-and-bottom, body, and header/footer origin selection.

## Why

Rendering and drag persistence used different coordinate origins. Front-of-text and behind-text drawings were persisted from the padded content origin and snapped left after mouseup. Square and top-and-bottom drawings also subtracted the top margin twice when dragged vertically, producing a 133.333 px rebound in the browser demo.

## Impact

Front, behind, square, and top-and-bottom document drawings now remain at the exact floating position where the user releases them. Inline drawings keep their expected text-anchor behavior.

## Validation

- Focused controller tests: 14/14 pass.
- `@univerjs/docs-drawing-ui` TypeScript typecheck passes.
- ESLint: 0 errors; only pre-existing warnings.
- Browser transformer-chain verification: front, behind, square, and top-and-bottom horizontal/vertical drags all refresh with 0 px rebound.
- Browser inline verification: dragging moved the text anchor from offset 304 to 469 and placed the image near the requested text position.
- Full package suite: 92 pass; 12 existing happy-dom React panel tests still fail because their controls do not render in the test DOM.
