### PR TITLE
fix(design): preserve gallery controls in RTL

### DIFF
--- a/packages/design/src/components/gallery/Gallery.tsx
+++ b/packages/design/src/components/gallery/Gallery.tsx
@@ -158,6 +158,7 @@ export function Gallery(props: IGalleryProps) {
                   univer-absolute univer-bottom-6 univer-left-1/2 univer-flex -univer-translate-x-1/2
                   univer-items-center univer-gap-3 univer-rounded-full univer-bg-gray-800 univer-px-6 univer-py-3
                   univer-text-gray-400
+                  rtl:univer-flex-row-reverse
                 `}
             >
                 {hasPagination && (

--- a/packages/design/src/components/gallery/__tests__/Gallery.spec.tsx
+++ b/packages/design/src/components/gallery/__tests__/Gallery.spec.tsx
@@ -84,6 +84,16 @@ describe('Gallery', () => {
         expect(screen.getByRole('button', { name: /reset zoom/i })).toBeInTheDocument();
     });
 
+    it('keeps the toolbar controls in logical order in RTL', () => {
+        render(
+            <ConfigProvider locale={enUS.design} direction="rtl" mountContainer={document.body}>
+                <Gallery images={images} open />
+            </ConfigProvider>
+        );
+
+        expect(screen.getByRole('dialog').querySelector('footer')).toHaveClass('rtl:univer-flex-row-reverse');
+    });
+
     it('zoom in/out/reset buttons adjust the image scale', () => {
         renderGallery({ images, open: true });
         const img = screen.getByRole('img');


### PR DESCRIPTION
## What changed
- Preserve the logical order of Gallery toolbar controls in RTL layouts.
- Rename the Gallery test file to match its source file and add RTL coverage.

## Why
The toolbar used a fixed horizontal flex direction, so controls were presented in the wrong logical order when the interface direction was RTL.

## Impact
Gallery controls now follow the expected RTL order without changing LTR behavior.

## Validation
- `pnpm --filter @univerjs/design test -- Gallery.spec.tsx --run`
- Result: 54 test files passed, 266 tests passed
- Pre-commit ESLint hook passed