### PR TITLE
feat(docs-ui): export list type pickers

### DIFF
--- a/packages/docs-ui/src/index.ts
+++ b/packages/docs-ui/src/index.ts
@@ -266,7 +266,6 @@ export { getCanvasOffsetByEngine, getTextRangeFromCharIndex } from './services/s
 export { getAnchorBounding, getLineBounding, TEXT_RANGE_LAYER_INDEX, TextRange } from './services/selection/text-range';
 export { whenDocAndEditorFocused } from './shortcuts/utils';
 export { DOC_VERTICAL_PADDING } from './types/const/padding';
-// TODO(@ai-review): Confirm this public picker export remains the supported reuse point for Shape ribbon consumers.
 export { BulletListTypePicker, OrderListTypePicker } from './views/list-type-picker/Picker';
 export {
     createEditorUndoRedoKeyboardConfig,

--- a/packages/docs-ui/src/index.ts
+++ b/packages/docs-ui/src/index.ts
@@ -266,6 +266,8 @@ export { getCanvasOffsetByEngine, getTextRangeFromCharIndex } from './services/s
 export { getAnchorBounding, getLineBounding, TEXT_RANGE_LAYER_INDEX, TextRange } from './services/selection/text-range';
 export { whenDocAndEditorFocused } from './shortcuts/utils';
 export { DOC_VERTICAL_PADDING } from './types/const/padding';
+// TODO(@ai-review): Confirm this public picker export remains the supported reuse point for Shape ribbon consumers.
+export { BulletListTypePicker, OrderListTypePicker } from './views/list-type-picker/Picker';
 export {
     createEditorUndoRedoKeyboardConfig,
     executeEditorUndoRedoCommand,


### PR DESCRIPTION
Refs dream-num/univer-cli#1210

## Summary

- Export the existing ordered-list and bullet-list picker components from the owning `@univerjs/docs-ui` package.
- Allow Shape ribbon consumers to reuse the same Doc list-style UI instead of duplicating picker behavior.

## Validation

- `pnpm exec eslint packages/docs-ui/src/index.ts`
- `pnpm --filter @univerjs/docs-ui typecheck`
- Consumer validation in Univer Pro: `pnpm --filter ./examples esbuild:demo -- --demo=slides-local`

## Architecture notes

This exposes an existing Docs UI component with a confirmed external SDK consumer. It adds no new implementation, dependency, image, document, demo behavior, Facade API, or cross-plugin i18n.

## Pull Request Checklist

- [x] Related issue is linked.
- [x] Naming conventions are followed.
- [x] No new unit test is needed for a public export of existing tested components.
- [x] No breaking change is introduced.
