### PR TITLE
chore(engine-render): remove resolved review notes

### DIFF
--- a/packages/core/src/docs/data-model/__tests__/preset-list-type.spec.ts
+++ b/packages/core/src/docs/data-model/__tests__/preset-list-type.spec.ts
@@ -18,7 +18,6 @@ import { describe, expect, it } from 'vitest';
 import { PRESET_LIST_TYPE } from '../preset-list-type';
 
 describe('preset list types', () => {
-    // TODO(@ai-review): Confirm every built-in marker inherits paragraph font size unless its document data explicitly provides one.
     it('does not assign absolute font sizes to built-in list markers', () => {
         for (const [listType, listData] of Object.entries(PRESET_LIST_TYPE)) {
             for (const [level, nesting] of listData.nestingLevel.entries()) {

--- a/packages/core/src/docs/data-model/preset-list-type.ts
+++ b/packages/core/src/docs/data-model/preset-list-type.ts
@@ -96,7 +96,6 @@ const orderListSymbolMap = {
 };
 
 type BulletSymbols = [string, string, string];
-// TODO(@ai-review): Verify built-in markers inherit effective paragraph fonts while imported marker styles remain explicit overrides.
 const bulletListFactory = (symbols: BulletSymbols): INestingLevel[] => {
     return [
         ...symbols,

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/bullet.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/bullet.spec.ts
@@ -251,7 +251,6 @@ describe('bullet', () => {
     });
 
     describe('getDefaultBulletSke', () => {
-        // TODO(@ai-review): Confirm fallback markers inherit effective paragraph fonts instead of imposing a hidden default.
         it('returns a default bullet skeleton without an absolute font style', () => {
             const result = getDefaultBulletSke('list-default');
             expect(result.listId).toBe('list-default');

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/bullet.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/bullet.ts
@@ -62,7 +62,6 @@ export function dealWithBullet(
 }
 
 export function getDefaultBulletSke(listId: string, startIndex: number = 1): IDocumentSkeletonBullet {
-    // TODO(@ai-review): Confirm fallback markers inherit the paragraph font without weakening explicit imported marker styles.
     return {
         listId,
         symbol: '\u25CF', // symbol list content


### PR DESCRIPTION
## Summary

- remove the resolved `TODO(@ai-review)` notes from the built-in and fallback list marker implementation
- keep the regression tests and production behavior unchanged

## Review outcome

The notes were checked against the merged implementation and its tests. Built-in markers inherit paragraph font styles, while explicit imported marker styles remain supported by the existing glyph layout coverage.

## Validation

- targeted Core and Engine Render tests: 23 passed
- Core and Engine Render typecheck: passed
- ESLint: passed
- `git diff --check`: passed