### PR TITLE
feat(engine-render): support transformer control layers

### DIFF
--- a/packages/engine-render/src/__tests__/scene.transformer.spec.ts
+++ b/packages/engine-render/src/__tests__/scene.transformer.spec.ts
@@ -52,4 +52,29 @@ describe('Transformer', () => {
         scene.dispose();
         engine.dispose();
     });
+
+    it('renders controls on the configured layer without moving the selected object', () => {
+        const engine = new Engine('transformer-layer-engine', { elementWidth: 100, elementHeight: 100, dpr: 1 });
+        const scene = new Scene('transformer-layer-scene', engine);
+        const rect = new Rect('transformer-layer-rect', { width: 10, height: 10 });
+        scene.addObject(rect, 2);
+        const transformer = new Transformer(scene, {
+            borderEnabled: true,
+            controlLayerIndex: 4,
+        });
+        let controlLayerIndex: number | undefined;
+        const controlSubscription = transformer.createControl$.subscribe((control) => {
+            controlLayerIndex = control.getLayerIndex();
+        });
+
+        transformer.setSelectedControl(rect);
+
+        expect(rect.getLayerIndex()).toBe(2);
+        expect(controlLayerIndex).toBe(4);
+
+        controlSubscription.unsubscribe();
+        transformer.dispose();
+        scene.dispose();
+        engine.dispose();
+    });
 });

--- a/packages/engine-render/src/basics/transformer-config.ts
+++ b/packages/engine-render/src/basics/transformer-config.ts
@@ -72,6 +72,9 @@ export interface ITransformerConfig {
     useSingleNodeRotation?: boolean;
     shouldOverdrawWholeArea?: boolean;
 
+    /** Render transformer controls on a layer independent from the selected object. */
+    controlLayerIndex?: number;
+
     zeroLeft?: number;
     zeroTop?: number;
     moveBoundaryEnabled?: boolean;

--- a/packages/engine-render/src/scene.transformer.ts
+++ b/packages/engine-render/src/scene.transformer.ts
@@ -222,6 +222,7 @@ export class Transformer extends Disposable implements ITransformerConfig {
 
     useSingleNodeRotation: boolean = false;
     shouldOverdrawWholeArea: boolean = false;
+    controlLayerIndex: number | undefined;
 
     private readonly _changeStart$ = new Subject<IChangeObserverConfig>();
 
@@ -1847,7 +1848,9 @@ export class Transformer extends Disposable implements ITransformerConfig {
         }
         const oKey = applyObject.oKey;
         const zIndex = this._selectedObjectMap.size + applyObject.maxZIndex + DEFAULT_CONTROL_PLUS_INDEX;
-        const layerIndex = applyObject.getLayerIndex() || DEFAULT_TRANSFORMER_LAYER_INDEX;
+        const layerIndex = applyObject.transformerConfig?.controlLayerIndex ??
+            this.controlLayerIndex ??
+            (applyObject.getLayerIndex() || DEFAULT_TRANSFORMER_LAYER_INDEX);
         const groupElements: BaseObject[] = [];
 
         if (borderEnabled && !isCropper) {


### PR DESCRIPTION
Refs dream-num/univer-cli#1246

## Summary

- Add an optional `controlLayerIndex` to the shared Transformer configuration.
- Render Transformer controls on the configured scene layer while preserving the current default behavior.
- Cover both the default layer and an explicitly configured control layer with unit tests.

This is the engine-render prerequisite for keeping transient Board controls separate from persistent Board content. It is intentionally generic and contains no Board-specific branching.

## Validation

- `pnpm vitest run packages/engine-render/src --passWithNoTests` (95 files; 864 passed, 59 skipped)
- `pnpm --filter @univerjs/engine-render typecheck`
- `pnpm lint-staged`
- `git diff --check`

No breaking changes are introduced. Existing consumers continue to use the scene's default object layer unless `controlLayerIndex` is configured.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
