### PR TITLE
perf(sheet): optimize merge-aware incremental scrolling

### DIFF
--- a/e2e/visual-comparison/sheets/sheets-scroll.spec.ts
+++ b/e2e/visual-comparison/sheets/sheets-scroll.spec.ts
@@ -58,25 +58,81 @@ test('cells rendering after scrolling', async () => {
     });
     await page.waitForTimeout(1000);
 
-    await page.locator(SHEET_MAIN_CANVAS_ID).evaluate((source: HTMLCanvasElement) => {
+    const filename = generateSnapshotName('mergedCellsRenderingScrolling');
+    const screenshot = await page.locator(SHEET_MAIN_CANVAS_ID).screenshot();
+    await expect(screenshot).toMatchSnapshot(filename, { maxDiffPixelRatio: 0.005 });
+});
+
+test('incremental merged-cell repaint matches a full refresh', async () => {
+    const browser = await chromium.launch({ headless: isCI });
+    const context = await browser.newContext({
+        viewport: { width: 1280, height: 1280 },
+        deviceScaleFactor: 2,
+    });
+    const page = await context.newPage();
+    await page.goto('http://localhost:3000/sheets/');
+    await page.waitForTimeout(2000);
+
+    await page.evaluate(() => window.E2EControllerAPI.loadMergeCellSheet());
+    await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))));
+    await expect(page.getByText('Custom Loading...', { exact: true })).toHaveCount(0, { timeout: 15_000 });
+    await page.evaluate(async () => {
+        await document.fonts.ready;
+        await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+    });
+
+    const canvas = page.locator(SHEET_MAIN_CANVAS_ID);
+    await canvas.evaluate(async (element: HTMLCanvasElement) => {
+        const scroll = async (deltaY: number) => {
+            for (let elapsed = 0; elapsed < 1000; elapsed += 30) {
+                element.dispatchEvent(new WheelEvent('wheel', {
+                    bubbles: true,
+                    cancelable: true,
+                    deltaY,
+                    clientX: 580,
+                    clientY: 580,
+                }));
+                await new Promise((resolve) => setTimeout(resolve, 30));
+            }
+        };
+        await scroll(100);
+        await scroll(-100);
+    });
+    await page.evaluate(() => new Promise<void>((resolve) => {
+        let previous = '';
+        let stableFrames = 0;
+        const check = () => {
+            const current = JSON.stringify(window.univerAPI.getActiveWorkbook().getActiveSheet().getScrollState());
+            stableFrames = current === previous ? stableFrames + 1 : 0;
+            previous = current;
+            if (stableFrames >= 5) {
+                resolve();
+                return;
+            }
+            requestAnimationFrame(check);
+        };
+        requestAnimationFrame(check);
+    }));
+
+    await canvas.evaluate((source: HTMLCanvasElement) => {
         const reference = document.createElement('canvas');
         reference.id = 'merge-scroll-incremental-reference';
+        reference.style.display = 'none';
         reference.width = source.width;
         reference.height = source.height;
+        const sourceContext = source.getContext('2d');
         const referenceContext = reference.getContext('2d');
-        if (!referenceContext) {
-            throw new Error('Failed to get incremental reference canvas context');
+        if (!sourceContext || !referenceContext) {
+            throw new Error('Failed to read incremental canvas pixels');
         }
-        referenceContext.drawImage(source, 0, 0);
+        referenceContext.putImageData(sourceContext.getImageData(0, 0, source.width, source.height), 0, 0);
         document.body.appendChild(reference);
     });
 
-    await page.setViewportSize({ width: 1281, height: 1280 });
-    await page.waitForTimeout(100);
-    await page.setViewportSize({ width: 1280, height: 1280 });
-    await page.waitForTimeout(500);
+    await page.evaluate(() => window.univerAPI.getActiveWorkbook().getActiveSheet().refreshCanvas());
+    await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))));
 
