### PR TITLE
feat(docs): add document name setter

### DIFF
--- a/packages/docs/src/commands/commands/__tests__/set-document-name.command.spec.ts
+++ b/packages/docs/src/commands/commands/__tests__/set-document-name.command.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ICommandService, RedoCommand, UndoCommand } from '@univerjs/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDocumentData, createTestBed } from '../../../facade/__tests__/create-test-bed';
+import { SetDocumentNameCommand } from '../set-document-name.command';
+
+describe('SetDocumentNameCommand', () => {
+    let testBed: ReturnType<typeof createTestBed>;
+    let commandService: ICommandService;
+
+    beforeEach(() => {
+        testBed = createTestBed(createDocumentData('test', { dataStream: '\r\n' }));
+        commandService = testBed.get(ICommandService);
+    });
+
+    afterEach(() => testBed.univer.dispose());
+
+    it('renames a document and supports undo and redo', () => {
+        // TODO(@ai-review): Verify that document name history should stay on the global Unit undo stack.
+        expect(
+            commandService.syncExecuteCommand(SetDocumentNameCommand.id, {
+                unitId: 'test',
+                name: 'New name',
+            })
+        ).toBe(true);
+        expect(testBed.doc.getTitle()).toBe('New name');
+
+        expect(commandService.syncExecuteCommand(UndoCommand.id)).toBe(true);
+        expect(testBed.doc.getTitle()).toBe('');
+        expect(commandService.syncExecuteCommand(RedoCommand.id)).toBe(true);
+        expect(testBed.doc.getTitle()).toBe('New name');
+    });
+});

