### PR TITLE
fix(formula): queue other formulas in the shared trigger

### DIFF
--- a/packages/engine-formula/src/controllers/__tests__/formula-calculation-trigger.controller.spec.ts
+++ b/packages/engine-formula/src/controllers/__tests__/formula-calculation-trigger.controller.spec.ts
@@ -18,7 +18,6 @@ import * as core from '@univerjs/core';
 import { BehaviorSubject } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FormulaCalculationTriggerService } from '../../services/formula-calculation-trigger.service';
-import { RegisterOtherFormulaService } from '../../services/register-other-formula.service';
 import { FormulaCalculationTriggerController } from '../formula-calculation-trigger.controller';
 
 describe('FormulaCalculationTriggerController', () => {
@@ -27,39 +26,32 @@ describe('FormulaCalculationTriggerController', () => {
     it('starts immediately in Node.js', () => {
         vi.spyOn(core, 'isNodeEnv').mockReturnValue(true);
         const start = vi.fn();
-        const calculateStarted$ = new BehaviorSubject(false);
         const lifecycle$ = new BehaviorSubject(core.LifecycleStages.Ready);
 
         const injector = new core.Injector([
             [FormulaCalculationTriggerService, { useValue: { start } }],
-            [RegisterOtherFormulaService, { useValue: { calculateStarted$ } }],
             [core.LifecycleService, { useValue: { lifecycle$ } }],
         ]);
         const controller = injector.createInstance(FormulaCalculationTriggerController);
 
         expect(start).toHaveBeenCalledOnce();
-        expect(calculateStarted$.getValue()).toBe(true);
         controller.dispose();
     });
 
     it('starts after rendering in the browser', () => {
         vi.spyOn(core, 'isNodeEnv').mockReturnValue(false);
         const start = vi.fn();
-        const calculateStarted$ = new BehaviorSubject(false);
         const lifecycle$ = new BehaviorSubject(core.LifecycleStages.Ready);
 
         const injector = new core.Injector([
             [FormulaCalculationTriggerService, { useValue: { start } }],
-            [RegisterOtherFormulaService, { useValue: { calculateStarted$ } }],
             [core.LifecycleService, { useValue: { lifecycle$ } }],
         ]);
         const controller = injector.createInstance(FormulaCalculationTriggerController);
 
         expect(start).not.toHaveBeenCalled();
-        expect(calculateStarted$.getValue()).toBe(false);
         lifecycle$.next(core.LifecycleStages.Rendered);
         expect(start).toHaveBeenCalledOnce();
-        expect(calculateStarted$.getValue()).toBe(true);
 
         lifecycle$.next(core.LifecycleStages.Steady);
         expect(start).toHaveBeenCalledOnce();

--- a/packages/engine-formula/src/controllers/formula-calculation-trigger.controller.ts
+++ b/packages/engine-formula/src/controllers/formula-calculation-trigger.controller.ts
@@ -17,20 +17,15 @@
 import { Disposable, Inject, isNodeEnv, LifecycleService, LifecycleStages } from '@univerjs/core';
 import { filter, take } from 'rxjs';
 import { FormulaCalculationTriggerService } from '../services/formula-calculation-trigger.service';
-import { RegisterOtherFormulaService } from '../services/register-other-formula.service';
 
 export class FormulaCalculationTriggerController extends Disposable {
     constructor(
         @Inject(FormulaCalculationTriggerService) formulaCalculationTriggerService: FormulaCalculationTriggerService,
-        @Inject(RegisterOtherFormulaService) registerOtherFormulaService: RegisterOtherFormulaService,
         @Inject(LifecycleService) lifecycleService: LifecycleService
     ) {
         super();
 
-        const start = () => {
-            formulaCalculationTriggerService.start();
-            registerOtherFormulaService.calculateStarted$.next(true);
-        };
+        const start = () => formulaCalculationTriggerService.start();
 
         if (isNodeEnv()) {
             start();

--- a/packages/engine-formula/src/services/__tests__/formula-calculation-trigger.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/formula-calculation-trigger.service.spec.ts
@@ -94,6 +94,36 @@ describe('FormulaCalculationTriggerService', () => {
         testBed.service.dispose();
     });
 
+    it('queues Other Formula dirty data before start and flushes it after start', async () => {
+        const testBed = createTestBed(false);
+        testBed.conversions.set('other-formula-dirty', {
+            commandId: 'other-formula-dirty',
+            getDirtyData: () => ({
+                dirtyUnitOtherFormulaMap: {
+                    'doc-unit': { 'shape-unit': { 'formula-1': true } },
+                },
+            }),
+        });
+
+        testBed.emit({ id: 'other-formula-dirty' } as ICommandInfo);
+        await vi.advanceTimersByTimeAsync(10);
+        expect(testBed.executed).toEqual([]);
+
+        testBed.service.start();
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect(testBed.executed).toHaveLength(1);
+        expect(testBed.executed[0]).toMatchObject({
+            id: SetFormulaCalculationStartMutation.id,
+            params: {
+                dirtyUnitOtherFormulaMap: {
+                    'doc-unit': { 'shape-unit': { 'formula-1': true } },
+                },
+            },
+        });
+        testBed.service.dispose();
+    });
+
     it('merges dirty data from different unit types into one calculation', async () => {
         const testBed = createTestBed();
         testBed.conversions.set('sheet-dirty', {

--- a/packages/engine-formula/src/services/__tests__/register-other-formula.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/register-other-formula.service.spec.ts
@@ -73,32 +73,28 @@ describe('RegisterOtherFormulaService', () => {
         expect(activeDirtyManagerService.get(OtherFormulaMarkDirty.id)?.commandId).toBe(OtherFormulaMarkDirty.id);
     });
 
-    it('should buffer register requests until calculation starts', async () => {
+    it('should register immediately and leave pre-start scheduling to the calculation trigger', async () => {
         const { service, commandService } = createService();
         const executedIds: string[] = [];
         commandService.onCommandExecuted((command) => executedIds.push(command.id));
 
         const formulaId = service.registerFormulaWithRange('unit-1', 'sheet-1', '=A1');
         expect(formulaId.startsWith('formula.unit-1_sheet-1_default_')).toBe(true);
-        expect(executedIds).not.toContain(SetOtherFormulaMutation.id);
-
-        service.calculateStarted$.next(true);
         await flushCommandChain();
 
         expect(executedIds).toEqual([SetOtherFormulaMutation.id, OtherFormulaMarkDirty.id]);
     });
 
-    it('should register immediately after calculation started', async () => {
+    it('should register every formula once without a second lifecycle gate', async () => {
         const { service, commandService } = createService();
         const executedIds: string[] = [];
         commandService.onCommandExecuted((command) => executedIds.push(command.id));
 
-        service.calculateStarted$.next(true);
         service.registerFormulaWithRange('unit-2', 'sheet-2', '=SUM(A1:A5)', [], { source: 'test' }, OtherFormulaBizType.DOC, 'doc-1');
 
         await flushCommandChain();
 
-        expect(executedIds).toContain(SetOtherFormulaMutation.id);
+        expect(executedIds).toEqual([SetOtherFormulaMutation.id, OtherFormulaMarkDirty.id]);
     });
 
     it('should expose all registered formulas for host-level dirty propagation', () => {

--- a/packages/engine-formula/src/services/register-other-formula.service.ts
+++ b/packages/engine-formula/src/services/register-other-formula.service.ts
@@ -26,11 +26,9 @@ import {
     Disposable,
     generateRandomId,
     ICommandService,
-    Inject,
-    LifecycleService,
     ObjectMatrix,
 } from '@univerjs/core';
-import { BehaviorSubject, bufferWhen, filter, skip, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { OtherFormulaMarkDirty } from '../commands/mutations/formula.mutation';
 import { SetFormulaCalculationResultMutation } from '../commands/mutations/set-formula-calculation.mutation';
 import { RemoveOtherFormulaMutation, SetOtherFormulaMutation } from '../commands/mutations/set-other-formula.mutation';
@@ -60,12 +58,9 @@ export class RegisterOtherFormulaService extends Disposable {
     private _otherFormulaResultApplied$ = new Subject<ISetFormulaCalculationResultMutation>();
     public otherFormulaResultApplied$ = this._otherFormulaResultApplied$.asObservable();
 
-    public calculateStarted$ = new BehaviorSubject(false);
-
     constructor(
         @ICommandService private readonly _commandService: ICommandService,
-        @IActiveDirtyManagerService private _activeDirtyManagerService: IActiveDirtyManagerService,
-        @Inject(LifecycleService) private readonly _lifecycleService: LifecycleService
+        @IActiveDirtyManagerService private _activeDirtyManagerService: IActiveDirtyManagerService
     ) {
         super();
         this._initFormulaRegister();
@@ -78,7 +73,6 @@ export class RegisterOtherFormulaService extends Disposable {
         this._formulaChangeWithRange$.complete();
         this._formulaResult$.complete();
         this._otherFormulaResultApplied$.complete();
-        this.calculateStarted$.complete();
     }
 
     private _ensureCacheMap(unitId: string, subUnitId: string) {
@@ -149,17 +143,7 @@ export class RegisterOtherFormulaService extends Disposable {
             });
         };
 
-        this.disposeWithMe(
-            this._formulaChangeWithRange$
-                .pipe(bufferWhen(() => this.calculateStarted$.pipe(skip(1), filter((calculateStarted) => calculateStarted))))
-                .subscribe((options) => options.forEach(handleRegister))
-        );
-
-        this.disposeWithMe(
-            this._formulaChangeWithRange$
-                .pipe(filter(() => this.calculateStarted$.getValue()))
-                .subscribe(handleRegister)
-        );
+        this.disposeWithMe(this._formulaChangeWithRange$.subscribe(handleRegister));
     }
 
     private _initFormulaCalculationResultChange() {

--- a/packages/sheets-formula/src/controllers/__tests__/sheet-formula-trigger.integration.spec.ts
+++ b/packages/sheets-formula/src/controllers/__tests__/sheet-formula-trigger.integration.spec.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import * as core from '@univerjs/core';
+import {
+    ICommandService,
+    isNodeEnv,
+    LifecycleService,
+    LifecycleStages,
+    LocaleService,
+    LocaleType,
+    Univer,
+} from '@univerjs/core';
 import { FUniver } from '@univerjs/core/facade';
 import { SetFormulaCalculationStartMutation } from '@univerjs/engine-formula';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -23,12 +31,12 @@ import '@univerjs/engine-formula/facade';
 import '@univerjs/sheets/facade';
 import '../../facade';
 
-function createWorkbookData(): core.IWorkbookData {
+function createWorkbookData() {
     return {
         id: 'standalone-sheet-formula',
         name: 'Standalone Sheet Formula',
         appVersion: 'test',
-        locale: core.LocaleType.EN_US,
+        locale: LocaleType.EN_US,
         styles: {},
         sheetOrder: ['sheet-1'],
         sheets: {
@@ -49,7 +57,7 @@ function createWorkbookData(): core.IWorkbookData {
 }
 
 describe('standalone Sheet formula calculation trigger', () => {
-    let univer: core.Univer | undefined;
+    let univer: Univer | undefined;
 
     afterEach(() => {
         univer?.dispose();
@@ -58,16 +66,16 @@ describe('standalone Sheet formula calculation trigger', () => {
     });
 
     it('calculates on cold start and recalculates after value and formula edits', async () => {
-        vi.spyOn(core, 'isNodeEnv').mockReturnValue(false);
+        vi.mocked(isNodeEnv).mockReturnValue(false);
 
-        univer = new core.Univer();
+        univer = new Univer();
         const injector = univer.__getInjector();
-        injector.get(core.LocaleService).load({ [core.LocaleType.EN_US]: {} });
-        injector.get(core.LocaleService).setLocale(core.LocaleType.EN_US);
+        injector.get(LocaleService).load({ [LocaleType.EN_US]: {} });
+        injector.get(LocaleService).setLocale(LocaleType.EN_US);
         univer.registerPlugin(UniverSheetsFormulaPlugin);
 
         let calculationStarts = 0;
-        injector.get(core.ICommandService).onCommandExecuted((command) => {
+        injector.get(ICommandService).onCommandExecuted((command) => {
             if (command.id === SetFormulaCalculationStartMutation.id) {
                 calculationStarts++;
             }
@@ -80,7 +88,7 @@ describe('standalone Sheet formula calculation trigger', () => {
         const output = sheet.getRange('B1');
 
         const startupResultApplied = api.getFormula().onCalculationResultApplied(10_000);
-        injector.get(core.LifecycleService).stage = core.LifecycleStages.Rendered;
+        injector.get(LifecycleService).stage = LifecycleStages.Rendered;
         await startupResultApplied;
         expect(output.getValue()).toBe(4);
         expect(calculationStarts).toBe(1);
@@ -97,4 +105,13 @@ describe('standalone Sheet formula calculation trigger', () => {
         expect(output.getValue()).toBe(9);
         expect(calculationStarts).toBe(3);
     });
+});
+
+vi.mock('@univerjs/core', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@univerjs/core')>();
+
+    return {
+        ...actual,
+        isNodeEnv: vi.fn(actual.isNodeEnv),
+    };
 });

--- a/packages/sheets-formula/src/controllers/__tests__/sheet-formula-trigger.integration.spec.ts
+++ b/packages/sheets-formula/src/controllers/__tests__/sheet-formula-trigger.integration.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as core from '@univerjs/core';
+import { FUniver } from '@univerjs/core/facade';
+import { SetFormulaCalculationStartMutation } from '@univerjs/engine-formula';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { UniverSheetsFormulaPlugin } from '../../plugin';
+import '@univerjs/engine-formula/facade';
+import '@univerjs/sheets/facade';
+import '../../facade';
+
+function createWorkbookData(): core.IWorkbookData {
+    return {
+        id: 'standalone-sheet-formula',
+        name: 'Standalone Sheet Formula',
+        appVersion: 'test',
+        locale: core.LocaleType.EN_US,
+        styles: {},
+        sheetOrder: ['sheet-1'],
+        sheets: {
+            'sheet-1': {
+                id: 'sheet-1',
+                name: 'Sheet1',
+                rowCount: 20,
+                columnCount: 20,
+                cellData: {
+                    0: {
+                        0: { v: 2 },
+                        1: { f: '=A1*2' },
+                    },
+                },
+            },
+        },
+    };
+}
+
+describe('standalone Sheet formula calculation trigger', () => {
+    let univer: core.Univer | undefined;
+
+    afterEach(() => {
+        univer?.dispose();
+        univer = undefined;
+        vi.restoreAllMocks();
+    });
+
+    it('calculates on cold start and recalculates after value and formula edits', async () => {
+        vi.spyOn(core, 'isNodeEnv').mockReturnValue(false);
+
+        univer = new core.Univer();
+        const injector = univer.__getInjector();
+        injector.get(core.LocaleService).load({ [core.LocaleType.EN_US]: {} });
+        injector.get(core.LocaleService).setLocale(core.LocaleType.EN_US);
+        univer.registerPlugin(UniverSheetsFormulaPlugin);
+
+        let calculationStarts = 0;
+        injector.get(core.ICommandService).onCommandExecuted((command) => {
+            if (command.id === SetFormulaCalculationStartMutation.id) {
+                calculationStarts++;
+            }
+        });
+
+        const api = FUniver.newAPI(univer);
+        const workbook = api.createWorkbook(createWorkbookData());
+        const sheet = workbook.getActiveSheet();
+        const input = sheet.getRange('A1');
+        const output = sheet.getRange('B1');
+
+        const startupResultApplied = api.getFormula().onCalculationResultApplied(10_000);
+        injector.get(core.LifecycleService).stage = core.LifecycleStages.Rendered;
+        await startupResultApplied;
+        expect(output.getValue()).toBe(4);
+        expect(calculationStarts).toBe(1);
+
+        const valueEditResultApplied = api.getFormula().onCalculationResultApplied(10_000);
+        input.setValue(3);
+        await valueEditResultApplied;
+        expect(output.getValue()).toBe(6);
+        expect(calculationStarts).toBe(2);
+
+        const formulaEditResultApplied = api.getFormula().onCalculationResultApplied(10_000);
+        output.setFormula('=A1*3');
+        await formulaEditResultApplied;
+        expect(output.getValue()).toBe(9);
+        expect(calculationStarts).toBe(3);
+    });
+});


### PR DESCRIPTION
## Summary

- remove the second lifecycle gate from Other Formula registration
- queue pre-render Other Formula dirty data in the shared calculation trigger
- preserve the existing Sheet formula trigger path and batching behavior

Refs dream-num/univer-pro#5286

## Validation

- `pnpm --filter @univerjs/engine-formula test` (561 files, 4094 tests)
- `pnpm --filter @univerjs/sheets-formula test` (28 files, 116 tests)
- `pnpm --filter @univerjs/engine-formula typecheck`
- `pnpm --filter @univerjs/sheets-formula typecheck`
- Sheet integration verifies one calculation start for cold start, one for a value edit, and one for a formula edit

## Architecture

No long-lived architecture documentation change is required. This removes a duplicate lifecycle gate and keeps formula scheduling in the existing shared trigger service.

## Pull Request Checklist

- [x] Related issues are linked.
- [x] Naming conventions are followed.
- [x] Unit and integration tests cover the change.
- [x] No breaking change is introduced.