### PR TITLE
fix(sheets-ui): defer Facade pointer events

### DIFF
--- a/e2e/smoking/sheets-facade-pointer-events.spec.ts
+++ b/e2e/smoking/sheets-facade-pointer-events.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+const SHEET_MAIN_CANVAS = '[id^="univer-sheet-main-canvas_"]';
+
+test('bridges sheet pointer events when the workbook is created after the Facade', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.goto('/sheets/');
+    await page.waitForFunction(() => !!window.univerAPI && !!window.E2EControllerAPI);
+    await page.evaluate(() => window.E2EControllerAPI.loadDefaultSheet());
+
+    await page.evaluate(() => {
+        document.documentElement.dataset.cellPointerDown = '0';
+        document.documentElement.dataset.cellHovered = '0';
+        window.univerAPI.addEvent(window.univerAPI.Event.CellPointerDown, () => {
+            document.documentElement.dataset.cellPointerDown = '1';
+        });
+        window.univerAPI.addEvent(window.univerAPI.Event.CellHover, () => {
+            document.documentElement.dataset.cellHovered = '1';
+        });
+    });
+
+    const canvas = page.locator(SHEET_MAIN_CANVAS);
+    await expect(canvas).toBeVisible();
+    const canvasBox = await canvas.boundingBox();
+    if (!canvasBox) throw new Error('Sheet canvas is not visible');
+
+    await page.mouse.move(canvasBox.x + 160, canvasBox.y + 100);
+    await page.mouse.move(canvasBox.x + 260, canvasBox.y + 140);
+    await page.mouse.click(canvasBox.x + 260, canvasBox.y + 140, { delay: 50 });
+
+    await expect.poll(() => page.evaluate(() => document.documentElement.dataset.cellHovered)).toBe('1');
+    await expect.poll(() => page.evaluate(() => document.documentElement.dataset.cellPointerDown)).toBe('1');
+    expect(pageErrors).toEqual([]);
+});

--- a/packages/sheets-ui/src/facade/__tests__/create-test-bed.ts
+++ b/packages/sheets-ui/src/facade/__tests__/create-test-bed.ts
@@ -36,6 +36,8 @@ import {
     SheetInterceptorService,
     SheetSkeletonService,
 } from '@univerjs/sheets';
+import { DragManagerService } from '../../services/drag-manager.service';
+import { HoverManagerService } from '../../services/hover-manager.service';
 
 function getTestWorkbookDataDemo(): IWorkbookData {
     return {
@@ -126,7 +128,10 @@ export function createFacadeTestBed(workbookData?: IWorkbookData, dependencies?:
             injector.add([IRenderManagerService, { useClass: RenderManagerServiceTestBed }]);
             injector.add([LexerTreeBuilder]);
 
-            dependencies?.forEach((d) => injector.add(d));
+            const dependencyIds = new Set(dependencies?.map((dependency) => Array.isArray(dependency) ? dependency[0] : dependency));
+            if (!dependencyIds.has(HoverManagerService)) injector.add([HoverManagerService]);
+            if (!dependencyIds.has(DragManagerService)) injector.add([DragManagerService]);
+            dependencies?.forEach((dependency) => injector.add(dependency));
 
             this._injector.get(SheetInterceptorService);
         }

--- a/packages/sheets-ui/src/facade/f-univer.ts
+++ b/packages/sheets-ui/src/facade/f-univer.ts
@@ -63,7 +63,7 @@ import {
     SheetScrollManagerService,
 } from '@univerjs/sheets-ui';
 import { CopyCommand, CutCommand, HTML_CLIPBOARD_MIME_TYPE, IClipboardInterfaceService, KeyCode, PasteCommand, PLAIN_TEXT_CLIPBOARD_MIME_TYPE, supportClipboardAPI } from '@univerjs/ui';
-import { combineLatest, filter } from 'rxjs';
+import { combineLatest, filter, of, take } from 'rxjs';
 
 /**
  * @ignore
@@ -408,17 +408,13 @@ export class FUniverSheetsUIMixin extends FUniver implements IFUniverSheetsUIMix
     private _initObserverListener(injector: Injector): void {
         const renderManagerService = injector.get(IRenderManagerService);
         const lifeCycleService = injector.get(LifecycleService);
+        const univerInstanceService = injector.get(IUniverInstanceService);
 
         const lifecycle$Disposable = new DisposableCollection();
         // eslint-disable-next-line max-lines-per-function
-        this.disposeWithMe(lifeCycleService.lifecycle$.subscribe((lifecycle) => {
-            if (lifecycle !== LifecycleStages.Rendered) return;
+        const registerPointerEventListeners = (): void => {
             const hoverManagerService = injector.get(HoverManagerService);
             const dragManagerService = injector.get(DragManagerService);
-            if (!hoverManagerService) return;
-
-            // Prevent multiple registrations
-            lifecycle$Disposable.dispose();
 
             // Cell events
             lifecycle$Disposable.add(
@@ -764,7 +760,17 @@ export class FUniverSheetsUIMixin extends FUniver implements IFUniverSheetsUIMix
             );
 
             this.disposeWithMe(lifecycle$Disposable);
-        }));
+        };
+
+        const sheetAvailable$ = univerInstanceService.getAllUnitsForType(UniverInstanceType.UNIVER_SHEET).length > 0
+            ? of(true)
+            : univerInstanceService.getTypeOfUnitAdded$(UniverInstanceType.UNIVER_SHEET).pipe(take(1));
+        this.disposeWithMe(
+            combineLatest([sheetAvailable$, lifeCycleService.lifecycle$]).pipe(
+                filter(([, lifecycle]) => lifecycle >= LifecycleStages.Rendered),
+                take(1)
+            ).subscribe(() => registerPointerEventListeners())
+        );
 
         // UI Events in renderUnit
         let sheetRenderUnit: Nullable<IRender>;


### PR DESCRIPTION
Refs dream-num/univer-cli#1261

## What changed

- defer Sheet UI Facade pointer-event registration until both the first Sheet unit exists and the application lifecycle reaches `Rendered`
- keep `HoverManagerService` and `DragManagerService` as required Sheet UI dependencies
- add a browser smoke regression for creating the workbook after the Facade

## Root cause

The Facade can be created and reach the global `Rendered` lifecycle before any Sheet unit exists. Sheet-type plugins register the pointer services only when the first Sheet is created, so resolving them from the global lifecycle callback could fail.

The registration now joins the Sheet unit lifecycle with the global render lifecycle and runs once. This keeps the fix in the Sheet UI Facade boundary without optional injection or product-specific fallback behavior.

## Validation

- `pnpm --filter @univerjs/sheets-ui test -- src/facade/__tests__/f-univer.spec.ts` (11 passed)
- `pnpm --filter @univerjs/sheets-ui test` (562 passed)
- `pnpm --filter @univerjs/sheets-ui typecheck`
- `pnpm build:e2e`
- `pnpm exec playwright test e2e/smoking/sheets-facade-pointer-events.spec.ts` with local Chrome (1 passed)
- `pnpm lint` (0 errors)

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Tests have been added for the changes.
- [x] No breaking changes are introduced.
