### PR TITLE
perf(engine-formula): make forced cache updates constant time

### DIFF
--- a/packages/engine-formula/src/basics/__tests__/inverted-index-cache.spec.ts
+++ b/packages/engine-formula/src/basics/__tests__/inverted-index-cache.spec.ts
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { InvertedIndexCache } from '../inverted-index-cache';
 
 describe('InvertedIndexCache', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('keeps empty string lookups distinct from numeric zero lookups', () => {
         const cache = new InvertedIndexCache();
         const unitId = 'unit';
@@ -32,5 +36,21 @@ describe('InvertedIndexCache', () => {
 
         expect(cache.getCellPositions(unitId, sheetId, column, 0, rows)?.matchingRows).toEqual([0, 1, 2]);
         expect(cache.getCellPositions(unitId, sheetId, column, '', rows)?.matchingRows).toEqual([1, 2]);
+    });
+
+    it('force-updates a row without scanning every distinct column value', () => {
+        const cache = new InvertedIndexCache();
+        const rows = 500;
+
+        for (let row = 0; row < rows; row++) {
+            cache.set('unit', 'sheet', 0, row, row);
+        }
+
+        const setHas = vi.spyOn(Set.prototype, 'has');
+        cache.set('unit', 'sheet', 0, 'updated', rows - 1, true);
+
+        expect(setHas.mock.calls.length).toBeLessThan(5);
+        expect(cache.getCellPositions('unit', 'sheet', 0, rows - 1, [[0, rows - 1]])?.matchingRows).toEqual([]);
+        expect(cache.getCellPositions('unit', 'sheet', 0, 'UPDATED', [[0, rows - 1]])?.matchingRows).toEqual([rows - 1]);
     });
 });

--- a/packages/engine-formula/src/basics/inverted-index-cache.ts
+++ b/packages/engine-formula/src/basics/inverted-index-cache.ts
@@ -67,6 +67,8 @@ export class InvertedIndexCache {
      */
     private _cache: Map<string, Map<string, Map<number, Map<ValueTypeWithSymbol, Set<number>>>>> = new Map();
 
+    private _rowValues: Map<string, Map<string, Map<number, Map<number, ValueTypeWithSymbol>>>> = new Map();
+
     private _continueBuildingCache: Map<string, Map<string, Map<number, IntervalTree<NumericTuple>>>> = new Map();
 
     set(unitId: string, sheetId: string, column: number, value: ValueTypeWithNullUndefined, row: number, isForceUpdate: boolean = false) {
@@ -92,12 +94,31 @@ export class InvertedIndexCache {
             sheetMap.set(column, columnMap);
         }
 
-        // If is force update, we need to remove the old value from the map
-        if (isForceUpdate) {
-            for (const [_, _cellList] of columnMap) {
-                if (_cellList.has(row)) {
-                    _cellList.delete(row);
-                    break;
+        let rowUnitMap = this._rowValues.get(unitId);
+        if (rowUnitMap == null) {
+            rowUnitMap = new Map();
+            this._rowValues.set(unitId, rowUnitMap);
+        }
+
+        let rowSheetMap = rowUnitMap.get(sheetId);
+        if (rowSheetMap == null) {
+            rowSheetMap = new Map();
+            rowUnitMap.set(sheetId, rowSheetMap);
+        }
+
+        let rowMap = rowSheetMap.get(column);
+        if (rowMap == null) {
+            rowMap = new Map();
+            rowSheetMap.set(column, rowMap);
+        }
+
+        if (isForceUpdate && rowMap.has(row)) {
+            const previousValue = rowMap.get(row) as ValueTypeWithSymbol;
+            const previousCellList = columnMap.get(previousValue);
+            if (previousCellList != null) {
+                previousCellList.delete(row);
+                if (previousCellList.size === 0) {
+                    columnMap.delete(previousValue);
                 }
             }
         }
@@ -111,6 +132,7 @@ export class InvertedIndexCache {
         }
 
         cellList.add(row);
+        rowMap.set(row, _value);
     }
 
     getCellValuePositions(unitId: string, sheetId: string, column: number) {
@@ -269,6 +291,7 @@ export class InvertedIndexCache {
 
     clear() {
         this._cache.clear();
+        this._rowValues.clear();
         this._continueBuildingCache.clear();
         normalizedValueMap.clear();
     }


### PR DESCRIPTION
## Summary

Make `InvertedIndexCache.set(..., isForceUpdate = true)` evict a row in O(1) by maintaining a per-column `row -> normalizedValue` reverse index.

The previous implementation scanned every distinct value bucket in the column until it found the row. Committing `n` recalculated cells down a high-cardinality column therefore performed O(n^2) `Set.has` calls.

## Reproduction and mechanism

A synthetic column with 500 distinct values followed by one forced update produced this regression-test failure before the change:

```text
AssertionError: expected 500 to be less than 5
```

The count comes directly from a spy on `Set.prototype.has`. The hot loop was:

```ts
for (const [_, cellList] of columnMap) {
    if (cellList.has(row)) { ... }
}
```

On a separate 16,000-result structural-edit benchmark, `setRuntimeData` accounted for 2,993 ms of a 3,371 ms result commit. The reverse index removes that distinct-value scan.

## Correctness

- Uses the same `normalizeValue` result as the forward index.
- Removes an empty old-value bucket after eviction.
- Clears the reverse index alongside the forward and interval caches.
- Regression coverage verifies both the bounded call count and that case-normalized lookup points only to the updated value.

## Verification

```text
pnpm exec vitest run src/basics/__tests__/inverted-index-cache.spec.ts --maxWorkers=1
Test Files  1 passed (1)
Tests       2 passed (2)

pnpm typecheck
@univerjs/engine-formula: tsc --noEmit (passed)

pnpm exec eslint --max-warnings=0 <changed files>
passed
```
