### PR TITLE
fix(docs-drawing): refresh drawings after undo and redo

### DIFF
--- a/e2e/visual-comparison/docs/docs-drawing-undo.spec.ts
+++ b/e2e/visual-comparison/docs/docs-drawing-undo.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+const DRAWING_SELECTED_OPERATION_ID = 'drawing.operation.set-drawing-selected';
+const SHAPE_SOURCE = `data:image/svg+xml;utf8,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="144" height="96"><rect x="4" y="4" width="136" height="88" rx="14" fill="#3A60F7" stroke="#1D3EA6" stroke-width="4" /></svg>')}`;
+const WRAPPING_STYLES = [
+    'WRAP_SQUARE',
+    'WRAP_TOP_AND_BOTTOM',
+    'BEHIND_TEXT',
+    'IN_FRONT_OF_TEXT',
+] as const;
+
+for (const wrappingStyle of WRAPPING_STYLES) {
+    test(`restores drawing layout across undo and redo for ${wrappingStyle}`, async ({ page }) => {
+        await page.goto('/docs/');
+        await page.evaluate(() => window.E2EControllerAPI.loadDefaultDoc(0));
+        const drawing = await page.evaluate(async ({ selectedOperationId, source }) => {
+            const document = window.univerAPI.getActiveDocument();
+            const image = await document.insertImage({
+                source,
+                imageSourceType: window.univerAPI.Enum.ImageSourceType.BASE64,
+                width: 144,
+                height: 96,
+                wrappingStyle: window.univerAPI.Enum.TextWrappingStyle.INLINE,
+                textRange: { startOffset: 50, endOffset: 50, collapsed: true, segmentId: '' },
+            });
+            if (!image) {
+                throw new Error('Failed to insert the E2E drawing');
+            }
+            const unitId = document.getId();
+            const drawingId = image.getId();
+            await window.univerAPI.executeCommand(selectedOperationId, [{
+                unitId,
+                subUnitId: unitId,
+                drawingId,
+            }]);
+            return { drawingId };
+        }, { selectedOperationId: DRAWING_SELECTED_OPERATION_ID, source: SHAPE_SOURCE });
+        await page.waitForTimeout(500);
+
+        const clip = { x: 240, y: 300, width: 800, height: 300 };
+        const inline = await page.screenshot({ clip });
+
+        await page.evaluate(({ drawingId, style }) => {
+            const image = window.univerAPI.getActiveDocument().getImage(drawingId);
+            if (!image?.setWrappingStyle(window.univerAPI.Enum.TextWrappingStyle[style])) {
+                throw new Error(`Failed to set ${style} wrapping style`);
+            }
+        }, { drawingId: drawing.drawingId, style: wrappingStyle });
+        await page.waitForTimeout(500);
+        const wrapped = await page.screenshot({ clip });
+        expect(wrapped.equals(inline)).toBe(false);
+
+        await page.evaluate(() => window.univerAPI.undo());
+        await page.waitForTimeout(500);
+        expect((await page.screenshot({ clip })).equals(inline)).toBe(true);
+
+        await page.evaluate(() => window.univerAPI.redo());
+        await page.waitForTimeout(500);
+        expect((await page.screenshot({ clip })).equals(wrapped)).toBe(true);
+    });
+}

--- a/examples/src/docs/main.ts
+++ b/examples/src/docs/main.ts
@@ -16,6 +16,7 @@ import zhCN from '@univerjs/mockdata/locales/zh-CN';
 import { UniverUIPlugin } from '@univerjs/ui';
 import { UniverWatermarkPlugin } from '@univerjs/watermark';
 import '@univerjs/docs/facade';
+import '@univerjs/docs-drawing/facade';
 import '@univerjs/docs-ui/facade';
 import '@univerjs/watermark/facade';
 import '../global.css';

--- a/packages/docs-drawing-ui/src/controllers/__tests__/doc-drawing-notification.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/__tests__/doc-drawing-notification.controller.spec.ts
@@ -19,6 +19,7 @@ import {
     ObjectRelativeFromH,
     ObjectRelativeFromV,
     PositionedObjectLayoutType,
+    RedoCommand,
     UndoCommand,
 } from '@univerjs/core';
 import { RichTextEditingMutation } from '@univerjs/docs';
