### PR TITLE
feat(core): expose theme controls through facade

### DIFF
--- a/packages/core/src/facade/__tests__/f-univer.spec.ts
+++ b/packages/core/src/facade/__tests__/f-univer.spec.ts
@@ -81,7 +81,6 @@ describe('FUniver integration', () => {
         const injector = univer.__getInjector();
         const commandService = injector.get(ICommandService);
         const localeService = injector.get(LocaleService);
-        const themeService = injector.get(ThemeService);
         const logs: string[] = [];
         const disposables: IDisposable[] = [];
 
@@ -103,11 +102,9 @@ describe('FUniver integration', () => {
             facade: { hello: 'Hola {0}' },
         } as never);
         univerAPI.setLocale('esES');
-        univerAPI.toggleDarkMode(true);
 
         expect(localeService.getCurrentLocale()).toBe('esES');
         expect(localeService.t('facade.hello', 'Univer')).toBe('Hola Univer');
-        expect(themeService.darkMode).toBe(true);
 
         expect(await univerAPI.executeCommand(TEST_COMMAND_ID, { value: 'ok' })).toBe(true);
         expect(univerAPI.syncExecuteCommand(TEST_COMMAND_ID, { value: 'ok' })).toBe(true);
@@ -158,6 +155,26 @@ describe('FUniver integration', () => {
         ]));
 
         disposables.forEach((disposable) => disposable.dispose());
+    });
+
+    it('should configure and read the theme through the facade api', () => {
+        const themeService = univer.__getInjector().get(ThemeService);
+        const currentTheme = univerAPI.getCurrentTheme();
+        const theme = {
+            ...currentTheme,
+            primary: {
+                ...currentTheme.primary,
+                600: '#123456',
+            },
+        };
+
+        univerAPI.setTheme(theme);
+        univerAPI.toggleDarkMode(true);
+
+        expect(univerAPI.getCurrentTheme().primary[600]).toBe('#123456');
+        expect(univerAPI.isDarkMode()).toBe(true);
+        expect(themeService.getCurrentTheme().primary[600]).toBe('#123456');
+        expect(themeService.darkMode).toBe(true);
     });
 
     it('should support cancelable commands and undo-redo facade events', async () => {

--- a/packages/core/src/facade/f-univer.ts
+++ b/packages/core/src/facade/f-univer.ts
@@ -26,6 +26,7 @@ import type {
     LifecycleStages,
     LocaleType,
 } from '@univerjs/core';
+import type { Theme } from '@univerjs/themes';
 import type { Subscription } from 'rxjs';
 import type { ICommandEvent, IEventParamConfig } from './f-event';
 import {
@@ -368,6 +369,54 @@ export class FUniver extends Disposable {
      */
     redo(): Promise<boolean> {
         return this._commandService.executeCommand(RedoCommand.id);
+    }
+
+    /**
+     * Set the theme used by Univer.
+     * @param {Theme} theme - The complete theme to use.
+     * @example
+     * ```ts
+     * import { defaultTheme } from '@univerjs/themes';
+     *
+     * univerAPI.setTheme({
+     *   ...defaultTheme,
+     *   primary: {
+     *     ...defaultTheme.primary,
+     *     600: '#274fee',
+     *   },
+     * });
+     * ```
+     */
+    setTheme(theme: Theme): void {
+        const themeService = this._injector.get(ThemeService);
+        themeService.setTheme(theme);
+    }
+
+    /**
+     * Get the theme currently used by Univer.
+     * @returns {Theme} The current theme.
+     * @example
+     * ```ts
+     * const theme = univerAPI.getCurrentTheme();
+     * console.log(theme.primary[600]);
+     * ```
+     */
+    getCurrentTheme(): Theme {
+        const themeService = this._injector.get(ThemeService);
+        return themeService.getCurrentTheme();
+    }
+
+    /**
+     * Whether Univer is currently using dark mode.
+     * @returns {boolean} Whether dark mode is enabled.
+     * @example
+     * ```ts
+     * const darkMode = univerAPI.isDarkMode();
+     * ```
+     */
+    isDarkMode(): boolean {
+        const themeService = this._injector.get(ThemeService);
+        return themeService.darkMode;
     }
 
     /**


### PR DESCRIPTION
## Summary
- expose theme replacement and current-theme reads through the Core Facade
- expose dark-mode state reads alongside the existing setter
- add integration coverage for the public theme Facade methods

## Validation
- pnpm exec vitest run src/facade/__tests__/f-univer.spec.ts
- pnpm run typecheck
- node scripts/check-conventions.mjs
- pre-commit eslint --fix