### PR TITLE
fix(build): support Windows paths when importing tsdown configs

### DIFF
--- a/common/shared/preset-build/index.ts
+++ b/common/shared/preset-build/index.ts
@@ -4,6 +4,7 @@ import type { IPresetBuildOptions, IPresetPackageJson } from './types.ts';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 import { mergeConfig, build as tsdownBuild } from 'tsdown';
 import { createModuleConfig } from '../tsdown/configs/module.ts';
 import { BUILD_OUTPUT_DIRECTORIES, CLEANUP_DIRECTORIES } from '../tsdown/constants.ts';
@@ -37,7 +38,7 @@ async function loadUserConfig(options: IPresetBuildOptions, packageDir: string) 
     }
 
     const configPath = path.resolve(packageDir, options.tsdownConfigPath);
-    let userConfig = (await import(configPath)).default;
+    let userConfig = (await import(pathToFileURL(configPath).href)).default;
 
     if (typeof userConfig === 'function') {
         userConfig = await userConfig();

--- a/common/shared/tsdown/index.ts
+++ b/common/shared/tsdown/index.ts
@@ -3,6 +3,7 @@ import type { IBuildContext, IBuildOptions } from './types.ts';
 import { existsSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 import { mergeConfig, build as tsdownBuild } from 'tsdown';
 import { createModuleConfig } from './configs/module.ts';
 import { createUmdConfig } from './configs/umd.ts';
@@ -112,7 +113,7 @@ export async function build(options: IBuildOptions = {}) {
         for (const ext of configExtensions) {
             const defaultConfigPath = path.resolve(packageDir, `tsdown.config${ext}`);
             if (existsSync(defaultConfigPath)) {
-                const { default: userConfigModule } = await import(defaultConfigPath);
+                const { default: userConfigModule } = await import(pathToFileURL(defaultConfigPath).href);
                 if (userConfigModule.obfuscatorIgnorePatterns) {
                     options.obfuscatorIgnorePatterns = userConfigModule.obfuscatorIgnorePatterns;
                 }
@@ -126,7 +127,7 @@ export async function build(options: IBuildOptions = {}) {
 
     if (options.tsdownConfigPath) {
         const configPath = path.resolve(packageDir, options.tsdownConfigPath);
-        let userConfig = (await import(configPath)).default;
+        let userConfig = (await import(pathToFileURL(configPath).href)).default;
         if (typeof userConfig === 'function') {
             userConfig = await userConfig();
         }


### PR DESCRIPTION
## Description
  
  Fix Windows build failures caused by importing absolute Windows paths directly with the native ESM loader.
  
  On Windows, dynamic imports such as:
  
  ```ts
  await import('D:\\work\\project\\personal\\univer\\packages\\engine-render\\tsdown.override.mts');
  
  are interpreted as URLs with the d: protocol. Node.js only accepts file:, data:, and node: URL schemes for ESM imports, which results in:

  ERR_UNSUPPORTED_ESM_URL_SCHEME

  This change converts resolved configuration paths to valid file:// URLs through pathToFileURL(...).href before dynamically importing them.

  The fix covers:

  - Regular package tsdown configuration loading.
  - Explicit tsdown configuration loading.
  - Preset package tsdown configuration loading.

  No breaking changes are introduced.

  How to test

  Run the following command on Windows:

  pnpm --filter @univerjs/engine-render build

  Expected result:

  - Bundle build completes successfully.
  - TypeScript declaration build completes successfully.
  - No ERR_UNSUPPORTED_ESM_URL_SCHEME error is thrown.

  The command was verified successfully with exit code 0.

  Pull Request Checklist

  - [ ] Related tickets or issues have been linked in the PR description (no related issue).
  - [x] Naming convention is followed.
  - [ ] Unit tests have been added for the changes (not applicable; this is a platform-specific build configuration fix).
  - [x] No breaking changes are introduced.