### PR TITLE
fix(conditional-formatting): keep wrapper errors in layout

### DIFF
--- a/packages/sheets-conditional-formatting-ui/src/views/wrapper-error/WrapperError.tsx
+++ b/packages/sheets-conditional-formatting-ui/src/views/wrapper-error/WrapperError.tsx
@@ -22,13 +22,13 @@ export const WrapperError = (props: {
     children: ReactElement;
 }) => {
     return (
-        <div className="univer-relative">
-            <div
-                className="univer-absolute univer-bottom-[-13px] univer-z-[999] univer-text-[10px] univer-text-red-500"
-            >
-                {props.errorText}
-            </div>
+        <div>
             {props.children}
+            {props.errorText && (
+                <div className="univer-mt-1 univer-text-xs univer-text-red-500">
+                    {props.errorText}
+                </div>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## What changed
- Render conditional-formatting wrapper errors only when an error message exists.
- Keep the error message in normal document flow beneath the wrapped content.

## Why
The previous absolutely positioned error could overlap nearby controls and reserved space even when no error was present.

## Impact
Validation messages remain visible without overlaying the conditional-formatting UI, and empty error states no longer add an unnecessary positioned element.

## Validation
- `pnpm --filter @univerjs/sheets-conditional-formatting-ui test --run`
- Result: 11 test files passed, 60 tests passed
- Pre-commit ESLint hook passed