### PR TITLE
fix(engine-render): coordinate scene object event locks

### DIFF
--- a/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
+++ b/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
@@ -212,6 +212,27 @@ describe('engine scene viewport extra', () => {
         container.remove();
     });
 
+    it('keeps object events disabled until every named owner releases its lock', () => {
+        const { engine, scene, container } = createFixture();
+
+        // TODO(@ai-review): Confirm legacy enable calls cannot release named locks owned by other render interactions.
+        scene.setObjectsEventLock('pending-insert', true);
+        scene.setObjectsEventLock('mind-map-insert', true);
+        scene.enableObjectsEvent();
+
+        expect(scene.objectsEvented).toBe(false);
+
+        scene.setObjectsEventLock('mind-map-insert', false);
+        expect(scene.objectsEvented).toBe(false);
+
+        scene.setObjectsEventLock('pending-insert', false);
+        expect(scene.objectsEvented).toBe(true);
+
+        scene.dispose();
+        engine.dispose();
+        container.remove();
+    });
+
     it('locks vertical wheel jitter by raw delta before doc scrollbar scaling', () => {
         const { engine, scene, viewport, container } = createFixture();
         scene.transformByState({

--- a/packages/engine-render/src/scene.ts
+++ b/packages/engine-render/src/scene.ts
@@ -60,6 +60,8 @@ export class Scene extends Disposable {
     private _scaleY: number = 1;
     private _transform = new Transform();
     private _evented = true;
+    private _objectsEventDisabled = false;
+    private readonly _objectsEventLocks = new Set<string>();
 
     private _layers: Layer[] = [];
     private _viewports: Viewport[] = [];
@@ -1204,13 +1206,29 @@ export class Scene extends Disposable {
      * see sceneInputManager@_onPointerMove
      */
     // Disable object events
-    disableObjectsEvent() {
-        // Set the _evented property to false
-        this._evented = false;
+    disableObjectsEvent(): void {
+        this._objectsEventDisabled = true;
+        this._syncObjectsEvented();
     }
 
-    enableObjectsEvent() {
-        this._evented = true;
+    enableObjectsEvent(): void {
+        this._objectsEventDisabled = false;
+        this._syncObjectsEvented();
+    }
+
+    // TODO(@ai-review): Verify named locks must continue to override legacy enable/disable calls from unrelated render interactions.
+    setObjectsEventLock(owner: string, locked: boolean): void {
+        if (locked) {
+            this._objectsEventLocks.add(owner);
+        } else {
+            this._objectsEventLocks.delete(owner);
+        }
+
+        this._syncObjectsEvented();
+    }
+
+    private _syncObjectsEvented(): void {
+        this._evented = !this._objectsEventDisabled && this._objectsEventLocks.size === 0;
     }
 
     _capturedObject: BaseObject | null = null;


### PR DESCRIPTION
Refs dream-num/univer-cli#1160

Companion Pro integration: dream-num/univer-pro#5395.

## What changed

- Add owner-aware object event locks to `Scene`.
- Keep the existing `disableObjectsEvent()` and `enableObjectsEvent()` behavior for current callers.
- Prevent an unrelated legacy enable call from releasing named interaction locks.
- Add one focused regression case for overlapping owners.

## Root cause

Board render plugins independently enabled and disabled scene object events. One plugin could re-enable object events while another interaction still required them to remain disabled, allowing existing objects to consume pending-insert pointer events.

## Validation

- `pnpm --filter @univerjs/engine-render exec vitest run src/__tests__/engine-scene-viewport.spec.ts --reporter=verbose`
- `pnpm --filter @univerjs/engine-render typecheck`
- Targeted ESLint: 0 errors (existing warnings only)
- `git diff --check`

No documentation, images, generated assets, dependencies, or build configuration changes are included.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the behavior change.
- [x] No breaking changes are introduced.
