### PR TITLE
feat(core): define Base text preview hit test

### DIFF
--- a/packages/core/src/bases/typedef.ts
+++ b/packages/core/src/bases/typedef.ts
@@ -815,6 +815,20 @@ export interface IGalleryCardSelection {
 
 export type BaseHitTestResult =
     | { type: 'empty'; x: number; y: number }
+    // TODO(@ai-review): Verify this Text preview hit-test contract contains only renderer interaction data shared with Base UI consumers.
+    | {
+        type: 'grid-text-preview';
+        tableId: TableId;
+        viewId: ViewId;
+        recordId: RecordId;
+        fieldId: FieldId;
+        virtual?: boolean;
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+        maxScroll: number;
+    }
     | {
         type: 'grid-fill-handle';
         tableId: TableId;

--- a/packages/core/src/bases/typedef.ts
+++ b/packages/core/src/bases/typedef.ts
@@ -815,7 +815,6 @@ export interface IGalleryCardSelection {
 
 export type BaseHitTestResult =
     | { type: 'empty'; x: number; y: number }
-    // TODO(@ai-review): Verify this Text preview hit-test contract contains only renderer interaction data shared with Base UI consumers.
     | {
         type: 'grid-text-preview';
         tableId: TableId;


### PR DESCRIPTION
## Summary

- add a formal `grid-text-preview` member to `BaseHitTestResult`
- expose the preview bounds, target cell identity, virtual-row state, and maximum vertical scroll range
- let Base renderer consumers narrow the hit result without handwritten shapes or type assertions

## Why

The Base text overflow preview needs to intercept wheel input independently from the grid. The shared hit-test union did not describe that renderer interaction, which otherwise forced Pro consumers to bypass the canonical Core contract.

## How to test

- `pnpm --filter @univerjs/core typecheck`

## Impact

- No breaking changes.
- No external SDK dependency changes.
- No behavior from an unpublished SDK version is required.
- No architecture documentation update is needed for this additive renderer contract.

Refs dream-num/univer-cli#1273

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Naming convention is followed.
- [x] Unit tests are not applicable to this type-only additive contract; Core typecheck covers it.
- [x] No breaking changes are introduced.

