### PR TITLE
fix(sheets-ui): smooth sheet tab wheel scrolling

### DIFF
--- a/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/utils/__tests__/slide-tab-bar.spec.ts
+++ b/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/utils/__tests__/slide-tab-bar.spec.ts
@@ -180,6 +180,101 @@ describe('slide-tab-bar', () => {
         expect(bar.getSlideTabItems()).toEqual([]);
     });
 
+    it('uses the dominant wheel axis and the live DOM scroll position', () => {
+        const { root, bar: barElement, events } = setupDOM();
+        const bar = createBar(root, events);
+
+        const horizontalWheel = new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaX: 20,
+            deltaY: 2,
+        });
+        barElement.dispatchEvent(horizontalWheel);
+
+        expect(horizontalWheel.defaultPrevented).toBe(true);
+        expect(barElement.scrollLeft).toBe(20);
+
+        barElement.scrollLeft = 60;
+        barElement.dispatchEvent(new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaX: -15,
+        }));
+        expect(barElement.scrollLeft).toBe(45);
+
+        barElement.dispatchEvent(new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaY: 20,
+        }));
+        expect(barElement.scrollLeft).toBe(65);
+        expect(events.scrollStates.at(-1)).toEqual({ leftEnd: false, rightEnd: false });
+
+        bar.destroy();
+    });
+
+    it('normalizes wheel delta modes and clamps both scroll boundaries', () => {
+        const { root, bar: barElement, events } = setupDOM();
+        const bar = createBar(root, events);
+
+        barElement.dispatchEvent(new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaMode: WheelEvent.DOM_DELTA_LINE,
+            deltaY: 2,
+        }));
+        expect(barElement.scrollLeft).toBe(32);
+
+        barElement.dispatchEvent(new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaX: 200,
+        }));
+        expect(barElement.scrollLeft).toBe(120);
+        expect(bar.isRightEnd()).toBe(true);
+        expect(events.scrollStates.at(-1)).toEqual({ leftEnd: false, rightEnd: true });
+
+        Object.defineProperty(root, 'clientWidth', { configurable: true, value: 80 });
+        barElement.dispatchEvent(new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaX: 20,
+        }));
+        expect(barElement.scrollLeft).toBe(140);
+        expect(bar.isRightEnd()).toBe(true);
+
+        barElement.dispatchEvent(new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaX: -200,
+        }));
+        expect(barElement.scrollLeft).toBe(0);
+        expect(bar.isLeftEnd()).toBe(true);
+        expect(events.scrollStates.at(-1)).toEqual({ leftEnd: true, rightEnd: false });
+
+        bar.destroy();
+    });
+
+    it('leaves wheel events alone when the sheet tabs do not overflow', () => {
+        const { root, bar: barElement, events } = setupDOM();
+        Object.defineProperty(barElement, 'scrollWidth', { configurable: true, value: 80 });
+        const bar = createBar(root, events);
+        const wheel = new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaY: 20,
+        });
+
+        barElement.dispatchEvent(wheel);
+
+        expect(wheel.defaultPrevented).toBe(false);
+        expect(barElement.scrollLeft).toBe(0);
+        expect(events.scrollStates).toEqual([]);
+
+        bar.destroy();
+    });
+
     it('supports editing, fixed dragging style, and per-item animation', () => {
         const { root, events } = setupDOM();
         const frameState = new TestAnimationFrameState();

--- a/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/utils/slide-tab-bar.ts
+++ b/packages/sheets-ui/src/views/sheet-bar/sheet-bar-tabs/utils/slide-tab-bar.ts
@@ -299,28 +299,24 @@ export class SlideTabItem {
 export class SlideScrollbar {
     protected _slideTabBar: SlideTabBar;
 
-    protected _scrollX: number;
-
     constructor(slideTabBar: SlideTabBar) {
-        const primeval = slideTabBar.primeval();
-        this._scrollX = primeval.scrollLeft;
         this._slideTabBar = slideTabBar;
     }
 
     scrollX(x: number) {
         const primeval = this._slideTabBar.primeval();
-        primeval.scrollLeft = x;
-        this._scrollX = primeval.scrollLeft;
+        const viewportWidth = primeval.parentElement?.clientWidth ?? primeval.clientWidth;
+        const maxScrollX = Math.max(0, primeval.scrollWidth - viewportWidth);
+        primeval.scrollLeft = Math.min(maxScrollX, Math.max(0, x));
     }
 
     scrollRight() {
         const primeval = this._slideTabBar.primeval();
-        primeval.scrollLeft = primeval.scrollWidth;
-        this._scrollX = primeval.scrollLeft;
+        this.scrollX(primeval.scrollWidth);
     }
 
     getScrollX(): number {
-        return this._scrollX;
+        return this._slideTabBar.primeval().scrollLeft;
     }
 }
 
@@ -558,7 +554,26 @@ export class SlideTabBar {
         };
 
         this._wheelAction = (wheelEvent: WheelEvent) => {
-            this.setScroll(wheelEvent.deltaY);
+            const viewportWidth = this._slideTabBar.parentElement?.clientWidth ?? this._slideTabBar.clientWidth;
+            if (this._slideTabBar.scrollWidth <= viewportWidth) {
+                return;
+            }
+
+            const dominantDelta = Math.abs(wheelEvent.deltaX) > Math.abs(wheelEvent.deltaY)
+                ? wheelEvent.deltaX
+                : wheelEvent.deltaY;
+            if (dominantDelta === 0) {
+                return;
+            }
+
+            const deltaModeMultiplier = wheelEvent.deltaMode === WheelEvent.DOM_DELTA_LINE
+                ? 16
+                : wheelEvent.deltaMode === WheelEvent.DOM_DELTA_PAGE
+                    ? viewportWidth
+                    : 1;
+
+            wheelEvent.preventDefault();
+            this.setScroll(dominantDelta * deltaModeMultiplier);
         };
 
         this.addListener();
@@ -628,17 +643,18 @@ export class SlideTabBar {
     }
 
     isLeftEnd(): boolean {
-        return this._slideTabBar.scrollLeft === 0;
+        return this._slideTabBar.scrollLeft <= 1;
     }
 
     isRightEnd(): boolean {
         const parent = this._slideTabBar.parentElement;
         if (!parent) return false;
-        return this._slideTabBar.scrollWidth - parent.clientWidth === this._slideTabBar.scrollLeft;
+        const maxScrollX = Math.max(0, this._slideTabBar.scrollWidth - parent.clientWidth);
+        return maxScrollX - this._slideTabBar.scrollLeft <= 1;
     }
 
     addListener() {
-        this._slideTabBar.addEventListener('wheel', this._wheelAction);
+        this._slideTabBar.addEventListener('wheel', this._wheelAction, { passive: false });
         this._slideTabItems.forEach((item) => {
             item.addEventListener('pointerdown', this._downAction);
         });
@@ -653,13 +669,6 @@ export class SlideTabBar {
 
     setScroll(x: number) {
         this._slideScrollbar.scrollX(this._slideScrollbar.getScrollX() + x);
-        if (x > 0) {
-            const left = this.calculateLeftScrollX();
-            this._slideScrollbar.scrollX(this._slideScrollbar.getScrollX() + left);
-        } else if (x < 0) {
-            const right = this.calculateRightScrollX();
-            this._slideScrollbar.scrollX(this._slideScrollbar.getScrollX() + right);
-        }
 
         this._config.onScroll({
             leftEnd: this.isLeftEnd(),


### PR DESCRIPTION
## What changed

- use the DOM scroll position as the single source of truth for sheet tabs
- support both horizontal trackpad and vertical mouse-wheel deltas
- preserve inertial scrolling while keeping arrow paging behavior
- add regression coverage for both directions, dynamic widths, delta modes, and non-overflow tabs

## Why

The sheet tab bar mixed browser-native horizontal scrolling with a vertical-delta-only handler backed by a cached scroll position. The two states could diverge, causing wheel events to snap the bar back toward an edge and preventing reliable access to the opposite end.

## Validation

- pnpm exec vitest run src/views/sheet-bar/sheet-bar-tabs/utils/__tests__/slide-tab-bar.spec.ts (11/11)
- pnpm --filter @univerjs/sheets-ui typecheck
- ESLint on changed files
- browser verification for horizontal trackpad, vertical wheel, reverse motion, and dynamic right boundary