### PR TITLE
fix(ui): prevent sidebar content overflow

### DIFF
--- a/packages/ui/src/views/components/sidebar/Sidebar.tsx
+++ b/packages/ui/src/views/components/sidebar/Sidebar.tsx
@@ -268,7 +268,7 @@ export function Sidebar() {
                     </button>
                 </header>
 
-                <section className="univer-box-border univer-cursor-default univer-px-4">
+                <section className="univer-box-border univer-min-w-0 univer-cursor-default univer-px-4">
                     {options?.children}
                 </section>
 

--- a/packages/ui/src/views/components/sidebar/__tests__/Sidebar.spec.tsx
+++ b/packages/ui/src/views/components/sidebar/__tests__/Sidebar.spec.tsx
@@ -113,4 +113,20 @@ describe('Sidebar', () => {
         expect(sidebarService.width).toBe(800);
         rendered.dispose();
     });
+
+    it('allows panel content to shrink within the sidebar width', () => {
+        const rendered = renderWithDependencies(<Sidebar />);
+        const sidebarService = rendered.injector.get(ISidebarService);
+        const longUnbrokenText = 'x'.repeat(512);
+
+        act(() => {
+            sidebarService.open({
+                id: 'long-content',
+                children: { title: <span>{longUnbrokenText}</span> },
+            });
+        });
+
+        expect(screen.getByText(longUnbrokenText).closest('section')?.classList.contains('univer-min-w-0')).toBe(true);
+        rendered.dispose();
+    });
 });


### PR DESCRIPTION
Refs dream-num/univer-cli#1117

## What changed

- Allow the Sidebar content grid item to shrink within the configured sidebar width.
- Add a focused regression test covering long unbroken panel content.

## Root cause

The Sidebar content row kept its default grid-item `min-width: auto`. Long unbroken content therefore contributed its intrinsic width to the grid and expanded the scroll container beyond the visible sidebar.

## Impact

Long comment references and other sidebar panel content no longer create a horizontal scrollbar or stretch the panel beyond its configured width.

## Validation

- `pnpm --filter @univerjs/ui exec vitest run src/views/components/sidebar/__tests__/Sidebar.spec.tsx` — 3 tests passed
- `pnpm --filter @univerjs/ui typecheck` — passed
- Browser reproduction at 1416×892: Sidebar scroller changed from `clientWidth/scrollWidth = 319/525` to `319/319`

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