-    const differentPixels = await page.locator(SHEET_MAIN_CANVAS_ID).evaluate((source: HTMLCanvasElement) => {
+    const differentPixels = await canvas.evaluate((source: HTMLCanvasElement) => {
         const reference = document.querySelector<HTMLCanvasElement>('#merge-scroll-incremental-reference');
         const sourceContext = source.getContext('2d');
         const referenceContext = reference?.getContext('2d');
@@ -102,11 +158,8 @@ test('cells rendering after scrolling', async () => {
         reference.remove();
         return count;
     });
+    await browser.close();
     expect(differentPixels).toBe(0);
-
-    const filename = generateSnapshotName('mergedCellsRenderingScrolling');
-    const screenshot = await page.locator(SHEET_MAIN_CANVAS_ID).screenshot();
-    await expect(screenshot).toMatchSnapshot(filename, { maxDiffPixelRatio: 0.005 });
 });
 
 test('rendering after scrolling by API', async () => {

--- a/e2e/visual-comparison/sheets/sheets-scroll.spec.ts
+++ b/e2e/visual-comparison/sheets/sheets-scroll.spec.ts
@@ -58,6 +58,52 @@ test('cells rendering after scrolling', async () => {
     });
     await page.waitForTimeout(1000);
 
+    await page.locator(SHEET_MAIN_CANVAS_ID).evaluate((source: HTMLCanvasElement) => {
+        const reference = document.createElement('canvas');
+        reference.id = 'merge-scroll-incremental-reference';
+        reference.width = source.width;
+        reference.height = source.height;
+        const referenceContext = reference.getContext('2d');
+        if (!referenceContext) {
+            throw new Error('Failed to get incremental reference canvas context');
+        }
+        referenceContext.drawImage(source, 0, 0);
+        document.body.appendChild(reference);
+    });
+
+    await page.setViewportSize({ width: 1281, height: 1280 });
+    await page.waitForTimeout(100);
+    await page.setViewportSize({ width: 1280, height: 1280 });
+    await page.waitForTimeout(500);
+
+    const differentPixels = await page.locator(SHEET_MAIN_CANVAS_ID).evaluate((source: HTMLCanvasElement) => {
+        const reference = document.querySelector<HTMLCanvasElement>('#merge-scroll-incremental-reference');
+        const sourceContext = source.getContext('2d');
+        const referenceContext = reference?.getContext('2d');
+        if (!reference || !sourceContext || !referenceContext) {
+            throw new Error('Failed to read canvas pixels');
+        }
+        if (source.width !== reference.width || source.height !== reference.height) {
+            return Number.POSITIVE_INFINITY;
+        }
+        const actual = sourceContext.getImageData(0, 0, source.width, source.height).data;
+        const expected = referenceContext.getImageData(0, 0, reference.width, reference.height).data;
+        let count = 0;
+        for (let index = 0; index < actual.length; index += 4) {
+            if (
+                actual[index] !== expected[index] ||
+                actual[index + 1] !== expected[index + 1] ||
+                actual[index + 2] !== expected[index + 2] ||
+                actual[index + 3] !== expected[index + 3]
+            ) {
+                count++;
+            }
+        }
+        reference.remove();
+        return count;
+    });
+    expect(differentPixels).toBe(0);
+
     const filename = generateSnapshotName('mergedCellsRenderingScrolling');
     const screenshot = await page.locator(SHEET_MAIN_CANVAS_ID).screenshot();
     await expect(screenshot).toMatchSnapshot(filename, { maxDiffPixelRatio: 0.005 });

--- a/packages/core/src/shared/numfmt/__tests__/parse-value.spec.ts
+++ b/packages/core/src/shared/numfmt/__tests__/parse-value.spec.ts
@@ -737,6 +737,41 @@ numfmtTest('parseDate locale support', (t) => {
     }
 });
 
+numfmtTest('parseDate refreshes cached locale tokens when locale data changes', (t) => {
+    const firstMonths = [
+        'cachejanuary',
+        'cachefebruary',
+        'cachemarch',
+        'cacheapril',
+        'cachemay',
+        'cachejune',
+        'cachejuly',
+        'cacheaugust',
+        'cacheseptember',
+        'cacheoctober',
+        'cachenovember',
+        'cachedecember',
+    ];
+    const secondMonths = firstMonths.map((month) => `new${month}`);
+    const expected = parseDate('13 January 1989', { locale: 'en' });
+
+    addLocale({ mmmm: firstMonths, mmm: firstMonths }, 'zz_cache');
+    t.deepEqual(parseDate('13 cachejanuary 1989', { locale: 'zz_cache' }), expected);
+
+    addLocale({ mmmm: secondMonths, mmm: secondMonths }, 'zz_cache');
+    t.deepEqual(parseDate('13 cachejanuary 1989', { locale: 'zz_cache' }), null);
+    t.deepEqual(parseDate('13 newcachejanuary 1989', { locale: 'zz_cache' }), expected);
+
+    const locale = getLocale('zz_cache');
+    t.ok(locale);
+    if (!locale) {
+        return;
+    }
+    locale.mmmm[0] = 'livecachejanuary';
+    t.deepEqual(parseDate('13 newcachejanuary 1989', { locale: 'zz_cache' }), null);
+    t.deepEqual(parseDate('13 livecachejanuary 1989', { locale: 'zz_cache' }), expected);
+});
+
 numfmtTest('parseTime locale support', (t) => {
     t.deepEqual(parseTime('01:31 a', { locale: 'fi' }), { v: 0.06319444444444444, z: 'hh:mm AM/PM' }, 'fi: 01:31 a');
     t.deepEqual(parseTime('01:31 am', { locale: 'fi' }), { v: 0.06319444444444444, z: 'hh:mm AM/PM' }, 'fi: 01:31 am');

--- a/packages/core/src/shared/numfmt/parse-value.ts
+++ b/packages/core/src/shared/numfmt/parse-value.ts
@@ -398,6 +398,18 @@ interface IDateLocaleData {
     locale?: string;
 }
 
+type DateLocaleLookups = Omit<IDateLocaleData, 'locale'>;
+
+interface ICachedDateLocaleLookups {
+    lookups: DateLocaleLookups;
+    mmmm: string[];
+    mmm: string[];
+    dddd: string[];
+    ddd: string[];
+}
+
+const dateLocaleLookupCache = new WeakMap<LocaleData, ICachedDateLocaleLookups>();
+
 interface IDateParseState {
     path: string;
     sep?: string;
@@ -585,15 +597,41 @@ const getLookups = (values: string[], symbol: LookupSymbol): LocaleLookup[] => {
     return lookups;
 };
 
+const tokensMatch = (values: string[], cachedValues: string[]): boolean =>
+    values.length === cachedValues.length && values.every((value, index) => value === cachedValues[index]);
+
+const getDateLocaleLookups = (locale: LocaleData): DateLocaleLookups => {
+    let cached = dateLocaleLookupCache.get(locale);
+    if (
+        !cached ||
+        !tokensMatch(locale.mmmm, cached.mmmm) ||
+        !tokensMatch(locale.mmm, cached.mmm) ||
+        !tokensMatch(locale.dddd, cached.dddd) ||
+        !tokensMatch(locale.ddd, cached.ddd)
+    ) {
+        cached = {
+            lookups: {
+                mon: getLookups(locale.mmmm, 'F').concat(getLookups(locale.mmm, 'M')),
+                mp: locale.mmm[0].at(-1) === '.',
+                day: getLookups(locale.dddd, 'l').concat(getLookups(locale.ddd, 'D')),
+                dp: locale.ddd[0].at(-1) === '.',
+            },
+            mmmm: [...locale.mmmm],
+            mmm: [...locale.mmm],
+            dddd: [...locale.dddd],
+            ddd: [...locale.ddd],
+        };
+        dateLocaleLookupCache.set(locale, cached);
+    }
+    return cached.lookups;
+};
+
 /** Parse a date or datetime string and return its serial value and format. */
 // eslint-disable-next-line complexity
 export function parseDate(value: string, options: ParseOptions = {}): ParseData<number> | null {
     const l10n = getLocale(options.locale || '') || defaultLocale;
     const localeData: IDateLocaleData = {
-        mon: getLookups(l10n.mmmm, 'F').concat(getLookups(l10n.mmm, 'M')),
-        mp: l10n.mmm[0].at(-1) === '.',
-        day: getLookups(l10n.dddd, 'l').concat(getLookups(l10n.ddd, 'D')),
-        dp: l10n.ddd[0].at(-1) === '.',
+        ...getDateLocaleLookups(l10n),
         locale: options.locale,
     };
     const date = nextToken(

--- a/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
+++ b/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
@@ -21,8 +21,10 @@ import {
     BorderStyleTypes,
     createSheetGapTestConfig,
     HorizontalAlign,
+
     ILogService,
     IUniverInstanceService,
+
     LocaleType,
     LogLevel,
     ObjectMatrix,
@@ -30,6 +32,7 @@ import {
     Univer,
     UniverInstanceType,
     VerticalAlign,
+
     WrapStrategy,
 } from '@univerjs/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -422,16 +425,13 @@ describe('spreadsheet integration', () => {
         const worksheet = workbook.getActiveSheet()!;
         const skeleton = fixture.univer.__getInjector().createInstance(SpreadsheetSkeleton, worksheet, workbook.getStyles()).calculate() as SpreadsheetSkeleton;
         skeleton.setScene(fixture.scene);
-        const mergeBorderSpy = vi.spyOn(
-            skeleton as unknown as { _setMergeBorderProps: (...args: unknown[]) => void },
-            '_setMergeBorderProps'
-        );
+        const borderStyleSpy = vi.spyOn(skeleton, '_setBorderStylesCache');
         skeleton.setStylesCache(createViewportInfo(fixture.scene, fixture.cacheCanvas));
 
         expect(skeleton.stylesCache.border?.getValue(3, 2)?.l).toEqual(expect.objectContaining({ color: '#000000' }));
         expect(skeleton.stylesCache.border?.getValue(4, 2)?.l).toEqual(expect.objectContaining({ color: '#000000' }));
         expect(skeleton.stylesCache.border?.getValue(5, 2)?.l).toEqual(expect.objectContaining({ color: '#000000' }));
-        expect(mergeBorderSpy).toHaveBeenCalledTimes(12);
+        expect(borderStyleSpy.mock.calls.filter(([, , , options]) => options?.mergeRange)).toHaveLength(3);
     });
 
     it('renders spreadsheet with cache refresh and scrolling diff paths in scene viewport', () => {
@@ -629,13 +629,12 @@ describe('spreadsheet integration', () => {
         expect(extensionDraw.mock.calls.at(-1)?.[4].hasMergeData).toBe(false);
     });
 
-    it('skips sparse extensions with no matching cell data during merge-free incremental drawing', () => {
+    it('skips sparse extensions outside merge repair bounds on sheets with merged cells', () => {
         const { spreadsheet, skeleton, scene, cacheCanvas, mainCanvas } = fixture;
         const context = mainCanvas.getContext() as any;
         const sparseDraw = vi.fn();
         const regularDraw = vi.fn();
 
-        vi.spyOn(skeleton.worksheet, 'getMergeData').mockReturnValue([]);
         vi.spyOn(skeleton.worksheet, 'getCell').mockReturnValue(undefined);
         vi.spyOn(spreadsheet as any, 'getExtensionsByOrder').mockReturnValue([
             {
@@ -817,14 +816,9 @@ describe('spreadsheet integration', () => {
     it('reuses cached member styles while rebuilding merged borders during scrolling', () => {
         const { skeleton, scene, cacheCanvas } = fixture;
         skeleton.setStylesCache(createViewportInfo(scene, cacheCanvas));
-        const styleCellSpy = vi.spyOn(
-            skeleton as unknown as { _setStylesCacheForOneCell: (row: number, column: number, options: { reuseExisting?: boolean; mergeRange?: unknown }) => void },
-            '_setStylesCacheForOneCell'
-        );
-        const mergeBorderSpy = vi.spyOn(
-            skeleton as unknown as { _setMergeBorderProps: (...args: unknown[]) => void },
-            '_setMergeBorderProps'
-        );
+        const cachedStyle = skeleton.stylesCache.fontMatrix.getValue(1, 1);
+        expect(cachedStyle).toBeDefined();
+        const borderStyleSpy = vi.spyOn(skeleton, '_setBorderStylesCache');
 
         skeleton.setStylesCache(createViewportInfo(scene, cacheCanvas, {
             diffBounds: [createBound(100, 60, 220, 140)],
@@ -836,8 +830,8 @@ describe('spreadsheet integration', () => {
             isForceDirty: false,
         }));
 
-        expect(styleCellSpy.mock.calls.some(([, , options]) => options.reuseExisting && !options.mergeRange)).toBe(true);
-        expect(mergeBorderSpy).toHaveBeenCalledTimes(4);
+        expect(skeleton.stylesCache.fontMatrix.getValue(1, 1)).toBe(cachedStyle);
+        expect(borderStyleSpy.mock.calls.some(([, , , options]) => options?.mergeRange)).toBe(true);
     });
 
     it('skips merge lookups for one-cell style cache when merge data is absent', () => {
@@ -1096,7 +1090,34 @@ describe('spreadsheet integration', () => {
         expect(paintSpy).toHaveBeenCalledOnce();
         expect(drawSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
             diffBounds: [mergedBound],
-        }));
+        }), true);
+    });
+
+    it('refreshes the cache when merge repair covers most of the cache area', () => {
+        const { spreadsheet, skeleton, mainCanvas, cacheCanvas, scene } = fixture;
+        const context = mainCanvas.getContext();
+        const viewportInfo = createViewportInfo(scene, cacheCanvas, {
+            diffBounds: [createBound(0, 200, 460, 280)],
+            diffCacheBounds: [],
+            diffX: 0,
+            diffY: -80,
+            isDirty: 0,
+            isForceDirty: false,
+            shouldCacheUpdate: 0,
+        });
+        spreadsheet.makeDirty(false);
+        spreadsheet.makeForceDirty(false);
+        vi.spyOn(skeleton.worksheet, 'getMergedCellRange').mockReturnValue([
+            { startRow: 0, endRow: 9, startColumn: 0, endColumn: 6, rangeType: RANGE_TYPE.NORMAL },
+        ]);
+
+        const paintSpy = vi.spyOn(spreadsheet, 'paintNewAreaForScrolling');
+        const refreshSpy = vi.spyOn(spreadsheet, 'refreshCacheCanvas');
+
+        spreadsheet.renderByViewports(context, viewportInfo, skeleton);
+
+        expect(refreshSpy).toHaveBeenCalledOnce();
+        expect(paintSpy).not.toHaveBeenCalled();
     });
 
     it('does not repaint merged cells outside the scroll diff', () => {
@@ -1119,28 +1140,6 @@ describe('spreadsheet integration', () => {
         spreadsheet.renderByViewports(context, viewportInfo, skeleton);
 
         expect(drawSpy).not.toHaveBeenCalled();
-    });
-
-    it('uses each repair bound when drawing merged fonts', () => {
-        const { spreadsheet, skeleton, mainCanvas, cacheCanvas, scene } = fixture;
-        const context = mainCanvas.getContext();
-        const fontExtension = { uKey: 'DefaultFontExtension', draw: vi.fn() };
-        (spreadsheet as any)._fontExtension = fontExtension;
-        vi.spyOn(spreadsheet as any, 'getExtensionsByOrder').mockReturnValue([fontExtension]);
-        (skeleton as any)._incrementalFontRenderRanges = [{
-            startRow: 10,
-            endRow: 10,
-            startColumn: 0,
-            endColumn: 4,
-        }];
-        (spreadsheet as any)._refreshIncrementalState = true;
-
-        spreadsheet.draw(context, createViewportInfo(scene, cacheCanvas, {
-            diffBounds: [createBound(100, 60, 220, 140)],
-        }));
-
-        expect(fontExtension.draw.mock.calls[0][4].fontRenderRanges).toBeUndefined();
-        (spreadsheet as any)._refreshIncrementalState = false;
     });
 
     it('refreshes cache for horizontal cache updates to avoid exposing stale cache edges', () => {

--- a/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
+++ b/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
@@ -828,10 +828,10 @@ describe('spreadsheet integration', () => {
 
         skeleton.setStylesCache(createViewportInfo(scene, cacheCanvas, {
             diffBounds: [createBound(100, 60, 220, 140)],
-            diffCacheBounds: [],
+            diffCacheBounds: [createBound(100, 60, 220, 140)],
             diffX: 0,
             diffY: 12,
-            shouldCacheUpdate: 0,
+            shouldCacheUpdate: 1,
             isDirty: 0,
             isForceDirty: false,
         }));
@@ -1064,7 +1064,42 @@ describe('spreadsheet integration', () => {
         cacheCanvas.dispose();
     });
 
-    it('refreshes cache for merged sheets while scrolling to keep merged text visible', () => {
+    it('repairs the full merged range incrementally so merged text remains visible', () => {
+        const { spreadsheet, skeleton, mainCanvas, cacheCanvas, scene } = fixture;
+        const context = mainCanvas.getContext();
+        const mergeInfo = skeleton.getCellWithCoordByIndex(2, 2, false).mergeInfo;
+        const mergedBound = createBound(
+            mergeInfo.startX + skeleton.rowHeaderWidthAndMarginLeft,
+            mergeInfo.startY + skeleton.columnHeaderHeightAndMarginTop,
+            mergeInfo.endX + skeleton.rowHeaderWidthAndMarginLeft,
+            mergeInfo.endY + skeleton.columnHeaderHeightAndMarginTop
+        );
+        const viewportInfo = createViewportInfo(scene, cacheCanvas, {
+            diffBounds: [createBound(mergedBound.right - 8, mergedBound.top, mergedBound.right, mergedBound.bottom)],
+            diffCacheBounds: [],
+            diffX: 0,
+            diffY: -8,
+            isDirty: 0,
+            isForceDirty: false,
+            shouldCacheUpdate: 0,
+        });
+        spreadsheet.makeDirty(false);
+        spreadsheet.makeForceDirty(false);
+
+        const paintSpy = vi.spyOn(spreadsheet, 'paintNewAreaForScrolling');
+        const refreshSpy = vi.spyOn(spreadsheet, 'refreshCacheCanvas');
+        const drawSpy = vi.spyOn(spreadsheet, 'draw').mockImplementation(() => {});
+
+        spreadsheet.renderByViewports(context, viewportInfo, skeleton);
+
+        expect(refreshSpy).not.toHaveBeenCalled();
+        expect(paintSpy).toHaveBeenCalledOnce();
+        expect(drawSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+            diffBounds: [mergedBound],
+        }));
+    });
+
+    it('does not repaint merged cells outside the scroll diff', () => {
         const { spreadsheet, skeleton, mainCanvas, cacheCanvas, scene } = fixture;
         const context = mainCanvas.getContext();
         const viewportInfo = createViewportInfo(scene, cacheCanvas, {
@@ -1079,13 +1114,33 @@ describe('spreadsheet integration', () => {
         spreadsheet.makeDirty(false);
         spreadsheet.makeForceDirty(false);
 
-        const paintSpy = vi.spyOn(spreadsheet, 'paintNewAreaForScrolling');
-        const refreshSpy = vi.spyOn(spreadsheet, 'refreshCacheCanvas');
+        const drawSpy = vi.spyOn(spreadsheet, 'draw').mockImplementation(() => {});
 
         spreadsheet.renderByViewports(context, viewportInfo, skeleton);
 
-        expect(refreshSpy).toHaveBeenCalledOnce();
-        expect(paintSpy).not.toHaveBeenCalled();
+        expect(drawSpy).not.toHaveBeenCalled();
+    });
+
+    it('uses each repair bound when drawing merged fonts', () => {
+        const { spreadsheet, skeleton, mainCanvas, cacheCanvas, scene } = fixture;
+        const context = mainCanvas.getContext();
+        const fontExtension = { uKey: 'DefaultFontExtension', draw: vi.fn() };
+        (spreadsheet as any)._fontExtension = fontExtension;
+        vi.spyOn(spreadsheet as any, 'getExtensionsByOrder').mockReturnValue([fontExtension]);
+        (skeleton as any)._incrementalFontRenderRanges = [{
+            startRow: 10,
+            endRow: 10,
+            startColumn: 0,
+            endColumn: 4,
+        }];
+        (spreadsheet as any)._refreshIncrementalState = true;
+
+        spreadsheet.draw(context, createViewportInfo(scene, cacheCanvas, {
+            diffBounds: [createBound(100, 60, 220, 140)],
+        }));
+
+        expect(fontExtension.draw.mock.calls[0][4].fontRenderRanges).toBeUndefined();
+        (spreadsheet as any)._refreshIncrementalState = false;
     });
 
     it('refreshes cache for horizontal cache updates to avoid exposing stale cache edges', () => {

--- a/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
+++ b/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
@@ -413,20 +413,25 @@ describe('spreadsheet integration', () => {
             { startRow: 5, endRow: 5, startColumn: 2, endColumn: 4, rangeType: RANGE_TYPE.NORMAL },
         ];
         workbookData.sheets['sheet-1'].cellData = {
-            3: { 2: { s: 'leftBorder' } },
-            4: { 2: { s: 'leftBorder' } },
-            5: { 2: { s: 'leftBorder' } },
+            3: { 2: { s: 'leftBorder' }, 3: { s: 'leftBorder' }, 4: { s: 'leftBorder' } },
+            4: { 2: { s: 'leftBorder' }, 3: { s: 'leftBorder' }, 4: { s: 'leftBorder' } },
+            5: { 2: { s: 'leftBorder' }, 3: { s: 'leftBorder' }, 4: { s: 'leftBorder' } },
         };
 
         const workbook = fixture.univer.createUnit<IWorkbookData, Workbook>(UniverInstanceType.UNIVER_SHEET, workbookData);
         const worksheet = workbook.getActiveSheet()!;
         const skeleton = fixture.univer.__getInjector().createInstance(SpreadsheetSkeleton, worksheet, workbook.getStyles()).calculate() as SpreadsheetSkeleton;
         skeleton.setScene(fixture.scene);
+        const mergeBorderSpy = vi.spyOn(
+            skeleton as unknown as { _setMergeBorderProps: (...args: unknown[]) => void },
+            '_setMergeBorderProps'
+        );
         skeleton.setStylesCache(createViewportInfo(fixture.scene, fixture.cacheCanvas));
 
         expect(skeleton.stylesCache.border?.getValue(3, 2)?.l).toEqual(expect.objectContaining({ color: '#000000' }));
         expect(skeleton.stylesCache.border?.getValue(4, 2)?.l).toEqual(expect.objectContaining({ color: '#000000' }));
         expect(skeleton.stylesCache.border?.getValue(5, 2)?.l).toEqual(expect.objectContaining({ color: '#000000' }));
+        expect(mergeBorderSpy).toHaveBeenCalledTimes(12);
     });
 
     it('renders spreadsheet with cache refresh and scrolling diff paths in scene viewport', () => {
@@ -807,6 +812,32 @@ describe('spreadsheet integration', () => {
 
         expect(styleCellSpy).not.toHaveBeenCalled();
         expect(skeleton.rowColumnSegment).toEqual(skeleton.getCacheRangeByViewport(viewportInfo));
+    });
+
+    it('reuses cached member styles while rebuilding merged borders during scrolling', () => {
+        const { skeleton, scene, cacheCanvas } = fixture;
+        skeleton.setStylesCache(createViewportInfo(scene, cacheCanvas));
+        const styleCellSpy = vi.spyOn(
+            skeleton as unknown as { _setStylesCacheForOneCell: (row: number, column: number, options: { reuseExisting?: boolean; mergeRange?: unknown }) => void },
+            '_setStylesCacheForOneCell'
+        );
+        const mergeBorderSpy = vi.spyOn(
+            skeleton as unknown as { _setMergeBorderProps: (...args: unknown[]) => void },
+            '_setMergeBorderProps'
+        );
+
+        skeleton.setStylesCache(createViewportInfo(scene, cacheCanvas, {
+            diffBounds: [createBound(100, 60, 220, 140)],
+            diffCacheBounds: [],
+            diffX: 0,
+            diffY: 12,
+            shouldCacheUpdate: 0,
+            isDirty: 0,
+            isForceDirty: false,
+        }));
+
+        expect(styleCellSpy.mock.calls.some(([, , options]) => options.reuseExisting && !options.mergeRange)).toBe(true);
+        expect(mergeBorderSpy).toHaveBeenCalledTimes(4);
     });
 
     it('skips merge lookups for one-cell style cache when merge data is absent', () => {

--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -442,12 +442,8 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
         const styleRanges = shouldUseIncrementalStyleRange
             ? (vpInfo.shouldCacheUpdate ? (vpInfo.diffCacheBounds?.map((bound) => this.getRangeByViewBound(bound)) ?? []) : [])
             : [rowColumnSegment];
-        const visibleCellOptions: ISetStylesCacheForOneCellOptions | null = hasMergeData
-            ? null
-            : { cacheItem: { bg: true, border: true }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true };
-        const overflowCellOptions: ISetStylesCacheForOneCellOptions | null = hasMergeData
-            ? null
-            : { cacheItem: { bg: false, border: false }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true };
+        const visibleCellOptions: ISetStylesCacheForOneCellOptions = { cacheItem: { bg: true, border: true }, reuseExisting: isIncrementalScroll, hasMergeData, rowVisible: true };
+        const overflowCellOptions: ISetStylesCacheForOneCellOptions = { cacheItem: { bg: false, border: false }, reuseExisting: isIncrementalScroll, hasMergeData, rowVisible: true };
         this._incrementalFontRenderRanges = [];
 
         // clear cache out of visible range
@@ -488,7 +484,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
                 }
 
                 for (let c = visibleStartColumn; c <= visibleEndColumn; c++) {
-                    this._setStylesCacheForOneCell(r, c, visibleCellOptions ?? { cacheItem: { bg: true, border: true }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true });
+                    this._setStylesCacheForOneCell(r, c, visibleCellOptions);
                 }
                 if (shouldUseIncrementalStyleRange) {
                     pushRowRange(this._incrementalFontRenderRanges, r, visibleStartColumn, visibleEndColumn);
@@ -496,7 +492,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
 
                 // Calculate text length for overflow cells just outside the visible range.
                 for (let c = visibleStartColumn - 1; c >= expandStartCol; c--) {
-                    this._setStylesCacheForOneCell(r, c, overflowCellOptions ?? { cacheItem: { bg: false, border: false }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true });
+                    this._setStylesCacheForOneCell(r, c, overflowCellOptions);
                     if (shouldUseIncrementalStyleRange) {
                         pushRowRange(this._incrementalFontRenderRanges, r, c, c);
                     }
@@ -509,7 +505,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
 
                 // Calculate text length for overflow cells just outside the visible range.
                 for (let c = visibleEndColumn + 1; c <= expandEndCol; c++) {
-                    this._setStylesCacheForOneCell(r, c, overflowCellOptions ?? { cacheItem: { bg: false, border: false }, reuseExisting: shouldUseIncrementalStyleRange, hasMergeData, rowVisible: true });
+                    this._setStylesCacheForOneCell(r, c, overflowCellOptions);
                     if (shouldUseIncrementalStyleRange) {
                         pushRowRange(this._incrementalFontRenderRanges, r, c, c);
                     }
@@ -528,7 +524,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
             for (const mergeRange of mergeRanges) {
                 this._setStylesCacheForOneCell(mergeRange.startRow, mergeRange.startColumn, {
                     mergeRange,
-                    reuseExisting: shouldUseIncrementalStyleRange,
+                    reuseExisting: isIncrementalScroll,
                     hasMergeData,
                 });
                 if (shouldUseIncrementalStyleRange) {
@@ -1483,10 +1479,6 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
             const mergeInfo = this.worksheet.getCellInfoInMergeData(row, col);
             isMerged = mergeInfo.isMerged;
             isMergedMainCell = mergeInfo.isMergedMainCell;
-            if (isMerged) {
-                const { startRow, startColumn, endRow, endColumn } = mergeInfo;
-                options.mergeRange = { startRow, startColumn, endRow, endColumn };
-            }
         }
 
         const rowVisible = options.rowVisible ?? this.worksheet.getRowVisible(row);

--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -433,11 +433,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
             !!vpInfo.diffY
         );
         const hasMergeData = this.worksheet.getMergeData().length > 0;
-        const isScrolling = !!vpInfo && (!!vpInfo.diffX || !!vpInfo.diffY);
-        const shouldRefreshCacheForScroll = isIncrementalScroll && (
-            (hasMergeData && isScrolling) ||
-            (!!vpInfo.shouldCacheUpdate && !!vpInfo.diffX)
-        );
+        const shouldRefreshCacheForScroll = isIncrementalScroll && !!vpInfo.shouldCacheUpdate && !!vpInfo.diffX;
         const shouldUseIncrementalStyleRange = isIncrementalScroll && !shouldRefreshCacheForScroll;
         const styleRanges = shouldUseIncrementalStyleRange
             ? (vpInfo.shouldCacheUpdate ? (vpInfo.diffCacheBounds?.map((bound) => this.getRangeByViewBound(bound)) ?? []) : [])

--- a/packages/engine-render/src/components/sheets/spreadsheet.ts
+++ b/packages/engine-render/src/components/sheets/spreadsheet.ts
@@ -181,6 +181,10 @@ interface IBlitRect {
     dh: number;
 }
 
+function boundsOverlap(a: IBoundRectNoAngle, b: IBoundRectNoAngle) {
+    return a.left <= b.right && a.right >= b.left && a.top <= b.bottom && a.bottom >= b.top;
+}
+
 /**
  * Clip a blit source rectangle to the source canvas bounds and shrink the destination
  * rectangle proportionally, as required by the HTML spec:
@@ -350,7 +354,9 @@ export class Spreadsheet extends SheetComponent {
             extension.draw(ctx, parentScale, spreadsheetSkeleton, extensionDiffRanges, {
                 viewRanges: extensionViewRanges,
                 checkOutOfViewBound: true,
-                fontRenderRanges: extension === this._fontExtension ? spreadsheetSkeleton.incrementalFontRenderRanges : undefined,
+                fontRenderRanges: extension === this._fontExtension && !hasMergeData
+                    ? spreadsheetSkeleton.incrementalFontRenderRanges
+                    : undefined,
                 hasMergeData,
                 viewportKey: viewportInfo.viewportKey,
                 viewBound: viewportInfo.cacheBound,
@@ -477,7 +483,8 @@ export class Spreadsheet extends SheetComponent {
             Math.abs(diffY) * scaleY >= cacheCanvas.getHeight() * cachePixelRatio;
         const hasMergeData = spreadsheetSkeleton.worksheet.getMergeData().length > 0;
         const isScrolling = diffX !== 0 || diffY !== 0;
-        const shouldRefreshCache = isDirty || isForceDirty || isScrollJumpOutsideCache || (hasMergeData && isScrolling) || (shouldCacheUpdate && diffX !== 0);
+        const mergeRepairBounds = this._getMergeRepairBounds(spreadsheetSkeleton, viewportInfo, hasMergeData, isScrolling);
+        const shouldRefreshCache = isDirty || isForceDirty || isScrollJumpOutsideCache || (shouldCacheUpdate && diffX !== 0);
         if (diffBounds.length === 0 || (diffX === 0 && diffY === 0) || shouldRefreshCache) {
             if (shouldRefreshCache) {
                 this.addRenderTagToScene('scrolling', false);
@@ -498,7 +505,7 @@ export class Spreadsheet extends SheetComponent {
                 scaleY,
                 columnHeaderHeightAndMarginTop,
                 rowHeaderWidthAndMarginLeft,
-            });
+            }, mergeRepairBounds);
         }
         // support for browser native zoom (only windows has this problem)
         const sourceLeft = bufferEdgeSizeX * Math.min(1, window.devicePixelRatio);
@@ -510,7 +517,39 @@ export class Spreadsheet extends SheetComponent {
         cacheCtx.restore();
     }
 
-    paintNewAreaForScrolling(viewportInfo: IViewportInfo, param: IPaintForScrolling) {
+    private _getMergeRepairBounds(spreadsheetSkeleton: SpreadsheetSkeleton, viewportInfo: IViewportInfo, hasMergeData: boolean, isScrolling: boolean) {
+        if (!hasMergeData || !isScrolling) {
+            return [];
+        }
+
+        const { columnWidthAccumulation, rowHeightAccumulation, rowHeaderWidthAndMarginLeft, columnHeaderHeightAndMarginTop } = spreadsheetSkeleton;
+        const dirtyBounds = viewportInfo.shouldCacheUpdate ? viewportInfo.diffCacheBounds : viewportInfo.diffBounds;
+        const mergeBounds: IBoundRectNoAngle[] = [];
+        const visited = new Set<string>();
+
+        for (const dirtyBound of dirtyBounds) {
+            const range = spreadsheetSkeleton.getRangeByViewBound(dirtyBound);
+            const mergeRanges = spreadsheetSkeleton.worksheet.getMergedCellRange(range.startRow, range.startColumn, range.endRow, range.endColumn);
+            for (const mergeRange of mergeRanges) {
+                const key = `${mergeRange.startRow}:${mergeRange.startColumn}`;
+                if (visited.has(key)) {
+                    continue;
+                }
+                visited.add(key);
+
+                mergeBounds.push({
+                    left: (columnWidthAccumulation[mergeRange.startColumn - 1] ?? 0) + rowHeaderWidthAndMarginLeft,
+                    top: (rowHeightAccumulation[mergeRange.startRow - 1] ?? 0) + columnHeaderHeightAndMarginTop,
+                    right: columnWidthAccumulation[mergeRange.endColumn] + rowHeaderWidthAndMarginLeft,
+                    bottom: rowHeightAccumulation[mergeRange.endRow] + columnHeaderHeightAndMarginTop,
+                });
+            }
+        }
+
+        return mergeBounds;
+    }
+
+    paintNewAreaForScrolling(viewportInfo: IViewportInfo, param: IPaintForScrolling, mergeRepairBounds: IBoundRectNoAngle[] = []) {
         const { cacheCanvas, cacheCtx, mainCtx, topOrigin, leftOrigin, bufferEdgeX, bufferEdgeY, scaleX, scaleY, columnHeaderHeightAndMarginTop, rowHeaderWidthAndMarginLeft } = param;
         const { shouldCacheUpdate, diffCacheBounds, diffX, diffY } = viewportInfo;
         cacheCtx.save();
@@ -529,8 +568,20 @@ export class Spreadsheet extends SheetComponent {
         // - (leftOrigin - bufferEdgeX)  ----> simplified to - leftOrigin + bufferEdgeX
         cacheCtx.translateWithPrecision(m.e / m.a - leftOrigin + bufferEdgeX, m.f / m.d - topOrigin + bufferEdgeY);
 
-        if (shouldCacheUpdate) {
-            for (const diffBound of diffCacheBounds) {
+        const repaintBounds = shouldCacheUpdate ? diffCacheBounds.map((bound) => ({ ...bound })) : [];
+        for (const mergeRepairBound of mergeRepairBounds) {
+            const overlappingBound = repaintBounds.find((bound) => boundsOverlap(bound, mergeRepairBound));
+            if (overlappingBound) {
+                overlappingBound.left = Math.min(overlappingBound.left, mergeRepairBound.left);
+                overlappingBound.top = Math.min(overlappingBound.top, mergeRepairBound.top);
+                overlappingBound.right = Math.max(overlappingBound.right, mergeRepairBound.right);
+                overlappingBound.bottom = Math.max(overlappingBound.bottom, mergeRepairBound.bottom);
+            } else {
+                repaintBounds.push(mergeRepairBound);
+            }
+        }
+        if (repaintBounds.length) {
+            for (const diffBound of repaintBounds) {
                 const { left: diffLeft, right: diffRight, bottom: diffBottom, top: diffTop } = diffBound;
 
                 // When this.draw, ctx.translate cell offset is relative to spreadsheet content

--- a/packages/engine-render/src/components/sheets/spreadsheet.ts
+++ b/packages/engine-render/src/components/sheets/spreadsheet.ts
@@ -37,6 +37,16 @@ import { SHEET_EXTENSION_PREFIX } from './extensions/sheet-extension';
 import { SheetComponent } from './sheet-component';
 
 const OBJECT_KEY = '__SHEET_EXTENSION_FONT_DOCUMENT_INSTANCE__';
+const MERGE_REPAIR_CACHE_REFRESH_RATIO = 0.6;
+const CUSTOM_EXTENSION_KEY = 'DefaultCustomExtension';
+const MARKER_EXTENSION_KEY = 'DefaultMarkerExtension';
+const RANGE_PROTECTION_VIEW_EXTENSION_KEY = 'RANGE_PROTECTION_CAN_VIEW_RENDER_EXTENSION_KEY';
+const RANGE_PROTECTION_HIDDEN_EXTENSION_KEY = 'RANGE_PROTECTION_CAN_NOT_VIEW_RENDER_EXTENSION_KEY';
+
+interface IRepaintBound {
+    bound: IBoundRectNoAngle;
+    repairsMerge: boolean;
+}
 
 interface ISparseExtensionFeatureFlags {
     hasCustomRender: boolean;
@@ -64,7 +74,7 @@ function pushSparseCellRange(ranges: IRange[], row: number, col: number) {
 
 function scanSparseExtensionFeatures(spreadsheetSkeleton: SpreadsheetSkeleton, ranges: IRange[]): ISparseExtensionFeatureFlags | null {
     const { worksheet } = spreadsheetSkeleton;
-    if (!worksheet || !ranges.length || worksheet.getMergeData().length > 0) {
+    if (!worksheet || !ranges.length) {
         return null;
     }
     const flags: ISparseExtensionFeatureFlags = {
@@ -126,12 +136,12 @@ function shouldSkipSparseExtension(uKey: string, flags: ISparseExtensionFeatureF
     }
 
     switch (uKey) {
-        case 'DefaultCustomExtension':
+        case CUSTOM_EXTENSION_KEY:
             return !flags.hasCustomRender;
-        case 'DefaultMarkerExtension':
+        case MARKER_EXTENSION_KEY:
             return !flags.hasMarkers;
-        case 'RANGE_PROTECTION_CAN_VIEW_RENDER_EXTENSION_KEY':
-        case 'RANGE_PROTECTION_CAN_NOT_VIEW_RENDER_EXTENSION_KEY':
+        case RANGE_PROTECTION_VIEW_EXTENSION_KEY:
+        case RANGE_PROTECTION_HIDDEN_EXTENSION_KEY:
             return !flags.hasSelectionProtection;
         default:
             return false;
@@ -141,10 +151,10 @@ function shouldSkipSparseExtension(uKey: string, flags: ISparseExtensionFeatureF
 function hasSparseExtension(extensions: Array<{ uKey: string }>) {
     return extensions.some((extension) => {
         switch (extension.uKey) {
-            case 'DefaultCustomExtension':
-            case 'DefaultMarkerExtension':
-            case 'RANGE_PROTECTION_CAN_VIEW_RENDER_EXTENSION_KEY':
-            case 'RANGE_PROTECTION_CAN_NOT_VIEW_RENDER_EXTENSION_KEY':
+            case CUSTOM_EXTENSION_KEY:
+            case MARKER_EXTENSION_KEY:
+            case RANGE_PROTECTION_VIEW_EXTENSION_KEY:
+            case RANGE_PROTECTION_HIDDEN_EXTENSION_KEY:
                 return true;
             default:
                 return false;
@@ -158,12 +168,12 @@ function getSparseExtensionDiffRanges(uKey: string, flags: ISparseExtensionFeatu
     }
 
     switch (uKey) {
-        case 'DefaultCustomExtension':
+        case CUSTOM_EXTENSION_KEY:
             return flags.customRenderRanges;
-        case 'DefaultMarkerExtension':
+        case MARKER_EXTENSION_KEY:
             return flags.markerRanges;
-        case 'RANGE_PROTECTION_CAN_VIEW_RENDER_EXTENSION_KEY':
-        case 'RANGE_PROTECTION_CAN_NOT_VIEW_RENDER_EXTENSION_KEY':
+        case RANGE_PROTECTION_VIEW_EXTENSION_KEY:
+        case RANGE_PROTECTION_HIDDEN_EXTENSION_KEY:
             return flags.selectionProtectionRanges;
         default:
             return diffRanges;
@@ -183,6 +193,21 @@ interface IBlitRect {
 
 function boundsOverlap(a: IBoundRectNoAngle, b: IBoundRectNoAngle) {
     return a.left <= b.right && a.right >= b.left && a.top <= b.bottom && a.bottom >= b.top;
+}
+
+function getClippedBoundArea(bound: IBoundRectNoAngle, clipBound: IBoundRectNoAngle) {
+    const width = Math.max(0, Math.min(bound.right, clipBound.right) - Math.max(bound.left, clipBound.left));
+    const height = Math.max(0, Math.min(bound.bottom, clipBound.bottom) - Math.max(bound.top, clipBound.top));
+    return width * height;
+}
+
+function exceedsMergeRepairThreshold(cacheBound: IBoundRectNoAngle, repaintBounds: IRepaintBound[], hasMergeRepair: boolean) {
+    if (!hasMergeRepair) {
+        return false;
+    }
+    const cacheArea = getClippedBoundArea(cacheBound, cacheBound);
+    const repaintArea = repaintBounds.reduce((area, repaintBound) => area + getClippedBoundArea(repaintBound.bound, cacheBound), 0);
+    return repaintArea >= cacheArea * MERGE_REPAIR_CACHE_REFRESH_RATIO;
 }
 
 /**
@@ -309,7 +334,7 @@ export class Spreadsheet extends SheetComponent {
      * @param ctx
      * @param viewportInfo
      */
-    override draw(ctx: UniverRenderingContext2D, viewportInfo: IViewportInfo) {
+    override draw(ctx: UniverRenderingContext2D, viewportInfo: IViewportInfo, isMergeRepair = false) {
         const spreadsheetSkeleton = this.getSkeleton();
         if (!spreadsheetSkeleton) {
             return;
@@ -334,7 +359,7 @@ export class Spreadsheet extends SheetComponent {
             }))
             : viewRanges;
         const extensions = this.getExtensionsByOrder();
-        const sparseExtensionFeatures = !hasMergeData && hasSparseExtension(extensions)
+        const sparseExtensionFeatures = !isMergeRepair && hasSparseExtension(extensions)
             ? scanSparseExtensionFeatures(spreadsheetSkeleton, viewRanges)
             : null;
         // At this moment, ctx.transform is at topLeft of sheet content, cell(0, 0)
@@ -354,7 +379,7 @@ export class Spreadsheet extends SheetComponent {
             extension.draw(ctx, parentScale, spreadsheetSkeleton, extensionDiffRanges, {
                 viewRanges: extensionViewRanges,
                 checkOutOfViewBound: true,
-                fontRenderRanges: extension === this._fontExtension && !hasMergeData
+                fontRenderRanges: extension === this._fontExtension && !isMergeRepair
                     ? spreadsheetSkeleton.incrementalFontRenderRanges
                     : undefined,
                 hasMergeData,
@@ -484,7 +509,9 @@ export class Spreadsheet extends SheetComponent {
         const hasMergeData = spreadsheetSkeleton.worksheet.getMergeData().length > 0;
         const isScrolling = diffX !== 0 || diffY !== 0;
         const mergeRepairBounds = this._getMergeRepairBounds(spreadsheetSkeleton, viewportInfo, hasMergeData, isScrolling);
-        const shouldRefreshCache = isDirty || isForceDirty || isScrollJumpOutsideCache || (shouldCacheUpdate && diffX !== 0);
+        const repaintBounds = this._getRepaintBounds(viewportInfo, mergeRepairBounds);
+        const shouldRefreshForMergeRepairArea = exceedsMergeRepairThreshold(viewportInfo.cacheBound, repaintBounds, mergeRepairBounds.length > 0);
+        const shouldRefreshCache = isDirty || isForceDirty || isScrollJumpOutsideCache || shouldRefreshForMergeRepairArea || (shouldCacheUpdate && diffX !== 0);
         if (diffBounds.length === 0 || (diffX === 0 && diffY === 0) || shouldRefreshCache) {
             if (shouldRefreshCache) {
                 this.addRenderTagToScene('scrolling', false);
@@ -549,9 +576,28 @@ export class Spreadsheet extends SheetComponent {
         return mergeBounds;
     }
 
+    private _getRepaintBounds(viewportInfo: IViewportInfo, mergeRepairBounds: IBoundRectNoAngle[]): IRepaintBound[] {
+        const repaintBounds: IRepaintBound[] = viewportInfo.shouldCacheUpdate
+            ? viewportInfo.diffCacheBounds.map((bound) => ({ bound: { ...bound }, repairsMerge: false }))
+            : [];
+        for (const mergeRepairBound of mergeRepairBounds) {
+            const overlappingBound = repaintBounds.find(({ bound }) => boundsOverlap(bound, mergeRepairBound));
+            if (overlappingBound) {
+                overlappingBound.bound.left = Math.min(overlappingBound.bound.left, mergeRepairBound.left);
+                overlappingBound.bound.top = Math.min(overlappingBound.bound.top, mergeRepairBound.top);
+                overlappingBound.bound.right = Math.max(overlappingBound.bound.right, mergeRepairBound.right);
+                overlappingBound.bound.bottom = Math.max(overlappingBound.bound.bottom, mergeRepairBound.bottom);
+                overlappingBound.repairsMerge = true;
+            } else {
+                repaintBounds.push({ bound: { ...mergeRepairBound }, repairsMerge: true });
+            }
+        }
+        return repaintBounds;
+    }
+
     paintNewAreaForScrolling(viewportInfo: IViewportInfo, param: IPaintForScrolling, mergeRepairBounds: IBoundRectNoAngle[] = []) {
         const { cacheCanvas, cacheCtx, mainCtx, topOrigin, leftOrigin, bufferEdgeX, bufferEdgeY, scaleX, scaleY, columnHeaderHeightAndMarginTop, rowHeaderWidthAndMarginLeft } = param;
-        const { shouldCacheUpdate, diffCacheBounds, diffX, diffY } = viewportInfo;
+        const { diffX, diffY } = viewportInfo;
         cacheCtx.save();
         cacheCtx.setTransform(1, 0, 0, 1, 0, 0);
         cacheCtx.globalCompositeOperation = 'copy';
@@ -568,20 +614,9 @@ export class Spreadsheet extends SheetComponent {
         // - (leftOrigin - bufferEdgeX)  ----> simplified to - leftOrigin + bufferEdgeX
         cacheCtx.translateWithPrecision(m.e / m.a - leftOrigin + bufferEdgeX, m.f / m.d - topOrigin + bufferEdgeY);
 
-        const repaintBounds = shouldCacheUpdate ? diffCacheBounds.map((bound) => ({ ...bound })) : [];
-        for (const mergeRepairBound of mergeRepairBounds) {
-            const overlappingBound = repaintBounds.find((bound) => boundsOverlap(bound, mergeRepairBound));
-            if (overlappingBound) {
-                overlappingBound.left = Math.min(overlappingBound.left, mergeRepairBound.left);
-                overlappingBound.top = Math.min(overlappingBound.top, mergeRepairBound.top);
-                overlappingBound.right = Math.max(overlappingBound.right, mergeRepairBound.right);
-                overlappingBound.bottom = Math.max(overlappingBound.bottom, mergeRepairBound.bottom);
-            } else {
-                repaintBounds.push(mergeRepairBound);
-            }
-        }
+        const repaintBounds = this._getRepaintBounds(viewportInfo, mergeRepairBounds);
         if (repaintBounds.length) {
-            for (const diffBound of repaintBounds) {
+            for (const { bound: diffBound, repairsMerge } of repaintBounds) {
                 const { left: diffLeft, right: diffRight, bottom: diffBottom, top: diffTop } = diffBound;
 
                 // When this.draw, ctx.translate cell offset is relative to spreadsheet content
@@ -604,7 +639,7 @@ export class Spreadsheet extends SheetComponent {
                 this.draw(cacheCtx, {
                     ...viewportInfo,
                     diffBounds: [diffBound],
-                });
+                }, repairsMerge);
                 cacheCtx.restore();
             }
         }


### PR DESCRIPTION
Closes dream-num/univer-cli#1096

Supersedes #7389 by folding the initial merged-cell style optimization into the complete merge-aware implementation.

## What changed

- reuse merged-cell style and border work during incremental sheet scrolling
- repair the full bounds of intersecting merged cells so text, background, and borders remain intact
- fall back to a full canvas refresh when a large scroll or repaired area makes incremental repainting more expensive
- scope conservative font and sparse rendering behavior to the repaired bounds
- cache locale date tokens with safe invalidation when locale data changes
- add focused unit/integration coverage plus a pixel-diff visual regression that compares incremental repaint with a forced full repaint

This is an engine-render/core performance fix. It does not add UI, Facade APIs, commands, DI wiring, menus, icons, translations, or new public contracts. No architecture documentation update is needed because package ownership and dependency directions are unchanged.

## Validation

- `pnpm --filter @univerjs/engine-render test` — 93 files, 843 passed, 59 skipped
- `pnpm --filter @univerjs/core test` — 148 files passed, 3 skipped; 978 tests passed, 10 skipped
- `pnpm --filter @univerjs/engine-render typecheck`
- `pnpm --filter @univerjs/core typecheck`
- ESLint on all six changed files
- `git diff --check origin/dev...HEAD`
- browser pixel comparison: 0 differing RGBA pixels between incremental and forced full repaint

Merge-heavy sample, 3-run median:

- ±96 px scrolling: 755 ms → 447 ms versus the initial style-only baseline (about 41% faster)
- ±600 px scrolling: 762 ms → 620 ms (about 19% faster)
- no long tasks observed

Date parsing microbenchmark, 20k calls:

- cached locale-token path: 40.84 ms
- forced token rebuild: 135.75 ms

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed; no new plugins, commands, or resources are introduced.
- [x] Unit and integration tests have been added for the changes.
- [x] No breaking changes are introduced.
