### PR TITLE
fix(engine-formula): materialize union reference offsets

### DIFF
--- a/packages/engine-formula/src/engine/reference-object/__tests__/cell-reference-object.spec.ts
+++ b/packages/engine-formula/src/engine/reference-object/__tests__/cell-reference-object.spec.ts
@@ -17,6 +17,7 @@
 import { CellValueType, ObjectMatrix } from '@univerjs/core';
 import { describe, expect, it } from 'vitest';
 import { CellReferenceObject } from '../cell-reference-object';
+import { RangeReferenceObject } from '../range-reference-object';
 
 describe('CellReferenceObject', () => {
     it('should allow blank cells inside the Excel grid even when they are outside snapshot row data', () => {
@@ -112,6 +113,45 @@ describe('CellReferenceObject', () => {
 
         expect(reference.getCellByPosition().getValue()).toBe(2);
         expect(reference.getCellByPosition(0, 0).getValue()).toBe(1);
+    });
+
+    it('should not apply a shared-formula offset twice when unioning a materialized reference', () => {
+        const sharedReference = new CellReferenceObject('$B$2');
+        const materializedReference = new CellReferenceObject('B3');
+        sharedReference.setRefOffset(0, 1);
+
+        const union = sharedReference.unionBy(materializedReference);
+
+        if (!(union instanceof RangeReferenceObject)) {
+            throw new TypeError('Expected a range reference');
+        }
+
+        expect(union.getRangePosition()).toEqual(expect.objectContaining({
+            startRow: 1,
+            endRow: 2,
+            startColumn: 1,
+            endColumn: 1,
+        }));
+    });
+
+    it('should apply matching shared-formula offsets once when unioning references', () => {
+        const startReference = new CellReferenceObject('A1');
+        const endReference = new CellReferenceObject('B1');
+        startReference.setRefOffset(0, 1);
+        endReference.setRefOffset(0, 1);
+
+        const union = startReference.unionBy(endReference);
+
+        if (!(union instanceof RangeReferenceObject)) {
+            throw new TypeError('Expected a range reference');
+        }
+
+        expect(union.getRangePosition()).toEqual(expect.objectContaining({
+            startRow: 1,
+            endRow: 1,
+            startColumn: 0,
+            endColumn: 1,
+        }));
     });
 
     it('should treat string enum number cell types as numeric cells', () => {

--- a/packages/engine-formula/src/engine/reference-object/cell-reference-object.ts
+++ b/packages/engine-formula/src/engine/reference-object/cell-reference-object.ts
@@ -59,7 +59,7 @@ export class CellReferenceObject extends BaseReferenceObject {
         //     return ErrorValueObject.create(ErrorType.REF);
         // }
 
-        const newRangeData = this.unionRange(this.getRangeData(), cellReferenceObject.getRangeData());
+        const newRangeData = this.unionRange(this.getRangePosition(), cellReferenceObject.getRangePosition());
 
         return this._createRange(newRangeData);
     }
@@ -125,10 +125,6 @@ export class CellReferenceObject extends BaseReferenceObject {
         rangeReferenceObject.setRuntimeArrayFormulaCellData(this.getRuntimeArrayFormulaCellData());
 
         rangeReferenceObject.setRuntimeFeatureCellData(this.getRuntimeFeatureCellData());
-
-        const { x, y } = this.getRefOffset();
-
-        rangeReferenceObject.setRefOffset(x, y);
 
         const forceSheetId = this.getForcedSheetId();
 


### PR DESCRIPTION
## Summary

- Materialize both cell references before combining them with the range operator.
- Prevent shared-formula offsets from being applied twice when one endpoint is already materialized by an address function such as `OFFSET`.
- Add regression coverage for mixed materialized references and ordinary matching shared offsets.

## Root cause

`CellReferenceObject.unionBy` combined raw range data and then copied the left reference offset to the resulting range. For formulas such as `=SUM($B$2:OFFSET(B2,0,0))`, `OFFSET` had already materialized its endpoint, so the shared-formula follower offset was applied a second time by the combined range.

## Impact

Shared-formula followers that combine a direct cell reference with an address-function result now read the same range as Excel. Ordinary relative range unions continue to apply their shared offset exactly once.

## Validation

- `pnpm --filter @univerjs/engine-formula exec vitest run src/engine/ast-node/__tests__/union-node.spec.ts src/functions/lookup/offset/__tests__/index.spec.ts src/engine/reference-object/__tests__/cell-reference-object.spec.ts` (25 tests passed)
- `pnpm --filter @univerjs/engine-formula typecheck`
- Dual-engine workbook snapshot suite in univer-rs (19 snapshots passed against Excel COM-verified caches)
- `git diff --check`

## Pull Request Checklist

- [x] Missing issue; this is a regression found by workbook-level compatibility snapshots.
- [x] Naming convention is followed.
- [x] Unit tests have been added.
- [x] No breaking changes are introduced.