### PR TITLE
perf(sheet): reduce merged cell scroll style work

### DIFF
--- a/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
+++ b/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
@@ -413,20 +413,25 @@ describe('spreadsheet integration', () => {
             { startRow: 5, endRow: 5, startColumn: 2, endColumn: 4, rangeType: RANGE_TYPE.NORMAL },
         ];
         workbookData.sheets['sheet-1'].cellData = {
-            3: { 2: { s: 'leftBorder' } },
-            4: { 2: { s: 'leftBorder' } },
-            5: { 2: { s: 'leftBorder' } },
+            3: { 2: { s: 'leftBorder' }, 3: { s: 'leftBorder' }, 4: { s: 'leftBorder' } },
+            4: { 2: { s: 'leftBorder' }, 3: { s: 'leftBorder' }, 4: { s: 'leftBorder' } },
+            5: { 2: { s: 'leftBorder' }, 3: { s: 'leftBorder' }, 4: { s: 'leftBorder' } },
         };
 
         const workbook = fixture.univer.createUnit<IWorkbookData, Workbook>(UniverInstanceType.UNIVER_SHEET, workbookData);
         const worksheet = workbook.getActiveSheet()!;
         const skeleton = fixture.univer.__getInjector().createInstance(SpreadsheetSkeleton, worksheet, workbook.getStyles()).calculate() as SpreadsheetSkeleton;
         skeleton.setScene(fixture.scene);
+        const mergeBorderSpy = vi.spyOn(
+            skeleton as unknown as { _setMergeBorderProps: (...args: unknown[]) => void },
+            '_setMergeBorderProps'
+        );
         skeleton.setStylesCache(createViewportInfo(fixture.scene, fixture.cacheCanvas));
 
         expect(skeleton.stylesCache.border?.getValue(3, 2)?.l).toEqual(expect.objectContaining({ color: '#000000' }));
         expect(skeleton.stylesCache.border?.getValue(4, 2)?.l).toEqual(expect.objectContaining({ color: '#000000' }));
         expect(skeleton.stylesCache.border?.getValue(5, 2)?.l).toEqual(expect.objectContaining({ color: '#000000' }));
+        expect(mergeBorderSpy).toHaveBeenCalledTimes(12);
     });
 
     it('renders spreadsheet with cache refresh and scrolling diff paths in scene viewport', () => {
@@ -807,6 +812,32 @@ describe('spreadsheet integration', () => {
 
         expect(styleCellSpy).not.toHaveBeenCalled();
         expect(skeleton.rowColumnSegment).toEqual(skeleton.getCacheRangeByViewport(viewportInfo));
+    });
+
+    it('reuses cached member styles while rebuilding merged borders during scrolling', () => {
+        const { skeleton, scene, cacheCanvas } = fixture;
+        skeleton.setStylesCache(createViewportInfo(scene, cacheCanvas));
+        const styleCellSpy = vi.spyOn(
+            skeleton as unknown as { _setStylesCacheForOneCell: (row: number, column: number, options: { reuseExisting?: boolean; mergeRange?: unknown }) => void },
+            '_setStylesCacheForOneCell'
+        );
+        const mergeBorderSpy = vi.spyOn(
+            skeleton as unknown as { _setMergeBorderProps: (...args: unknown[]) => void },
+            '_setMergeBorderProps'
+        );
+
+        skeleton.setStylesCache(createViewportInfo(scene, cacheCanvas, {
+            diffBounds: [createBound(100, 60, 220, 140)],
+            diffCacheBounds: [],
+            diffX: 0,
+            diffY: 12,
+            shouldCacheUpdate: 0,
+            isDirty: 0,
+            isForceDirty: false,
+        }));
+
+        expect(styleCellSpy.mock.calls.some(([, , options]) => options.reuseExisting && !options.mergeRange)).toBe(true);
+        expect(mergeBorderSpy).toHaveBeenCalledTimes(4);
     });
 
     it('skips merge lookups for one-cell style cache when merge data is absent', () => {

--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -442,12 +442,8 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
         const styleRanges = shouldUseIncrementalStyleRange
             ? (vpInfo.shouldCacheUpdate ? (vpInfo.diffCacheBounds?.map((bound) => this.getRangeByViewBound(bound)) ?? []) : [])
             : [rowColumnSegment];
-        const visibleCellOptions: ISetStylesCacheForOneCellOptions | null = hasMergeData
-            ? null
-            : { cacheItem: { bg: true, border: true }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true };
-        const overflowCellOptions: ISetStylesCacheForOneCellOptions | null = hasMergeData
-            ? null
-            : { cacheItem: { bg: false, border: false }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true };
+        const visibleCellOptions: ISetStylesCacheForOneCellOptions = { cacheItem: { bg: true, border: true }, reuseExisting: isIncrementalScroll, hasMergeData, rowVisible: true };
+        const overflowCellOptions: ISetStylesCacheForOneCellOptions = { cacheItem: { bg: false, border: false }, reuseExisting: isIncrementalScroll, hasMergeData, rowVisible: true };
         this._incrementalFontRenderRanges = [];
 
         // clear cache out of visible range
@@ -488,7 +484,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
                 }
 
                 for (let c = visibleStartColumn; c <= visibleEndColumn; c++) {
-                    this._setStylesCacheForOneCell(r, c, visibleCellOptions ?? { cacheItem: { bg: true, border: true }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true });
+                    this._setStylesCacheForOneCell(r, c, visibleCellOptions);
                 }
                 if (shouldUseIncrementalStyleRange) {
                     pushRowRange(this._incrementalFontRenderRanges, r, visibleStartColumn, visibleEndColumn);
@@ -496,7 +492,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
 
                 // Calculate text length for overflow cells just outside the visible range.
                 for (let c = visibleStartColumn - 1; c >= expandStartCol; c--) {
-                    this._setStylesCacheForOneCell(r, c, overflowCellOptions ?? { cacheItem: { bg: false, border: false }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true });
+                    this._setStylesCacheForOneCell(r, c, overflowCellOptions);
                     if (shouldUseIncrementalStyleRange) {
                         pushRowRange(this._incrementalFontRenderRanges, r, c, c);
                     }
@@ -509,7 +505,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
 
                 // Calculate text length for overflow cells just outside the visible range.
                 for (let c = visibleEndColumn + 1; c <= expandEndCol; c++) {
-                    this._setStylesCacheForOneCell(r, c, overflowCellOptions ?? { cacheItem: { bg: false, border: false }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true });
+                    this._setStylesCacheForOneCell(r, c, overflowCellOptions);
                     if (shouldUseIncrementalStyleRange) {
                         pushRowRange(this._incrementalFontRenderRanges, r, c, c);
                     }
@@ -528,7 +524,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
             for (const mergeRange of mergeRanges) {
                 this._setStylesCacheForOneCell(mergeRange.startRow, mergeRange.startColumn, {
                     mergeRange,
-                    reuseExisting: shouldUseIncrementalStyleRange,
+                    reuseExisting: isIncrementalScroll,
                     hasMergeData,
                 });
                 if (shouldUseIncrementalStyleRange) {
@@ -1483,10 +1479,6 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
             const mergeInfo = this.worksheet.getCellInfoInMergeData(row, col);
             isMerged = mergeInfo.isMerged;
             isMergedMainCell = mergeInfo.isMergedMainCell;
-            if (isMerged) {
-                const { startRow, startColumn, endRow, endColumn } = mergeInfo;
-                options.mergeRange = { startRow, startColumn, endRow, endColumn };
-            }
         }
 
         const rowVisible = options.rowVisible ?? this.worksheet.getRowVisible(row);


### PR DESCRIPTION
Refs dream-num/univer-cli#1096

## Summary

- avoid rebuilding merged borders once per styled member cell; process each merged range through the explicit merge pass
- reuse existing style cache entries during incremental scrolling while preserving the full canvas refresh required by #7207
- add focused regressions for merged-border work and cache reuse

## Root cause

A merged range was attached to every member-cell style calculation. Each member then rescanned the four merge edges, multiplying border work by the merged-cell area. During scrolling, merged sheets also discarded reusable member styles even when the canvas safety fallback still required a full repaint.

## Validation

- `pnpm --filter @univerjs/engine-render test` — 93 files passed; 841 passed, 59 skipped
- `pnpm --filter @univerjs/engine-render typecheck`
- `pnpm exec eslint --quiet packages/engine-render/src/components/sheets/sheet.render-skeleton.ts packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts`
- `git diff --check`

Synthetic 36-scroll comparison using the same fixture and runtime:

- average completion: 140.3 ms → 116.9 ms (16.7% lower)
- worst sample: 184 ms → 138 ms
- merged-border helper calls in the regression fixture: 36 → 12

The Long Task aggregate changed by 82.2%, but that metric is threshold-sensitive and is intentionally not presented as overall performance improvement.

## Scope

- No Pro source change is required: the hotspot and cache policy are owned by OSS `@univerjs/engine-render`; the Pro worktree was inspected and left untouched.
- No benchmark artifacts, screenshots, generated bundles, or documentation are included.
- This patch deliberately retains the #7207 merged-sheet full canvas fallback. Merge-aware incremental canvas refresh will follow separately.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.