### PR TITLE
feat(core): add result-aware command completion hook

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,8 @@ export {
     sequenceExecuteAsync,
 } from './services/command/command.service';
 export type {
+    CommandExecutionCompletedListener,
+    CommandExecutionCompletion,
     CommandListener,
     ICommand,
     ICommandInfo,

--- a/packages/core/src/services/command/__tests__/command.service.spec.ts
+++ b/packages/core/src/services/command/__tests__/command.service.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IMultiCommand } from '../command.service';
+import type { CommandExecutionCompletion, IMultiCommand } from '../command.service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Injector } from '../../../common/di';
 import { CustomCommandExecutionError } from '../../../common/error';
@@ -212,6 +212,144 @@ describe('Test CommandService', () => {
             disposable.dispose();
             commandService.syncExecuteCommand(pushValCommandID);
             expect(numbers).toEqual([-1, 0, 1, -1, 0, 1, 0]);
+        });
+
+        it('Should report fulfilled results for async, sync, false, and sync-only executions', async () => {
+            const completions: CommandExecutionCompletion[] = [];
+            const completionListener = vi.fn((_commandInfo, _options, completion: CommandExecutionCompletion) => {
+                completions.push(completion);
+            });
+            const regularListener = vi.fn();
+            const completionDisposable = commandService.onCommandExecutionCompleted(completionListener);
+            commandService.onCommandExecuted(regularListener);
+
+            expect(() => commandService.onCommandExecutionCompleted(completionListener)).toThrow(
+                '[CommandService]: could not add a completion listener twice.'
+            );
+            expect(commandService.syncExecuteCommand(commandID, { value: 1 })).toBe(true);
+            await expect(commandService.executeCommand(commandID, { value: 2 })).resolves.toBe(false);
+            await expect(commandService.executeCommand(commandID, { value: 1 }, { syncOnly: true })).resolves.toBe(
+                true
+            );
+
+            expect(completions).toEqual([
+                { status: 'fulfilled', result: true },
+                { status: 'fulfilled', result: false },
+                { status: 'fulfilled', result: true },
+            ]);
+            expect(regularListener).toHaveBeenCalledTimes(2);
+
+            completionDisposable.dispose();
+            commandService.syncExecuteCommand(commandID, { value: 1 });
+            expect(completionListener).toHaveBeenCalledTimes(3);
+        });
+
+        it('Should report rejections and isolate completion listener errors', async () => {
+            const completions: CommandExecutionCompletion[] = [];
+            const completionError = new Error('completion-listener-error');
+            const logError = vi.spyOn(logService, 'error').mockImplementation(() => undefined);
+            commandService.onCommandExecutionCompleted((_commandInfo, _options, completion) => {
+                completions.push(completion);
+            });
+            commandService.onCommandExecutionCompleted(() => {
+                throw completionError;
+            });
+
+            await expect(commandService.executeCommand(commandID, { value: 100 })).rejects.toThrow('100');
+            expect(() => commandService.syncExecuteCommand(commandID, { value: 100 })).toThrow('100');
+            expect(commandService.syncExecuteCommand(commandID, { value: 1 })).toBe(true);
+
+            expect(completions).toEqual([
+                { status: 'rejected', error: new Error('100') },
+                { status: 'rejected', error: new Error('100') },
+                { status: 'fulfilled', result: true },
+            ]);
+            expect(logError).toHaveBeenCalledTimes(3);
+            expect(logError).toHaveBeenCalledWith(
+                '[CommandService]',
+                'command completion listener failed',
+                completionError
+            );
+        });
+
+        it('Should complete a command disposed after before and clear failed command stack state', async () => {
+            const disposedCompletion = vi.fn();
+            const pushValCommandID = 'push-val-completion-dispose-before-hook';
+            commandService.registerCommand({
+                id: pushValCommandID,
+                type: CommandType.COMMAND,
+                handler: () => true,
+            });
+            commandService.onCommandExecutionCompleted(disposedCompletion);
+            commandService.beforeCommandExecuted(() => (commandService as CommandService).dispose());
+
+            await expect(commandService.executeCommand(pushValCommandID)).resolves.toBe(false);
+            expect(disposedCompletion).toHaveBeenCalledWith(
+                { id: pushValCommandID, type: CommandType.COMMAND, params: undefined },
+                {},
+                { status: 'fulfilled', result: false }
+            );
+        });
+
+        it('Should report a before-listener rejection and remove its command from the trigger stack', async () => {
+            const completions: CommandExecutionCompletion[] = [];
+            const beforeError = new Error('before-listener-error');
+            const beforeDisposable = commandService.beforeCommandExecuted(() => {
+                throw beforeError;
+            });
+            commandService.onCommandExecutionCompleted((_commandInfo, _options, completion) => {
+                completions.push(completion);
+            });
+
+            await expect(commandService.executeCommand(commandID, { value: 1 })).rejects.toThrow(beforeError);
+            beforeDisposable.dispose();
+
+            const mutationID = 'mutation-after-before-listener-error';
+            const mutationParams: { trigger?: string } = {};
+            commandService.registerCommand({
+                id: mutationID,
+                type: CommandType.MUTATION,
+                handler: (_accessor, params: { trigger?: string }) => {
+                    expect(params.trigger).toBeUndefined();
+                    return true;
+                },
+            });
+            expect(commandService.syncExecuteCommand(mutationID, mutationParams)).toBe(true);
+            expect(completions).toEqual([
+                { status: 'rejected', error: beforeError },
+                { status: 'fulfilled', result: true },
+            ]);
+        });
+
+        it('Should complete nested commands from inner to outer with each exact result', async () => {
+            const mutationID = 'nested-completion-mutation';
+            const commandID = 'nested-completion-command';
+            const completions: Array<{ id: string; completion: CommandExecutionCompletion }> = [];
+            let succeeds = false;
+            commandService.registerCommand({
+                id: mutationID,
+                type: CommandType.MUTATION,
+                handler: () => succeeds,
+            });
+            commandService.registerCommand({
+                id: commandID,
+                type: CommandType.COMMAND,
+                handler: (accessor) => accessor.get(ICommandService).syncExecuteCommand(mutationID),
+            });
+            commandService.onCommandExecutionCompleted((commandInfo, _options, completion) => {
+                completions.push({ id: commandInfo.id, completion });
+            });
+
+            await expect(commandService.executeCommand(commandID)).resolves.toBe(false);
+            succeeds = true;
+            expect(commandService.syncExecuteCommand(commandID)).toBe(true);
+
+            expect(completions).toEqual([
+                { id: mutationID, completion: { status: 'fulfilled', result: false } },
+                { id: commandID, completion: { status: 'fulfilled', result: false } },
+                { id: mutationID, completion: { status: 'fulfilled', result: true } },
+                { id: commandID, completion: { status: 'fulfilled', result: true } },
+            ]);
         });
 
         it('Should skip command execution after the command service is disposed', async () => {

--- a/packages/core/src/services/command/command.service.ts
+++ b/packages/core/src/services/command/command.service.ts
@@ -200,6 +200,16 @@ export interface IExecutionOptions {
 
 export type CommandListener = (commandInfo: Readonly<ICommandInfo>, options?: IExecutionOptions) => void;
 
+export type CommandExecutionCompletion<R = unknown> =
+    | Readonly<{ status: 'fulfilled'; result: R }>
+    | Readonly<{ status: 'rejected'; error: unknown }>;
+
+export type CommandExecutionCompletedListener = (
+    commandInfo: Readonly<ICommandInfo>,
+    options: IExecutionOptions,
+    completion: CommandExecutionCompletion
+) => void;
+
 /**
  * The identifier of the command service.
  */
@@ -256,6 +266,13 @@ export interface ICommandService {
      * @param listener
      */
     onCommandExecuted(listener: CommandListener): IDisposable;
+    /**
+     * Register a result-aware callback for every command that reached
+     * {@link beforeCommandExecuted}, including sync-only, false, and rejected executions.
+     * Listener errors are logged and do not change command execution semantics.
+     * @param listener
+     */
+    onCommandExecutionCompleted(listener: CommandExecutionCompletedListener): IDisposable;
     /**
      * Register a callback function that will be executed before a command is executed.
      * @param listener
@@ -322,6 +339,7 @@ export class CommandService extends Disposable implements ICommandService {
 
     private readonly _beforeCommandExecutionListeners: CommandListener[] = [];
     private readonly _commandExecutedListeners: CommandListener[] = [];
+    private readonly _commandExecutionCompletedListeners: CommandExecutionCompletedListener[] = [];
     private readonly _collabMutationListeners: CommandListener[] = [];
 
     private _multiCommandDisposables = new Map<string, IDisposable>();
@@ -346,6 +364,7 @@ export class CommandService extends Disposable implements ICommandService {
 
         this._commandExecutedListeners.length = 0;
         this._beforeCommandExecutionListeners.length = 0;
+        this._commandExecutionCompletedListeners.length = 0;
         this._collabMutationListeners.length = 0;
     }
 
@@ -400,6 +419,21 @@ export class CommandService extends Disposable implements ICommandService {
         throw new Error('[CommandService]: could not add a listener twice.');
     }
 
+    onCommandExecutionCompleted(listener: CommandExecutionCompletedListener): IDisposable {
+        if (this._commandExecutionCompletedListeners.indexOf(listener) === -1) {
+            this._commandExecutionCompletedListeners.push(listener);
+
+            return toDisposable(() => {
+                const index = this._commandExecutionCompletedListeners.indexOf(listener);
+                if (index >= 0) {
+                    this._commandExecutionCompletedListeners.splice(index, 1);
+                }
+            });
+        }
+
+        throw new Error('[CommandService]: could not add a completion listener twice.');
+    }
+
     onMutationExecutedForCollab(listener: CommandListener): IDisposable {
         if (this._collabMutationListeners.indexOf(listener) === -1) {
             this._collabMutationListeners.push(listener);
@@ -423,53 +457,54 @@ export class CommandService extends Disposable implements ICommandService {
             return false as R;
         }
 
-        try {
-            const item = this._commandRegistry.getCommand(id);
-            if (item) {
-                const [command] = item;
-                const commandInfo: ICommandInfo = {
-                    id: command.id,
-                    type: command.type,
-                    params,
-                };
+        const item = this._commandRegistry.getCommand(id);
+        if (item) {
+            const [command] = item;
+            const commandInfo: ICommandInfo = {
+                id: command.id,
+                type: command.type,
+                params,
+            };
 
-                const stackItemDisposable = this._pushCommandExecutionStack(commandInfo);
-                const _options = options ?? {};
+            const stackItemDisposable = this._pushCommandExecutionStack(commandInfo);
+            const _options = options ?? {};
+            const completionListeners = [...this._commandExecutionCompletedListeners];
 
+            try {
                 this._beforeCommandExecutionListeners.forEach((listener) => listener(commandInfo, _options));
                 if (this._disposed) {
-                    stackItemDisposable.dispose();
                     this._warnCommandSkippedAfterDisposed(id);
+                    this._notifyCommandExecutionCompleted(completionListeners, commandInfo, _options, {
+                        status: 'fulfilled',
+                        result: false,
+                    });
                     return false as R;
                 }
 
                 const result = await this._execute<P, R>(command as ICommand<P, R>, params, _options);
-                // For syncOnly mutations, only call collab listeners, not regular listeners
-                if (_options.syncOnly) {
-                    if (command.type === CommandType.MUTATION) {
-                        this._collabMutationListeners.forEach((listener) => listener(commandInfo, _options));
-                    }
-                } else {
-                    this._commandExecutedListeners.forEach((listener) => listener(commandInfo, _options));
-                    if (command.type === CommandType.MUTATION) {
-                        this._collabMutationListeners.forEach((listener) => listener(commandInfo, _options));
-                    }
-                }
+                this._notifyCommandExecuted(command, commandInfo, _options);
 
-                stackItemDisposable.dispose();
-
+                this._notifyCommandExecutionCompleted(completionListeners, commandInfo, _options, {
+                    status: 'fulfilled',
+                    result,
+                });
                 return result;
-            }
-
-            throw new Error(`[CommandService]: command "${id}" is not registered.`);
-        } catch (error) {
-            if (error instanceof CustomCommandExecutionError) {
-                // If need custom logic, can add it here
-                return false as R;
-            } else {
+            } catch (error) {
+                this._notifyCommandExecutionCompleted(completionListeners, commandInfo, _options, {
+                    status: 'rejected',
+                    error,
+                });
+                if (error instanceof CustomCommandExecutionError) {
+                    // If need custom logic, can add it here
+                    return false as R;
+                }
                 throw error;
+            } finally {
+                stackItemDisposable.dispose();
             }
         }
+
+        throw new Error(`[CommandService]: command "${id}" is not registered.`);
     }
 
     syncExecuteCommand<P extends object = object, R = boolean>(
@@ -482,65 +517,95 @@ export class CommandService extends Disposable implements ICommandService {
             return false as R;
         }
 
-        try {
-            const item = this._commandRegistry.getCommand(id);
-            if (item) {
-                const [command] = item;
-                const commandInfo: ICommandInfo = {
-                    id: command.id,
-                    type: command.type,
-                    params,
-                };
+        const item = this._commandRegistry.getCommand(id);
+        if (item) {
+            const [command] = item;
+            const commandInfo: ICommandInfo = {
+                id: command.id,
+                type: command.type,
+                params,
+            };
 
-                // If the executed command is of type `Mutation`, we should add a trigger params,
-                // whose value is the command's ID that triggers the mutation.
-                if (command.type === CommandType.MUTATION) {
-                    const triggerCommand = findLast(
-                        this._commandExecutionStack,
-                        (item) => item.type === CommandType.COMMAND
-                    );
-                    if (triggerCommand) {
-                        commandInfo.params = commandInfo.params ?? {};
-                        (commandInfo.params as IMutationCommonParams).trigger = triggerCommand.id;
-                    }
+            // If the executed command is of type `Mutation`, we should add a trigger params,
+            // whose value is the command's ID that triggers the mutation.
+            if (command.type === CommandType.MUTATION) {
+                const triggerCommand = findLast(
+                    this._commandExecutionStack,
+                    (item) => item.type === CommandType.COMMAND
+                );
+                if (triggerCommand) {
+                    commandInfo.params = commandInfo.params ?? {};
+                    (commandInfo.params as IMutationCommonParams).trigger = triggerCommand.id;
                 }
+            }
 
-                const stackItemDisposable = this._pushCommandExecutionStack(commandInfo);
-                const _options = options ?? {};
+            const stackItemDisposable = this._pushCommandExecutionStack(commandInfo);
+            const _options = options ?? {};
+            const completionListeners = [...this._commandExecutionCompletedListeners];
 
+            try {
                 this._beforeCommandExecutionListeners.forEach((listener) => listener(commandInfo, _options));
                 if (this._disposed) {
-                    stackItemDisposable.dispose();
                     this._warnCommandSkippedAfterDisposed(id);
+                    this._notifyCommandExecutionCompleted(completionListeners, commandInfo, _options, {
+                        status: 'fulfilled',
+                        result: false,
+                    });
                     return false as R;
                 }
 
                 const result = this._syncExecute<P, R>(command as ICommand<P, R>, params, _options);
-                // For syncOnly mutations, only call collab listeners, not regular listeners
-                if (_options.syncOnly) {
-                    if (command.type === CommandType.MUTATION) {
-                        this._collabMutationListeners.forEach((listener) => listener(commandInfo, _options));
-                    }
-                } else {
-                    this._commandExecutedListeners.forEach((listener) => listener(commandInfo, _options));
-                    if (command.type === CommandType.MUTATION) {
-                        this._collabMutationListeners.forEach((listener) => listener(commandInfo, _options));
-                    }
-                }
+                this._notifyCommandExecuted(command, commandInfo, _options);
 
-                stackItemDisposable.dispose();
-
+                this._notifyCommandExecutionCompleted(completionListeners, commandInfo, _options, {
+                    status: 'fulfilled',
+                    result,
+                });
                 return result;
-            }
-
-            throw new Error(`[CommandService]: command "${id}" is not registered.`);
-        } catch (error) {
-            if (error instanceof CustomCommandExecutionError) {
-                return false as R;
-            } else {
+            } catch (error) {
+                this._notifyCommandExecutionCompleted(completionListeners, commandInfo, _options, {
+                    status: 'rejected',
+                    error,
+                });
+                if (error instanceof CustomCommandExecutionError) {
+                    return false as R;
+                }
                 throw error;
+            } finally {
+                stackItemDisposable.dispose();
             }
         }
+
+        throw new Error(`[CommandService]: command "${id}" is not registered.`);
+    }
+
+    private _notifyCommandExecuted(
+        command: ICommand,
+        commandInfo: Readonly<ICommandInfo>,
+        options: IExecutionOptions
+    ): void {
+        // For syncOnly mutations, only call collab listeners, not regular listeners.
+        if (!options.syncOnly) {
+            this._commandExecutedListeners.forEach((listener) => listener(commandInfo, options));
+        }
+        if (command.type === CommandType.MUTATION) {
+            this._collabMutationListeners.forEach((listener) => listener(commandInfo, options));
+        }
+    }
+
+    private _notifyCommandExecutionCompleted(
+        listeners: readonly CommandExecutionCompletedListener[],
+        commandInfo: Readonly<ICommandInfo>,
+        options: IExecutionOptions,
+        completion: CommandExecutionCompletion
+    ): void {
+        listeners.forEach((listener) => {
+            try {
+                listener(commandInfo, options, completion);
+            } catch (error) {
+                this._logService.error('[CommandService]', 'command completion listener failed', error);
+            }
+        });
     }
 
     private _pushCommandExecutionStack(stackItem: ICommandExecutionStackItem): IDisposable {

--- a/packages/sheets-data-validation/src/facade/__tests__/create-test-bed.ts
+++ b/packages/sheets-data-validation/src/facade/__tests__/create-test-bed.ts
@@ -16,6 +16,7 @@
 
 import type { Dependency, IWorkbookData, UnitModel } from '@univerjs/core';
 import {
+    ICommandService,
     ILogService,
     Inject,
     Injector,
@@ -47,8 +48,11 @@ import {
     ISheetRowFilteredService,
     ISuperTableService,
     LexerTreeBuilder,
+    OtherFormulaMarkDirty,
     RegisterFunctionService,
     RegisterOtherFormulaService,
+    RemoveOtherFormulaMutation,
+    SetOtherFormulaMutation,
     SheetRowFilteredService,
     SuperTableService,
 } from '@univerjs/engine-formula';
@@ -183,7 +187,12 @@ export function createFacadeTestBed(workbookData?: IWorkbookData, dependencies?:
         }
 
         override onReady(): void {
-
+            const commandService = this._injector.get(ICommandService);
+            [
+                OtherFormulaMarkDirty,
+                SetOtherFormulaMutation,
+                RemoveOtherFormulaMutation,
+            ].forEach((command) => commandService.registerCommand(command));
         }
     }
 

--- a/packages/sheets-data-validation/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets-data-validation/src/facade/__tests__/f-range.spec.ts
@@ -38,7 +38,7 @@ import {
     UpdateSheetDataValidationRangeCommand,
     UpdateSheetDataValidationSettingCommand,
 } from '@univerjs/sheets-data-validation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFacadeTestBed } from './create-test-bed';
 import '@univerjs/sheets-formula/facade';
 
@@ -46,9 +46,10 @@ describe('Test FRange', () => {
     let get: Injector['get'];
     let commandService: ICommandService;
     let univerAPI: FUniver;
+    let testBed: ReturnType<typeof createFacadeTestBed>;
 
     beforeEach(() => {
-        const testBed = createFacadeTestBed();
+        testBed = createFacadeTestBed();
         get = testBed.get;
 
         univerAPI = testBed.univerAPI;
@@ -70,6 +71,11 @@ describe('Test FRange', () => {
             callback({ didTimeout: false, timeRemaining: () => 16 } as IdleDeadline);
             return 1;
         }) as typeof requestIdleCallback);
+    });
+
+    afterEach(() => {
+        testBed.univer.dispose();
+        vi.unstubAllGlobals();
     });
 
     it('Range set data validation', async () => {


### PR DESCRIPTION
## Summary

- add `ICommandService.onCommandExecutionCompleted` with a discriminated fulfilled/rejected result
- report async, synchronous, `syncOnly`, `false`, thrown, and disposed-after-before outcomes
- keep `onCommandExecuted` behavior unchanged and isolate completion-listener failures through logging
- always remove command stack frames after executions that reached the before hook

## Why

`onCommandExecuted` intentionally skips `syncOnly` commands and does not expose the handler result. Integrations that need an authoritative completion boundary therefore cannot distinguish `false` from success, observe rejected executions, or reliably clear nested state after a failure. This hook provides that boundary without changing existing listeners.

A downstream spreadsheet integration uses this result-aware signal to publish structural operation metadata only after the owning command and every nested mutation have completed successfully.

## Tests

- `pnpm --filter @univerjs/core test -- src/services/command/__tests__/command.service.spec.ts` (21 passed)
- `pnpm --filter @univerjs/core typecheck`
- `pnpm exec eslint packages/core/src/services/command/command.service.ts packages/core/src/services/command/__tests__/command.service.spec.ts packages/core/src/index.ts` (0 errors; one pre-existing `Record<string, any>` warning)
- `git diff --check`