### PR TITLE
fix(formula): normalize standard Base table references

### DIFF
--- a/packages/engine-formula/src/models/__tests__/formula-data.model.spec.ts
+++ b/packages/engine-formula/src/models/__tests__/formula-data.model.spec.ts
@@ -1090,7 +1090,7 @@ describe('Test formula data model', () => {
                 expect(formulaData['base-test']?.['table-main']).toEqual({
                     0: {
                         7: {
-                            f: '=SUM(table-main[[#This Row],[Amount]], table-main[[#This Row],[Qty]], tableOther[[#Data],[External]])',
+                            f: '=SUM(_T_table_x2d_main[[#This Row],[Amount]], _T_table_x2d_main[[#This Row],[Qty]], _T_tableOther[[#Data],[External]])',
                             si: 'total',
                         },
                     },
@@ -1104,6 +1104,8 @@ describe('Test formula data model', () => {
                     unitType: UniverInstanceType.UNIVER_BASE,
                 });
                 expect(calculateData.unitSheetNameMap['base-test']?.Sales).toBe('tableOther');
+                expect(calculateData.unitSheetNameMap['base-test']?._T_table_x2d_main).toBe('table-main');
+                expect(calculateData.unitSheetNameMap['base-test']?._T_tableOther).toBe('tableOther');
                 expect(tableData?.rowCount).toBe(1);
                 expect(tableData?.columnCount).toBe(8);
                 expect(tableData?.cellData.getValue(0, 0)).toEqual({ v: 'record-1', t: CellValueType.STRING });
@@ -1112,6 +1114,23 @@ describe('Test formula data model', () => {
                 expect(tableData?.cellData.getValue(0, 4)).toEqual({ v: 'paid, online', t: CellValueType.STRING });
                 expect(tableData?.cellData.getValue(0, 5)).toEqual({ v: 'Invoice', t: CellValueType.STRING });
                 expect(tableData?.cellData.getValue(0, 6)).toEqual({ v: '', t: CellValueType.STRING });
+            });
+
+            it('preserves explicit current-row scope and expands qualified columns to #Data', () => {
+                const univerInstanceService = get(IUniverInstanceService);
+                univerInstanceService.registerCtorForType(UniverInstanceType.UNIVER_BASE, BaseDataModel);
+                const snapshot = structuredClone(TEST_BASE_DATA);
+                snapshot.id = 'base-structured-scope';
+                snapshot.tables!['table-main'].name = 'Orders';
+                snapshot.tables!.tableOther.name = 'Pricing';
+                snapshot.tables!['table-main'].fields.total.config = {
+                    formula: '=Orders[@[Amount]]+[@[Qty]]+SUM(Pricing[External])',
+                };
+                univer.createUnit(UniverInstanceType.UNIVER_BASE, snapshot);
+
+                expect(formulaDataModel.getFormulaData()['base-structured-scope']?.['table-main']?.[0]?.[7]?.f).toBe(
+                    '=Orders[[#This Row],[Amount]]+Orders[[#This Row],[Qty]]+SUM(Pricing[[#Data],[External]])'
+                );
             });
 
             it('should preserve workbook-qualified A1 references in Base formulas', () => {

--- a/packages/engine-formula/src/models/formula-data.model.ts
+++ b/packages/engine-formula/src/models/formula-data.model.ts
@@ -416,7 +416,7 @@ export class FormulaDataModel extends Disposable {
                     rowData: {},
                     columnData: {},
                 };
-                tableNameMap[table.name] = table.id;
+                addEngineBaseTableNameMappings(tableNameMap, table, snapshot);
             }
 
             allUnitData[unitId] = baseData;
@@ -942,8 +942,12 @@ export function initSheetFormulaData(
 }
 
 const BASE_LEGACY_FIELD_REF_PATTERN = /\{([^}]+)\}/g;
-const BASE_TABLE_FIELD_REF_PATTERN = /\b([A-Z_]\w*)\[([^\]]+)\]/gi;
-const BASE_BRACKET_FIELD_REF_PATTERN = /(^|[^A-Za-z0-9_\]\[])\[([^\]]+)\]/g;
+const BASE_TABLE_SCOPED_FIELD_REF_PATTERN = /\b([A-Z_][\w.]*)\[\[\s*#(This Row|Data)\s*\],\s*\[([^\]]+)\]\]/gi;
+const BASE_TABLE_CURRENT_ROW_FIELD_REF_PATTERN = /\b([A-Z_][\w.]*)\[@\[([^\]]+)\]\]/gi;
+const BASE_TABLE_FIELD_REF_PATTERN = /\b([A-Z_][\w.]*)\[([^\[\]#]+)\]/gi;
+const BASE_SCOPED_FIELD_REF_PATTERN = /(^|[^\w\[])\[\[\s*#(This Row|Data)\s*\],\s*\[([^\]]+)\]\]/gi;
+const BASE_CURRENT_ROW_FIELD_REF_PATTERN = /(^|[^\w\[])\[@\[([^\]]+)\]\](?!\])/g;
+const BASE_BRACKET_FIELD_REF_PATTERN = /(^|[^\w\[])\[@?([^\[\]#]+)\](?!\])/g;
 const BASE_EXTERNAL_A1_REF_PATTERN = /(?:'\[[^\]]+\](?:[^']|'')+'|\[[^\]]+\][^\s'!]+)!\$?[A-Z]{1,3}\$?\d+(?::\$?[A-Z]{1,3}\$?\d+)?/gi;
 const BASE_EXTERNAL_STRUCTURED_REFERENCE_PREFIX = /(?:'((?:[^']|'')+)'|\[[^\]]+\]|[A-Za-z0-9_.-]+)![^\s!\[\]]+\[/g;
 
@@ -953,11 +957,35 @@ function normalizeBaseFormulaForEngine(formula: string, currentTable: ITableSnap
         const index = refs.push(ref) - 1;
         return `__BASE_FORMULA_REF_${index}__`;
     };
-    const normalized = protectBaseExternalReferences(formula, hold)
+    const normalized = protectBaseFormulaParts(formula, hold)
         .replace(BASE_LEGACY_FIELD_REF_PATTERN, (_match, fieldName: string) => hold(createEngineThisRowRef(currentTable, fieldName, snapshot)))
+        .replace(BASE_TABLE_SCOPED_FIELD_REF_PATTERN, (_match, sourceTableName: string, scope: string, fieldName: string) => {
+            const targetTable = resolveBaseFormulaTable(sourceTableName, currentTable, snapshot)
+                ?? (sourceTableName.toLowerCase() === 'table' ? currentTable : undefined);
+            if (!targetTable) return `${sourceTableName}[[#${scope}],[${fieldName}]]`;
+            return hold(scope.toLowerCase() === 'data'
+                ? createEngineColumnRef(targetTable, fieldName, snapshot)
+                : createEngineThisRowRef(targetTable, fieldName, snapshot));
+        })
+        .replace(BASE_TABLE_CURRENT_ROW_FIELD_REF_PATTERN, (_match, sourceTableName: string, fieldName: string) => {
+            const targetTable = resolveBaseFormulaTable(sourceTableName, currentTable, snapshot);
+            return targetTable
+                ? hold(createEngineThisRowRef(targetTable, fieldName, snapshot))
+                : `${sourceTableName}[@[${fieldName}]]`;
+        })
+        .replace(BASE_SCOPED_FIELD_REF_PATTERN, (_match, prefix: string, scope: string, fieldName: string) => `${prefix}${hold(
+            scope.toLowerCase() === 'data'
+                ? createEngineColumnRef(currentTable, fieldName, snapshot)
+                : createEngineThisRowRef(currentTable, fieldName, snapshot)
+        )}`)
+        .replace(BASE_CURRENT_ROW_FIELD_REF_PATTERN, (_match, prefix: string, fieldName: string) =>
+            `${prefix}${hold(createEngineThisRowRef(currentTable, fieldName, snapshot))}`)
         .replace(BASE_TABLE_FIELD_REF_PATTERN, (_match, sourceTableName: string, fieldName: string) => {
             const targetTable = resolveBaseFormulaTable(sourceTableName, currentTable, snapshot);
-            return targetTable ? hold(createEngineColumnRef(targetTable, fieldName, snapshot)) : `${sourceTableName}[${fieldName}]`;
+            if (targetTable) return hold(createEngineColumnRef(targetTable, fieldName, snapshot));
+            return sourceTableName.toLowerCase() === 'table'
+                ? hold(createEngineThisRowRef(currentTable, fieldName, snapshot))
+                : `${sourceTableName}[${fieldName}]`;
         })
         .replace(BASE_BRACKET_FIELD_REF_PATTERN, (_match, prefix: string, fieldName: string) => `${prefix}${hold(createEngineThisRowRef(currentTable, fieldName, snapshot))}`);
     return normalized.replace(/__BASE_FORMULA_REF_(\d+)__/g, (_match, index: string) => refs[Number(index)] ?? '');
@@ -969,14 +997,23 @@ function protectBaseExternalReferences(formula: string, replace: (reference: str
     return protectBaseExternalStructuredReferences(withProtectedA1, replace);
 }
 
+function protectBaseFormulaParts(formula: string, replace: (reference: string) => string): string {
+    return protectBaseFormulaStrings(protectBaseExternalReferences(formula, replace), replace);
+}
+
+function protectBaseFormulaStrings(formula: string, replace: (reference: string) => string): string {
+    return formula.replace(/"(?:""|[^"])*"/g, replace);
+}
+
 function protectBaseExternalStructuredReferences(
     formula: string,
     replace: (reference: string) => string
 ): string {
     const spans: Array<{ start: number; end: number }> = [];
     BASE_EXTERNAL_STRUCTURED_REFERENCE_PREFIX.lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = BASE_EXTERNAL_STRUCTURED_REFERENCE_PREFIX.exec(formula)) != null) {
+    while (true) {
+        const match = BASE_EXTERNAL_STRUCTURED_REFERENCE_PREFIX.exec(formula);
+        if (match == null) break;
         if (isInsideBaseFormulaString(formula, match.index)) continue;
         const openBracket = BASE_EXTERNAL_STRUCTURED_REFERENCE_PREFIX.lastIndex - 1;
         let depth = 0;
@@ -1029,14 +1066,41 @@ function getEngineBaseTableName(table: ITableSnapshot, snapshot: IBaseSnapshot):
     let sameNameCount = 0;
     for (let i = 0; i < tables.length; i++) {
         const item = tables[i];
-        if (item.name === table.name) {
+        if (item.name.trim().toLowerCase() === table.name.trim().toLowerCase()) {
             sameNameCount++;
             if (sameNameCount > 1) {
                 break;
             }
         }
     }
-    return sameNameCount === 1 ? table.name : table.id;
+    return sameNameCount === 1 && isExcelTableName(table.name)
+        ? table.name
+        : createStableExcelTableName(table.id);
+}
+
+function addEngineBaseTableNameMappings(
+    tableNameMap: Record<string, string>,
+    table: ITableSnapshot,
+    snapshot: IBaseSnapshot
+): void {
+    tableNameMap[table.name] = table.id;
+    tableNameMap[getEngineBaseTableName(table, snapshot)] = table.id;
+}
+
+function isExcelTableName(name: string): boolean {
+    if (name.length === 0 || name.length > 255 || !/^[A-Za-z_][A-Za-z0-9_.]*$/.test(name)) {
+        return false;
+    }
+    return !/^[RC]$/i.test(name)
+        && !/^[A-Za-z]{1,3}[1-9]\d*$/.test(name)
+        && !/^R(?:\d+)?C(?:\d+)?$/i.test(name);
+}
+
+function createStableExcelTableName(tableId: string): string {
+    const encoded = Array.from(tableId, (character) => /[A-Za-z0-9]/.test(character)
+        ? character
+        : `_x${character.codePointAt(0)?.toString(16) ?? '0'}_`).join('');
+    return `_T_${encoded}`;
 }
 
 function buildBaseRuntimeCellData(table: ITableSnapshot): Record<number, Record<number, IBaseCellData>> {


### PR DESCRIPTION
## Summary

- normalize OOXML current-row and data-column Base structured references without changing their scope
- register stable Excel-compatible formula identifiers for Base table names that are duplicated or invalid in Excel
- keep persisted legacy `table[Field]` formulas readable while new writes are validated in the Pro Base layer
- protect quoted strings and external structured references during normalization

Refs dream-num/univer-cli#1139

## Validation

- `pnpm --filter @univerjs/engine-formula test` (561 files, 4094 tests)
- `pnpm --filter @univerjs/engine-formula typecheck`
- changed-file lint has no new warnings; the four reported warnings are present on `dev`

## Architecture

No new trigger or Base-specific calculation path is introduced. FormulaDataModel remains the OSS owner of runtime snapshot normalization, including Base Units loaded without Pro UI services.

## Pull Request Checklist

- [x] Related issue is linked.
- [x] Naming conventions are followed.
- [x] Regression tests cover structured-reference scopes and stable table names.
- [x] No breaking change is introduced for persisted legacy formulas.