### PR TITLE
perf(sheets-formula): index structural formula references

### DIFF
--- a/packages/sheets-formula-ui/src/controllers/__tests__/formula-reference-index.spec.ts
+++ b/packages/sheets-formula-ui/src/controllers/__tests__/formula-reference-index.spec.ts
@@ -149,6 +149,26 @@ describe('formula reference index', () => {
 
         expect(testBedSheetFormulaData(formulaDataModel)[2]?.[0]?.f).toBe('=Target!A11');
     });
+
+    it('refreshes the index after a by-range command moves the formula host', async () => {
+        await commandService.executeCommand(InsertRowByRangeCommand.id, {
+            unitId: 'test',
+            subUnitId: 'formula',
+            range: { startRow: 0, endRow: 0, startColumn: 0, endColumn: 1 },
+            direction: Direction.UP,
+        });
+
+        await commandService.executeCommand(InsertRowByRangeCommand.id, {
+            unitId: 'test',
+            subUnitId: 'target',
+            range: { startRow: 4, endRow: 4, startColumn: 0, endColumn: 7 },
+            direction: Direction.UP,
+        });
+
+        const formulaSheet = testBedSheetFormulaData(formulaDataModel);
+        expect(formulaSheet[0]?.[0]).toBeUndefined();
+        expect(formulaSheet[1]?.[0]?.f).toBe('=Target!A11');
+    });
 });
 
 function testBedSheetFormulaData(formulaDataModel: FormulaDataModel) {

--- a/packages/sheets-formula-ui/src/controllers/__tests__/formula-reference-index.spec.ts
+++ b/packages/sheets-formula-ui/src/controllers/__tests__/formula-reference-index.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IFormulaData, IUnitSheetNameMap } from '@univerjs/engine-formula';
+import { Direction, ICommandService, IUndoRedoService, LocaleType, RedoCommand, UndoCommand } from '@univerjs/core';
+import { FormulaDataModel, LexerTreeBuilder, SetArrayFormulaDataMutation, SetFormulaDataMutation } from '@univerjs/engine-formula';
+import { InsertRowByRangeCommand, InsertRowCommand, InsertRowMutation, SetRangeValuesMutation } from '@univerjs/sheets';
+import { UpdateFormulaController } from '@univerjs/sheets-formula';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createCommandTestBed } from './create-command-test-bed';
+
+describe('formula reference index', () => {
+    let commandService: ICommandService;
+    let controller: UpdateFormulaController;
+    let lexerTreeBuilder: LexerTreeBuilder;
+    let formulaDataModel: FormulaDataModel;
+    let dispose: () => void;
+
+    beforeEach(() => {
+        const testBed = createCommandTestBed({
+            id: 'test',
+            appVersion: '3.0.0-alpha',
+            locale: LocaleType.EN_US,
+            name: '',
+            sheetOrder: ['target', 'formula'],
+            styles: {},
+            sheets: {
+                target: {
+                    id: 'target',
+                    name: 'Target',
+                    rowCount: 30,
+                    columnCount: 8,
+                    cellData: {},
+                },
+                formula: {
+                    id: 'formula',
+                    name: 'Formula',
+                    rowCount: 10,
+                    columnCount: 2,
+                    cellData: {
+                        0: { 0: { f: '=Target!A10' } },
+                        1: { 0: { f: '=Target!A10' } },
+                        2: { 0: { f: '=Target!A1' } },
+                        3: { 0: { f: '=OFFSET(Target!A1,9,0)' } },
+                    },
+                },
+            },
+        }, [[UpdateFormulaController]]);
+
+        commandService = testBed.get(ICommandService);
+        testBed.get(IUndoRedoService);
+        controller = testBed.get(UpdateFormulaController);
+        lexerTreeBuilder = testBed.get(LexerTreeBuilder);
+        formulaDataModel = testBed.get(FormulaDataModel);
+        dispose = () => testBed.univer.dispose();
+
+        commandService.registerCommand(InsertRowCommand);
+        commandService.registerCommand(InsertRowByRangeCommand);
+        commandService.registerCommand(InsertRowMutation);
+        commandService.registerCommand(SetRangeValuesMutation);
+        commandService.registerCommand(SetFormulaDataMutation);
+        commandService.registerCommand(SetArrayFormulaDataMutation);
+    });
+
+    afterEach(() => dispose());
+
+    it('rewrites only affected and conservative formulas without reparsing warmed formulas', async () => {
+        const indexedFormulaInputs: IFormulaData[] = [];
+        const privateController = controller as unknown as {
+            _getFormulaReferenceMoveInfo: (
+                formulaData: IFormulaData,
+                unitSheetNameMap: IUnitSheetNameMap,
+                formulaReferenceMoveParam: unknown
+            ) => { newFormulaData: IFormulaData };
+        };
+        const originalMove = privateController._getFormulaReferenceMoveInfo.bind(privateController);
+        privateController._getFormulaReferenceMoveInfo = (formulaData, unitSheetNameMap, formulaReferenceMoveParam) => {
+            indexedFormulaInputs.push(formulaData);
+            return originalMove(formulaData, unitSheetNameMap, formulaReferenceMoveParam);
+        };
+
+        const originalBuilder = lexerTreeBuilder.sequenceNodesBuilder.bind(lexerTreeBuilder);
+        let commandPathParseCount = 0;
+        lexerTreeBuilder.sequenceNodesBuilder = (formulaString) => {
+            commandPathParseCount++;
+            return originalBuilder(formulaString);
+        };
+
+        try {
+            await commandService.executeCommand(InsertRowCommand.id, {
+                unitId: 'test',
+                subUnitId: 'target',
+                range: { startRow: 4, endRow: 4, startColumn: 0, endColumn: 7 },
+                direction: Direction.UP,
+            });
+
+            expect(commandPathParseCount).toBe(0);
+            const indexedFormulaData = indexedFormulaInputs[0].test?.formula ?? {};
+            const indexedFormulas = Object.values(indexedFormulaData)
+                .flatMap((row) => Object.values(row ?? {}))
+                .map((item) => (item as { f?: string } | null)?.f);
+            expect(indexedFormulas).toEqual([
+                '=Target!A10',
+                '=Target!A10',
+                '=OFFSET(Target!A1,9,0)',
+            ]);
+
+            const formulaSheet = testBedSheetFormulaData(formulaDataModel);
+            expect(formulaSheet[0]?.[0]?.f).toBe('=Target!A11');
+            expect(formulaSheet[1]?.[0]?.f).toBe('=Target!A11');
+            expect(formulaSheet[2]?.[0]?.f).toBe('=Target!A1');
+            expect(formulaSheet[3]?.[0]?.f).toBe('=OFFSET(Target!A1,9,0)');
+
+            await commandService.executeCommand(UndoCommand.id);
+            await commandService.executeCommand(RedoCommand.id);
+            expect(commandPathParseCount).toBe(0);
+            expect(testBedSheetFormulaData(formulaDataModel)[0]?.[0]?.f).toBe('=Target!A11');
+        } finally {
+            lexerTreeBuilder.sequenceNodesBuilder = originalBuilder;
+        }
+    });
+
+    it('refreshes the index after a formula-data mutation', async () => {
+        await commandService.executeCommand(SetRangeValuesMutation.id, {
+            unitId: 'test',
+            subUnitId: 'formula',
+            cellValue: { 2: { 0: { f: '=Target!A10' } } },
+        });
+
+        await commandService.executeCommand(InsertRowCommand.id, {
+            unitId: 'test',
+            subUnitId: 'target',
+            range: { startRow: 4, endRow: 4, startColumn: 0, endColumn: 7 },
+            direction: Direction.UP,
+        });
+
+        expect(testBedSheetFormulaData(formulaDataModel)[2]?.[0]?.f).toBe('=Target!A11');
+    });
+});
+
+function testBedSheetFormulaData(formulaDataModel: FormulaDataModel) {
+    return formulaDataModel.getFormulaData().test?.formula ?? {};
+}

