### PR TITLE
fix(engine-render): align preset list indentation

### DIFF
--- a/packages/core/src/docs/data-model/__tests__/preset-list-type.spec.ts
+++ b/packages/core/src/docs/data-model/__tests__/preset-list-type.spec.ts
@@ -25,4 +25,13 @@ describe('preset list types', () => {
             }
         }
     });
+
+    it('keeps wrapped text aligned after the hanging marker at every level', () => {
+        for (const [listType, listData] of Object.entries(PRESET_LIST_TYPE)) {
+            for (const [level, nesting] of listData.nestingLevel.entries()) {
+                expect(nesting.paragraphProperties?.hanging, `${listType} level ${level}`).toEqual({ v: 21 });
+                expect(nesting.paragraphProperties?.indentStart, `${listType} level ${level}`).toEqual({ v: 21 * (level + 1) });
+            }
+        }
+    });
 });

--- a/packages/core/src/docs/data-model/preset-list-type.ts
+++ b/packages/core/src/docs/data-model/preset-list-type.ts
@@ -108,7 +108,7 @@ const bulletListFactory = (symbols: BulletSymbols): INestingLevel[] => {
         startNumber: 0,
         paragraphProperties: {
             hanging: { v: 21 },
-            indentStart: { v: 21 * (i) },
+            indentStart: { v: 21 * (i + 1) },
         },
     }));
 };
@@ -120,7 +120,7 @@ const orderListFactory = (options: { glyphFormat: string; glyphType: ListGlyphTy
         startNumber: 0,
         paragraphProperties: {
             hanging: { v: 21 },
-            indentStart: { v: 21 * (i) },
+            indentStart: { v: 21 * (i + 1) },
         },
     }));
 };
@@ -133,7 +133,7 @@ const checkListFactory = (symbol: string, textStyle?: ITextStyle): INestingLevel
         startNumber: 0,
         paragraphProperties: {
             hanging: { v: 21 },
-            indentStart: { v: 21 * (i) },
+            indentStart: { v: 21 * (i + 1) },
             textStyle,
         },
     } as INestingLevel));

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/bullet.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/bullet.spec.ts
@@ -258,7 +258,10 @@ describe('bullet', () => {
             expect(result.ts.ff).toBeUndefined();
             expect(result.ts.fs).toBeUndefined();
             expect(result.startIndexItem).toBe(1);
-            expect(result.paragraphProperties).toBeDefined();
+            expect(result.paragraphProperties).toMatchObject({
+                hanging: { v: 21 },
+                indentStart: { v: 21 },
+            });
         });
 
         it('uses custom startIndex', () => {

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/linebreaking.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/linebreaking.spec.ts
@@ -1364,6 +1364,52 @@ describe('linebreaking', () => {
         expect(result.length).toBeGreaterThanOrEqual(1);
     });
 
+    it('aligns wrapped list lines with the body text after the hanging marker', () => {
+        const content = 'A wrapped list item with enough text to continue';
+        const { viewModel, ctx, paragraphNode, sectionBreakConfig, curPage } = createParagraphLayoutTestBed(content, {
+            documentStyle: {
+                pageSize: { width: 160, height: 600 },
+                marginLeft: 20,
+                marginRight: 20,
+            },
+            body: {
+                paragraphs: [{
+                    startIndex: content.length,
+                    bullet: {
+                        listId: 'list-1',
+                        listType: 'test-list',
+                        nestingLevel: 0,
+                    },
+                }],
+            },
+            lists: {
+                'test-list': {
+                    listType: 'test-list',
+                    nestingLevel: [{
+                        bulletAlignment: 1,
+                        glyphFormat: '•',
+                        startNumber: 1,
+                        glyphType: 0,
+                        paragraphProperties: {
+                            hanging: { v: 21 },
+                            indentStart: { v: 21 },
+                        },
+                    }],
+                },
+            },
+        });
+        const shapedTextList = shaping(ctx, paragraphNode.content!, viewModel, paragraphNode, sectionBreakConfig);
+
+        const result = lineBreaking(ctx, viewModel, shapedTextList, curPage, paragraphNode, sectionBreakConfig, null);
+        const lines = paragraphLines(result[0], paragraphNode.endIndex);
+
+        expect(lines.length).toBeGreaterThan(1);
+        expect(lines[0].divides[0].left).toBe(0);
+        expect(lines.slice(1).map((line) => line.divides[0].left)).toEqual(
+            Array.from({ length: lines.length - 1 }, () => 21)
+        );
+    });
+
     it('handles empty shaped text list', () => {
         const { viewModel, ctx, paragraphNode, sectionBreakConfig, curPage } = createParagraphLayoutTestBed('');
 

--- a/packages/engine-render/src/components/docs/layout/block/paragraph/bullet.ts
+++ b/packages/engine-render/src/components/docs/layout/block/paragraph/bullet.ts
@@ -82,7 +82,7 @@ export function getDefaultBulletSke(listId: string, startIndex: number = 1): IDo
         paragraphProperties: {
             indentFirstLine: { v: 0 },
             hanging: { v: 21 },
-            indentStart: { v: 0 },
+            indentStart: { v: 21 },
         },
     };
 }


### PR DESCRIPTION
## Summary

- align built-in bullet, ordered, and checklist indentation with hanging-indent semantics
- align the fallback bullet skeleton with the same model
- add regression coverage for wrapped continuation lines and nested preset levels

## Root cause

The renderer now treats `indentStart` as the body-text position and `hanging` as the amount that pulls the first-line marker left. Built-in list presets still stored the legacy `21 * level` start position, so wrapped lines shifted under the marker and nested levels moved one level left.

## Validation

- `pnpm exec vitest run packages/core/src/docs/data-model/__tests__/preset-list-type.spec.ts packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/bullet.spec.ts packages/engine-render/src/components/docs/layout/block/paragraph/__tests__/linebreaking.spec.ts` (94 tests passed)
- `pnpm --filter @univerjs/core typecheck`
- `pnpm --filter @univerjs/engine-render typecheck`

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (no related issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.