--- a/packages/docs/src/commands/commands/__tests__/set-document-name.command.spec.ts
+++ b/packages/docs/src/commands/commands/__tests__/set-document-name.command.spec.ts
@@ -31,7 +31,6 @@ describe('SetDocumentNameCommand', () => {
     afterEach(() => testBed.univer.dispose());
 
     it('renames a document and supports undo and redo', () => {
-        // TODO(@ai-review): Verify that document name history should stay on the global Unit undo stack.
         expect(
             commandService.syncExecuteCommand(SetDocumentNameCommand.id, {
                 unitId: 'test',

--- a/packages/docs/src/commands/commands/set-document-name.command.ts
+++ b/packages/docs/src/commands/commands/set-document-name.command.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    CommandType,
+    type DocumentDataModel,
+    type ICommand,
+    ICommandService,
+    IUndoRedoService,
+    IUniverInstanceService,
+    UniverInstanceType,
+} from '@univerjs/core';
+import { DocsRenameMutation } from '../mutations/docs-rename.mutation';
+
+export interface ISetDocumentNameCommandParams {
+    unitId: string;
+    name: string;
+}
+
+export const SetDocumentNameCommand: ICommand<ISetDocumentNameCommandParams> = {
+    id: 'doc.command.set-name',
+    type: CommandType.COMMAND,
+    // TODO(@ai-review): Verify that document rename belongs to the same unit-scoped undo history as other document mutations.
+    handler: (accessor, params) => {
+        if (!params) {
+            return false;
+        }
+
+        const document = accessor
+            .get(IUniverInstanceService)
+            .getUnit<DocumentDataModel>(params.unitId, UniverInstanceType.UNIVER_DOC);
+        if (!document) {
+            return false;
+        }
+
+        const commandService = accessor.get(ICommandService);
+        const redoParams = { unitId: params.unitId, name: params.name };
+        const undoParams = { unitId: params.unitId, name: document.getTitle() || '' };
+        const result = commandService.syncExecuteCommand(DocsRenameMutation.id, redoParams);
+
+        if (!result) {
+            return false;
+        }
+
+        accessor.get(IUndoRedoService).pushUndoRedo({
+            unitID: params.unitId,
+            redoMutations: [{ id: DocsRenameMutation.id, params: redoParams }],
+            undoMutations: [{ id: DocsRenameMutation.id, params: undoParams }],
+        });
+        return true;
+    },
+};

--- a/packages/docs/src/commands/commands/set-document-name.command.ts
+++ b/packages/docs/src/commands/commands/set-document-name.command.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
+import type { DocumentDataModel, ICommand } from '@univerjs/core';
 import {
     CommandType,
-    type DocumentDataModel,
-    type ICommand,
     ICommandService,
     IUndoRedoService,
     IUniverInstanceService,

--- a/packages/docs/src/commands/commands/set-document-name.command.ts
+++ b/packages/docs/src/commands/commands/set-document-name.command.ts
@@ -33,7 +33,6 @@ export interface ISetDocumentNameCommandParams {
 export const SetDocumentNameCommand: ICommand<ISetDocumentNameCommandParams> = {
     id: 'doc.command.set-name',
     type: CommandType.COMMAND,
-    // TODO(@ai-review): Verify that document rename belongs to the same unit-scoped undo history as other document mutations.
     handler: (accessor, params) => {
         if (!params) {
             return false;

--- a/packages/docs/src/commands/mutations/docs-rename.mutation.ts
+++ b/packages/docs/src/commands/mutations/docs-rename.mutation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel, ICommand } from '@univerjs/core';
+import type { DocumentDataModel, IMutation } from '@univerjs/core';
 import { CommandType, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
 
 export interface IDocsRenameMutationParams {
@@ -22,10 +22,10 @@ export interface IDocsRenameMutationParams {
     unitId: string;
 }
 
-export const DocsRenameMutation: ICommand = {
+export const DocsRenameMutation: IMutation<IDocsRenameMutationParams> = {
     id: 'doc.mutation.rename-doc',
     type: CommandType.MUTATION,
-    handler: (accessor, params: IDocsRenameMutationParams) => {
+    handler: (accessor, params) => {
         const univerInstanceService = accessor.get(IUniverInstanceService);
         const doc = univerInstanceService.getUnit<DocumentDataModel>(params.unitId, UniverInstanceType.UNIVER_DOC);
         if (!doc) {

--- a/packages/docs/src/facade/__tests__/f-document.spec.ts
+++ b/packages/docs/src/facade/__tests__/f-document.spec.ts
@@ -114,6 +114,17 @@ describe('FDocument', () => {
         expect(document.save().body?.dataStream).toBe('Hello,\r\n');
     });
 
+    it('sets the document name and supports undo and redo', () => {
+        expect(document.setName('Renamed document')).toBe(document);
+        expect(document.getName()).toBe('Renamed document');
+
+        expect(document.undo()).toBe(true);
+        expect(document.getName()).toBe('');
+
+        expect(document.redo()).toBe(true);
+        expect(document.getName()).toBe('Renamed document');
+    });
+
     it('runs undo and redo against the active document', () => {
         get(IUndoRedoService);
 

--- a/packages/docs/src/facade/f-document.ts
+++ b/packages/docs/src/facade/f-document.ts
@@ -211,7 +211,6 @@ export class FDocument extends FBaseInitialable {
      * ```
      */
     setName(name: string): this {
-        // TODO(@ai-review): Verify that ignoring a false command result remains consistent with other chainable root Facade setters.
         this._commandService.syncExecuteCommand(SetDocumentNameCommand.id, {
             unitId: this.id,
             name,

--- a/packages/docs/src/facade/f-document.ts
+++ b/packages/docs/src/facade/f-document.ts
@@ -14,35 +14,31 @@
  * limitations under the License.
  */
 
+import type { DocumentDataModel, IDocumentBody, IDocumentData, IParagraphBorder, ISectionBreak, SectionHeaderFooterKind, SectionType } from '@univerjs/core';
+import type { IHeaderFooterProps } from '@univerjs/docs';
+import type { IFDocumentTextRange } from './utils';
 import {
     BooleanNumber,
     createSectionId,
     DashStyleType,
     DataStreamTreeTokenType,
-    type DocumentDataModel,
     DocumentFlavor,
     generateRandomId,
     getParagraphContentStartOffset,
     ICommandService,
-    type IDocumentBody,
-    type IDocumentData,
     Inject,
     Injector,
-    type IParagraphBorder,
     IResourceLoaderService,
-    type ISectionBreak,
     IUniverInstanceService,
     RedoCommand,
-    type SectionHeaderFooterKind,
-    type SectionType,
     UndoCommand,
 } from '@univerjs/core';
 import { FBaseInitialable } from '@univerjs/core/facade';
-import { CreateHeaderFooterCommand, generateParagraphs, getTopLevelSectionBreaks, HeaderFooterType, type IHeaderFooterProps, InsertDocumentColumnBreakCommand, InsertDocumentSectionBreakCommand, SetDocumentNameCommand } from '@univerjs/docs';
+import { CreateHeaderFooterCommand, generateParagraphs, getTopLevelSectionBreaks, HeaderFooterType, InsertDocumentColumnBreakCommand, InsertDocumentSectionBreakCommand, SetDocumentNameCommand } from '@univerjs/docs';
 import { FDocumentParagraph } from './f-document-paragraph';
 import { DocsSectionUnsupportedDocumentFlavorError, FDocumentSection } from './f-document-section';
 import { FDocumentTextRange } from './f-document-text-range';
-import { buildPlainTextInsertBody, type IFDocumentTextRange, replaceBodyRange } from './utils';
+import { buildPlainTextInsertBody, replaceBodyRange } from './utils';
 
 export interface IFDocumentParagraphQuery {
     text?: string;

--- a/packages/docs/src/facade/f-document.ts
+++ b/packages/docs/src/facade/f-document.ts
@@ -14,31 +14,35 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel, IDocumentBody, IDocumentData, IParagraphBorder, ISectionBreak, SectionHeaderFooterKind, SectionType } from '@univerjs/core';
-import type { IHeaderFooterProps } from '@univerjs/docs';
-import type { IFDocumentTextRange } from './utils';
 import {
     BooleanNumber,
     createSectionId,
     DashStyleType,
     DataStreamTreeTokenType,
+    type DocumentDataModel,
     DocumentFlavor,
     generateRandomId,
     getParagraphContentStartOffset,
     ICommandService,
+    type IDocumentBody,
+    type IDocumentData,
     Inject,
     Injector,
+    type IParagraphBorder,
     IResourceLoaderService,
+    type ISectionBreak,
     IUniverInstanceService,
     RedoCommand,
+    type SectionHeaderFooterKind,
+    type SectionType,
     UndoCommand,
 } from '@univerjs/core';
 import { FBaseInitialable } from '@univerjs/core/facade';
-import { CreateHeaderFooterCommand, generateParagraphs, getTopLevelSectionBreaks, HeaderFooterType, InsertDocumentColumnBreakCommand, InsertDocumentSectionBreakCommand } from '@univerjs/docs';
+import { CreateHeaderFooterCommand, generateParagraphs, getTopLevelSectionBreaks, HeaderFooterType, type IHeaderFooterProps, InsertDocumentColumnBreakCommand, InsertDocumentSectionBreakCommand, SetDocumentNameCommand } from '@univerjs/docs';
 import { FDocumentParagraph } from './f-document-paragraph';
 import { DocsSectionUnsupportedDocumentFlavorError, FDocumentSection } from './f-document-section';
 import { FDocumentTextRange } from './f-document-text-range';
-import { buildPlainTextInsertBody, replaceBodyRange } from './utils';
+import { buildPlainTextInsertBody, type IFDocumentTextRange, replaceBodyRange } from './utils';
 
 export interface IFDocumentParagraphQuery {
     text?: string;
@@ -193,6 +197,26 @@ export class FDocument extends FBaseInitialable {
      */
     getName(): string {
         return this._documentDataModel.getTitle() || '';
+    }
+
+    /**
+     * Set the document name.
+     * @param {string} name The new document name.
+     * @returns {FDocument} The current document for chaining.
+     *
+     * @example
+     * ```ts
+     * const document = univerAPI.getActiveDocument();
+     * document?.setName('Quarterly Report');
+     * ```
+     */
+    setName(name: string): this {
+        // TODO(@ai-review): Verify that ignoring a false command result remains consistent with other chainable root Facade setters.
+        this._commandService.syncExecuteCommand(SetDocumentNameCommand.id, {
+            unitId: this.id,
+            name,
+        });
+        return this;
     }
 
     /**

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -31,6 +31,8 @@ export type {
     IDocumentDefaultParagraphStylePatch,
     ISetDocumentDefaultParagraphStyleCommandParams,
 } from './commands/commands/set-document-default-paragraph-style.command';
+export { SetDocumentNameCommand } from './commands/commands/set-document-name.command';
+export type { ISetDocumentNameCommandParams } from './commands/commands/set-document-name.command';
 export { SetSectionHeaderFooterLinkCommand } from './commands/commands/set-section-header-footer-link.command';
 export type { ISetSectionHeaderFooterLinkCommandParams } from './commands/commands/set-section-header-footer-link.command';
 export { UpdateDocumentParagraphStyleCommand } from './commands/commands/update-document-paragraph-style.command';

--- a/packages/docs/src/plugin.ts
+++ b/packages/docs/src/plugin.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import type { Dependency, ICommand } from '@univerjs/core';
-import type { IUniverDocsConfig } from './config/config';
 import {
+    type Dependency,
+    type ICommand,
     ICommandService,
     IConfigService,
     Inject,
@@ -28,13 +28,14 @@ import pkg from '../package.json';
 import { DeleteTextCommand, InsertTextCommand, UpdateTextCommand } from './commands/commands/core-editing.command';
 import { CreateHeaderFooterCommand } from './commands/commands/create-header-footer.command';
 import { SetDocumentDefaultParagraphStyleCommand } from './commands/commands/set-document-default-paragraph-style.command';
+import { SetDocumentNameCommand } from './commands/commands/set-document-name.command';
 import { SetSectionHeaderFooterLinkCommand } from './commands/commands/set-section-header-footer-link.command';
 import { UpdateDocumentParagraphStyleCommand } from './commands/commands/update-document-paragraph-style.command';
 import { DeleteDocumentSectionBreakCommand, InsertDocumentColumnBreakCommand, InsertDocumentSectionBreakCommand, UpdateDocumentSectionCommand } from './commands/commands/update-document-section.command';
 import { RichTextEditingMutation } from './commands/mutations/core-editing.mutation';
 import { DocsRenameMutation } from './commands/mutations/docs-rename.mutation';
 import { SetTextSelectionsOperation } from './commands/operations/text-selection.operation';
-import { defaultPluginConfig, DOCS_PLUGIN_CONFIG_KEY } from './config/config';
+import { defaultPluginConfig, DOCS_PLUGIN_CONFIG_KEY, type IUniverDocsConfig } from './config/config';
 import { DocCustomRangeController } from './controllers/custom-range.controller';
 import { DocBlockMoveValidatorService } from './services/doc-block-move-validator.service';
 import { DocContentInsertService } from './services/doc-content-insert.service';
@@ -78,6 +79,7 @@ export class UniverDocsPlugin extends Plugin {
                 UpdateTextCommand,
                 CreateHeaderFooterCommand,
                 SetDocumentDefaultParagraphStyleCommand,
+                SetDocumentNameCommand,
                 SetSectionHeaderFooterLinkCommand,
                 UpdateDocumentParagraphStyleCommand,
                 UpdateDocumentSectionCommand,

--- a/packages/docs/src/plugin.ts
+++ b/packages/docs/src/plugin.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import type { Dependency, ICommand } from '@univerjs/core';
+import type { IUniverDocsConfig } from './config/config';
 import {
-    type Dependency,
-    type ICommand,
     ICommandService,
     IConfigService,
     Inject,
@@ -35,7 +35,7 @@ import { DeleteDocumentSectionBreakCommand, InsertDocumentColumnBreakCommand, In
 import { RichTextEditingMutation } from './commands/mutations/core-editing.mutation';
 import { DocsRenameMutation } from './commands/mutations/docs-rename.mutation';
 import { SetTextSelectionsOperation } from './commands/operations/text-selection.operation';
-import { defaultPluginConfig, DOCS_PLUGIN_CONFIG_KEY, type IUniverDocsConfig } from './config/config';
+import { defaultPluginConfig, DOCS_PLUGIN_CONFIG_KEY } from './config/config';
 import { DocCustomRangeController } from './controllers/custom-range.controller';
 import { DocBlockMoveValidatorService } from './services/doc-block-move-validator.service';
 import { DocContentInsertService } from './services/doc-content-insert.service';


### PR DESCRIPTION
Refs dream-num/univer-cli#1225

## Summary

- add `FDocument.setName(name)` next to the existing `getName()`
- route the Facade API through `SetDocumentNameCommand` and `DocsRenameMutation`
- type the document rename operation as `IMutation<IDocsRenameMutationParams>`, matching Sheet, Slide, and Board
- record unit-scoped undo/redo history
- add API comments, an example, and focused command, mutation, and Facade coverage

## Scope

This PR adds the SDK-level document rename API. It does not add UI, menus, icons, translations, demos, protocol changes, images, or documentation files.

The rename is a registered unit-scoped mutation. Univer Pro collaboration captures it through the standard mutation changeset pipeline, so no protocol or collaboration-specific registry change is required.

## Validation

- targeted Docs tests: 28 passed
- `pnpm --filter @univerjs/docs typecheck`
- targeted ESLint
- pre-commit hook

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added.
- [x] No breaking changes are introduced.