### PR TITLE
fix(sheets-ui): remove all selected ranges and dedupe ctrl+click selections

### DIFF
--- a/packages/core/src/services/undoredo/__tests__/undoredo.service.spec.ts
+++ b/packages/core/src/services/undoredo/__tests__/undoredo.service.spec.ts
@@ -160,8 +160,117 @@ describe('LocalUndoRedoService', () => {
         expect(top?.redoMutations).toHaveLength(2);
 
         undoRedoService.rollback('batch');
-        expect(mutationLog).toEqual(['undo-batch-1', 'undo-batch-2']);
+        // undo mutations of batched items replay in reverse chronological order
+        expect(mutationLog).toEqual(['undo-batch-2', 'undo-batch-1']);
         expect(undoRedoService.pitchTopUndoElement()).toBeNull();
+    });
+
+    it('should restore both stacks and the status when a transaction is rolled back', () => {
+        // build up a redo history before the transaction starts
+        undoRedoService.pushUndoRedo({
+            unitID: 'unit-1',
+            undoMutations: [{ id: MUTATION_ID, params: { label: 'undo-first' } }],
+            redoMutations: [{ id: MUTATION_ID, params: { label: 'redo-first' } }],
+            id: 'first',
+        });
+        expect(commandService.syncExecuteCommand(UndoCommandId)).toBe(true);
+        expect(undoRedoService.pitchTopRedoElement()?.id).toBe('first');
+
+        const statuses: Array<{ undos: number; redos: number }> = [];
+        undoRedoService.undoRedoStatus$.subscribe((status) => {
+            statuses.push(status);
+        });
+
+        const transaction = undoRedoService.__tempUndoRedoTransaction('unit-1');
+        undoRedoService.pushUndoRedo({
+            unitID: 'unit-1',
+            undoMutations: [{ id: MUTATION_ID, params: { label: 'undo-txn-1' } }],
+            redoMutations: [{ id: MUTATION_ID, params: { label: 'redo-txn-1' } }],
+            id: 'txn',
+        });
+        undoRedoService.pushUndoRedo({
+            unitID: 'unit-1',
+            undoMutations: [{ id: MUTATION_ID, params: { label: 'undo-txn-2' } }],
+            redoMutations: [{ id: MUTATION_ID, params: { label: 'redo-txn-2' } }],
+            id: 'txn',
+        });
+        // pushing inside the transaction clears the redo stack as usual
+        expect(undoRedoService.pitchTopRedoElement()).toBeNull();
+
+        mutationLog.length = 0;
+        transaction.rollback();
+
+        // the batched undo mutations replay in reverse chronological order
+        expect(mutationLog).toEqual(['undo-txn-2', 'undo-txn-1']);
+        // the undo stack is back to empty and the redo history is restored
+        expect(undoRedoService.pitchTopUndoElement()).toBeNull();
+        expect(undoRedoService.pitchTopRedoElement()?.id).toBe('first');
+        expect(statuses.at(-1)).toEqual({ undos: 0, redos: 1 });
+        // rolling back twice has no further effect
+        transaction.rollback();
+        expect(mutationLog).toEqual(['undo-txn-2', 'undo-txn-1']);
+    });
+
+    it('should roll back a transaction when the undo stack is at capacity', () => {
+        // fill the undo stack up to its capacity of 20 elements
+        for (let i = 0; i < 20; i++) {
+            undoRedoService.pushUndoRedo({
+                unitID: 'unit-1',
+                undoMutations: [{ id: MUTATION_ID, params: { label: `undo-pre-${i}` } }],
+                redoMutations: [{ id: MUTATION_ID, params: { label: `redo-pre-${i}` } }],
+                id: `pre-${i}`,
+            });
+        }
+        expect(undoRedoService.pitchTopUndoElement()?.id).toBe('pre-19');
+
+        const statuses: Array<{ undos: number; redos: number }> = [];
+        undoRedoService.undoRedoStatus$.subscribe((status) => {
+            statuses.push(status);
+        });
+
+        const transaction = undoRedoService.__tempUndoRedoTransaction('unit-1');
+        // pushing on a full stack evicts the oldest element, keeping the stack length at 20
+        undoRedoService.pushUndoRedo({
+            unitID: 'unit-1',
+            undoMutations: [{ id: MUTATION_ID, params: { label: 'undo-txn' } }],
+            redoMutations: [{ id: MUTATION_ID, params: { label: 'redo-txn' } }],
+            id: 'txn',
+        });
+        expect(undoRedoService.pitchTopUndoElement()?.id).toBe('txn');
+
+        mutationLog.length = 0;
+        transaction.rollback();
+
+        // the transaction mutations are undone even though the stack length did not grow
+        expect(mutationLog).toEqual(['undo-txn']);
+        // the full 20 element history is restored, including the evicted oldest element
+        expect(undoRedoService.pitchTopUndoElement()?.id).toBe('pre-19');
+        expect(statuses.at(-1)).toEqual({ undos: 20, redos: 0 });
+    });
+
+    it('should keep the batched element when a transaction is committed', () => {
+        const transaction = undoRedoService.__tempUndoRedoTransaction('unit-1');
+        undoRedoService.pushUndoRedo({
+            unitID: 'unit-1',
+            undoMutations: [{ id: MUTATION_ID, params: { label: 'undo-commit-1' } }],
+            redoMutations: [{ id: MUTATION_ID, params: { label: 'redo-commit-1' } }],
+            id: 'commit',
+        });
+        undoRedoService.pushUndoRedo({
+            unitID: 'unit-1',
+            undoMutations: [{ id: MUTATION_ID, params: { label: 'undo-commit-2' } }],
+            redoMutations: [{ id: MUTATION_ID, params: { label: 'redo-commit-2' } }],
+            id: 'commit',
+        });
+        transaction.commit();
+
+        const top = undoRedoService.pitchTopUndoElement();
+        expect(top?.undoMutations).toHaveLength(2);
+        expect(top?.redoMutations).toHaveLength(2);
+
+        // rolling back after committing has no effect
+        transaction.rollback();
+        expect(undoRedoService.pitchTopUndoElement()?.undoMutations).toHaveLength(2);
     });
 
     it('should resolve focused unit id from sheet editor contexts and clear unit stacks', () => {

--- a/packages/core/src/services/undoredo/undoredo.service.ts
+++ b/packages/core/src/services/undoredo/undoredo.service.ts
@@ -40,6 +40,16 @@ export interface IUndoRedoItem {
     id?: string;
 }
 
+export interface IUndoRedoTransaction {
+    /** Keep the batched undo redo element and end the transaction. */
+    commit(): void;
+    /**
+     * Undo the elements pushed during the transaction and restore both the undo and the redo
+     * stack to the state they had when the transaction started, then end the transaction.
+     */
+    rollback(): void;
+}
+
 export interface IUndoRedoService {
     undoRedoStatus$: Observable<IUndoRedoStatus>;
 
@@ -64,6 +74,16 @@ export interface IUndoRedoService {
      * @returns a disposable to cancel batching undo redo elements
      */
     __tempBatchingUndoRedo(unitId: string): IDisposable;
+
+    /**
+     * Batch undo redo elements into a single `IUndoRedoItem` like `__tempBatchingUndoRedo`,
+     * and additionally allow rolling the batch back: the pushed elements are undone and the
+     * undo and redo stacks are restored to the state they had when the transaction started.
+     *
+     * @deprecated This is a temporary solution. We are going to refactor the undo redo service shortly.
+     * @returns a transaction that must be either committed or rolled back
+     */
+    __tempUndoRedoTransaction(unitId: string): IUndoRedoTransaction;
 }
 
 enum BatchingStatus {
@@ -288,6 +308,7 @@ export class LocalUndoRedoService extends Disposable implements IUndoRedoService
         if (item && item.id === id) {
             stack.pop();
             sequenceExecute(item.undoMutations, this._commandService);
+            this._updateStatus();
         }
     }
 
@@ -298,6 +319,47 @@ export class LocalUndoRedoService extends Disposable implements IUndoRedoService
 
         this._batchingStatus.set(unitId, BatchingStatus.WAITING);
         return toDisposable(() => this._batchingStatus.delete(unitId));
+    }
+
+    __tempUndoRedoTransaction(unitId: string): IUndoRedoTransaction {
+        const undoStack = this._getUndoStack(unitId, true);
+        const redoStack = this._getRedoStack(unitId, true);
+        const undoSnapshot = undoStack.slice();
+        const redoSnapshot = redoStack.slice();
+        const batching = this.__tempBatchingUndoRedo(unitId);
+        let finished = false;
+
+        return {
+            commit: () => {
+                if (finished) return;
+                finished = true;
+
+                batching.dispose();
+            },
+            rollback: () => {
+                if (finished) return;
+                finished = true;
+
+                batching.dispose();
+
+                // Undo the elements pushed since the transaction started, then restore both
+                // stacks, so a rolled back transaction does not clear the redo history and
+                // leaves no undo element behind. The pushed elements are identified by
+                // reference: when the stack is at capacity, pushing evicts the oldest element
+                // and the stack length no longer reflects what was pushed.
+                const snapshotItems = new Set(undoSnapshot);
+                const pushedDuringTransaction = undoStack.filter((item) => !snapshotItems.has(item));
+                for (let i = pushedDuringTransaction.length - 1; i >= 0; i--) {
+                    sequenceExecute(pushedDuringTransaction[i].undoMutations, this._commandService);
+                }
+
+                undoStack.length = 0;
+                undoStack.push(...undoSnapshot);
+                redoStack.length = 0;
+                redoStack.push(...redoSnapshot);
+                this._updateStatus();
+            },
+        };
     }
 
     protected _updateStatus(): void {
@@ -356,9 +418,11 @@ export class LocalUndoRedoService extends Disposable implements IUndoRedoService
     }
 
     private _tryBatchingElements(item: IUndoRedoItem, newItem: IUndoRedoItem): void {
-        // this could be not that easy in other sitatuations than Find & Replace
+        // Redo mutations replay in chronological order, while undo mutations must replay in
+        // reverse chronological order. This matters for order-sensitive mutations, e.g. batched
+        // row removals: rows removed bottom-up must be inserted back top-down on undo.
         item.redoMutations.push(...newItem.redoMutations);
-        item.undoMutations.push(...newItem.undoMutations);
+        item.undoMutations.unshift(...newItem.undoMutations);
     }
 
     private _getFocusedUnitId() {

--- a/packages/docs-drawing-ui/src/commands/commands/__tests__/drawing-commands.spec.ts
+++ b/packages/docs-drawing-ui/src/commands/commands/__tests__/drawing-commands.spec.ts
@@ -741,9 +741,11 @@ describe('docs drawing commands integration', () => {
             removeResourceMutation.id,
             RichTextEditingMutation.id,
         ]);
+        // undo mutations replay in reverse chronological order: the resource is removed before
+        // the rich-text mutation on execution, so it is restored after it on undo
         expect(undoItem?.undoMutations.map((mutation) => mutation.id)).toEqual([
-            restoreResourceMutation.id,
             RichTextEditingMutation.id,
+            restoreResourceMutation.id,
         ]);
 
         testBed.univer.dispose();

--- a/packages/sheets-ui/src/commands/commands/__tests__/remove-row-col-confirm.command.spec.ts
+++ b/packages/sheets-ui/src/commands/commands/__tests__/remove-row-col-confirm.command.spec.ts
@@ -15,15 +15,22 @@
  */
 
 import type { Injector, Univer, Workbook } from '@univerjs/core';
-import { ICommandService, IConfirmService, IUniverInstanceService, LocaleService, RANGE_TYPE, TestConfirmService, UniverInstanceType } from '@univerjs/core';
+import { ICommandService, IConfirmService, IPermissionService, IUndoRedoService, IUniverInstanceService, LocaleService, RANGE_TYPE, RedoCommand, TestConfirmService, UndoCommand, UniverInstanceType } from '@univerjs/core';
+import { DefinedNamesService, IDefinedNamesService } from '@univerjs/engine-formula';
+import { UnitObject } from '@univerjs/protocol';
 import {
     AddWorksheetMergeAllCommand,
     AddWorksheetMergeCommand,
     AddWorksheetMergeHorizontalCommand,
     AddWorksheetMergeMutation,
     AddWorksheetMergeVerticalCommand,
+    EditStateEnum,
     InsertColByRangeCommand,
+    InsertColMutation,
     InsertRowByRangeCommand,
+    InsertRowMutation,
+    RangeProtectionPermissionEditPoint,
+    RangeProtectionRuleModel,
     RemoveColByRangeCommand,
     RemoveColCommand,
     RemoveColMutation,
@@ -34,7 +41,10 @@ import {
     RemoveWorksheetMergeMutation,
     SetRangeValuesMutation,
     SetSelectionsOperation,
+    SheetInterceptorService,
+    SheetPermissionCheckController,
     SheetsSelectionsService,
+    ViewStateEnum,
 } from '@univerjs/sheets';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { RemoveColConfirmCommand, RemoveRowConfirmCommand } from '../remove-row-col-confirm.command';
@@ -48,6 +58,9 @@ describe('Test remove row col confirm commands', () => {
     beforeEach(() => {
         const testBed = createCommandTestBed(undefined, [
             [IConfirmService, { useClass: TestConfirmService }],
+            [IDefinedNamesService, { useClass: DefinedNamesService }],
+            // registered lazily; instantiated only by the tests covering permission checks
+            [SheetPermissionCheckController],
         ]);
         univer = testBed.univer;
 
@@ -69,6 +82,8 @@ describe('Test remove row col confirm commands', () => {
         commandService.registerCommand(RemoveColCommand);
         commandService.registerCommand(RemoveColMutation);
         commandService.registerCommand(SetSelectionsOperation);
+        commandService.registerCommand(InsertRowMutation);
+        commandService.registerCommand(InsertColMutation);
 
         [
             RemoveColByRangeCommand,
@@ -130,6 +145,346 @@ describe('Test remove row col confirm commands', () => {
             expect(await commandService.executeCommand(RemoveRowConfirmCommand.id)).toBeFalsy();
             expect(getRowCount()).toBe(1000);
         });
+
+        it('Will remove all row ranges when there are multiple selections and undo in one step', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: 1, startColumn: Number.NaN, endRow: 1, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 3, startColumn: Number.NaN, endRow: 3, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 5, startColumn: Number.NaN, endRow: 5, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            function getWorksheet() {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)!
+                    .getSheetBySheetId('sheet1')!;
+            }
+
+            expect(getWorksheet().getRowCount()).toBe(1000);
+            expect(await commandService.executeCommand(RemoveRowConfirmCommand.id)).toBeTruthy();
+            expect(getWorksheet().getRowCount()).toBe(997);
+            // the cell at B21 (row 20) moves up by the three removed rows above it
+            expect(getWorksheet().getCellMatrix().getValue(17, 1)?.v).toBe(2);
+
+            // a single undo restores all removed rows at their original positions
+            expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
+            expect(getWorksheet().getRowCount()).toBe(1000);
+            expect(getWorksheet().getCellMatrix().getValue(20, 1)?.v).toBe(2);
+        });
+
+        it('Will remove duplicate and overlapping row selections only once', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: 1, startColumn: Number.NaN, endRow: 1, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 1, startColumn: Number.NaN, endRow: 1, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 1, startColumn: Number.NaN, endRow: 2, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            function getRowCount(): number | undefined {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)
+                    ?.getSheetBySheetId('sheet1')
+                    ?.getRowCount();
+            }
+
+            expect(getRowCount()).toBe(1000);
+            expect(await commandService.executeCommand(RemoveRowConfirmCommand.id)).toBeTruthy();
+            expect(getRowCount()).toBe(998);
+        });
+
+        it('Will not remove any rows when one of the selected ranges is rejected', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: 1, startColumn: Number.NaN, endRow: 1, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 3, startColumn: Number.NaN, endRow: 3, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 5, startColumn: Number.NaN, endRow: 5, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            // reject removing row 1, which is the last range to be removed in bottom-up order,
+            // so a partial removal would already have happened without the pre-check
+            const sheetInterceptorService = get(SheetInterceptorService);
+            const disposable = sheetInterceptorService.interceptBeforeCommand({
+                performCheck: async (info) => {
+                    if (info.id !== RemoveRowCommand.id) {
+                        return true;
+                    }
+                    const range = (info.params as { range?: { startRow: number; endRow: number } })?.range;
+                    return !(range && range.startRow <= 1 && range.endRow >= 1);
+                },
+            });
+
+            function getRowCount(): number | undefined {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)
+                    ?.getSheetBySheetId('sheet1')
+                    ?.getRowCount();
+            }
+
+            expect(getRowCount()).toBe(1000);
+            expect(await commandService.executeCommand(RemoveRowConfirmCommand.id)).toBeFalsy();
+            expect(getRowCount()).toBe(1000);
+
+            disposable.dispose();
+        });
+
+        it('Will roll back already removed rows when a later range is rejected during execution', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: 1, startColumn: Number.NaN, endRow: 1, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 3, startColumn: Number.NaN, endRow: 3, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 5, startColumn: Number.NaN, endRow: 5, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            function getWorksheet() {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)!
+                    .getSheetBySheetId('sheet1')!;
+            }
+
+            // the check on row 1 passes while nothing has been removed yet (pre-check) but fails
+            // once other rows were removed, simulating a veto that only occurs mid-execution
+            const sheetInterceptorService = get(SheetInterceptorService);
+            const disposable = sheetInterceptorService.interceptBeforeCommand({
+                performCheck: async (info) => {
+                    if (info.id !== RemoveRowCommand.id) {
+                        return true;
+                    }
+                    const range = (info.params as { range?: { startRow: number; endRow: number } })?.range;
+                    if (!(range && range.startRow <= 1 && range.endRow >= 1)) {
+                        return true;
+                    }
+                    return getWorksheet().getRowCount() === 1000;
+                },
+            });
+
+            expect(getWorksheet().getRowCount()).toBe(1000);
+            expect(await commandService.executeCommand(RemoveRowConfirmCommand.id)).toBeFalsy();
+            // rows 5 and 3 were removed before the rejection and must be restored by the rollback
+            expect(getWorksheet().getRowCount()).toBe(1000);
+            expect(getWorksheet().getCellMatrix().getValue(20, 1)?.v).toBe(2);
+            // the rolled back removal must not stay on the undo stack
+            expect(await commandService.executeCommand(UndoCommand.id)).toBeFalsy();
+            expect(getWorksheet().getRowCount()).toBe(1000);
+
+            disposable.dispose();
+        });
+
+        it('Will preserve redo history, status and selections when a later range fails', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            const undoRedoService = get(IUndoRedoService);
+
+            function getWorksheet() {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)!
+                    .getSheetBySheetId('sheet1')!;
+            }
+
+            // build up a redo history: remove row 10, then undo it
+            selectionManager.addSelections([
+                {
+                    range: { startRow: 10, startColumn: Number.NaN, endRow: 10, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+            expect(await commandService.executeCommand(RemoveRowConfirmCommand.id)).toBeTruthy();
+            expect(getWorksheet().getRowCount()).toBe(999);
+            expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
+            expect(getWorksheet().getRowCount()).toBe(1000);
+
+            // let the trailing edge of the single removal's selection throttle pass
+            await new Promise((resolve) => {
+                setTimeout(resolve, 350);
+            });
+
+            selectionManager.setSelections([
+                {
+                    range: { startRow: 1, startColumn: Number.NaN, endRow: 1, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 3, startColumn: Number.NaN, endRow: 3, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 5, startColumn: Number.NaN, endRow: 5, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            // reject removing row 1 only once other rows were removed (i.e. after the pre-check)
+            const sheetInterceptorService = get(SheetInterceptorService);
+            const disposable = sheetInterceptorService.interceptBeforeCommand({
+                performCheck: async (info) => {
+                    if (info.id !== RemoveRowCommand.id) {
+                        return true;
+                    }
+                    const range = (info.params as { range?: { startRow: number; endRow: number } })?.range;
+                    if (!(range && range.startRow <= 1 && range.endRow >= 1)) {
+                        return true;
+                    }
+                    return getWorksheet().getRowCount() === 1000;
+                },
+            });
+
+            const statuses: Array<{ undos: number; redos: number }> = [];
+            const subscription = undoRedoService.undoRedoStatus$.subscribe((status) => {
+                statuses.push(status);
+            });
+
+            expect(await commandService.executeCommand(RemoveRowConfirmCommand.id)).toBeFalsy();
+            expect(getWorksheet().getRowCount()).toBe(1000);
+
+            // the previous redo history survives the failed removal
+            expect(statuses.at(-1)).toEqual({ undos: 0, redos: 1 });
+
+            // the original multi-selection is restored...
+            const rowsOf = () => selectionManager.getCurrentSelections()?.map((s) => [s.range.startRow, s.range.endRow]);
+            expect(rowsOf()).toEqual([[1, 1], [3, 3], [5, 5]]);
+            // ...and stays restored after the selection throttle window has passed
+            await new Promise((resolve) => {
+                setTimeout(resolve, 350);
+            });
+            expect(rowsOf()).toEqual([[1, 1], [3, 3], [5, 5]]);
+
+            // redo is still executable and removes row 10 again
+            expect(await commandService.executeCommand(RedoCommand.id)).toBeTruthy();
+            expect(getWorksheet().getRowCount()).toBe(999);
+
+            subscription.unsubscribe();
+            disposable.dispose();
+        });
+
+        it('Will roll back already removed rows when range protection denies a protected row', async () => {
+            // activate the real permission check controller
+            get(SheetPermissionCheckController);
+
+            const ruleModel = get(RangeProtectionRuleModel);
+            ruleModel.addRule('test', 'sheet1', {
+                id: 'rule-1',
+                permissionId: 'permission-1',
+                ranges: [{ startRow: 1, endRow: 1, startColumn: 0, endColumn: 19 }],
+                unitId: 'test',
+                subUnitId: 'sheet1',
+                unitType: UnitObject.SelectRange,
+                viewState: ViewStateEnum.OthersCanView,
+                editState: EditStateEnum.OnlyMe,
+            });
+            const permissionService = get(IPermissionService);
+            const editPoint = new RangeProtectionPermissionEditPoint('test', 'sheet1', 'permission-1');
+            permissionService.addPermissionPoint(editPoint);
+            permissionService.updatePermissionPoint(editPoint.id, false);
+
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: 1, startColumn: Number.NaN, endRow: 1, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 3, startColumn: Number.NaN, endRow: 3, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 5, startColumn: Number.NaN, endRow: 5, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            function getWorksheet() {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)!
+                    .getSheetBySheetId('sheet1')!;
+            }
+
+            expect(getWorksheet().getRowCount()).toBe(1000);
+            expect(await commandService.executeCommand(RemoveRowConfirmCommand.id)).toBeFalsy();
+            // rows 5 and 3 were removed before the protected row 1 was rejected,
+            // and must be restored by the rollback
+            expect(getWorksheet().getRowCount()).toBe(1000);
+            expect(getWorksheet().getCellMatrix().getValue(20, 1)?.v).toBe(2);
+        });
+
+        it('Will not apply when multiple selections cover all rows', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: 0, startColumn: Number.NaN, endRow: 499, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: 500, startColumn: Number.NaN, endRow: 999, endColumn: Number.NaN, rangeType: RANGE_TYPE.ROW },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            function getRowCount(): number | undefined {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)
+                    ?.getSheetBySheetId('sheet1')
+                    ?.getRowCount();
+            }
+
+            expect(getRowCount()).toBe(1000);
+            expect(await commandService.executeCommand(RemoveRowConfirmCommand.id)).toBeFalsy();
+            expect(getRowCount()).toBe(1000);
+        });
     });
 
     describe('Remove col', () => {
@@ -160,6 +515,200 @@ describe('Test remove row col confirm commands', () => {
             selectionManager.addSelections([
                 {
                     range: { startRow: Number.NaN, startColumn: 0, endRow: Number.NaN, endColumn: 19, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            function getColumnCount(): number | undefined {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)
+                    ?.getSheetBySheetId('sheet1')
+                    ?.getColumnCount();
+            }
+
+            expect(getColumnCount()).toBe(20);
+            expect(await commandService.executeCommand(RemoveColConfirmCommand.id)).toBeFalsy();
+            expect(getColumnCount()).toBe(20);
+        });
+
+        it('Will remove all column ranges when there are multiple selections and undo in one step', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: Number.NaN, startColumn: 2, endRow: Number.NaN, endColumn: 2, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: Number.NaN, startColumn: 4, endRow: Number.NaN, endColumn: 4, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: Number.NaN, startColumn: 6, endRow: Number.NaN, endColumn: 6, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            function getWorksheet() {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)!
+                    .getSheetBySheetId('sheet1')!;
+            }
+
+            expect(getWorksheet().getColumnCount()).toBe(20);
+            expect(await commandService.executeCommand(RemoveColConfirmCommand.id)).toBeTruthy();
+            expect(getWorksheet().getColumnCount()).toBe(17);
+
+            // a single undo restores all removed columns
+            expect(await commandService.executeCommand(UndoCommand.id)).toBeTruthy();
+            expect(getWorksheet().getColumnCount()).toBe(20);
+        });
+
+        it('Will remove duplicate and overlapping column selections only once', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: Number.NaN, startColumn: 1, endRow: Number.NaN, endColumn: 1, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: Number.NaN, startColumn: 1, endRow: Number.NaN, endColumn: 1, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: Number.NaN, startColumn: 1, endRow: Number.NaN, endColumn: 2, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            function getColumnCount(): number | undefined {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)
+                    ?.getSheetBySheetId('sheet1')
+                    ?.getColumnCount();
+            }
+
+            expect(getColumnCount()).toBe(20);
+            expect(await commandService.executeCommand(RemoveColConfirmCommand.id)).toBeTruthy();
+            expect(getColumnCount()).toBe(18);
+        });
+
+        it('Will not remove any columns when one of the selected ranges is rejected', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: Number.NaN, startColumn: 1, endRow: Number.NaN, endColumn: 1, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: Number.NaN, startColumn: 3, endRow: Number.NaN, endColumn: 3, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: Number.NaN, startColumn: 5, endRow: Number.NaN, endColumn: 5, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            // reject removing column 1, which is the last range to be removed in right-to-left
+            // order, so a partial removal would already have happened without the pre-check
+            const sheetInterceptorService = get(SheetInterceptorService);
+            const disposable = sheetInterceptorService.interceptBeforeCommand({
+                performCheck: async (info) => {
+                    if (info.id !== RemoveColCommand.id) {
+                        return true;
+                    }
+                    const range = (info.params as { range?: { startColumn: number; endColumn: number } })?.range;
+                    return !(range && range.startColumn <= 1 && range.endColumn >= 1);
+                },
+            });
+
+            function getColumnCount(): number | undefined {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)
+                    ?.getSheetBySheetId('sheet1')
+                    ?.getColumnCount();
+            }
+
+            expect(getColumnCount()).toBe(20);
+            expect(await commandService.executeCommand(RemoveColConfirmCommand.id)).toBeFalsy();
+            expect(getColumnCount()).toBe(20);
+
+            disposable.dispose();
+        });
+
+        it('Will roll back already removed columns when range protection denies a protected column', async () => {
+            // activate the real permission check controller
+            get(SheetPermissionCheckController);
+
+            const ruleModel = get(RangeProtectionRuleModel);
+            ruleModel.addRule('test', 'sheet1', {
+                id: 'rule-1',
+                permissionId: 'permission-1',
+                ranges: [{ startRow: 0, endRow: 999, startColumn: 1, endColumn: 1 }],
+                unitId: 'test',
+                subUnitId: 'sheet1',
+                unitType: UnitObject.SelectRange,
+                viewState: ViewStateEnum.OthersCanView,
+                editState: EditStateEnum.OnlyMe,
+            });
+            const permissionService = get(IPermissionService);
+            const editPoint = new RangeProtectionPermissionEditPoint('test', 'sheet1', 'permission-1');
+            permissionService.addPermissionPoint(editPoint);
+            permissionService.updatePermissionPoint(editPoint.id, false);
+
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: Number.NaN, startColumn: 1, endRow: Number.NaN, endColumn: 1, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: Number.NaN, startColumn: 3, endRow: Number.NaN, endColumn: 3, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: Number.NaN, startColumn: 5, endRow: Number.NaN, endColumn: 5, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+            ]);
+
+            function getWorksheet() {
+                return get(IUniverInstanceService)
+                    .getUnit<Workbook>('test', UniverInstanceType.UNIVER_SHEET)!
+                    .getSheetBySheetId('sheet1')!;
+            }
+
+            expect(getWorksheet().getColumnCount()).toBe(20);
+            expect(await commandService.executeCommand(RemoveColConfirmCommand.id)).toBeFalsy();
+            // columns 5 and 3 were removed before the protected column 1 was rejected,
+            // and must be restored by the rollback
+            expect(getWorksheet().getColumnCount()).toBe(20);
+            expect(getWorksheet().getCellMatrix().getValue(20, 1)?.v).toBe(2);
+        });
+
+        it('Will not apply when multiple selections cover all cols', async () => {
+            const selectionManager = get(SheetsSelectionsService);
+            selectionManager.addSelections([
+                {
+                    range: { startRow: Number.NaN, startColumn: 0, endRow: Number.NaN, endColumn: 9, rangeType: RANGE_TYPE.COLUMN },
+                    primary: null,
+                    style: null,
+                },
+                {
+                    range: { startRow: Number.NaN, startColumn: 10, endRow: Number.NaN, endColumn: 19, rangeType: RANGE_TYPE.COLUMN },
                     primary: null,
                     style: null,
                 },

--- a/packages/sheets-ui/src/commands/commands/remove-row-col-confirm.command.ts
+++ b/packages/sheets-ui/src/commands/commands/remove-row-col-confirm.command.ts
@@ -14,28 +14,99 @@
  * limitations under the License.
  */
 
-import type { IAccessor, ICommand } from '@univerjs/core';
+import type { IAccessor, ICommand, IRange, Workbook, Worksheet } from '@univerjs/core';
 import type { IRemoveRowColCommandParams } from '@univerjs/sheets';
 import type { LocaleKey } from '../../locale/types';
-import { CommandType, ICommandService, IConfirmService, IUniverInstanceService, LocaleService } from '@univerjs/core';
-import { getSheetCommandTarget, RemoveColCommand, RemoveRowCommand, SheetsSelectionsService } from '@univerjs/sheets';
+import { CommandType, ICommandService, IConfirmService, IUndoRedoService, IUniverInstanceService, LocaleService, mergeIntervals, RANGE_TYPE } from '@univerjs/core';
+import { followSelectionOperation, getSheetCommandTarget, RemoveColCommand, RemoveRowCommand, SetSelectionsOperation, SheetInterceptorService, SheetsSelectionsService } from '@univerjs/sheets';
 import { isAllColumnsCovered, isAllRowsCovered } from './utils/selection-utils';
+
+function getTargetRanges(accessor: IAccessor, params?: IRemoveRowColCommandParams): IRange[] {
+    if (params?.range) {
+        return [params.range];
+    }
+
+    return accessor.get(SheetsSelectionsService).getCurrentSelections()?.map((s) => s.range) ?? [];
+}
+
+async function removeRangesWithAtomicUndo(
+    accessor: IAccessor,
+    removeCommandId: string,
+    removeRanges: IRange[],
+    target: { workbook: Workbook; worksheet: Worksheet; unitId: string; subUnitId: string }
+): Promise<boolean> {
+    const { workbook, worksheet, unitId, subUnitId } = target;
+    const commandService = accessor.get(ICommandService);
+
+    // A single range removal is atomic by itself and keeps its default behavior.
+    if (removeRanges.length === 1) {
+        return commandService.executeCommand(removeCommandId, { range: removeRanges[0] });
+    }
+
+    // Pre-check every range before removing anything, so a rejection (e.g. an interceptor
+    // veto) aborts the whole operation before any range is removed.
+    const sheetInterceptorService = accessor.get(SheetInterceptorService);
+    for (const range of removeRanges) {
+        const canPerform = await sheetInterceptorService.beforeCommandExecute({
+            id: removeCommandId,
+            params: { range, unitId, subUnitId },
+        });
+        if (!canPerform) {
+            return false;
+        }
+    }
+
+    // Remove the ranges inside an undo redo transaction: the removals batch into a single
+    // undo element, and a failure while removing a later range (e.g. a permission check
+    // rejecting a protected range) rolls the finished removals back instead of leaving a
+    // partial removal behind, without clearing the previous redo history.
+    const selections = accessor.get(SheetsSelectionsService).getCurrentSelections()?.map((selection) => ({
+        range: { ...selection.range },
+        primary: selection.primary ? { ...selection.primary } : null,
+        style: selection.style,
+    })) ?? [];
+
+    const transaction = accessor.get(IUndoRedoService).__tempUndoRedoTransaction(unitId);
+
+    const rollbackTransaction = () => {
+        transaction.rollback();
+        // restore the selections the ranges were removed for
+        if (selections.length) {
+            commandService.syncExecuteCommand(SetSelectionsOperation.id, { unitId, subUnitId, selections });
+        }
+    };
+
+    try {
+        for (const range of removeRanges) {
+            // per-range selection updates are suppressed; the selection is set once afterwards
+            const result = await commandService.executeCommand(removeCommandId, { range, followSelection: false });
+            if (!result) {
+                rollbackTransaction();
+                return false;
+            }
+        }
+    } catch (error) {
+        rollbackTransaction();
+        throw error;
+    }
+
+    transaction.commit();
+
+    const followSelection = followSelectionOperation(removeRanges[removeRanges.length - 1], workbook, worksheet);
+    commandService.syncExecuteCommand(followSelection.id, followSelection.params);
+
+    return true;
+}
 
 export const RemoveRowConfirmCommand: ICommand = {
     id: 'sheet.command.remove-row-confirm',
     type: CommandType.COMMAND,
     handler: async (accessor: IAccessor, params?: IRemoveRowColCommandParams) => {
-        const selectionManagerService = accessor.get(SheetsSelectionsService);
-
-        let range = params?.range;
-        if (!range) {
-            range = selectionManagerService.getCurrentLastSelection()?.range;
-        }
-        if (!range) {
+        const ranges = getTargetRanges(accessor, params);
+        if (!ranges.length) {
             return false;
         }
 
-        const commandService = accessor.get(ICommandService);
         const univerInstanceService = accessor.get(IUniverInstanceService);
 
         const target = getSheetCommandTarget(univerInstanceService);
@@ -44,7 +115,7 @@ export const RemoveRowConfirmCommand: ICommand = {
         const { worksheet } = target;
         const allRowRanges = worksheet.getVisibleRows();
 
-        if (isAllRowsCovered(allRowRanges, [range])) {
+        if (isAllRowsCovered(allRowRanges, ranges)) {
             const confirmService = accessor.get(IConfirmService);
             const localeService = accessor.get(LocaleService);
 
@@ -61,8 +132,14 @@ export const RemoveRowConfirmCommand: ICommand = {
             return false;
         }
 
-        await commandService.executeCommand(RemoveRowCommand.id, { range });
-        return true;
+        // Merge duplicate and overlapping selections, then remove bottom-up so that removing
+        // a range does not shift the rows of the ranges that are still to be removed.
+        const endColumn = Math.max(worksheet.getMaxColumns() - 1, 0);
+        const removeRanges: IRange[] = mergeIntervals(ranges.map((range) => [range.startRow, range.endRow]))
+            .reverse()
+            .map(([startRow, endRow]) => ({ startRow, endRow, startColumn: 0, endColumn, rangeType: RANGE_TYPE.ROW }));
+
+        return removeRangesWithAtomicUndo(accessor, RemoveRowCommand.id, removeRanges, target);
     },
 };
 
@@ -70,17 +147,11 @@ export const RemoveColConfirmCommand: ICommand = {
     id: 'sheet.command.remove-col-confirm',
     type: CommandType.COMMAND,
     handler: async (accessor: IAccessor, params?: IRemoveRowColCommandParams) => {
-        const selectionManagerService = accessor.get(SheetsSelectionsService);
-
-        let range = params?.range;
-        if (!range) {
-            range = selectionManagerService.getCurrentLastSelection()?.range;
-        }
-        if (!range) {
+        const ranges = getTargetRanges(accessor, params);
+        if (!ranges.length) {
             return false;
         }
 
-        const commandService = accessor.get(ICommandService);
         const univerInstanceService = accessor.get(IUniverInstanceService);
 
         const target = getSheetCommandTarget(univerInstanceService);
@@ -89,7 +160,7 @@ export const RemoveColConfirmCommand: ICommand = {
         const { worksheet } = target;
         const allColumnRanges = worksheet.getVisibleCols();
 
-        if (isAllColumnsCovered(allColumnRanges, [range])) {
+        if (isAllColumnsCovered(allColumnRanges, ranges)) {
             const confirmService = accessor.get(IConfirmService);
             const localeService = accessor.get(LocaleService);
 
@@ -106,7 +177,13 @@ export const RemoveColConfirmCommand: ICommand = {
             return false;
         }
 
-        await commandService.executeCommand(RemoveColCommand.id, { range });
-        return true;
+        // Merge duplicate and overlapping selections, then remove right-to-left so that removing
+        // a range does not shift the columns of the ranges that are still to be removed.
+        const endRow = Math.max(worksheet.getMaxRows() - 1, 0);
+        const removeRanges: IRange[] = mergeIntervals(ranges.map((range) => [range.startColumn, range.endColumn]))
+            .reverse()
+            .map(([startColumn, endColumn]) => ({ startRow: 0, endRow, startColumn, endColumn, rangeType: RANGE_TYPE.COLUMN }));
+
+        return removeRangesWithAtomicUndo(accessor, RemoveColCommand.id, removeRanges, target);
     },
 };

--- a/packages/sheets-ui/src/services/selection/__tests__/base-selection-render.service.spec.ts
+++ b/packages/sheets-ui/src/services/selection/__tests__/base-selection-render.service.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IRange } from '@univerjs/core';
 import type { ISelectionWithStyle } from '@univerjs/sheets';
 import {
     CommandService,
@@ -111,6 +112,10 @@ class TestSelectionRenderService extends BaseSelectionRenderService {
 
     checkClearPreviousControlsForTest(evt: { ctrlKey?: boolean; shiftKey?: boolean }) {
         this._checkClearPreviousControls(evt as never);
+    }
+
+    activateDuplicateControlForTest(range: IRange) {
+        return this._activateDuplicateControl(range);
     }
 
     setSingleModeForTest(enabled: boolean) {
@@ -316,6 +321,29 @@ describe('BaseSelectionRenderService', () => {
         expect(service.getSelectionControls()).toHaveLength(1);
         expect(service.isSelectionDisabled()).toBe(true);
         expect(service.inRefSelectionMode()).toBe(false);
+    });
+
+    it('moves a reused duplicate selection control to the end so it becomes the active selection', () => {
+        const { service } = createSelectionRenderService();
+        service.changeRuntimeForTest();
+        service.resetSelectionsByModelData(selections);
+
+        const [first, second] = service.getSelectionControls();
+        expect(service.getActiveSelectionControl()).toBe(second);
+
+        // a range without an identical selection control is not reused
+        expect(service.activateDuplicateControlForTest(
+            { startRow: 9, endRow: 9, startColumn: 9, endColumn: 9, rangeType: RANGE_TYPE.NORMAL }
+        )).toBeNull();
+        expect(service.getSelectionControls()).toEqual([first, second]);
+
+        // reusing the first control moves it to the end and makes it active
+        const reused = service.activateDuplicateControlForTest(
+            { startRow: 1, endRow: 1, startColumn: 1, endColumn: 1, rangeType: RANGE_TYPE.NORMAL }
+        );
+        expect(reused).toBe(first);
+        expect(service.getSelectionControls()).toEqual([second, first]);
+        expect(service.getActiveSelectionControl()).toBe(first);
     });
 
     it('chooses the visible viewport for frozen row and column selections', () => {

--- a/packages/sheets-ui/src/services/selection/base-selection-render.service.ts
+++ b/packages/sheets-ui/src/services/selection/base-selection-render.service.ts
@@ -37,6 +37,7 @@ import {
     Disposable,
     InterceptorManager,
     RANGE_TYPE,
+    Rectangle,
     ThemeService,
 } from '@univerjs/core';
 import { ScrollTimer, ScrollTimerType, SHEET_VIEWPORT_KEY, Vector2 } from '@univerjs/engine-render';
@@ -455,6 +456,27 @@ export class BaseSelectionRenderService extends Disposable implements ISheetSele
 
             return controls[this._activeControlIndex] as T;
         }
+    }
+
+    /**
+     * Find the selection control whose range is identical to the given range and move it to
+     * the end of the control list, so it becomes the active (last) selection. Used to reuse
+     * an existing selection instead of stacking a duplicate on top of it.
+     */
+    protected _activateDuplicateControl(range: IRange): Nullable<SelectionControl> {
+        const controls = this.getSelectionControls();
+        const duplicateControl = controls.find((control) => Rectangle.equals(control.model, range));
+        if (!duplicateControl) {
+            return null;
+        }
+
+        const index = controls.indexOf(duplicateControl);
+        if (index !== controls.length - 1) {
+            controls.splice(index, 1);
+            controls.push(duplicateControl);
+        }
+
+        return duplicateControl;
     }
 
     endSelection(): void {

--- a/packages/sheets-ui/src/services/selection/selection-render.service.ts
+++ b/packages/sheets-ui/src/services/selection/selection-render.service.ts
@@ -428,8 +428,18 @@ export class SheetSelectionRenderService extends BaseSelectionRenderService impl
 
             activeSelectionControl.updateRangeBySelectionWithCoord(selectionCellWithCoord);// (cursorRangeWidthCoord, primaryCursorCellRange);
         } else {
-            // In normal situation, pointerdown ---> Create new SelectionControl,
-            activeSelectionControl = this.newSelectionControl(scene, skeleton, selectionWithStyle);
+            // When holding ctrl, reuse the selection control whose range is identical to the
+            // clicked cell instead of stacking a duplicate selection on top of it. The reused
+            // control is moved to the end of the control list so it becomes the active selection.
+            const duplicateControl = evt.ctrlKey ? this._activateDuplicateControl(cursorRangeWidthCoord) : null;
+
+            if (duplicateControl) {
+                activeSelectionControl = duplicateControl;
+                duplicateControl.updateRangeBySelectionWithCoord(selectionCellWithCoord);
+            } else {
+                // In normal situation, pointerdown ---> Create new SelectionControl,
+                activeSelectionControl = this.newSelectionControl(scene, skeleton, selectionWithStyle);
+            }
         }
         // clear highlight except last one.
         for (let i = 0; i < this.getSelectionControls().length - 1; i++) {

--- a/packages/sheets/src/commands/commands/remove-row-col.command.ts
+++ b/packages/sheets/src/commands/commands/remove-row-col.command.ts
@@ -47,6 +47,8 @@ import { getSheetCommandTarget } from './utils/target-util';
 
 export interface IRemoveRowColCommandParams extends Partial<ISheetCommandSharedParams> {
     range: IRange;
+    /** Whether the selection should follow the removed range after removal. Defaults to true. */
+    followSelection?: boolean;
 }
 
 export interface IRemoveRowColCommandInterceptParams extends IRemoveRowColCommandParams {
@@ -59,12 +61,16 @@ export interface IRemoveRowByRangeCommandParams {
     range: IRange;
     unitId: string;
     subUnitId: string;
+    /** Whether the selection should follow the removed range after removal. Defaults to true. */
+    followSelection?: boolean;
 }
 
 export interface IRemoveColByRangeCommandParams {
     range: IRange;
     unitId: string;
     subUnitId: string;
+    /** Whether the selection should follow the removed range after removal. Defaults to true. */
+    followSelection?: boolean;
 }
 
 /**
@@ -145,7 +151,9 @@ export const RemoveRowByRangeCommand: ICommand<IRemoveRowByRangeCommandParams> =
         );
 
         if (result.result) {
-            setSelection(range, workbook, worksheet, commandService);
+            if (params.followSelection !== false) {
+                setSelection(range, workbook, worksheet, commandService);
+            }
 
             const afterInterceptors = sheetInterceptorService.afterCommandExecute({
                 id: RemoveRowCommandId,
@@ -216,6 +224,7 @@ export const RemoveRowCommand: ICommand<IRemoveRowColCommandParams> = {
             range,
             unitId,
             subUnitId,
+            followSelection: params?.followSelection,
         });
     },
 };
@@ -267,7 +276,9 @@ export const RemoveColByRangeCommand: ICommand<IRemoveColByRangeCommandParams> =
         );
 
         if (result.result) {
-            setSelection(range, workbook, worksheet, commandService);
+            if (params.followSelection !== false) {
+                setSelection(range, workbook, worksheet, commandService);
+            }
 
             const afterInterceptors = sheetInterceptorService.afterCommandExecute({
                 id: RemoveColCommandId,
@@ -339,6 +350,7 @@ export const RemoveColCommand: ICommand = {
             range,
             unitId,
             subUnitId,
+            followSelection: params?.followSelection,
         });
     },
 };


### PR DESCRIPTION
close #7060

### Description

Fixes two multi-selection defects reported in #7060:

1. **"Delete Selected Row / Column" only removed the last selection.** `RemoveRowConfirmCommand` / `RemoveColConfirmCommand` read only `getCurrentLastSelection()`, so with ctrl multi-selection (e.g. rows 3, 6 and 9) only the last selected range was removed. They now collect every selection, merge duplicate and overlapping spans, and remove them bottom-up (rows) / right-to-left (columns) through the existing single-range pipeline, batched into a single undo step. The "cannot delete all rows / columns" safety check now also accounts for every selection instead of only the last one.
2. **Ctrl+clicking the same cell stacked unlimited duplicate selections.** Row and column headers already guard against re-selecting an already selected row / column (`isThisRowSelected` / `isThisColSelected`), but the normal cell path had no such check. When ctrl is held and the clicked cell range is identical to an existing selection, the existing selection control is now reused instead of stacking a duplicate — a plain click adds nothing, while ctrl+drag starting from that cell still extends the selection.

Supporting change: `LocalUndoRedoService` batching (`__tempBatchingUndoRedo`) now prepends undo mutations so that batched undos replay in reverse chronological order, which order-sensitive mutations such as row re-insertion require. Redo order is unchanged. The existing batching consumers (find & replace, docs clipboard, docs drawing) use order-independent mutations and are unaffected — their test suites pass.

### How to test

- Select row 3, then ctrl+select rows 6 and 9, right-click a selected row header → "Delete Selected Row": all three rows are removed, and a single undo restores them at their original positions. Same for columns.
- Hold ctrl and click the same cell repeatedly: the selection list no longer accumulates duplicates; ctrl+clicking different cells still multi-selects; ctrl+dragging from an already-selected cell still extends the selection.
- Unit tests: six new cases in `remove-row-col-confirm.command.spec.ts` cover multi-range removal, duplicate / overlapping span merging, the all-rows / all-columns guard with multiple selections, and single-step undo; `undoredo.service.spec.ts` covers the batching order.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
