### PR TITLE
feat(ui): group emoji skin tone variants

### DIFF
--- a/packages/ui/scripts/generate-emojis.mts
+++ b/packages/ui/scripts/generate-emojis.mts
@@ -6,9 +6,13 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { discoverUniverUiLocales } from '@univerjs-infra/shared/locale';
 
-interface IEmojiItem {
+interface IEmojiVariant {
     emoji: string;
     title: string;
+}
+
+interface IEmojiItem extends IEmojiVariant {
+    skinToneVariants?: IEmojiVariant[];
 }
 
 interface ICldrAnnotationsData {
@@ -58,6 +62,14 @@ const downloadTimeoutMs = 30_000;
 const envProxyNodeArg = '--use-env-proxy';
 const envProxyRelaunchEnv = 'UNIVER_UI_EMOJI_ENV_PROXY_REEXEC';
 const emojiCategories: EmojiCategory[] = ['people', 'nature', 'foods', 'activity', 'places', 'objects', 'symbols'];
+const emojiSkinToneModifierRegex = /[\u{1F3FB}-\u{1F3FF}]/u;
+const emojiSkinToneNames = new Set([
+    'Light Skin Tone',
+    'Medium-light Skin Tone',
+    'Medium Skin Tone',
+    'Medium-dark Skin Tone',
+    'Dark Skin Tone',
+]);
 const cldrLocaleMap: Record<string, string> = {
     'ar-SA': 'ar',
     'ca-ES': 'ca',
@@ -145,7 +157,45 @@ export function buildEmojisFromEmojiTest(emojiTest: string, options: { supported
         })
         .filter(isEmojiItem);
 
+    emojiCategories.forEach((category) => {
+        groups[category] = groupSkinToneVariants(groups[category]);
+    });
+
     return groups;
+}
+
+export function groupSkinToneVariants(items: IEmojiItem[]): IEmojiItem[] {
+    const baseItemsByTitle = new Map(
+        items
+            .filter((item) => !hasSkinToneModifier(item.emoji))
+            .map((item) => [item.title, item])
+    );
+    const variantsByBaseEmoji = new Map<string, IEmojiVariant[]>();
+    const groupedVariants = new Set<string>();
+
+    items.forEach((item) => {
+        if (!hasSkinToneModifier(item.emoji)) {
+            return;
+        }
+
+        const familyTitle = getSkinToneFamilyTitle(item.title, baseItemsByTitle);
+        const baseItem = baseItemsByTitle.get(familyTitle);
+        if (!baseItem) {
+            return;
+        }
+
+        const variants = variantsByBaseEmoji.get(baseItem.emoji) ?? [];
+        variants.push({ emoji: item.emoji, title: item.title });
+        variantsByBaseEmoji.set(baseItem.emoji, variants);
+        groupedVariants.add(item.emoji);
+    });
+
+    return items
+        .filter((item) => !groupedVariants.has(item.emoji))
+        .map((item) => {
+            const skinToneVariants = variantsByBaseEmoji.get(item.emoji);
+            return skinToneVariants?.length ? { ...item, skinToneVariants } : item;
+        });
 }
 
 export function buildEmojiSearchIndexFromCldrAnnotations(emojis: Array<string | IEmojiItem>, ...sources: ICldrAnnotationsData[]): IGeneratedEmojiLocale {
@@ -213,6 +263,32 @@ function getCldrAnnotation(source: ICldrAnnotationsData, emoji: string) {
 
 function stripEmojiVariationSelectors(emoji: string): string {
     return emoji.replace(/\uFE0F/g, '');
+}
+
+function hasSkinToneModifier(emoji: string): boolean {
+    return emojiSkinToneModifierRegex.test(emoji);
+}
+
+function getSkinToneFamilyTitle(title: string, baseItemsByTitle: Map<string, IEmojiItem>): string {
+    const separatorIndex = title.indexOf(': ');
+    if (separatorIndex < 0) {
+        return title;
+    }
+
+    const baseTitle = title.slice(0, separatorIndex);
+    const descriptors = title
+        .slice(separatorIndex + 2)
+        .split(', ')
+        .filter((descriptor) => !emojiSkinToneNames.has(descriptor));
+    const familyTitle = descriptors.length ? `${baseTitle}: ${descriptors.join(', ')}` : baseTitle;
+
+    // Unicode uses neutral person ZWJ sequences for mixed-tone variants while the unmodified
+    // kiss/couple emoji is a single code point with the shorter base title.
+    if (familyTitle.endsWith(': Person, Person') && baseItemsByTitle.has(baseTitle)) {
+        return baseTitle;
+    }
+
+    return familyTitle;
 }
 
 function toTitleCase(value: string): string {
@@ -398,7 +474,12 @@ async function generate(): Promise<void> {
     const emojiTest = await downloadUnicodeEmojiTest();
     const emojis = buildEmojisFromEmojiTest(emojiTest);
     const allEmojis = [
-        ...new Map(Object.values(emojis).flat().map((item) => [item.emoji, item])).values(),
+        ...new Map(
+            Object.values(emojis)
+                .flat()
+                .flatMap((item) => [item, ...(item.skinToneVariants ?? [])])
+                .map((item) => [item.emoji, item])
+        ).values(),
     ];
 
     writeGeneratedEmojis(outputPath, emojis);

--- a/packages/ui/src/views/emoji-picker/EmojiPicker.tsx
+++ b/packages/ui/src/views/emoji-picker/EmojiPicker.tsx
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-import type { ReactElement, UIEvent } from 'react';
+import type { KeyboardEvent, ReactElement, UIEvent } from 'react';
 import type { LocaleKey } from '../../locale/types';
 import type { IPopup } from '../../services/popup/canvas-popup.service';
-import type { EmojiCategory, IEmojiItem } from './emoji-picker-utils';
+import type { EmojiCategory, EmojiSkinTone, IEmojiItem, IEmojiVariant } from './emoji-picker-utils';
 import { ILocalStorageService, LocaleService } from '@univerjs/core';
-import { borderTopClassName, clsx, Input, scrollbarClassName } from '@univerjs/design';
+import { borderTopClassName, Button, clsx, Dropdown, Input, scrollbarClassName } from '@univerjs/design';
 import {
     ActivityIcon,
     FoodsIcon,
+    MoreDownIcon,
     NatureIcon,
     ObjectsIcon,
     PeopleIcon,
@@ -36,11 +37,20 @@ import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import { useDependency, useObservable } from '../../utils/di';
 import { useVirtualList } from '../hooks/virtual-list';
 import {
+    applyEmojiSkinTone,
     EMOJI_CATEGORIES,
+    EMOJI_SKIN_TONE_OPTIONS,
+
     getDefaultRecentEmojis,
+    getEmojiFamilyKey,
+
+    getEmojiFamilyVariants,
     getEmojiLocaleData,
     getLocalizedEmojiTitle,
     getRandomEmoji,
+    hasMixedSkinToneVariants,
+
+    parseStoredEmojiSkinTone,
     parseStoredRecentEmojis,
     promoteRecentEmoji,
     searchEmojis,
@@ -50,6 +60,7 @@ import { emojis } from './emojis.generated';
 export const EMOJI_PICKER_COMPONENT = 'ui.emoji-picker';
 
 const RECENTS_STORAGE_KEY = 'univer.ui.recent-emojis';
+const SKIN_TONE_STORAGE_KEY = 'univer.ui.emoji-skin-tone';
 const ACTIVE_SECTION_SCROLL_OFFSET = 28;
 const EMOJI_COLUMN_COUNT = 10;
 const EMOJI_ROW_HEIGHT = 32;
@@ -82,10 +93,13 @@ export function EmojiPicker(props: IEmojiPickerProps) {
     const currentLocale = useObservable(localeService.currentLocale$, localeService.getCurrentLocale());
     const scrollRef = useRef<HTMLDivElement>(undefined!);
     const pendingSectionRef = useRef<EmojiSectionKey | null>(null);
+    const skinToneChangedRef = useRef(false);
     const [query, setQuery] = useState('');
     const [activeEmoji, setActiveEmoji] = useState(extraProps?.activeEmoji);
     const [activeTab, setActiveTab] = useState<EmojiSectionKey>('recent');
     const [recents, setRecents] = useState<IEmojiItem[]>(() => getDefaultRecentEmojis());
+    const [skinTone, setSkinTone] = useState<EmojiSkinTone>('');
+    const [skinToneMenuOpen, setSkinToneMenuOpen] = useState(false);
     const deferredQuery = useDeferredValue(query);
     const emojiLocaleData = getEmojiLocaleData(localeService);
     const searchResults = useMemo(
@@ -95,20 +109,24 @@ export function EmojiPicker(props: IEmojiPickerProps) {
     const recentStorageKey = extraProps?.recentStorageKey ?? RECENTS_STORAGE_KEY;
     const isSearching = deferredQuery.trim().length > 0;
     const { rows, sectionPositions } = useMemo(() => {
-        const normalSections = [
-            { key: 'recent' as const, title: localeService.t<LocaleKey>('ui.emojiPicker.recents'), emojis: recents },
+        const normalSections: IEmojiSection[] = [
+            { key: 'recent', title: localeService.t<LocaleKey>('ui.emojiPicker.recents'), emojis: recents },
             ...EMOJI_CATEGORIES.map((category) => ({
                 key: category.key,
                 title: localeService.t(category.titleKey),
-                emojis: emojis[category.key],
+                emojis: emojis[category.key].map((item) => applyEmojiSkinTone(item, skinTone)),
             })),
         ];
-        const sections = isSearching
-            ? [{ key: 'people' as const, title: localeService.t<LocaleKey>('ui.emojiPicker.searchResults'), emojis: searchResults }]
+        const sections: IEmojiSection[] = isSearching
+            ? [{
+                key: 'people',
+                title: localeService.t<LocaleKey>('ui.emojiPicker.searchResults'),
+                emojis: searchResults.map((item) => applyEmojiSkinTone(item, skinTone)),
+            }]
             : normalSections;
 
         return createEmojiVirtualRows(sections, currentLocale);
-    }, [currentLocale, isSearching, localeService, recents, searchResults]);
+    }, [currentLocale, isSearching, localeService, recents, searchResults, skinTone]);
     const [virtualRows, { containerProps, scrollTo, wrapperStyle }] = useVirtualList(rows, {
         containerTarget: scrollRef,
         itemHeight: getEmojiVirtualRowHeight,
@@ -133,6 +151,23 @@ export function EmojiPicker(props: IEmojiPickerProps) {
     }, [localStorageService, recentStorageKey]);
 
     useEffect(() => {
+        let disposed = false;
+
+        localStorageService
+            .getItem<unknown>(SKIN_TONE_STORAGE_KEY)
+            .then((storedSkinTone) => {
+                if (!disposed && !skinToneChangedRef.current) {
+                    setSkinTone(parseStoredEmojiSkinTone(storedSkinTone));
+                }
+            })
+            .catch(() => undefined);
+
+        return () => {
+            disposed = true;
+        };
+    }, [localStorageService]);
+
+    useEffect(() => {
         const pendingSection = pendingSectionRef.current;
         if (isSearching || !pendingSection) {
             return;
@@ -149,13 +184,19 @@ export function EmojiPicker(props: IEmojiPickerProps) {
         const nextRecents = promoteRecentEmoji(recents, item);
         setActiveEmoji(item.emoji);
         setRecents(nextRecents);
-        writeRecents(localStorageService, recentStorageKey, nextRecents);
+        writeStorageItem(localStorageService, recentStorageKey, nextRecents);
         props.onChange?.(item.emoji);
         extraProps?.onSelect?.(item.emoji, options);
     };
 
     const handleRandom = () => {
-        handleSelect(getRandomEmoji(), { keepOpen: true });
+        handleSelect(getRandomEmoji(Math.random, skinTone), { keepOpen: true });
+    };
+
+    const handleSkinToneChange = (nextSkinTone: EmojiSkinTone) => {
+        skinToneChangedRef.current = true;
+        setSkinTone(nextSkinTone);
+        writeStorageItem(localStorageService, SKIN_TONE_STORAGE_KEY, nextSkinTone);
     };
 
     const handleScroll = (event: UIEvent<HTMLDivElement>) => {
@@ -182,6 +223,10 @@ export function EmojiPicker(props: IEmojiPickerProps) {
     return (
         <section
             data-u-comp={EMOJI_PICKER_COMPONENT}
+            onClick={(event) => {
+                event.stopPropagation();
+                setSkinToneMenuOpen(false);
+            }}
             className={clsx(
                 'univer-flex univer-h-[340px] univer-w-[420px] univer-flex-col univer-overflow-hidden',
                 !props.embedded && `
@@ -207,22 +252,25 @@ export function EmojiPicker(props: IEmojiPickerProps) {
                         />
                     )}
                 />
-                <button
-                    type="button"
+                <Button
                     aria-label={localeService.t<LocaleKey>('ui.emojiPicker.random')}
                     title={localeService.t<LocaleKey>('ui.emojiPicker.random')}
                     className="
-                      univer-box-border univer-flex univer-size-8 univer-cursor-pointer univer-items-center
-                      univer-justify-center univer-rounded-lg univer-border univer-border-solid univer-border-gray-300
-                      univer-bg-white univer-p-0 univer-text-gray-500
-                      hover:univer-border-gray-400 hover:univer-bg-gray-50
-                      dark:!univer-border-gray-600 dark:!univer-bg-gray-800 dark:!univer-text-gray-400
-                      dark:hover:!univer-bg-gray-700
+                      univer-flex-shrink-0 univer-text-gray-500
+                      dark:!univer-text-gray-400
                     "
+                    size="icon"
                     onClick={handleRandom}
                 >
                     <RandomIcon />
-                </button>
+                </Button>
+                <SkinToneDropdown
+                    emojiTitles={emojiLocaleData.emojiTitles}
+                    open={skinToneMenuOpen}
+                    skinTone={skinTone}
+                    onChange={handleSkinToneChange}
+                    onOpenChange={setSkinToneMenuOpen}
+                />
             </div>
 
             <div
@@ -256,6 +304,7 @@ export function EmojiPicker(props: IEmojiPickerProps) {
                                         emojiTitles={emojiLocaleData.emojiTitles}
                                         items={row.items}
                                         keyPrefix={row.key}
+                                        moreTitle={localeService.t<LocaleKey>('ui.ribbon.more')}
                                         onSelect={handleSelect}
                                     />
                                 ))}
@@ -307,6 +356,7 @@ function EmojiGrid(props: {
     emojiTitles?: Record<string, string>;
     items: IEmojiItem[];
     keyPrefix: string;
+    moreTitle: string;
     onSelect: (item: IEmojiItem, options?: { keepOpen?: boolean }) => void;
 }) {
     return (
@@ -315,37 +365,242 @@ function EmojiGrid(props: {
             style={{ height: EMOJI_ROW_HEIGHT }}
         >
             {props.items.map((item) => {
-                const title = getLocalizedEmojiTitle(item, props.emojiTitles);
-                const active = props.activeEmoji === item.emoji;
-
                 return (
-                    <button
+                    <EmojiButton
                         key={`${props.keyPrefix}-${item.emoji}-${item.title}`}
-                        type="button"
-                        aria-label={title}
-                        title={title}
-                        className={clsx(
-                            `
-                              univer-flex univer-size-7 univer-cursor-pointer univer-items-center univer-justify-center
-                              univer-rounded-lg univer-border-0 univer-bg-transparent univer-p-0 univer-text-lg
-                              dark:!univer-text-gray-200
-                            `,
-                            active
-                                ? `
-                                  univer-bg-primary-50 univer-shadow-sm
-                                  dark:!univer-bg-gray-800 dark:!univer-shadow-sm
-                                `
-                                : `
-                                  hover:univer-bg-gray-100
-                                  dark:hover:!univer-bg-gray-800
-                                `
-                        )}
-                        onClick={() => props.onSelect(item, { keepOpen: true })}
-                    >
-                        {item.emoji}
-                    </button>
+                        activeEmoji={props.activeEmoji}
+                        emojiTitles={props.emojiTitles}
+                        item={item}
+                        moreTitle={props.moreTitle}
+                        onSelect={props.onSelect}
+                    />
                 );
             })}
+        </div>
+    );
+}
+
+function EmojiButton(props: {
+    activeEmoji?: string;
+    emojiTitles?: Record<string, string>;
+    item: IEmojiItem;
+    moreTitle: string;
+    onSelect: (item: IEmojiItem, options?: { keepOpen?: boolean }) => void;
+}) {
+    const [variantsOpen, setVariantsOpen] = useState(false);
+    const title = getLocalizedEmojiTitle(props.item, props.emojiTitles);
+    const active = props.activeEmoji != null
+        && getEmojiFamilyKey(props.activeEmoji) === getEmojiFamilyKey(props.item.emoji);
+    const mixedToneVariants = hasMixedSkinToneVariants(props.item);
+    const button = (
+        <button
+            type="button"
+            aria-label={title}
+            title={title}
+            className={clsx(
+                `
+                  univer-flex univer-size-7 univer-cursor-pointer univer-items-center univer-justify-center
+                  univer-rounded-lg univer-border-0 univer-bg-transparent univer-p-0 univer-text-lg
+                  focus-visible:univer-outline-none focus-visible:univer-ring-1 focus-visible:univer-ring-primary-600
+                  dark:!univer-text-gray-200
+                `,
+                active
+                    ? `
+                      univer-bg-primary-50 univer-shadow-sm
+                      dark:!univer-bg-gray-800 dark:!univer-shadow-sm
+                    `
+                    : `
+                      hover:univer-bg-gray-100
+                      dark:hover:!univer-bg-gray-800
+                    `
+            )}
+            onClick={() => props.onSelect(props.item, { keepOpen: true })}
+        >
+            {props.item.emoji}
+        </button>
+    );
+
+    if (!mixedToneVariants) {
+        return button;
+    }
+
+    const variants = getEmojiFamilyVariants(props.item.emoji);
+    return (
+        <div className="univer-relative univer-size-7">
+            {button}
+            <Dropdown
+                align="end"
+                open={variantsOpen}
+                onOpenChange={setVariantsOpen}
+                overlay={(
+                    <div
+                        data-u-comp="ui.emoji-picker.skin-tone-variants"
+                        className="univer-grid univer-grid-cols-6 univer-gap-1 univer-p-1"
+                    >
+                        {variants.map((variant) => (
+                            <EmojiVariantButton
+                                key={variant.emoji}
+                                active={props.activeEmoji === variant.emoji}
+                                emojiTitles={props.emojiTitles}
+                                item={variant}
+                                onSelect={(item) => {
+                                    setVariantsOpen(false);
+                                    props.onSelect(item, { keepOpen: true });
+                                }}
+                            />
+                        ))}
+                    </div>
+                )}
+            >
+                <button
+                    type="button"
+                    aria-label={`${title}, ${props.moreTitle}`}
+                    title={`${title}, ${props.moreTitle}`}
+                    className="
+                      univer-bg-white/90
+                      dark:!univer-bg-gray-800/90
+                      univer-absolute univer-bottom-0 univer-right-0 univer-flex univer-size-3 univer-cursor-pointer
+                      univer-items-center univer-justify-center univer-rounded-sm univer-border-0 univer-p-0
+                      univer-text-gray-500
+                      hover:univer-bg-gray-100 hover:univer-text-gray-700
+                      focus-visible:univer-outline-none focus-visible:univer-ring-1
+                      focus-visible:univer-ring-primary-600
+                      dark:!univer-text-gray-300
+                      dark:hover:!univer-bg-gray-700
+                    "
+                >
+                    <MoreDownIcon className="!univer-size-2.5" />
+                </button>
+            </Dropdown>
+        </div>
+    );
+}
+
+function EmojiVariantButton(props: {
+    active: boolean;
+    emojiTitles?: Record<string, string>;
+    item: IEmojiVariant;
+    onSelect: (item: IEmojiVariant) => void;
+}) {
+    const title = getLocalizedEmojiTitle(props.item, props.emojiTitles);
+
+    return (
+        <button
+            type="button"
+            aria-label={title}
+            aria-pressed={props.active}
+            title={title}
+            className={clsx(`
+              univer-flex univer-size-8 univer-cursor-pointer univer-items-center univer-justify-center
+              univer-rounded-md univer-border-0 univer-bg-transparent univer-p-0 univer-text-lg
+              hover:univer-bg-gray-100
+              focus-visible:univer-outline-none focus-visible:univer-ring-1 focus-visible:univer-ring-primary-600
+              dark:hover:!univer-bg-gray-700
+            `, {
+                'univer-bg-primary-50 univer-ring-1 univer-ring-primary-600 dark:!univer-bg-gray-700': props.active,
+            })}
+            onClick={() => props.onSelect(props.item)}
+        >
+            {props.item.emoji}
+        </button>
+    );
+}
+
+function SkinToneDropdown(props: {
+    emojiTitles?: Record<string, string>;
+    open: boolean;
+    skinTone: EmojiSkinTone;
+    onChange: (skinTone: EmojiSkinTone) => void;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const currentOption = EMOJI_SKIN_TONE_OPTIONS.find((option) => option.value === props.skinTone)
+        ?? EMOJI_SKIN_TONE_OPTIONS[0];
+    const currentTitle = getLocalizedEmojiTitle(currentOption, props.emojiTitles);
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+        const direction = event.key === 'ArrowRight' || event.key === 'ArrowDown'
+            ? 1
+            : event.key === 'ArrowLeft' || event.key === 'ArrowUp'
+                ? -1
+                : 0;
+        if (!direction) {
+            return;
+        }
+
+        event.preventDefault();
+        const nextIndex = (index + direction + EMOJI_SKIN_TONE_OPTIONS.length) % EMOJI_SKIN_TONE_OPTIONS.length;
+        const nextOption = EMOJI_SKIN_TONE_OPTIONS[nextIndex];
+        props.onChange(nextOption.value);
+        const radioButtons = event.currentTarget.parentElement
+            ?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+        radioButtons?.[nextIndex]?.focus();
+    };
+
+    return (
+        <div className="univer-flex-shrink-0" onClick={(event) => event.stopPropagation()}>
+            <Dropdown
+                align="end"
+                open={props.open}
+                onOpenChange={props.onOpenChange}
+                overlay={(
+                    <div
+                        data-u-comp="ui.emoji-picker.skin-tone-menu"
+                        role="radiogroup"
+                        aria-label={currentTitle}
+                        className="univer-flex univer-gap-1 univer-p-1"
+                    >
+                        {EMOJI_SKIN_TONE_OPTIONS.map((option, index) => {
+                            const title = getLocalizedEmojiTitle(option, props.emojiTitles);
+                            const selected = option.value === props.skinTone;
+
+                            return (
+                                <button
+                                    key={option.value || 'default'}
+                                    type="button"
+                                    role="radio"
+                                    aria-checked={selected}
+                                    aria-label={title}
+                                    title={title}
+                                    tabIndex={selected ? 0 : -1}
+                                    className={clsx(`
+                                      univer-flex univer-size-8 univer-cursor-pointer univer-items-center
+                                      univer-justify-center univer-rounded-md univer-border-0 univer-bg-transparent
+                                      univer-p-0 univer-text-lg
+                                      hover:univer-bg-gray-100
+                                      focus-visible:univer-outline-none focus-visible:univer-ring-1
+                                      focus-visible:univer-ring-primary-600
+                                      dark:hover:!univer-bg-gray-700
+                                    `, {
+                                        'univer-bg-primary-50 univer-ring-1 univer-ring-primary-600 dark:!univer-bg-gray-700': selected,
+                                    })}
+                                    onClick={() => {
+                                        props.onChange(option.value);
+                                        props.onOpenChange(false);
+                                    }}
+                                    onKeyDown={(event) => handleKeyDown(event, index)}
+                                >
+                                    {option.emoji}
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
+            >
+                <Button
+                    aria-label={currentTitle}
+                    title={currentTitle}
+                    className="univer-relative univer-flex-shrink-0"
+                    size="icon"
+                >
+                    <span className="univer-text-lg">{currentOption.emoji}</span>
+                    <MoreDownIcon
+                        className="
+                          !univer-absolute !univer-bottom-0.5 !univer-right-0.5 !univer-size-2.5 univer-text-gray-500
+                          dark:!univer-text-gray-300
+                        "
+                    />
+                </Button>
+            </Dropdown>
         </div>
     );
 }
@@ -381,9 +636,9 @@ function CategoryButton(props: { children: ReactElement; onClick: () => void; se
     );
 }
 
-function writeRecents(localStorageService: ILocalStorageService, storageKey: string, recents: IEmojiItem[]): void {
+function writeStorageItem<T>(localStorageService: ILocalStorageService, storageKey: string, value: T): void {
     localStorageService
-        .setItem(storageKey, recents)
+        .setItem(storageKey, value)
         .catch(() => undefined);
 }
 

--- a/packages/ui/src/views/emoji-picker/__tests__/EmojiPicker.spec.tsx
+++ b/packages/ui/src/views/emoji-picker/__tests__/EmojiPicker.spec.tsx
@@ -94,6 +94,42 @@ describe('picker callbacks', () => {
         expect(onChange).toHaveBeenCalledWith('😀');
     });
 
+    it('keeps random selection and applies an icon-only skin tone preference', async () => {
+        const onChange = vi.fn();
+        const { container, getAllByRole, getByRole, queryAllByRole } = renderWithDependencies(<EmojiPicker onChange={onChange} />);
+
+        expect(getByRole('button', { name: 'Random emoji' })).toBeTruthy();
+        fireEvent.click(getByRole('button', { name: 'raised hand' }));
+
+        const skinToneOptions = getAllByRole('radio');
+        expect(skinToneOptions).toHaveLength(6);
+        expect(skinToneOptions.map((option) => option.textContent)).toEqual(['✋', '✋🏻', '✋🏼', '✋🏽', '✋🏾', '✋🏿']);
+
+        fireEvent.click(container.querySelector('[data-u-comp="ui.emoji-picker"]')!);
+        await waitFor(() => expect(queryAllByRole('radio')).toHaveLength(0));
+
+        fireEvent.click(getByRole('button', { name: 'raised hand' }));
+        fireEvent.click(getByRole('radio', { name: 'raised hand: medium skin tone' }));
+        await waitFor(() => expect(queryAllByRole('radio')).toHaveLength(0));
+        expect(onChange).not.toHaveBeenCalled();
+
+        fireEvent.change(getByRole('textbox', { name: 'Search' }), { target: { value: 'waving hand' } });
+        await waitFor(() => expect(getByRole('button', { name: 'waving hand: medium skin tone' })).toBeTruthy());
+    });
+
+    it('keeps mixed skin tone variants behind the family secondary entry', async () => {
+        const { getByRole } = renderWithDependencies(<EmojiPicker />);
+
+        fireEvent.change(getByRole('textbox', { name: 'Search' }), { target: { value: 'handshake' } });
+        await waitFor(() => expect(getByRole('button', { name: 'handshake, More' })).toBeTruthy());
+        fireEvent.click(getByRole('button', { name: 'handshake, More' }));
+
+        await waitFor(() => {
+            const variants = document.querySelector('[data-u-comp="ui.emoji-picker.skin-tone-variants"]');
+            expect(variants?.querySelectorAll('button')).toHaveLength(26);
+        });
+    });
+
     it('uses the design scrollbar styles for emoji content', () => {
         const { container } = renderWithDependencies(<EmojiPicker />);
         const scrollContainer = container.querySelector('.univer-overflow-y-auto');

--- a/packages/ui/src/views/emoji-picker/__tests__/emoji-picker-utils.spec.ts
+++ b/packages/ui/src/views/emoji-picker/__tests__/emoji-picker-utils.spec.ts
@@ -16,7 +16,11 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+    applyEmojiSkinTone,
     getDefaultRecentEmojis,
+    getRandomEmoji,
+    hasMixedSkinToneVariants,
+    parseStoredEmojiSkinTone,
     parseStoredRecentEmojis,
     promoteRecentEmoji,
     searchEmojis,
@@ -40,6 +44,60 @@ describe('emoji picker utils', () => {
         ], { emoji: '💡', title: 'Light Bulb' });
 
         expect(result.map((item) => item.emoji)).toEqual(['💡', '😀']);
+    });
+
+    it('groups skin tones into one generated emoji family', () => {
+        const wavingHand = emojis.people.find((item) => item.emoji === '👋');
+
+        expect(wavingHand?.skinToneVariants?.map((item) => item.emoji)).toEqual([
+            '👋🏻',
+            '👋🏼',
+            '👋🏽',
+            '👋🏾',
+            '👋🏿',
+        ]);
+        expect(emojis.people.some((item) => item.emoji === '👋🏽')).toBe(false);
+    });
+
+    it('applies one preferred skin tone and falls back for unsupported emoji', () => {
+        const wavingHand = emojis.people.find((item) => item.emoji === '👋')!;
+        const lightBulb = emojis.objects.find((item) => item.emoji === '💡')!;
+
+        expect(applyEmojiSkinTone(wavingHand, '🏽').emoji).toBe('👋🏽');
+        expect(applyEmojiSkinTone(lightBulb, '🏽').emoji).toBe('💡');
+        expect(applyEmojiSkinTone(wavingHand, '').emoji).toBe('👋');
+    });
+
+    it('deduplicates recent skin tone variants by family', () => {
+        const result = promoteRecentEmoji([
+            { emoji: '👋🏻', title: 'Waving Hand: Light Skin Tone' },
+            { emoji: '💡', title: 'Light Bulb' },
+        ], { emoji: '👋🏿', title: 'Waving Hand: Dark Skin Tone' });
+
+        expect(result.map((item) => item.emoji)).toEqual(['👋🏿', '💡']);
+    });
+
+    it('keeps mixed skin tone combinations inside their family', () => {
+        const handshake = emojis.people.find((item) => item.emoji === '🤝')!;
+
+        expect(hasMixedSkinToneVariants(handshake)).toBe(true);
+        expect(handshake.skinToneVariants).toHaveLength(25);
+    });
+
+    it('randomizes families before applying the preferred skin tone', () => {
+        const families = Object.entries(emojis)
+            .filter(([category]) => category !== 'frequent')
+            .flatMap(([, items]) => items);
+        const wavingHandIndex = families.findIndex((item) => item.emoji === '👋');
+        const random = () => (wavingHandIndex + 0.1) / families.length;
+
+        expect(getRandomEmoji(random, '🏽').emoji).toBe('👋🏽');
+    });
+
+    it('validates stored skin tone preferences', () => {
+        expect(parseStoredEmojiSkinTone('🏾')).toBe('🏾');
+        expect(parseStoredEmojiSkinTone('invalid')).toBe('');
+        expect(parseStoredEmojiSkinTone(null)).toBe('');
     });
 
     it('searches emoji title case-insensitively', () => {

--- a/packages/ui/src/views/emoji-picker/emoji-picker-utils.ts
+++ b/packages/ui/src/views/emoji-picker/emoji-picker-utils.ts
@@ -18,9 +18,13 @@ import type { LocaleService } from '@univerjs/core';
 import type { LocaleKey } from '../../locale/types';
 import { emojis } from './emojis.generated';
 
-export interface IEmojiItem {
+export interface IEmojiVariant {
     emoji: string;
     title: string;
+}
+
+export interface IEmojiItem extends IEmojiVariant {
+    skinToneVariants?: IEmojiVariant[];
 }
 
 export interface IEmojiLocaleData {
@@ -29,6 +33,18 @@ export interface IEmojiLocaleData {
 }
 
 export type EmojiCategory = Exclude<keyof typeof emojis, 'frequent'>;
+
+export const EMOJI_SKIN_TONES = ['', '🏻', '🏼', '🏽', '🏾', '🏿'] as const;
+export type EmojiSkinTone = (typeof EMOJI_SKIN_TONES)[number];
+
+export const EMOJI_SKIN_TONE_OPTIONS: ReadonlyArray<IEmojiVariant & { value: EmojiSkinTone }> = [
+    { emoji: '✋', title: 'Raised Hand', value: '' },
+    { emoji: '✋🏻', title: 'Raised Hand: Light Skin Tone', value: '🏻' },
+    { emoji: '✋🏼', title: 'Raised Hand: Medium-light Skin Tone', value: '🏼' },
+    { emoji: '✋🏽', title: 'Raised Hand: Medium Skin Tone', value: '🏽' },
+    { emoji: '✋🏾', title: 'Raised Hand: Medium-dark Skin Tone', value: '🏾' },
+    { emoji: '✋🏿', title: 'Raised Hand: Dark Skin Tone', value: '🏿' },
+];
 
 export const EMOJI_RECENT_LIMIT = 11;
 
@@ -49,12 +65,21 @@ export const EMOJI_CATEGORIES = Object.keys(emojis)
         titleKey: EMOJI_CATEGORY_LABEL_KEYS[category],
     }));
 
+const EMOJI_SKIN_TONE_MODIFIER_REGEX = /[\u{1F3FB}-\u{1F3FF}]/gu;
+const emojiFamilyByEmoji = new Map<string, IEmojiItem>();
+
+getEmojiFamilies().forEach((family) => {
+    [family, ...(family.skinToneVariants ?? [])].forEach((item) => {
+        emojiFamilyByEmoji.set(item.emoji, family);
+    });
+});
+
 export function getDefaultRecentEmojis(): IEmojiItem[] {
     return emojis.frequent.slice(0, EMOJI_RECENT_LIMIT);
 }
 
 export function getAllEmojis(): IEmojiItem[] {
-    return EMOJI_CATEGORIES.flatMap((category) => emojis[category.key]);
+    return getEmojiFamilies().flatMap((family) => [family, ...(family.skinToneVariants ?? [])]);
 }
 
 export function searchEmojis(keyword: string, searchIndex?: Record<string, string>): IEmojiItem[] {
@@ -63,13 +88,18 @@ export function searchEmojis(keyword: string, searchIndex?: Record<string, strin
         return [];
     }
 
-    return getAllEmojis().filter((item) => getEmojiSearchText(item, searchIndex).includes(query));
+    return getEmojiFamilies().filter((item) => getEmojiSearchText(item, searchIndex).includes(query));
 }
 
 export function promoteRecentEmoji(recents: IEmojiItem[], item: IEmojiItem): IEmojiItem[] {
+    const recentItem = { emoji: item.emoji, title: item.title };
+    const familyKey = getEmojiFamilyKey(item.emoji);
+
     return [
-        item,
-        ...recents.filter((recent) => recent.emoji !== item.emoji),
+        recentItem,
+        ...recents
+            .filter((recent) => getEmojiFamilyKey(recent.emoji) !== familyKey)
+            .map((recent) => ({ emoji: recent.emoji, title: recent.title })),
     ].slice(0, EMOJI_RECENT_LIMIT);
 }
 
@@ -90,9 +120,46 @@ export function parseStoredRecentEmojis(value: IEmojiItem[] | string | null): IE
     }
 }
 
-export function getRandomEmoji(random = Math.random): IEmojiItem {
-    const allEmojis = getAllEmojis();
-    return allEmojis[Math.floor(random() * allEmojis.length)] ?? getDefaultRecentEmojis()[0];
+export function getRandomEmoji(random = Math.random, skinTone: EmojiSkinTone = ''): IEmojiItem {
+    const families = getEmojiFamilies();
+    const family = families[Math.floor(random() * families.length)] ?? getDefaultRecentEmojis()[0];
+    return applyEmojiSkinTone(family, skinTone);
+}
+
+export function applyEmojiSkinTone(item: IEmojiItem, skinTone: EmojiSkinTone): IEmojiItem {
+    const family = emojiFamilyByEmoji.get(item.emoji) ?? item;
+    if (!skinTone) {
+        return family;
+    }
+
+    const variant = family.skinToneVariants?.find((candidate) => {
+        const modifiers = candidate.emoji.match(EMOJI_SKIN_TONE_MODIFIER_REGEX) ?? [];
+        return modifiers.length > 0 && modifiers.every((modifier) => modifier === skinTone);
+    });
+
+    return variant ? { ...variant, skinToneVariants: family.skinToneVariants } : family;
+}
+
+export function getEmojiFamilyKey(emoji: string): string {
+    return emojiFamilyByEmoji.get(emoji)?.emoji ?? emoji;
+}
+
+export function getEmojiFamilyVariants(emoji: string): IEmojiVariant[] {
+    const family = emojiFamilyByEmoji.get(emoji);
+    return family
+        ? [{ emoji: family.emoji, title: family.title }, ...(family.skinToneVariants ?? [])]
+        : [];
+}
+
+export function hasMixedSkinToneVariants(item: IEmojiItem): boolean {
+    const family = emojiFamilyByEmoji.get(item.emoji) ?? item;
+    return Boolean(family.skinToneVariants?.some((variant) => (
+        variant.emoji.match(EMOJI_SKIN_TONE_MODIFIER_REGEX) ?? []
+    ).length > 1));
+}
+
+export function parseStoredEmojiSkinTone(value: unknown): EmojiSkinTone {
+    return EMOJI_SKIN_TONES.find((skinTone) => skinTone === value) ?? '';
 }
 
 export function getLocalizedEmojiTitle(item: IEmojiItem, emojiTitles?: Record<string, string>): string {
@@ -112,10 +179,11 @@ export function getEmojiLocaleData(localeService: Pick<LocaleService, 'getLocale
 }
 
 function getEmojiSearchText(item: IEmojiItem, searchIndex?: Record<string, string>): string {
-    return [
-        item.title,
-        searchIndex?.[item.emoji],
-    ].filter(Boolean).join(' ').toLowerCase();
+    return [item, ...(item.skinToneVariants ?? [])]
+        .flatMap((candidate) => [candidate.title, searchIndex?.[candidate.emoji]])
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
 }
 
 function normalizeStoredRecentEmojis(value: unknown): IEmojiItem[] {
@@ -124,5 +192,23 @@ function normalizeStoredRecentEmojis(value: unknown): IEmojiItem[] {
     }
 
     const valid = value.filter((item) => typeof item?.emoji === 'string' && typeof item?.title === 'string');
-    return valid.length ? valid.slice(0, EMOJI_RECENT_LIMIT) : getDefaultRecentEmojis();
+    const seenFamilies = new Set<string>();
+    const recents = valid
+        .filter((item) => {
+            const familyKey = getEmojiFamilyKey(item.emoji);
+            if (seenFamilies.has(familyKey)) {
+                return false;
+            }
+
+            seenFamilies.add(familyKey);
+            return true;
+        })
+        .map((item) => ({ emoji: item.emoji, title: item.title }))
+        .slice(0, EMOJI_RECENT_LIMIT);
+
+    return recents.length ? recents : getDefaultRecentEmojis();
+}
+
+function getEmojiFamilies(): IEmojiItem[] {
+    return EMOJI_CATEGORIES.flatMap((category) => emojis[category.key]);
 }


### PR DESCRIPTION
## Summary

- group Unicode skin-tone variants into their base emoji families during emoji data generation
- add an icon-only skin-tone dropdown to the Emoji Picker while preserving random selection
- apply the selected tone to supported families, keep unsupported emoji unchanged, and keep mixed-tone combinations behind a family-level secondary menu
- persist the tone preference, deduplicate recents by family, and dismiss the tone menu when users interact elsewhere in the picker

No new dependencies, demo-specific behavior, public re-exports, documentation, or image assets are included.

## Validation

- `pnpm --filter @univerjs/ui prepare`
- `pnpm --filter @univerjs/ui typecheck`
- `pnpm --filter @univerjs/ui test` — 70 files, 341 tests passed
- targeted ESLint for all changed files
- `git diff --check`
- manually verified in the Pro `docs-advanced` demo: the tone dropdown exposes six choices, selecting a tone updates supported emoji, random remains available, and clicking elsewhere dismisses only the secondary menu

## Pull Request Checklist

- [x] No related issue
- [x] Naming conventions are followed
- [x] Unit tests cover the changed behavior
- [x] No breaking changes are introduced