@@ -181,8 +182,8 @@ describe('DocDrawingAddRemoveController', () => {
         controller.dispose();
     });
 
-    it('updates drawing order and refreshes controls after reorder and undo commands', () => {
-        const { controller, executedHandlers, drawingManagerService, docDrawingService, refreshControls } = createController();
+    it('updates drawing order after a reorder mutation', () => {
+        const { controller, executedHandlers, drawingManagerService, docDrawingService } = createController();
 
         executedHandlers[0]({
             id: RichTextEditingMutation.id,
@@ -191,8 +192,6 @@ describe('DocDrawingAddRemoveController', () => {
                 actions: ['drawingsOrder', [0, { d: 0 }], [1, { p: 0 }]],
             },
         });
-        executedHandlers.forEach((handler) => handler({ id: UndoCommand.id }));
-
         expect(drawingManagerService.setDrawingOrder).toHaveBeenCalledWith('doc-1', 'doc-1', ['drawing-1', 'drawing-2']);
         expect(docDrawingService.setDrawingOrder).toHaveBeenCalledWith('doc-1', 'doc-1', ['drawing-2', 'drawing-1']);
         expect(drawingManagerService.orderNotification).toHaveBeenCalledWith({
@@ -205,7 +204,17 @@ describe('DocDrawingAddRemoveController', () => {
             subUnitId: 'doc-1',
             drawingIds: ['drawing-2', 'drawing-1'],
         });
-        expect(refreshControls).toHaveBeenCalled();
+        controller.dispose();
+    });
+
+    it.each([UndoCommand.id, RedoCommand.id])('refreshes drawings before controls after %s', (commandId) => {
+        const { controller, executedHandlers, refreshControls, refreshDrawings, skeleton } = createController();
+
+        executedHandlers.forEach((handler) => handler({ id: commandId }));
+
+        expect(refreshDrawings).toHaveBeenCalledExactlyOnceWith(skeleton);
+        expect(refreshControls).toHaveBeenCalledOnce();
+        expect(refreshDrawings.mock.invocationCallOrder[0]).toBeLessThan(refreshControls.mock.invocationCallOrder[0]);
 
         controller.dispose();
     });

--- a/packages/docs-drawing-ui/src/controllers/doc-drawing-notification.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/doc-drawing-notification.controller.ts
@@ -301,9 +301,10 @@ export class DocDrawingAddRemoveController extends Disposable {
 
                 const renderObject = this._renderManagerService.getRenderUnitById(unitId);
                 const scene = renderObject?.scene;
-                if (scene == null) {
+                if (renderObject == null || scene == null) {
                     return false;
                 }
+                this._docRefreshDrawingsService.refreshDrawings(renderObject.with(DocSkeletonManagerService).getSkeleton());
                 const transformer = scene.getTransformerByCreate();
 
                 transformer.refreshControls();


### PR DESCRIPTION
Closes dream-num/univer-cli#1116

## Summary

- Refresh document drawings before transformer controls after Undo/Redo so wrapping-layout geometry is rebuilt immediately.
- Add focused unit coverage for Undo and Redo refresh behavior and invocation order.
- Add Facade-driven browser regression coverage for Square, Top and Bottom, Behind text, and In front of text layouts.

## Root cause

Undo/Redo refreshed transformer controls without rebuilding the document drawing layout first. After switching wrapping layouts, the model state was restored but the rendered drawing geometry could remain stale.

## How to test

- `pnpm --filter @univerjs/docs-drawing-ui test` — 17 files, 108 tests passed
- `pnpm --filter @univerjs/docs-drawing-ui typecheck`
- `pnpm --filter univer-examples typecheck`
- Targeted TypeScript check for `e2e/visual-comparison/docs/docs-drawing-undo.spec.ts`
- Forced `univer-examples` E2E build
- Browser E2E for the four wrapping layouts — 4 passed
- Negative control confirmed the test fails against the previous refresh sequence

## Pull Request Checklist

- [x] Related Issue is linked above.
- [x] Naming follows the project conventions.
- [x] Unit and browser regression tests cover the change.
- [x] This change does not introduce breaking changes.