### PR TITLE
fix(drawing): position image popup correctly in RTL

### DIFF
--- a/packages/sheets-drawing-ui/src/menu/__tests__/drawing-popup-menu.controller.spec.ts
+++ b/packages/sheets-drawing-ui/src/menu/__tests__/drawing-popup-menu.controller.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    DrawingTypeEnum,
+    ICommandService,
+    IContextService,
+    IImageIoService,
+    Injector,
+    IUniverInstanceService,
+    LocaleService,
+    toDisposable,
+} from '@univerjs/core';
+import { IDrawingManagerService } from '@univerjs/drawing';
+import { IRenderManagerService } from '@univerjs/engine-render';
+import { SheetCanvasPopManagerService } from '@univerjs/sheets-ui';
+import { IMessageService } from '@univerjs/ui';
+import { Subject } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { DrawingPopupMenuController } from '../drawing-popup-menu.controller';
+
+describe('DrawingPopupMenuController', () => {
+    it('places the image popup on the left in RTL', () => {
+        const injector = new Injector();
+        const createControl$ = new Subject<void>();
+        const clearControl$ = new Subject<void>();
+        const changing$ = new Subject<void>();
+        const contextChanged$ = new Subject<Record<string, boolean>>();
+        const imageIoChange$ = new Subject<number>();
+        const currentWorkbook$ = new Subject<never>();
+        const disposedWorkbook$ = new Subject<never>();
+        const imageObject = { oKey: 'image-1' };
+        const attachPopupToObject = vi.fn(() => ({
+            dispose: vi.fn(),
+            canDispose: () => true,
+        }));
+
+        injector.add([LocaleService]);
+        injector.add([IDrawingManagerService, {
+            useValue: {
+                getDrawingOKey: () => ({
+                    unitId: 'unit-1',
+                    subUnitId: 'sheet-1',
+                    drawingId: 'image-1',
+                    drawingType: DrawingTypeEnum.DRAWING_IMAGE,
+                }),
+            } as never,
+        }]);
+        injector.add([SheetCanvasPopManagerService, {
+            useValue: {
+                attachPopupToObject,
+                getFeatureMenu: () => undefined,
+            } as never,
+        }]);
+        injector.add([IRenderManagerService, {
+            useValue: {
+                has: () => true,
+                getRenderUnitById: () => ({
+                    scene: {
+                        getAllObjectsByOrder: () => [],
+                        getTransformerByCreate: () => ({
+                            createControl$,
+                            clearControl$,
+                            changing$,
+                            getSelectedObjectMap: () => new Map([['image-1', imageObject]]),
+                        }),
+                    },
+                }),
+            } as never,
+        }]);
+        injector.add([IUniverInstanceService, {
+            useValue: {
+                getCurrentTypeOfUnit$: () => currentWorkbook$,
+                getTypeOfUnitDisposed$: () => disposedWorkbook$,
+                getAllUnitsForType: () => [{ getUnitId: () => 'unit-1' }],
+            } as never,
+        }]);
+        injector.add([IMessageService, { useValue: { show: () => toDisposable(() => {}) } as never }]);
+        injector.add([IContextService, {
+            useValue: {
+                contextChanged$,
+                setContextValue: vi.fn(),
+            } as never,
+        }]);
+        injector.add([IImageIoService, { useValue: { change$: imageIoChange$ } as never }]);
+        injector.add([ICommandService, { useValue: { syncExecuteCommand: vi.fn() } as never }]);
+        injector.add([DrawingPopupMenuController]);
+
+        injector.get(LocaleService).setDirection('rtl');
+        const controller = injector.get(DrawingPopupMenuController);
+        createControl$.next();
+
+        expect(attachPopupToObject).toHaveBeenCalledWith(
+            imageObject,
+            expect.objectContaining({ direction: 'left' })
+        );
+
+        controller.dispose();
+        injector.dispose();
+    });
+});

--- a/packages/sheets-drawing-ui/src/menu/drawing-popup-menu.controller.ts
+++ b/packages/sheets-drawing-ui/src/menu/drawing-popup-menu.controller.ts
@@ -172,7 +172,7 @@ export class DrawingPopupMenuController extends RxDisposable {
             const menus = this._canvasPopManagerService.getFeatureMenu(unitId, subUnitId, drawingId, drawingType);
             singletonPopupDisposer = this.disposeWithMe(this._canvasPopManagerService.attachPopupToObject(object, {
                 componentKey: COMPONENT_IMAGE_POPUP_MENU,
-                direction: 'horizontal',
+                direction: this._localeService.getDirection() === 'rtl' ? 'left' : 'horizontal',
                 offset: [2, 0],
                 extraProps: {
                     menuItems: menus || this._getImageMenuItems(unitId, subUnitId, drawingId, drawingType),


### PR DESCRIPTION
## What changed
- Position image drawing popups on the left when the interface direction is RTL.
- Add a DI-backed regression test for the RTL popup direction.

## Why
The image popup menu always used the horizontal direction, which placed it incorrectly in RTL layouts.

## Impact
Image drawing popup menus now open on the expected side in RTL mode while preserving the existing LTR behavior.

## Validation
- `pnpm --filter @univerjs/sheets-drawing-ui test -- drawing-popup-menu.controller.spec.ts --run`
- Result: 26 test files passed, 131 tests passed
- Pre-commit ESLint hook passed