### PR TITLE
fix(engine-render): resolve effective group flip state

### DIFF
--- a/packages/engine-render/src/base-object.ts
+++ b/packages/engine-render/src/base-object.ts
@@ -605,6 +605,26 @@ export abstract class BaseObject extends Disposable {
         };
     }
 
+    /**
+     * Returns the flip state after composing this object with every ancestor
+     * drawing group whose transform participates in rendering.
+     */
+    getEffectiveFlipState(): { flipX: boolean; flipY: boolean } {
+        let flipX = this.flipX;
+        let flipY = this.flipY;
+        let isInGroup = this.isInGroup;
+        let parent = this.getParent();
+
+        while (isInGroup && parent?.classType === RENDER_CLASS_TYPE.GROUP) {
+            flipX = flipX !== Boolean(parent.flipX);
+            flipY = flipY !== Boolean(parent.flipY);
+            isInGroup = Boolean(parent.isInGroup);
+            parent = parent.getParent();
+        }
+
+        return { flipX, flipY };
+    }
+
     getRealBound(): IGroupBaseBound {
         let { width: realWidth, height: realHeight, left: realLeft, top: realTop } = this;
         let baseBound;


### PR DESCRIPTION
## What changed

- add `BaseObject.getEffectiveFlipState()`
- XOR-compose local flip flags with every rendered drawing-group ancestor
- expose a neutral engine capability for shape-text consumers

## Why

Drawing groups correctly apply their transforms to descendants, but consumers that inspect only an object's local `flipX` cannot detect reflection inherited from a parent group. This is the OSS prerequisite for fixing mirrored Slide text in dream-num/univer-cli#1020.

## Validation

- `@univerjs/engine-render` typecheck
- 93 test files passed
- 843 tests passed, 59 skipped
- targeted lint: 0 errors