--- a/packages/sheets-formula/src/controllers/update-formula.controller.ts
+++ b/packages/sheets-formula/src/controllers/update-formula.controller.ts
@@ -23,7 +23,7 @@ import type {
     Nullable,
     Workbook,
 } from '@univerjs/core';
-import type { IDirtyUnitDefinedNameMap, IDirtyUnitFeatureMap, IDirtyUnitOtherFormulaMap, IDirtyUnitSheetNameMap, IFormulaData, IFormulaDataItem, IFormulaDirtyData, IUnitSheetNameMap } from '@univerjs/engine-formula';
+import type { IDirtyUnitDefinedNameMap, IDirtyUnitFeatureMap, IDirtyUnitOtherFormulaMap, IDirtyUnitSheetNameMap, IFormulaData, IFormulaDataItem, IFormulaDirtyData, ISequenceNode, IUnitSheetNameMap } from '@univerjs/engine-formula';
 import type {
     IInsertSheetMutationParams,
     IRemoveSheetMutationParams,
@@ -47,7 +47,11 @@ import {
 import { deserializeRangeWithSheetWithCache, ErrorType, FormulaDataModel, generateStringWithSequence, IDefinedNamesService, initSheetFormulaData, LexerTreeBuilder, refactorFormulaUnitQualifier, sequenceNodeType, serializeRangeToRefString, SetArrayFormulaDataMutation, SetFormulaDataMutation, SetTriggerFormulaCalculationStartMutation, splitTableStructuredRef } from '@univerjs/engine-formula';
 import {
     ClearSelectionFormatCommand,
+    InsertColCommand,
+    InsertRowCommand,
     InsertSheetMutation,
+    RemoveColCommand,
+    RemoveRowCommand,
     RemoveSheetMutation,
     SetBorderCommand,
     SetRangeCustomMetadataCommand,
@@ -62,6 +66,14 @@ import { checkIsSameUnitAndSheet, formulaDataToCellData, FormulaReferenceMoveTyp
 import { getNewRangeByMoveParam } from './utils/ref-range-move';
 import { getReferenceMoveParams } from './utils/ref-range-param';
 
+interface IFormulaReferenceIndexEntry {
+    unitId: string;
+    sheetId: string;
+    row: number;
+    column: number;
+    formulaDataItem: IFormulaDataItem;
+}
+
 /**
  * Update formula process
  *
@@ -74,6 +86,11 @@ import { getReferenceMoveParams } from './utils/ref-range-param';
  * 3. onCommandExecuted, before formula calculation, use the setRangeValues information to delete the old formulaData, ArrayFormula and ArrayFormulaCellData, and send the worker (complementary setRangeValues after collaborative conflicts, normal operation triggers formula update, undo/redo are captured and processed here)
  */
 export class UpdateFormulaController extends Disposable {
+    private readonly _formulaReferenceEntries = new Map<string, IFormulaReferenceIndexEntry>();
+    private readonly _formulaReferenceTargets = new Map<string, Map<string, { maxRow: number; maxColumn: number }>>();
+    private readonly _dynamicFormulaKeys = new Set<string>();
+    private readonly _parsedFormulaCache = new Map<string, ReadonlyArray<string | Readonly<ISequenceNode>> | undefined>();
+
     constructor(
         @IUniverInstanceService private readonly _univerInstanceService: IUniverInstanceService,
         @ICommandService private readonly _commandService: ICommandService,
@@ -87,6 +104,152 @@ export class UpdateFormulaController extends Disposable {
         super();
 
         this._commandExecutedListener();
+        this._rebuildFormulaReferenceIndex();
+    }
+
+    private _getFormulaKey(unitId: string, sheetId: string, row: number, column: number) {
+        return `${unitId}\0${sheetId}\0${row}\0${column}`;
+    }
+
+    private _getTargetKey(unitId: string, sheetId: string) {
+        return `${unitId}\0${sheetId}`;
+    }
+
+    private _cacheParsedFormula(formulaString: string, sequenceNodes: Array<string | ISequenceNode> | undefined) {
+        const immutableNodes = sequenceNodes == null
+            ? undefined
+            : Object.freeze(sequenceNodes.map((node) => typeof node === 'string' ? node : Object.freeze({ ...node })));
+
+        this._parsedFormulaCache.set(formulaString, immutableNodes);
+    }
+
+    private _getParsedFormula(formulaString: string): Array<string | ISequenceNode> | undefined {
+        if (!this._parsedFormulaCache.has(formulaString)) {
+            this._cacheParsedFormula(formulaString, this._lexerTreeBuilder.sequenceNodesBuilder(formulaString));
+        }
+
+        return this._parsedFormulaCache.get(formulaString)?.map((node) => typeof node === 'string' ? node : { ...node });
+    }
+
+    // eslint-disable-next-line max-lines-per-function
+    private _rebuildFormulaReferenceIndex() {
+        this._formulaReferenceEntries.clear();
+        this._formulaReferenceTargets.clear();
+        this._dynamicFormulaKeys.clear();
+
+        const formulaData = this._formulaDataModel.getFormulaData();
+        const { unitSheetNameMap } = this._formulaDataModel.getCalculateData();
+
+        for (const unitId of Object.keys(formulaData)) {
+            const sheets = formulaData[unitId];
+            if (!sheets) continue;
+
+            for (const sheetId of Object.keys(sheets)) {
+                // eslint-disable-next-line complexity
+                new ObjectMatrix(sheets[sheetId] || {}).forValue((row, column, formulaDataItem) => {
+                    if (!formulaDataItem || typeof formulaDataItem.f !== 'string' || formulaDataItem.f.length === 0) return true;
+                    if (formulaDataItem.si && ((formulaDataItem.x || 0) !== 0 || (formulaDataItem.y || 0) !== 0)) return true;
+
+                    const key = this._getFormulaKey(unitId, sheetId, row, column);
+                    const sequenceNodes = this._getParsedFormula(formulaDataItem.f);
+                    this._formulaReferenceEntries.set(key, { unitId, sheetId, row, column, formulaDataItem });
+
+                    if (!sequenceNodes) {
+                        this._dynamicFormulaKeys.add(key);
+                        return true;
+                    }
+
+                    if (
+                        formulaDataItem.f.includes('[') ||
+                        formulaDataItem.f.includes('#') ||
+                        formulaDataItem.f.includes('{') ||
+                        /^=[A-Za-z_\\][A-Za-z_.]*$/.test(formulaDataItem.f) ||
+                        formulaDataItem.si
+                    ) {
+                        this._dynamicFormulaKeys.add(key);
+                    }
+
+                    let hasDirectReference = false;
+                    let hasSemanticNode = false;
+
+                    for (const node of sequenceNodes) {
+                        if (typeof node === 'string') continue;
+
+                        hasSemanticNode = true;
+                        if (
+                            node.nodeType === sequenceNodeType.FUNCTION &&
+                            ['INDIRECT', 'OFFSET', 'INDEX', 'CHOOSE', 'ADDRESS'].includes(node.token.toUpperCase())
+                        ) {
+                            this._dynamicFormulaKeys.add(key);
+                        }
+                        if (node.nodeType === sequenceNodeType.DEFINED_NAME) {
+                            this._dynamicFormulaKeys.add(key);
+                        }
+                        if (node.nodeType !== sequenceNodeType.REFERENCE) continue;
+
+                        hasDirectReference = true;
+                        const { range, sheetName, unitId: sequenceUnitId } = deserializeRangeWithSheetWithCache(node.token);
+                        const targetUnitId = sequenceUnitId || unitId;
+                        const targetSheetId = sheetName ? unitSheetNameMap?.[targetUnitId]?.[sheetName] : sheetId;
+                        if (!targetSheetId) continue;
+
+                        const targetKey = this._getTargetKey(targetUnitId, targetSheetId);
+                        let targetEntries = this._formulaReferenceTargets.get(targetKey);
+                        if (!targetEntries) {
+                            targetEntries = new Map();
+                            this._formulaReferenceTargets.set(targetKey, targetEntries);
+                        }
+
+                        const bounds = targetEntries.get(key) || { maxRow: -1, maxColumn: -1 };
+                        bounds.maxRow = Math.max(bounds.maxRow, range.endRow);
+                        bounds.maxColumn = Math.max(bounds.maxColumn, range.endColumn);
+                        targetEntries.set(key, bounds);
+                    }
+
+                    if (!hasDirectReference && hasSemanticNode) {
+                        this._dynamicFormulaKeys.add(key);
+                    }
+
+                    return true;
+                });
+            }
+        }
+    }
+
+    private _queryFormulaReferenceIndex(moveParam: IFormulaReferenceMoveParam) {
+        const targetEntries = this._formulaReferenceTargets.get(this._getTargetKey(moveParam.unitId, moveParam.sheetId));
+        const keys = new Set<string>();
+        const isRowOperation = moveParam.type === FormulaReferenceMoveType.InsertRow || moveParam.type === FormulaReferenceMoveType.RemoveRow;
+        const threshold = isRowOperation ? moveParam.range?.startRow : moveParam.range?.startColumn;
+
+        if (targetEntries && threshold != null) {
+            for (const [key, bounds] of targetEntries) {
+                if ((isRowOperation ? bounds.maxRow : bounds.maxColumn) >= threshold) {
+                    keys.add(key);
+                }
+            }
+        }
+
+        for (const key of this._dynamicFormulaKeys) {
+            keys.add(key);
+        }
+
+        return [...keys]
+            .map((key) => this._formulaReferenceEntries.get(key))
+            .filter((entry): entry is NonNullable<typeof entry> => entry != null);
+    }
+
+    private _getIndexedFormulaData(entries: IFormulaReferenceIndexEntry[]): IFormulaData {
+        const formulaData: IFormulaData = {};
+
+        for (const entry of entries) {
+            formulaData[entry.unitId] ||= {};
+            formulaData[entry.unitId]![entry.sheetId] ||= {};
+            formulaData[entry.unitId]![entry.sheetId]![entry.row] ||= {};
+            formulaData[entry.unitId]![entry.sheetId]![entry.row]![entry.column] = entry.formulaDataItem;
+        }
+
+        return formulaData;
     }
 
     private _commandExecutedListener() {
@@ -98,11 +261,19 @@ export class UpdateFormulaController extends Disposable {
             this._commandService.onCommandExecuted((command: ICommandInfo) => {
                 if (!command.params) return;
 
+                if (command.id === SetFormulaDataMutation.id) {
+                    this._rebuildFormulaReferenceIndex();
+                }
+
                 if (command.id === RemoveSheetMutation.id) {
                     const { subUnitId: sheetId, unitId } = command.params as IRemoveSheetMutationParams;
                     this._handleWorkbookDisposed(unitId, sheetId);
                 } else if (command.id === InsertSheetMutation.id) {
                     this._handleInsertSheetMutation(command.params as IInsertSheetMutationParams);
+                }
+
+                if ([InsertRowCommand.id, InsertColCommand.id, RemoveRowCommand.id, RemoveColCommand.id].includes(command.id)) {
+                    this._rebuildFormulaReferenceIndex();
                 }
             })
         );
@@ -282,6 +453,7 @@ export class UpdateFormulaController extends Disposable {
         const params = this._getDirtyDataByCalculationMode(calculationMode);
 
         this._commandService.executeCommand(SetTriggerFormulaCalculationStartMutation.id, params, { onlyLocal: true });
+        this._rebuildFormulaReferenceIndex();
     }
 
     private _getDirtyDataByCalculationMode(calculationMode: CalculationMode): IFormulaDirtyData {
@@ -325,10 +497,19 @@ export class UpdateFormulaController extends Disposable {
                 result.oldUnitName = unitNameMap?.[result.unitId]?.name;
             }
             const oldFormulaData = this._formulaDataModel.getFormulaData();
+            const indexedStructuralOperation = [
+                FormulaReferenceMoveType.InsertRow,
+                FormulaReferenceMoveType.InsertColumn,
+                FormulaReferenceMoveType.RemoveRow,
+                FormulaReferenceMoveType.RemoveColumn,
+            ].includes(result.type);
+            const formulaData = indexedStructuralOperation
+                ? this._getIndexedFormulaData(this._queryFormulaReferenceIndex(result))
+                : oldFormulaData;
 
             // change formula reference
             const { newFormulaData } = this._getFormulaReferenceMoveInfo(
-                oldFormulaData,
+                formulaData,
                 unitSheetNameMap,
                 result
             );
@@ -401,7 +582,7 @@ export class UpdateFormulaController extends Disposable {
                         return true;
                     }
 
-                    const sequenceNodes = this._lexerTreeBuilder.sequenceNodesBuilder(formulaString);
+                    const sequenceNodes = this._getParsedFormula(formulaString);
 
                     if (sequenceNodes == null) {
                         return true;
@@ -652,9 +833,9 @@ export class UpdateFormulaController extends Disposable {
 
                     const newSequenceNodes = updateRefOffset(sequenceNodes, refChangeIds, x, y);
 
-                    newFormulaDataItem.setValue(row, column, {
-                        f: `=${generateStringWithSequence(newSequenceNodes)}`,
-                    });
+                    const newFormulaString = `=${generateStringWithSequence(newSequenceNodes)}`;
+                    this._cacheParsedFormula(newFormulaString, newSequenceNodes);
+                    newFormulaDataItem.setValue(row, column, { f: newFormulaString });
                 });
 
                 if (newFormulaData[unitId]) {

--- a/packages/sheets-formula/src/controllers/update-formula.controller.ts
+++ b/packages/sheets-formula/src/controllers/update-formula.controller.ts
@@ -47,10 +47,14 @@ import {
 import { deserializeRangeWithSheetWithCache, ErrorType, FormulaDataModel, generateStringWithSequence, IDefinedNamesService, initSheetFormulaData, LexerTreeBuilder, refactorFormulaUnitQualifier, sequenceNodeType, serializeRangeToRefString, SetArrayFormulaDataMutation, SetFormulaDataMutation, SetTriggerFormulaCalculationStartMutation, splitTableStructuredRef } from '@univerjs/engine-formula';
 import {
     ClearSelectionFormatCommand,
+    InsertColByRangeCommand,
     InsertColCommand,
+    InsertRowByRangeCommand,
     InsertRowCommand,
     InsertSheetMutation,
+    RemoveColByRangeCommand,
     RemoveColCommand,
+    RemoveRowByRangeCommand,
     RemoveRowCommand,
     RemoveSheetMutation,
     SetBorderCommand,
@@ -272,7 +276,16 @@ export class UpdateFormulaController extends Disposable {
                     this._handleInsertSheetMutation(command.params as IInsertSheetMutationParams);
                 }
 
-                if ([InsertRowCommand.id, InsertColCommand.id, RemoveRowCommand.id, RemoveColCommand.id].includes(command.id)) {
+                if ([
+                    InsertRowCommand.id,
+                    InsertRowByRangeCommand.id,
+                    InsertColCommand.id,
+                    InsertColByRangeCommand.id,
+                    RemoveRowCommand.id,
+                    RemoveRowByRangeCommand.id,
+                    RemoveColCommand.id,
+                    RemoveColByRangeCommand.id,
+                ].includes(command.id)) {
                     this._rebuildFormulaReferenceIndex();
                 }
             })


### PR DESCRIPTION
## Summary

- index formula references by resolved target sheet and maximum row/column boundary so full-row and full-column structural edits only visit formulas that can be affected
- keep formulas with dynamic or unsupported reference semantics in a conservative candidate set
- cache immutable parsed templates and clone nodes for every formula rewrite, including identical formulas, then seed the cache with rewritten nodes
- rebuild the index at workbook/formula-data lifecycle boundaries and after structural commands so subsequent edits and undo/redo cannot observe stale entries

## Regression oracle

Before this change, the focused oracle receives the whole formula model for an insert and calls `sequenceNodesBuilder` in the command path. The test requires only affected plus conservative formulas, zero warmed-path builder calls through insert/undo/redo, and two identical formulas independently rewriting `A10` to `A11` (never cumulatively to `A12`). It also mutates an initially unaffected formula and proves the rebuilt index selects it on the next structural edit.

## Verification

- `pnpm --filter @univerjs/sheets-formula-ui exec vitest run src/controllers/__tests__/formula-reference-index.spec.ts` — 2 passed
- `pnpm --filter @univerjs/sheets-formula typecheck` — passed
- `pnpm --filter @univerjs/sheets-formula-ui typecheck` — passed
- `pnpm exec eslint packages/sheets-formula/src/controllers/update-formula.controller.ts packages/sheets-formula-ui/src/controllers/__tests__/formula-reference-index.spec.ts` — 0 errors; 4 unchanged legacy warnings remain in the pre-existing `_getFormulaReferenceMoveInfo` body (one complexity warning and three unused-destructure warnings)