### PR TITLE
fix(engine-formula): preserve declared LINEST array spills

### DIFF
--- a/packages/engine-formula/src/engine/ast-node/function-node.ts
+++ b/packages/engine-formula/src/engine/ast-node/function-node.ts
@@ -206,6 +206,13 @@ export class FunctionNode extends BaseAstNode {
             return result;
         }
 
+        if (
+            this._runtimeService.hasFunctionRefInfoOverride() &&
+            (this._runtimeService.currentRowCount > 1 || this._runtimeService.currentColumnCount > 1)
+        ) {
+            return result;
+        }
+
         return array.getFirstCell();
     }
 

--- a/packages/engine-formula/src/services/__tests__/runtime.service.spec.ts
+++ b/packages/engine-formula/src/services/__tests__/runtime.service.spec.ts
@@ -149,6 +149,16 @@ describe('FormulaRuntimeService', () => {
         expect(runtime.currentSubUnitId).toBe('sheet');
         expect(runtime.currentUnitId).toBe('unit');
 
+        expect(runtime.hasFunctionRefInfoOverride()).toBe(false);
+        const restoreRefInfo = runtime.setFunctionRefInfoOverride(1, 2);
+        expect(runtime.hasFunctionRefInfoOverride()).toBe(true);
+        expect(runtime.currentRowCount).toBe(1);
+        expect(runtime.currentColumnCount).toBe(2);
+        restoreRefInfo();
+        expect(runtime.hasFunctionRefInfoOverride()).toBe(false);
+        expect(runtime.currentRowCount).toBe(99);
+        expect(runtime.currentColumnCount).toBe(88);
+
         const lambdaVar = new Map<string, Nullable<BaseAstNode>>([['x', null]]);
         runtime.registerFunctionDefinitionPrivacyVar('lambda-1', lambdaVar);
         expect(runtime.getFunctionDefinitionPrivacyVar('lambda-1')).toBe(lambdaVar);

--- a/packages/engine-formula/src/services/runtime.service.ts
+++ b/packages/engine-formula/src/services/runtime.service.ts
@@ -123,6 +123,8 @@ export interface IFormulaRuntimeService {
 
     setFunctionRefInfoOverride(rowCount: number, columnCount: number): () => void;
 
+    hasFunctionRefInfoOverride(): boolean;
+
     registerFunctionDefinitionPrivacyVar(lambdaId: string, lambdaVar: Map<string, Nullable<BaseAstNode>>): void;
 
     getFunctionDefinitionPrivacyVar(lambdaId: string): Nullable<Map<string, Nullable<BaseAstNode>>>;
@@ -439,6 +441,10 @@ export class FormulaRuntimeService extends Disposable implements IFormulaRuntime
         return () => {
             this._functionRefInfoOverrideStack.pop();
         };
+    }
+
+    hasFunctionRefInfoOverride(): boolean {
+        return this._functionRefInfoOverrideStack.length > 0;
     }
 
     clearFunctionDefinitionPrivacyVar() {


### PR DESCRIPTION
## Summary

- preserve top-level legacy-array results when a declared array range is active
- keep normal single-cell LINEST formulas on the existing scalar compatibility path
- cover function-reference override lifecycle behavior

## Root cause

`FunctionNode` always reduced top-level legacy-array results to their first cell. The calculation runtime already supplied an explicit row/column override for declared array formulas, but the normalization step did not distinguish that case from a normal single-cell formula.

## Validation

- `pnpm --filter @univerjs/engine-formula typecheck`
- `pnpm exec vitest run src/services/__tests__/runtime.service.spec.ts src/functions/statistical/linest/__tests__/index.spec.ts` (22 tests passed)
- targeted ESLint: 0 errors
- `git diff --check`

## Pull Request Checklist

- [x] No related issue.
- [x] Naming conventions are followed.
- [x] Unit tests cover the change.
- [x] No breaking changes are introduced.