### PR TITLE
fix(ui): restore custom dropdown panel padding

### DIFF
--- a/packages/sheets-crosshair-highlight/src/menu/crosshair.menu.ts
+++ b/packages/sheets-crosshair-highlight/src/menu/crosshair.menu.ts
@@ -41,6 +41,7 @@ export function CrosshairHighlightMenuItemFactory(accessor: IAccessor): IMenuSel
                     name: CROSSHAIR_HIGHLIGHT_OVERLAY_COMPONENT,
                     hoverable: false,
                     selectable: false,
+                    props: { embedded: true },
                 },
             },
         ],

--- a/packages/ui/src/views/components/ribbon/TooltipButtonWrapper.tsx
+++ b/packages/ui/src/views/components/ribbon/TooltipButtonWrapper.tsx
@@ -309,12 +309,16 @@ export function DropdownMenuWrapper({
 
     // options menu
     if (options?.length) {
-        const isSingleCustomPanel = options.length === 1 && typeof options[0].label === 'object' && options[0].label?.hoverable === false;
+        const isSingleEmbeddedCustomPanel = filteredMenuItems.length === 0 &&
+            options.length === 1 &&
+            typeof options[0].label === 'object' &&
+            options[0].label?.hoverable === false &&
+            options[0].label.props?.embedded === true;
         const items: IDropdownMenuProps['items'] = options.map((option) => ({
             type: 'item',
             className: clsx({
                 'focus:univer-bg-white': typeof option.label !== 'string' && option.label?.hoverable === false,
-                '!univer-p-0': typeof option.label !== 'string' && option.label?.hoverable === false,
+                '!univer-p-0': isSingleEmbeddedCustomPanel,
             }),
             children: (
                 <DropdownMenuLabel
@@ -375,7 +379,7 @@ export function DropdownMenuWrapper({
         return (
             <DropdownMenu
                 align="start"
-                className={clsx({ '!univer-p-0': isSingleCustomPanel })}
+                className={clsx({ '!univer-p-0': isSingleEmbeddedCustomPanel })}
                 items={items}
                 disabled={disabled}
                 open={dropdownVisible}

--- a/packages/ui/src/views/components/ribbon/__tests__/TooltipButtonWrapper.spec.tsx
+++ b/packages/ui/src/views/components/ribbon/__tests__/TooltipButtonWrapper.spec.tsx
@@ -23,8 +23,10 @@ import { cleanup, fireEvent, render } from '@testing-library/react';
 import { ILogService, Injector, LocaleService } from '@univerjs/core';
 import { of } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { ComponentManager } from '../../../../common/component-manager';
 import { IconManager } from '../../../../common/icon-manager';
+import { MenuItemType } from '../../../../services/menu/menu';
 import { IMenuManagerService } from '../../../../services/menu/menu-manager.service';
 import { connectInjector } from '../../../../utils/di';
 import {
@@ -45,7 +47,10 @@ class TestLogService {
     warn(): void {}
 }
 
-function renderWithDependencies(element: ReactElement) {
+function renderWithDependencies(
+    element: ReactElement,
+    menuItems: ReturnType<IMenuManagerService['getMenuByPositionKey']> = []
+) {
     const injector = new Injector();
     injector.add([LocaleService, { useClass: TestLocaleService as never }]);
     injector.add([ILogService, { useClass: TestLogService as never }]);
@@ -56,7 +61,7 @@ function renderWithDependencies(element: ReactElement) {
             menuChanged$: of(undefined),
             mergeMenu: () => {},
             appendRootMenu: () => {},
-            getMenuByPositionKey: () => [],
+            getMenuByPositionKey: () => menuItems,
             getFlatMenuByPositionKey: () => [],
         },
     }]);
@@ -120,7 +125,7 @@ describe('DropdownWrapper', () => {
 });
 
 describe('DropdownMenuWrapper', () => {
-    it('renders a single non-hoverable custom panel flush with the dropdown edge', async () => {
+    it('renders a single embedded custom panel flush with the dropdown edge', async () => {
         const { findByRole, getByRole } = renderWithDependencies(
             <ToolbarDropdownProvider>
                 <TooltipWrapper dropdownKey="test-custom-panel">
@@ -131,6 +136,7 @@ describe('DropdownMenuWrapper', () => {
                                 name: 'TestDynamicOption',
                                 hoverable: false,
                                 selectable: false,
+                                props: { embedded: true },
                             },
                         }]}
                         onOptionSelect={vi.fn()}
@@ -148,5 +154,75 @@ describe('DropdownMenuWrapper', () => {
 
         expect(menuItem?.className).toContain('!univer-p-0');
         expect(menuContent?.className).toContain('!univer-p-0');
+    });
+
+    it('keeps padding around a non-embedded custom panel', async () => {
+        const { findByRole, getByRole } = renderWithDependencies(
+            <ToolbarDropdownProvider>
+                <TooltipWrapper dropdownKey="test-non-embedded-custom-panel">
+                    <DropdownMenuWrapper
+                        menuId="test-menu"
+                        options={[{
+                            label: {
+                                name: 'TestDynamicOption',
+                                hoverable: false,
+                                selectable: false,
+                            },
+                        }]}
+                        onOptionSelect={vi.fn()}
+                    >
+                        <button type="button">Open non-embedded custom panel</button>
+                    </DropdownMenuWrapper>
+                </TooltipWrapper>
+            </ToolbarDropdownProvider>
+        );
+
+        fireEvent.pointerDown(getByRole('button', { name: 'Open non-embedded custom panel' }), { button: 0, ctrlKey: false });
+        const option = await findByRole('button', { name: 'Choose dynamic value' });
+        const menuItem = option.closest('[data-slot="dropdown-menu-item"]');
+        const menuContent = option.closest('[data-slot="dropdown-menu-content"]');
+
+        expect(menuItem?.className).not.toContain('!univer-p-0');
+        expect(menuContent?.className).not.toContain('!univer-p-0');
+    });
+
+    it('keeps padding around a custom panel when menu actions follow it', async () => {
+        const { findByRole, getByRole } = renderWithDependencies(
+            <ToolbarDropdownProvider>
+                <TooltipWrapper dropdownKey="test-custom-panel-with-action">
+                    <DropdownMenuWrapper
+                        menuId="test-menu"
+                        options={[{
+                            label: {
+                                name: 'TestDynamicOption',
+                                hoverable: false,
+                                selectable: false,
+                                props: { embedded: true },
+                            },
+                        }]}
+                        onOptionSelect={vi.fn()}
+                    >
+                        <button type="button">Open custom panel with action</button>
+                    </DropdownMenuWrapper>
+                </TooltipWrapper>
+            </ToolbarDropdownProvider>,
+            [{
+                key: 'reset',
+                order: 0,
+                item: {
+                    id: 'reset',
+                    type: MenuItemType.BUTTON,
+                    title: 'Reset',
+                },
+            }]
+        );
+
+        fireEvent.pointerDown(getByRole('button', { name: 'Open custom panel with action' }), { button: 0, ctrlKey: false });
+        const option = await findByRole('button', { name: 'Choose dynamic value' });
+        const menuItem = option.closest('[data-slot="dropdown-menu-item"]');
+        const menuContent = option.closest('[data-slot="dropdown-menu-content"]');
+
+        expect(menuItem?.className).not.toContain('!univer-p-0');
+        expect(menuContent?.className).not.toContain('!univer-p-0');
     });
 });


### PR DESCRIPTION
## Summary

- Restore the default dropdown inset for non-embedded custom panels.
- Preserve edge-to-edge rendering only for a single embedded panel with no additional menu actions.
- Mark the self-padded Crosshair panel as embedded and add regression coverage.

## Root cause

The shared dropdown wrapper treated every non-hoverable custom option as an edge-to-edge panel. It also removed menu padding when actions such as Reset followed the panel, causing controls and selection rings to touch or clip against the dropdown edge.

## Tests

- `pnpm --filter @univerjs/ui exec vitest run src/views/components/ribbon/__tests__/TooltipButtonWrapper.spec.tsx`
- `pnpm --filter @univerjs/sheets-crosshair-highlight exec vitest run src/views/components/__tests__/CrosshairHighlight.spec.tsx`
- `pnpm --filter @univerjs/ui typecheck`
- `pnpm --filter @univerjs/sheets-crosshair-highlight typecheck`
- Focused ESLint and `git diff --check`

## Pull Request Checklist

- [x] Related tickets or issues are missing.
- [x] Naming conventions are followed.
- [x] Unit tests cover the changed behavior.
- [x] No breaking changes are introduced.
