### PR TITLE
feat(core): support merging consecutive undo history

### DIFF
--- a/packages/core/src/services/undoredo/__tests__/undoredo.service.spec.ts
+++ b/packages/core/src/services/undoredo/__tests__/undoredo.service.spec.ts
@@ -137,6 +137,27 @@ describe('LocalUndoRedoService', () => {
         expect(undoRedoService.pitchTopUndoElement()?.id).toBe('run');
     });
 
+    it('should merge consecutive history items with the same id when requested', () => {
+        undoRedoService.pushUndoRedo({
+            unitID: 'unit-1',
+            undoMutations: [{ id: MUTATION_ID, params: { label: 'undo-insert' } }],
+            redoMutations: [{ id: MUTATION_ID, params: { label: 'redo-insert' } }],
+            id: 'edit-session',
+        });
+        undoRedoService.pushUndoRedo({
+            unitID: 'unit-1',
+            undoMutations: [{ id: MUTATION_ID, params: { label: 'undo-edit' } }],
+            redoMutations: [{ id: MUTATION_ID, params: { label: 'redo-edit' } }],
+            id: 'edit-session',
+        }, { mergeWithPrevious: true });
+
+        expect(commandService.syncExecuteCommand(UndoCommandId)).toBe(true);
+        expect(mutationLog).toEqual(['undo-edit', 'undo-insert']);
+
+        expect(commandService.syncExecuteCommand(RedoCommandId)).toBe(true);
+        expect(mutationLog).toEqual(['undo-edit', 'undo-insert', 'redo-insert', 'redo-edit']);
+    });
+
     it('should rollback the latest undo item and support batching', () => {
         const batching = undoRedoService.__tempBatchingUndoRedo('unit-1');
 

--- a/packages/core/src/services/undoredo/undoredo.service.ts
+++ b/packages/core/src/services/undoredo/undoredo.service.ts
@@ -43,7 +43,7 @@ export interface IUndoRedoItem {
 export interface IUndoRedoService {
     undoRedoStatus$: Observable<IUndoRedoStatus>;
 
-    pushUndoRedo(item: IUndoRedoItem): void;
+    pushUndoRedo(item: IUndoRedoItem, options?: { mergeWithPrevious?: boolean }): void;
 
     /** Pitch the top redo element of the currently focused Univer document instance. */
     pitchTopUndoElement(): Nullable<IUndoRedoItem>;
@@ -190,7 +190,7 @@ export class LocalUndoRedoService extends Disposable implements IUndoRedoService
         this.disposeWithMe(toDisposable(this._univerInstanceService.focused$.subscribe(() => this._updateStatus())));
     }
 
-    pushUndoRedo(item: IUndoRedoItem): void {
+    pushUndoRedo(item: IUndoRedoItem, options?: { mergeWithPrevious?: boolean }): void {
         const { unitID } = item;
 
         const redoStack = this._getRedoStack(unitID, true);
@@ -198,6 +198,14 @@ export class LocalUndoRedoService extends Disposable implements IUndoRedoService
 
         // redo stack should be cleared when pushing an undo
         redoStack.length = 0;
+
+        const previousItem = this._pitchUndoElement(unitID);
+        if (options?.mergeWithPrevious && item.id && previousItem?.id === item.id) {
+            previousItem.redoMutations.push(...item.redoMutations);
+            previousItem.undoMutations = [...item.undoMutations, ...previousItem.undoMutations];
+            this._updateStatus();
+            return;
+        }
 
         // should try to append first and then
         if (this._batchingStatus.has(item.unitID)) {


### PR DESCRIPTION
Refs dream-num/univer-cli#1230

## Summary

- Add an opt-in `mergeWithPrevious` mode to `IUndoRedoService.pushUndoRedo`.
- Merge only adjacent history items with the same explicit id.
- Preserve forward redo order and reverse undo order.
- Add a focused core regression test for the merged history round trip.

## Root cause

Interactive editing sessions can emit several commands for one user action. The existing temporary batching API is deprecated and has broad unit-level scope, while manually manipulating undo and redo stacks in consumers is not an appropriate public integration pattern.

## Validation

- `pnpm --filter @univerjs/core test -- --run src/services/undoredo/__tests__/undoredo.service.spec.ts` — 6 tests passed.
- `pnpm --filter @univerjs/core typecheck` — passed.
- ESLint on the two changed files — passed.
- Commit-time lint-staged ESLint — passed.

## Architecture

No ADR is required. This is a small, explicit extension of the existing undo/redo service contract and replaces use of the deprecated broad batching mechanism for this workflow.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.