### PR TITLE
perf(engine-render): use native canvas shadows for text effects

### DIFF
--- a/packages/engine-render/src/components/docs/extensions/__tests__/font-and-base-line.spec.ts
+++ b/packages/engine-render/src/components/docs/extensions/__tests__/font-and-base-line.spec.ts
@@ -54,6 +54,11 @@ function createContext(): MockRenderContext {
         fillStyle: '',
         filter: 'none',
         font: '10px Arial',
+        globalCompositeOperation: 'source-over',
+        shadowColor: 'transparent',
+        shadowBlur: 0,
+        shadowOffsetX: 0,
+        shadowOffsetY: 0,
         save: vi.fn(),
         restore: vi.fn(),
         fillText: vi.fn(),
@@ -114,12 +119,18 @@ function createGlyph(content: string, overrides?: GlyphOverrides): IDocumentSkel
 }
 
 describe('docs font and baseline extension', () => {
-    it('renders public glow and outer shadow fields in one text draw', () => {
+    it('renders public glow and outer shadow behind the source text without canvas filters', () => {
         const extension = new FontAndBaseLine();
         const TestContext = createContext();
-        let filterDuringDraw = '';
+        const effectsDuringDraw: Array<{ composite: string; color: string; blur: number; offsetX: number; offsetY: number }> = [];
         TestContext.fillText.mockImplementation(() => {
-            filterDuringDraw = TestContext.filter;
+            effectsDuringDraw.push({
+                composite: TestContext.globalCompositeOperation,
+                color: TestContext.shadowColor,
+                blur: TestContext.shadowBlur,
+                offsetX: TestContext.shadowOffsetX,
+                offsetY: TestContext.shadowOffsetY,
+            });
         });
         extension.extensionOffset = {
             spanPointWithFont: Vector2.create(12, 20),
@@ -149,9 +160,22 @@ describe('docs font and baseline extension', () => {
             },
         }));
 
-        expect(TestContext.fillText).toHaveBeenCalledTimes(1);
-        expect(filterDuringDraw).toContain('drop-shadow(0px 0px 2px #5b9bd5)');
-        expect(filterDuringDraw).toContain('drop-shadow(2px 0px 3px rgba(0,0,0,0.4))');
+        expect(TestContext.fillText).toHaveBeenCalledTimes(2);
+        expect(effectsDuringDraw[0]).toEqual({
+            composite: 'source-over',
+            color: '#5b9bd5',
+            blur: 2,
+            offsetX: 0,
+            offsetY: 0,
+        });
+        expect(effectsDuringDraw[1]).toEqual({
+            composite: 'source-over',
+            color: 'rgba(0,0,0,0.4)',
+            blur: 3,
+            offsetX: 2,
+            offsetY: 0,
+        });
+        expect(TestContext.filter).toBe('none');
         expect(TestContext.save).toHaveBeenCalledTimes(1);
         expect(TestContext.restore).toHaveBeenCalledTimes(1);
     });

--- a/packages/engine-render/src/components/docs/extensions/font-and-base-line.ts
+++ b/packages/engine-render/src/components/docs/extensions/font-and-base-line.ts
@@ -23,7 +23,7 @@ import { BaselineOffset, getColorStyle } from '@univerjs/core';
 import { GlyphType } from '../../../basics';
 import { cjk } from '../../../basics/cjk-regexp';
 import { COLOR_BLACK_RGB } from '../../../basics/const';
-import { combineDrawingEffectFilter, createDrawingEffectFilter } from '../../../basics/drawing-effect';
+import { resolveGlowEffect, resolveOuterShadowEffect } from '../../../basics/drawing-effect';
 import { Vector2 } from '../../../basics/vector2';
 import { CheckboxShape } from '../../../shape';
 import { DocumentsSpanAndLineExtensionRegistry } from '../../extension';
@@ -123,15 +123,20 @@ export class FontAndBaseLine extends docExtension {
             return;
         }
 
-        const effectFilter = createDrawingEffectFilter(glow, outerShadow);
-        if (!effectFilter) {
+        const effects = [resolveGlowEffect(glow), resolveOuterShadowEffect(outerShadow)].filter((effect) => effect != null);
+        if (effects.length === 0) {
             drawText();
             return;
         }
 
         ctx.save();
-        ctx.filter = combineDrawingEffectFilter(ctx.filter, effectFilter);
-        drawText();
+        for (const effect of effects) {
+            ctx.shadowColor = effect.color;
+            ctx.shadowBlur = effect.blurRadius;
+            ctx.shadowOffsetX = effect.offsetX;
+            ctx.shadowOffsetY = effect.offsetY;
+            drawText();
+        }
         ctx.restore();
     }
 


### PR DESCRIPTION
## Summary

- 将文档/幻灯片文字的 glow 与 outer shadow 从 CSS `drop-shadow()` filter 改为 Canvas 原生 shadow 绘制。
- glow 和 outer shadow 分别绘制，保持各自颜色、模糊半径和偏移。
- 更新针对性单测，确认不再写入 `ctx.filter`。

## Why

Costco Membership Flywheel 样张中，文字特效使用 CSS filter 会在页面加载和组件交互时触发长任务。Canvas 原生 shadow 路径可避免这类 filter 合成开销。

## Impact

变更仅影响带 glow/outer shadow 的文字特效绘制；不改变无特效文字。样张第 24 页从每次加载约 2 个 808–869 ms Long Task 降为 0，点击画布事件约 40 ms、无 Long Task。

## Validation

- [x] `font-and-base-line.spec.ts`：8/8 passed
- [x] `@univerjs/engine-render` tests：840 passed，59 skipped
- [x] `@univerjs/engine-render` TypeScript check
- [x] `pnpm --filter univer-cli build`
- [x] Costco 样张第 24 页：3 次加载均为 0 Long Task
- [x] 截图像素平均绝对差 0.666/255；差异集中在 3 个文字特效框
- [ ] `pnpm check`：format 与 lint 通过；被现有且无关的 `engine-formula-rust` decorator 类型标识问题阻断

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes introduced.
