### PR TITLE
fix(docs): support headless rich text mutations

### DIFF
--- a/packages/docs-ui/src/controllers/__tests__/doc-render-controller.spec.ts
+++ b/packages/docs-ui/src/controllers/__tests__/doc-render-controller.spec.ts
@@ -128,9 +128,13 @@ function createControllerFixture(options?: {
             })),
         })),
     };
+    const viewModel = {
+        reset: vi.fn(),
+    };
     const skeletonManager = {
         currentSkeletonBefore$: new Subject(),
         getSkeleton: vi.fn(() => skeleton),
+        getViewModel: vi.fn(() => viewModel),
     };
     const unitId = options?.unitId ?? 'doc-unit';
     const context = {
@@ -201,6 +205,7 @@ function createControllerFixture(options?: {
             })),
         },
         {
+            getUnit: vi.fn(() => context.unit),
             getCurrentUnitOfType: vi.fn(() => ({
                 getUnitId: vi.fn(() => unitId),
             })),
@@ -224,6 +229,7 @@ function createControllerFixture(options?: {
         canvasElement,
         canvasColorService,
         skeletonManager,
+        viewModel,
         pageLayoutService,
         selectionManager,
     };
@@ -253,7 +259,7 @@ describe('doc render controller', () => {
     });
 
     it('refreshes page layout and selection after rich text mutations resize the document', () => {
-        const { commandCallbacks, pageLayoutService, selectionManager } = createControllerFixture();
+        const { commandCallbacks, context, pageLayoutService, selectionManager, viewModel } = createControllerFixture();
 
         commandCallbacks[0]({
             id: RichTextEditingMutation.id,
@@ -263,6 +269,7 @@ describe('doc render controller', () => {
             },
         } as unknown as ICommandInfo);
 
+        expect(viewModel.reset).toHaveBeenCalledWith(context.unit);
         expect(pageLayoutService.calculatePagePosition).toHaveBeenCalledTimes(1);
         expect(selectionManager.refreshSelection).toHaveBeenCalledTimes(1);
     });

--- a/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
@@ -52,17 +52,22 @@ export class DocRenderController extends RxDisposable implements IRenderModule {
 
     reRender(unitId: string) {
         const docSkeletonManagerService = this._renderManagerService.getRenderUnitById(unitId)?.with(DocSkeletonManagerService);
-        const skeleton = docSkeletonManagerService?.getSkeleton();
-        if (!skeleton) {
+        if (!docSkeletonManagerService) {
             return;
         }
+        const skeleton = docSkeletonManagerService.getSkeleton();
 
         // TODO: `disabled` is only used for read only demo, and will be removed in the future.
-        const disabled = !!skeleton.getViewModel().getDataModel().getSnapshot().disabled;
+        const documentDataModel = this._univerInstanceService.getUnit<DocumentDataModel>(unitId, UniverInstanceType.UNIVER_DOC);
+        if (!documentDataModel) {
+            return;
+        }
+        const disabled = !!documentDataModel.getSnapshot().disabled;
         if (disabled) {
             return;
         }
 
+        docSkeletonManagerService.getViewModel().reset(documentDataModel);
         skeleton.calculate();
 
         // REFACTOR: @Jocs, should not use scroll bar to indicate a Zen Editor. refactor after support modern doc.
@@ -221,12 +226,13 @@ export class DocRenderController extends RxDisposable implements IRenderModule {
         const updateCommandList = [RichTextEditingMutation.id];
 
         this.disposeWithMe(this._commandService.onCommandExecuted((command: ICommandInfo) => {
-            // TODO@Jocs: performance, only update the skeleton when the command is related to the current unit.
             if (updateCommandList.includes(command.id)) {
                 const params = command.params as IRichTextEditingMutationParams;
                 const { unitId } = params;
 
-                this.reRender(unitId);
+                if (unitId === this._context.unitId) {
+                    this.reRender(unitId);
+                }
             }
         }));
     }

--- a/packages/docs/src/__tests__/docs.integration.spec.ts
+++ b/packages/docs/src/__tests__/docs.integration.spec.ts
@@ -31,6 +31,7 @@ import {
 import { IRenderManagerService, RenderManagerService } from '@univerjs/engine-render';
 import { BehaviorSubject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { InsertTextCommand } from '../commands/commands/core-editing.command';
 import { DocsRenameMutation } from '../commands/mutations/docs-rename.mutation';
 import { SetTextSelectionsOperation } from '../commands/operations/text-selection.operation';
 import { UniverDocsPlugin } from '../plugin';
@@ -135,6 +136,29 @@ describe('docs integration', () => {
 
         expect(ok).toBeTruthy();
         expect(doc.getTitle()).toBe('Renamed');
+    });
+
+    it('edits a document without a render manager', () => {
+        univer.registerPlugin(UniverDocsPlugin);
+        const doc = univer.createUnit<IDocumentData, DocumentDataModel>(
+            UniverInstanceType.UNIVER_DOC,
+            createTestDocData('doc-headless')
+        );
+
+        injector.get(IUniverInstanceService).focusUnit(doc.getUnitId());
+
+        const ok = injector.get(ICommandService).syncExecuteCommand(InsertTextCommand.id, {
+            unitId: doc.getUnitId(),
+            body: { dataStream: '!' },
+            range: {
+                startOffset: 5,
+                endOffset: 5,
+                collapsed: true,
+            },
+        });
+
+        expect(ok).toBeTruthy();
+        expect(doc.getSnapshot().body?.dataStream).toBe('Hello!\r\n');
     });
 
     it('manages selections and emits selection operations via real command flow', async () => {

--- a/packages/docs/src/commands/mutations/core-editing.mutation.ts
+++ b/packages/docs/src/commands/mutations/core-editing.mutation.ts
@@ -18,9 +18,7 @@ import type { DocumentDataModel, IExecutionOptions, IMutation, IMutationCommonPa
 import type { ITextRangeWithStyle } from '@univerjs/engine-render';
 import type { IDocStateChangeInfo } from '../../services/doc-state-emit.service';
 import { CommandType, IUniverInstanceService, JSONX, UniverInstanceType, validateDocBodyStructure } from '@univerjs/core';
-import { IRenderManagerService } from '@univerjs/engine-render';
 import { DocSelectionManagerService } from '../../services/doc-selection-manager.service';
-import { DocSkeletonManagerService } from '../../services/doc-skeleton-manager.service';
 import { DocStateEmitService } from '../../services/doc-state-emit.service';
 
 export interface IRichTextEditingMutationParams extends IMutationCommonParams {
@@ -106,11 +104,9 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
         } = params;
         const isSync = paramsIsSync || options?.fromCollab || options?.fromChangeset;
         const univerInstanceService = accessor.get(IUniverInstanceService);
-        const renderManagerService = accessor.get(IRenderManagerService);
         const docStateEmitService = accessor.get(DocStateEmitService);
 
         const documentDataModel = univerInstanceService.getUnit<DocumentDataModel>(unitId, UniverInstanceType.UNIVER_DOC);
-        const documentViewModel = renderManagerService.getRenderUnitById(unitId)?.with(DocSkeletonManagerService).getViewModel();
         if (documentDataModel == null) {
             throw new Error(`DocumentDataModel not found for unitId: ${unitId}`);
         }
@@ -141,9 +137,7 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
             throw error;
         }
 
-        // Step 2: Update Doc View Model.
-        documentViewModel?.reset(documentDataModel);
-        // Step 3: Update cursor & selection.
+        // Step 2: Update cursor & selection.
         // Make sure update cursor & selection after doc skeleton is calculated.
         if (!noNeedSetTextRange && textRanges && trigger != null && !isSync) {
             queueMicrotask(() => {
@@ -151,7 +145,7 @@ export const RichTextEditingMutation: IMutation<IRichTextEditingMutationParams, 
             });
         }
 
-        // Step 4: Emit state change event.
+        // Step 3: Emit state change event.
         const changeState: IDocStateChangeInfo = {
             commandId: RichTextEditingMutationId,
             unitId,


### PR DESCRIPTION
## What changed

- remove the render manager dependency from the canonical Docs rich-text mutation
- reset the document view model in `DocRenderController` before recalculating the skeleton
- limit render refreshes to the document targeted by the mutation
- add headless editing and render-refresh regression coverage

## Why

The collaboration apply server had to maintain a reduced Docs mutation because the canonical mutation required browser rendering services. Once Docs Drawing declared its real dependency on `UniverDocsPlugin`, both implementations registered `doc.mutation.rich-text-editing` and the server crashed when creating a collaborative document.

Keeping the data mutation headless-safe allows Node services to use the same command implementation while leaving view-model updates in the render layer.

## Impact

Docs rich-text mutations can now execute without `IRenderManagerService`. Browser rendering, selection refresh, undo/redo, and collaboration state behavior remain covered.

## Validation

- `@univerjs/docs`: 103 tests passed
- `@univerjs/docs-ui`: targeted controller tests passed
- `@univerjs/docs` typecheck passed
- `@univerjs/docs-ui` typecheck passed
- ESLint passed for all changed files
