### PR TITLE
fix(sheets): report invalid row insertion parameters

### DIFF
--- a/packages/sheets/src/facade/__tests__/f-worksheet.spec.ts
+++ b/packages/sheets/src/facade/__tests__/f-worksheet.spec.ts
@@ -320,6 +320,42 @@ describe('Test FWorksheet', () => {
         expect(sheet?.getMaxRows()).toBe(102);
     });
 
+    it('Worksheet inserts rows after the last valid row index', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getSheetByName('sheet1')!;
+        const rowCount = activeSheet.getMaxRows();
+
+        activeSheet.insertRowsAfter(rowCount - 1, 30);
+
+        expect(activeSheet.getMaxRows()).toBe(rowCount + 30);
+    });
+
+    it('Worksheet rejects invalid row insertion indexes with actionable errors', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getSheetByName('sheet1')!;
+        const rowCount = activeSheet.getMaxRows();
+        const executeCommand = vi.spyOn(commandService, 'syncExecuteCommand');
+
+        expect(() => activeSheet.insertRows(rowCount, 30)).toThrowError(
+            `insertRows(): row index ${rowCount} is out of bounds. ` +
+            `The worksheet has ${rowCount} rows; expected an integer from 0 to ${rowCount - 1}. ` +
+            `To insert 30 row(s) at the bottom, use insertRowsAfter(${rowCount - 1}, 30). ` +
+            `To resize the worksheet directly, use setRowCount(${rowCount + 30}).`
+        );
+        expect(() => activeSheet.insertRowsAfter(-1, 1)).toThrowError(/expected an integer from 0 to 99/);
+        expect(() => activeSheet.insertRowAfter(rowCount)).toThrowError(/insertRowsAfter\(\): row index 100/);
+        expect(() => activeSheet.insertRowBefore(-1)).toThrowError(/insertRowsBefore\(\): row index -1/);
+        expect(executeCommand).not.toHaveBeenCalled();
+    });
+
+    it('Worksheet rejects invalid row insertion counts', () => {
+        const activeSheet = univerAPI.getActiveWorkbook()!.getSheetByName('sheet1')!;
+        const executeCommand = vi.spyOn(commandService, 'syncExecuteCommand');
+
+        expect(() => activeSheet.insertRows(0, 0)).toThrowError('insertRows(): row count 0 must be a positive integer.');
+        expect(() => activeSheet.insertRowsBefore(0, -1)).toThrowError('insertRowsBefore(): row count -1 must be a positive integer.');
+        expect(() => activeSheet.insertRowsAfter(0, 1.5)).toThrowError('insertRowsAfter(): row count 1.5 must be a positive integer.');
+        expect(executeCommand).not.toHaveBeenCalled();
+    });
+
     it('Worksheet deleteRow', async () => {
         const activeSheet = univerAPI.getActiveWorkbook()?.getSheetByName('sheet1');
 
@@ -629,10 +665,17 @@ describe('Test FWorksheet', () => {
     it('Worksheet appends rows and updates sheet dimensions through facade APIs', () => {
         const activeSheet = univerAPI.getActiveWorkbook()!.getActiveSheet();
 
+        const initialMaxRows = activeSheet.getMaxRows();
         const initialLastRow = activeSheet.getLastRow();
         activeSheet.appendRow(['North', 100, true]);
         expect(activeSheet.getRange(initialLastRow + 1, 0, 1, 3).getValues()).toEqual([['North', 100, 1]]);
         expect(activeSheet.getDataRange().getA1Notation()).toBe(`A1:C${initialLastRow + 2}`);
+        expect(activeSheet.getMaxRows()).toBe(initialMaxRows);
+
+        activeSheet.getRange(initialMaxRows - 1, 0).setValue('at capacity');
+        activeSheet.appendRow(['expanded']);
+        expect(activeSheet.getMaxRows()).toBe(initialMaxRows + 1);
+        expect(activeSheet.getRange(initialMaxRows, 0).getValue()).toBe('expanded');
 
         activeSheet.setRowCount(120);
         activeSheet.setColumnCount(80);

--- a/packages/sheets/src/facade/f-worksheet.ts
+++ b/packages/sheets/src/facade/f-worksheet.ts
@@ -97,6 +97,22 @@ import { FSelection } from './f-selection';
 import { FWorksheetPermission } from './permission/f-worksheet-permission';
 import { covertToColRange, covertToRowRange } from './utils';
 
+function assertValidRowInsertion(methodName: string, rowIndex: number, rowCount: number, howMany: number): void {
+    if (!Number.isInteger(howMany) || howMany <= 0) {
+        throw new RangeError(`${methodName}(): row count ${howMany} must be a positive integer.`);
+    }
+
+    const lastRowIndex = rowCount - 1;
+    if (!Number.isInteger(rowIndex) || rowIndex < 0 || rowIndex > lastRowIndex) {
+        throw new RangeError(
+            `${methodName}(): row index ${rowIndex} is out of bounds. ` +
+            `The worksheet has ${rowCount} rows; expected an integer from 0 to ${lastRowIndex}. ` +
+            `To insert ${howMany} row(s) at the bottom, use insertRowsAfter(${lastRowIndex}, ${howMany}). ` +
+            `To resize the worksheet directly, use setRowCount(${rowCount + howMany}).`
+        );
+    }
+}
+
 export interface IFacadeClearOptions {
     contentsOnly?: boolean;
     formatOnly?: boolean;
@@ -536,7 +552,7 @@ export class FWorksheet extends FBaseInitialable {
 
     /**
      * Inserts a row after the given row position.
-     * @param {number} afterPosition - The row after which the new row should be added, starting at 0 for the first row.
+     * @param {number} afterPosition - The existing row after which the new row should be added. The index is zero-based and must be between 0 and `getMaxRows() - 1`.
      * @returns {FWorksheet} This sheet, for chaining.
      * @example
      * ```typescript
@@ -554,7 +570,7 @@ export class FWorksheet extends FBaseInitialable {
 
     /**
      * Inserts a row before the given row position.
-     * @param {number} beforePosition - The row before which the new row should be added, starting at 0 for the first row.
+     * @param {number} beforePosition - The existing row before which the new row should be added. The index is zero-based and must be between 0 and `getMaxRows() - 1`.
      * @returns {FWorksheet} This sheet, for chaining.
      * @example
      * ```typescript
@@ -572,8 +588,8 @@ export class FWorksheet extends FBaseInitialable {
 
     /**
      * Inserts one or more consecutive blank rows in a sheet starting at the specified location.
-     * @param {number} rowIndex - The index indicating where to insert a row, starting at 0 for the first row.
-     * @param {number} numRows - The number of rows to insert.
+     * @param {number} rowIndex - The existing row before which rows are inserted. The index is zero-based and must be between 0 and `getMaxRows() - 1`.
+     * @param {number} numRows - The positive number of rows to insert.
      * @returns {FWorksheet} This sheet, for chaining.
      * @example
      * ```typescript
@@ -586,13 +602,14 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     insertRows(rowIndex: number, numRows: number = 1): FWorksheet {
+        assertValidRowInsertion('insertRows', rowIndex, this.getMaxRows(), numRows);
         return this.insertRowsBefore(rowIndex, numRows);
     }
 
     /**
      * Inserts a number of rows after the given row position.
-     * @param {number} afterPosition - The row after which the new rows should be added, starting at 0 for the first row.
-     * @param {number} howMany - The number of rows to insert.
+     * @param {number} afterPosition - The existing row after which the new rows should be added. The index is zero-based and must be between 0 and `getMaxRows() - 1`.
+     * @param {number} howMany - The positive number of rows to insert.
      * @returns {FWorksheet} This sheet, for chaining.
      * @example
      * ```typescript
@@ -605,6 +622,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     insertRowsAfter(afterPosition: number, howMany: number): FWorksheet {
+        assertValidRowInsertion('insertRowsAfter', afterPosition, this.getMaxRows(), howMany);
+
         const unitId = this._workbook.getUnitId();
         const subUnitId = this._worksheet.getSheetId();
         const direction = Direction.DOWN;
@@ -635,8 +654,8 @@ export class FWorksheet extends FBaseInitialable {
 
     /**
      * Inserts a number of rows before the given row position.
-     * @param {number} beforePosition - The row before which the new rows should be added, starting at 0 for the first row.
-     * @param {number} howMany - The number of rows to insert.
+     * @param {number} beforePosition - The existing row before which the new rows should be added. The index is zero-based and must be between 0 and `getMaxRows() - 1`.
+     * @param {number} howMany - The positive number of rows to insert.
      * @returns {FWorksheet} This sheet, for chaining.
      * @example
      * ```typescript
@@ -649,6 +668,8 @@ export class FWorksheet extends FBaseInitialable {
      * ```
      */
     insertRowsBefore(beforePosition: number, howMany: number): FWorksheet {
+        assertValidRowInsertion('insertRowsBefore', beforePosition, this.getMaxRows(), howMany);
+
         const unitId = this._workbook.getUnitId();
         const subUnitId = this._worksheet.getSheetId();
         const direction = Direction.UP;
@@ -2650,7 +2671,8 @@ export class FWorksheet extends FBaseInitialable {
     }
 
     /**
-     * Appends a row to the bottom of the current data region in the sheet. If a cell's content begins with =, it's interpreted as a formula.
+     * Appends a row to the bottom of the current data region in the sheet. If the destination row is already within the worksheet capacity,
+     * this method writes into that row without increasing `getMaxRows()`. If a cell's content begins with =, it's interpreted as a formula.
      * @param {CellValue[]} rowContents - An array of values for the new row.
      * @returns {FWorksheet} Returns the current worksheet instance for method chaining.
      * @example


### PR DESCRIPTION
Refs dream-num/univer-cli#1066

## Summary

- validate row indexes and insertion counts at the `FWorksheet` Facade boundary
- throw actionable `RangeError` messages with the valid range, bottom-insertion call, and `setRowCount` alternative
- clarify the zero-based insertion contract and `appendRow` capacity behavior
- preserve the existing command, mutation, and undo/redo flow for valid calls

## Validation

- `pnpm --filter @univerjs/sheets test -- f-worksheet.spec.ts` — 101 files, 725 tests passed
- `pnpm eslint packages/sheets/src/facade/f-worksheet.ts packages/sheets/src/facade/__tests__/f-worksheet.spec.ts`
- `pnpm --filter @univerjs/sheets typecheck`

## Compatibility

No public signatures change. Unsupported indexes and counts now fail with `RangeError` instead of being silently ignored.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking API signature changes are introduced.