### PR TITLE
fix(engine-render): honor bullet text styles during layout

### DIFF
--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/fixtures/issue-1207-bullet-style.snapshot.json
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/fixtures/issue-1207-bullet-style.snapshot.json
@@ -1,0 +1,380 @@
+{
+    "source": {
+        "issue": 1207,
+        "format": "pptx",
+        "generatedBy": "@univerjs-pro/uexcli 0.3.0",
+        "description": "Real slide shape snapshots imported from issue-1207-bullet-style-cases.pptx"
+    },
+    "cases": [
+        {
+            "id": "shape-12",
+            "name": "case-A",
+            "doc": {
+                "body": {
+                    "dataStream": "Wingdings bullet; Arial body\r\n",
+                    "paragraphs": [
+                        {
+                            "bullet": {
+                                "listId": "shape-12-shape-text-list",
+                                "listType": "BULLET_LIST",
+                                "nestingLevel": 0,
+                                "textStyle": {
+                                    "ff": "Wingdings"
+                                }
+                            },
+                            "paragraphStyle": {
+                                "hanging": {
+                                    "v": 26
+                                },
+                                "horizontalAlign": 1,
+                                "indentStart": {
+                                    "v": 16
+                                }
+                            },
+                            "startIndex": 28
+                        }
+                    ],
+                    "textRuns": [
+                        {
+                            "ed": 28,
+                            "st": 0,
+                            "ts": {
+                                "cl": {
+                                    "rgb": "#111111",
+                                    "th": 0
+                                },
+                                "ff": "Arial",
+                                "fs": 18
+                            }
+                        }
+                    ]
+                },
+                "documentStyle": {
+                    "renderConfig": {
+                        "horizontalAlign": 1,
+                        "shapeTextOpticalVerticalAlign": 1,
+                        "verticalAlign": 2
+                    },
+                    "textStyle": {
+                        "cl": {
+                            "rgb": "#111111",
+                            "th": 0
+                        },
+                        "ff": "Arial",
+                        "fs": 18
+                    }
+                },
+                "id": "shape-12-shape-text",
+                "lists": {
+                    "BULLET_LIST": {
+                        "listType": "BULLET_LIST",
+                        "nestingLevel": [
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %1",
+                                "glyphSymbol": "p",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %2",
+                                "glyphSymbol": "○",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %3",
+                                "glyphSymbol": "■",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %4",
+                                "glyphSymbol": "●",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %5",
+                                "glyphSymbol": "○",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %6",
+                                "glyphSymbol": "■",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %7",
+                                "glyphSymbol": "●",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %8",
+                                "glyphSymbol": "○",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %9",
+                                "glyphSymbol": "■",
+                                "startNumber": 0
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "id": "shape-14",
+            "name": "case-B",
+            "doc": {
+                "body": {
+                    "dataStream": "Red, larger bullet; black Arial body\r\n",
+                    "paragraphs": [
+                        {
+                            "bullet": {
+                                "listId": "shape-14-shape-text-list",
+                                "listType": "BULLET_LIST",
+                                "nestingLevel": 0,
+                                "textStyle": {
+                                    "cl": {
+                                        "rgb": "#E11D48"
+                                    },
+                                    "ff": "Wingdings",
+                                    "fs": 27
+                                }
+                            },
+                            "paragraphStyle": {
+                                "hanging": {
+                                    "v": 26
+                                },
+                                "horizontalAlign": 1,
+                                "indentStart": {
+                                    "v": 16
+                                }
+                            },
+                            "startIndex": 36
+                        }
+                    ],
+                    "textRuns": [
+                        {
+                            "ed": 36,
+                            "st": 0,
+                            "ts": {
+                                "cl": {
+                                    "rgb": "#111111",
+                                    "th": 0
+                                },
+                                "ff": "Arial",
+                                "fs": 18
+                            }
+                        }
+                    ]
+                },
+                "documentStyle": {
+                    "renderConfig": {
+                        "horizontalAlign": 1,
+                        "shapeTextOpticalVerticalAlign": 1,
+                        "verticalAlign": 2
+                    },
+                    "textStyle": {
+                        "cl": {
+                            "rgb": "#111111",
+                            "th": 0
+                        },
+                        "ff": "Arial",
+                        "fs": 18
+                    }
+                },
+                "id": "shape-14-shape-text",
+                "lists": {
+                    "BULLET_LIST": {
+                        "listType": "BULLET_LIST",
+                        "nestingLevel": [
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %1",
+                                "glyphSymbol": "p",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %2",
+                                "glyphSymbol": "○",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %3",
+                                "glyphSymbol": "■",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %4",
+                                "glyphSymbol": "●",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %5",
+                                "glyphSymbol": "○",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %6",
+                                "glyphSymbol": "■",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %7",
+                                "glyphSymbol": "●",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %8",
+                                "glyphSymbol": "○",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %9",
+                                "glyphSymbol": "■",
+                                "startNumber": 0
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "id": "shape-16",
+            "name": "case-C",
+            "doc": {
+                "body": {
+                    "dataStream": "Unicode square bullet\r\n",
+                    "paragraphs": [
+                        {
+                            "bullet": {
+                                "listId": "shape-16-shape-text-list",
+                                "listType": "BULLET_LIST",
+                                "nestingLevel": 0,
+                                "textStyle": {
+                                    "ff": "Arial"
+                                }
+                            },
+                            "paragraphStyle": {
+                                "hanging": {
+                                    "v": 26
+                                },
+                                "horizontalAlign": 1,
+                                "indentStart": {
+                                    "v": 16
+                                }
+                            },
+                            "startIndex": 21
+                        }
+                    ],
+                    "textRuns": [
+                        {
+                            "ed": 21,
+                            "st": 0,
+                            "ts": {
+                                "cl": {
+                                    "rgb": "#111111",
+                                    "th": 0
+                                },
+                                "ff": "Arial",
+                                "fs": 18
+                            }
+                        }
+                    ]
+                },
+                "documentStyle": {
+                    "renderConfig": {
+                        "horizontalAlign": 1,
+                        "shapeTextOpticalVerticalAlign": 1,
+                        "verticalAlign": 2
+                    },
+                    "textStyle": {
+                        "cl": {
+                            "rgb": "#111111",
+                            "th": 0
+                        },
+                        "ff": "Arial",
+                        "fs": 18
+                    }
+                },
+                "id": "shape-16-shape-text",
+                "lists": {
+                    "BULLET_LIST": {
+                        "listType": "BULLET_LIST",
+                        "nestingLevel": [
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %1",
+                                "glyphSymbol": "□",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %2",
+                                "glyphSymbol": "○",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %3",
+                                "glyphSymbol": "■",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %4",
+                                "glyphSymbol": "●",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %5",
+                                "glyphSymbol": "○",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %6",
+                                "glyphSymbol": "■",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %7",
+                                "glyphSymbol": "●",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %8",
+                                "glyphSymbol": "○",
+                                "startNumber": 0
+                            },
+                            {
+                                "bulletAlignment": 0,
+                                "glyphFormat": " %9",
+                                "glyphSymbol": "■",
+                                "startNumber": 0
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/layout-ruler.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/layout-ruler.spec.ts
@@ -37,6 +37,7 @@ import { __testing, getLineHeightMetrics, layoutParagraph, updateInlineDrawingPo
 import { lineBreaking } from '../linebreaking';
 import { shaping } from '../shaping';
 import { createParagraphLayoutTestBed } from './create-paragraph-layout-test-bed';
+import issue1207Snapshot from './fixtures/issue-1207-bullet-style.snapshot.json';
 
 describe('layout-ruler', () => {
     beforeEach(() => {
@@ -136,6 +137,66 @@ describe('layout-ruler', () => {
         expect(result.length).toBe(1);
         expect(result[0].sections.length).toBeGreaterThan(0);
         expect(result[0].sections[0].columns[0].lines[0].divides[0].glyphGroup[0].width).toBe(21);
+    });
+
+    it('preserves bullet styles from a real PowerPoint import snapshot', () => {
+        const expectedCases = {
+            'case-A': {
+                content: 'p',
+                fontFamily: 'Wingdings',
+                fontSize: 18,
+                color: '#111111',
+            },
+            'case-B': {
+                content: 'p',
+                fontFamily: 'Wingdings',
+                fontSize: 27,
+                color: '#E11D48',
+            },
+            'case-C': {
+                content: '□',
+                fontFamily: 'Arial',
+                fontSize: 18,
+                color: '#111111',
+            },
+        } as const;
+
+        for (const snapshotCase of issue1207Snapshot.cases) {
+            const { body, documentStyle, ...document } = snapshotCase.doc;
+            const content = body.dataStream.replace(/\r\n$/, '');
+            const testBed = createParagraphLayoutTestBed(content, {
+                ...document,
+                body,
+                documentStyle,
+            });
+            const shapedTextList = shaping(
+                testBed.ctx,
+                testBed.paragraphNode.content!,
+                testBed.viewModel,
+                testBed.paragraphNode,
+                testBed.sectionBreakConfig
+            );
+            const pages = lineBreaking(
+                testBed.ctx,
+                testBed.viewModel,
+                shapedTextList,
+                testBed.curPage,
+                testBed.paragraphNode,
+                testBed.sectionBreakConfig,
+                null
+            );
+            const bulletGlyph = pages[0].sections[0].columns[0].lines[0].divides[0].glyphGroup
+                .find((glyph) => glyph.glyphType === GlyphType.LIST);
+            const expected = expectedCases[snapshotCase.name as keyof typeof expectedCases];
+
+            expect(bulletGlyph, snapshotCase.name).toBeDefined();
+            expect(bulletGlyph?.content, snapshotCase.name).toBe(expected.content);
+            expect(bulletGlyph?.ts?.ff, snapshotCase.name).toBe(expected.fontFamily);
+            expect(bulletGlyph?.ts?.fs, snapshotCase.name).toBe(expected.fontSize);
+            expect(bulletGlyph?.ts?.cl?.rgb, snapshotCase.name).toBe(expected.color);
+            expect(bulletGlyph?.fontStyle?.fontFamily, snapshotCase.name).toBe(expected.fontFamily);
+            expect(bulletGlyph?.fontStyle?.originFontSize, snapshotCase.name).toBe(expected.fontSize);
+        }
     });
 
     it('uses trailing CJK punctuation shrinkability when deciding line overflow', () => {

--- a/packages/engine-render/src/components/docs/layout/model/__tests__/glyph.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/model/__tests__/glyph.spec.ts
@@ -15,10 +15,12 @@
  */
 
 import type { IDocumentSkeletonGlyph } from '../../../../../basics/i-document-skeleton-cached';
-import { DocumentFlavor } from '@univerjs/core';
+import { BooleanNumber, DataStreamTreeTokenType, DocumentFlavor } from '@univerjs/core';
 import { describe, expect, it, vi } from 'vitest';
+import { GlyphType } from '../../../../../basics/i-document-skeleton-cached';
 import { getDocumentCompatibilityPolicy } from '../../../document-compatibility';
-import { baseAdjustability, createSkeletonLetterGlyph, glyphShrinkLeft, glyphShrinkRight, isJustifiable, isSpace } from '../glyph';
+import { FontCache } from '../../shaping-engine/font-cache';
+import { baseAdjustability, createSkeletonBulletGlyph, createSkeletonLetterGlyph, glyphShrinkLeft, glyphShrinkRight, isJustifiable, isSpace } from '../glyph';
 
 describe('Glyph utils test cases', () => {
     describe('test baseAdjustability', () => {
@@ -133,6 +135,94 @@ describe('Glyph utils test cases', () => {
             expect(glyph.adjustability.shrinkability).toEqual([5, 10]);
             expect(glyph.width).toBe(15);
             expect(glyph.xOffset).toBe(-5);
+        });
+    });
+
+    describe('test bullet glyph style', () => {
+        it('uses explicit bullet style while inheriting omitted properties from the paragraph glyph', () => {
+            let measuredFont = '';
+            const measureSpy = vi.spyOn(FontCache, 'getTextSize').mockImplementation((_content, fontStyle) => {
+                measuredFont = fontStyle.fontString;
+                return {
+                    width: 12,
+                    ba: 18,
+                    bd: 4,
+                    aba: 18,
+                    abd: 4,
+                    sp: 0,
+                    sbr: 0,
+                    sbo: 0,
+                    spr: 0,
+                    spo: 0,
+                };
+            });
+            const paragraphGlyph = {
+                content: 'I',
+                raw: 'I',
+                ts: {
+                    ff: 'Arial',
+                    fs: 24,
+                    bl: BooleanNumber.TRUE,
+                    cl: { rgb: '#111111' },
+                },
+                fontStyle: {
+                    fontString: 'bold 24pt Arial',
+                    fontSize: 24,
+                    originFontSize: 24,
+                    fontFamily: 'Arial',
+                    fontCache: 'Arial-24-bold',
+                },
+                width: 12,
+                bBox: {
+                    width: 12,
+                    ba: 18,
+                    bd: 4,
+                    aba: 18,
+                    abd: 4,
+                    sp: 0,
+                    sbr: 0,
+                    sbo: 0,
+                    spr: 0,
+                    spo: 0,
+                },
+                xOffset: 0,
+                left: 0,
+                glyphType: GlyphType.LETTER,
+                streamType: DataStreamTreeTokenType.LETTER,
+                isJustifiable: false,
+                adjustability: {
+                    stretchability: [0, 0],
+                    shrinkability: [0, 0],
+                },
+                count: 1,
+            } as IDocumentSkeletonGlyph;
+
+            const bulletGlyph = createSkeletonBulletGlyph(
+                paragraphGlyph,
+                {
+                    listId: 'issue-1207-list',
+                    symbol: 'p',
+                    ts: {
+                        ff: 'Wingdings',
+                        cl: { rgb: '#FF0000' },
+                    },
+                    startIndexItem: 1,
+                },
+                10
+            );
+
+            expect(bulletGlyph.content).toBe('p');
+            expect(bulletGlyph.ts).toMatchObject({
+                ff: 'Wingdings',
+                fs: 24,
+                bl: BooleanNumber.TRUE,
+                cl: { rgb: '#FF0000' },
+            });
+            expect(bulletGlyph.fontStyle?.fontFamily).toBe('Wingdings');
+            expect(bulletGlyph.fontStyle?.originFontSize).toBe(24);
+            expect(measuredFont).toContain('Wingdings');
+            expect(measuredFont).toContain('24pt');
+            measureSpy.mockRestore();
         });
     });
 

--- a/packages/engine-render/src/components/docs/layout/model/glyph.ts
+++ b/packages/engine-render/src/components/docs/layout/model/glyph.ts
@@ -26,6 +26,7 @@ import { BooleanNumber, BulletAlignment, DataStreamTreeTokenType, GridType } fro
 import { cjk } from '../../../../basics/cjk-regexp';
 import { GlyphType } from '../../../../basics/i-document-skeleton-cached';
 import {
+    getFontStyleString,
     isCjkCenterAlignedPunctuation,
     isCjkLeftAlignedPunctuation,
     isCjkRightAlignedPunctuation,
@@ -292,17 +293,20 @@ export function createSkeletonBulletGlyph(
     charSpaceApply: number
 ): IDocumentSkeletonGlyph {
     const {
-        // bBox: boundingBox,
         symbol: content,
-        // ts: textStyle,
-        // fontStyle,
+        ts: bulletTextStyle,
         bulletAlign = BulletAlignment.START,
         bulletType = false,
     } = bulletSkeleton;
-    const { fontStyle } = glyph;
-    // glyph.fontStyle
-    // getFontStyleString(fontStyle, localeService);
-    const boundingBox = FontCache.getTextSize(content, fontStyle!);
+    const textStyle = {
+        ...glyph.ts,
+        ...bulletTextStyle,
+        st: {
+            s: BooleanNumber.FALSE,
+        },
+    };
+    const fontStyle = getFontStyleString(textStyle);
+    const boundingBox = FontCache.getTextSize(content, fontStyle);
     const contentWidth = boundingBox.width;
     // When text also needs to align to the grid, process it. LINES default reference is the global font size of the doc
 
@@ -326,13 +330,7 @@ export function createSkeletonBulletGlyph(
 
     return {
         content,
-        ts: {
-            ...glyph.ts,
-            // ...textStyle,
-            st: {
-                s: BooleanNumber.FALSE,
-            },
-        },
+        ts: textStyle,
         fontStyle,
         width,
         xOffset: 0,


### PR DESCRIPTION
Refs dream-num/univer-cli#1207

Companion exchange PR: dream-num/univer-rs#172

## Summary

- apply the resolved bullet text style when constructing list glyphs
- recompute bullet font metrics with the same style used for drawing
- add a focused glyph unit test and a real PowerPoint-import snapshot regression

## Root cause

`createSkeletonBulletGlyph` kept the paragraph glyph's `fontStyle` and ignored the resolved bullet skeleton style. A DrawingML character bullet such as `p` with `Wingdings` was therefore measured and rendered as paragraph text, producing a visible `p` and dropping bullet-specific color and size.

The fix merges paragraph fallback properties with the explicit bullet style, then derives the canvas font and measurements from that resolved style. Missing fonts continue to use the normal renderer fallback path; no PowerPoint-specific metadata is introduced.

## Validation

- `pnpm --filter @univerjs/engine-render typecheck`
- `pnpm exec vitest run packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/layout-ruler.spec.ts packages/engine-render/src/components/docs/layout/model/__tests__/glyph.spec.ts` — 44 tests passed
- `pnpm --filter @univerjs/engine-render test` — 95 files passed, 866 tests passed, 59 skipped
- real PowerPoint fixture verified against PowerPoint and the Univer slide renderer

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming conventions are followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
