### PR TITLE
feat(core): add base hierarchy contracts

### DIFF
--- a/packages/core/src/bases/index.ts
+++ b/packages/core/src/bases/index.ts
@@ -28,7 +28,7 @@ export {
     isBaseRecordIdFieldName,
     isValidBaseRecordId,
 } from './record-identity';
-export { BaseFieldType, BaseFilterConjunction, BaseFilterOperator, BaseSortDirection, BaseViewType } from './typedef';
+export { BaseFieldType, BaseFilterConjunction, BaseFilterOperator, BaseHierarchyInvalidReason, BaseRecordLinkRole, BaseSortDirection, BaseViewType } from './typedef';
 export type {
     BaseCellMatrix,
     BaseCellPrimitiveValue,
@@ -47,6 +47,8 @@ export type {
     IBaseAttachment,
     IBaseCellData,
     IBaseDateFieldConfig,
+    IBaseHierarchyNodeProjection,
+    IBaseHierarchyProjection,
     IBaseInvalidation,
     IBaseRect,
     IBaseResources,

--- a/packages/core/src/bases/typedef.ts
+++ b/packages/core/src/bases/typedef.ts
@@ -124,6 +124,11 @@ export enum BaseFieldType {
     Summary = 'summary',
 }
 
+/** Semantic roles supported by Base RecordLink fields. */
+export enum BaseRecordLinkRole {
+    Parent = 'parent',
+}
+
 export interface IRecordLinkFieldConfig extends Record<string, unknown> {
     targetTableId: TableId;
     multiple: boolean;
@@ -131,6 +136,8 @@ export interface IRecordLinkFieldConfig extends Record<string, unknown> {
     displayFieldId?: FieldId;
     /** Ordered target-table fields rendered as secondary context in the record picker. */
     pickerFieldIds?: FieldId[];
+    /** Optional table-level semantic role of this link. */
+    relationRole?: BaseRecordLinkRole;
 }
 
 export enum BaseViewType {
@@ -467,9 +474,35 @@ export interface IProjectedGroup {
     children?: IProjectedGroup[];
 }
 
+/** Why a stored Parent link cannot participate in the effective hierarchy. */
+export enum BaseHierarchyInvalidReason {
+    MissingParent = 'missingParent',
+    SelfParent = 'selfParent',
+    Cycle = 'cycle',
+    MaxDepth = 'maxDepth',
+}
+
+export interface IBaseHierarchyNodeProjection {
+    recordId: RecordId;
+    parentRecordId: RecordId | null;
+    depth: number;
+    directChildCount: number;
+    subtreeHeight: number;
+    subtreeEndIndex: number;
+    invalidReason?: BaseHierarchyInvalidReason;
+}
+
+export interface IBaseHierarchyProjection {
+    fieldId: FieldId;
+    rootRecordIds: RecordId[];
+    orderedRecordIds: RecordId[];
+    nodes: Record<RecordId, IBaseHierarchyNodeProjection>;
+}
+
 export interface IGridProjection extends IViewProjection {
     type: BaseViewType.Grid;
     frozenFieldCount?: number;
+    hierarchy?: IBaseHierarchyProjection;
 }
 
 export interface IKanbanProjection extends IViewProjection {
@@ -720,6 +753,45 @@ export type BaseHitTestResult =
         tableId: TableId;
         viewId: ViewId;
         recordId: RecordId;
+    }
+    | {
+        type: 'grid-hierarchy-toggle' | 'grid-hierarchy-add-child';
+        tableId: TableId;
+        viewId: ViewId;
+        recordId: RecordId;
+    }
+    | {
+        type: 'grid-cell-checkbox';
+        tableId: TableId;
+        viewId: ViewId;
+        recordId: RecordId;
+        fieldId: FieldId;
+    }
+    | {
+        type: 'grid-rating-icon';
+        tableId: TableId;
+        viewId: ViewId;
+        recordId: RecordId;
+        fieldId: FieldId;
+        value: number;
+    }
+    | {
+        type: 'grid-row-header' | 'grid-row-checkbox';
+        tableId: TableId;
+        viewId: ViewId;
+        recordId: RecordId;
+    }
+    | {
+        type: 'grid-row-header-select-all';
+        tableId: TableId;
+        viewId: ViewId;
+    }
+    | {
+        type: 'grid-row-drag-handle';
+        tableId: TableId;
+        viewId: ViewId;
+        recordId: RecordId;
+        disabled: boolean;
     }
     | {
         type: 'kanban-add-record';


### PR DESCRIPTION
## What
- Add typed RecordLink hierarchy roles and invalid-edge reasons.
- Add hierarchy metadata to Grid projections.
- Add typed Grid hierarchy and row interaction hit results.

## Why
Base hierarchical records need shared OSS contracts so Pro model, Facade, and renderer code use canonical SDK types rather than module augmentation or local interface lookalikes.

## Impact
Additive Base SDK contracts only. Existing snapshots remain compatible; hierarchy metadata and relation roles are optional.

## Checks
- pnpm --filter @univerjs/core typecheck
- pnpm --filter @univerjs/core test --run (148 files passed, 3 skipped; 977 tests passed, 10 skipped)
- Changed-file ESLint (0 errors)
- git diff --check

Related: https://github.com/dream-num/univer-cli/issues/1075