### PR TITLE
test(sheets-data-validation): wire formula lifecycle

### DIFF
--- a/packages/sheets-data-validation/src/facade/__tests__/create-test-bed.ts
+++ b/packages/sheets-data-validation/src/facade/__tests__/create-test-bed.ts
@@ -16,6 +16,7 @@
 
 import type { Dependency, IWorkbookData, UnitModel } from '@univerjs/core';
 import {
+    ICommandService,
     ILogService,
     Inject,
     Injector,
@@ -47,8 +48,11 @@ import {
     ISheetRowFilteredService,
     ISuperTableService,
     LexerTreeBuilder,
+    OtherFormulaMarkDirty,
     RegisterFunctionService,
     RegisterOtherFormulaService,
+    RemoveOtherFormulaMutation,
+    SetOtherFormulaMutation,
     SheetRowFilteredService,
     SuperTableService,
 } from '@univerjs/engine-formula';
@@ -183,7 +187,12 @@ export function createFacadeTestBed(workbookData?: IWorkbookData, dependencies?:
         }
 
         override onReady(): void {
-
+            const commandService = this._injector.get(ICommandService);
+            [
+                OtherFormulaMarkDirty,
+                SetOtherFormulaMutation,
+                RemoveOtherFormulaMutation,
+            ].forEach((command) => commandService.registerCommand(command));
         }
     }
 

--- a/packages/sheets-data-validation/src/facade/__tests__/f-range.spec.ts
+++ b/packages/sheets-data-validation/src/facade/__tests__/f-range.spec.ts
@@ -38,7 +38,7 @@ import {
     UpdateSheetDataValidationRangeCommand,
     UpdateSheetDataValidationSettingCommand,
 } from '@univerjs/sheets-data-validation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFacadeTestBed } from './create-test-bed';
 import '@univerjs/sheets-formula/facade';
 
@@ -46,9 +46,10 @@ describe('Test FRange', () => {
     let get: Injector['get'];
     let commandService: ICommandService;
     let univerAPI: FUniver;
+    let testBed: ReturnType<typeof createFacadeTestBed>;
 
     beforeEach(() => {
-        const testBed = createFacadeTestBed();
+        testBed = createFacadeTestBed();
         get = testBed.get;
 
         univerAPI = testBed.univerAPI;
@@ -70,6 +71,11 @@ describe('Test FRange', () => {
             callback({ didTimeout: false, timeRemaining: () => 16 } as IdleDeadline);
             return 1;
         }) as typeof requestIdleCallback);
+    });
+
+    afterEach(() => {
+        testBed.univer.dispose();
+        vi.unstubAllGlobals();
     });
 
     it('Range set data validation', async () => {


### PR DESCRIPTION
## Summary

- register the other-formula mutations in the sheets data-validation facade fixture at the Ready lifecycle stage, matching production FormulaController ownership
- dispose each FRange test Univer instance and restore stubbed globals
- prevent the deferred RegisterOtherFormulaService callback from outliving an incompletely wired fixture

## Validation

- focused FRange test: 3/3 passed with no unhandled rejection
- sheets-data-validation coverage: 14/14 files, 76/76 tests passed
- sheets-data-validation typecheck passed
- changed-file ESLint: 0 errors (one pre-existing max-lines warning)
- independent review: no correctness findings
