### PR TITLE
fix(engine-render): export document extension type

### DIFF
--- a/packages/engine-render/src/index.ts
+++ b/packages/engine-render/src/index.ts
@@ -46,6 +46,8 @@ export * from './components';
 export type { DocsCustomBlockRenderViewportProvider, IDocsCustomBlockRenderViewport, IDocsCustomBlockRenderViewportInput } from './components/docs/custom-block-render-viewport';
 export { getDocsCustomBlockRenderViewport, setDocsCustomBlockRenderViewportProvider } from './components/docs/custom-block-render-viewport';
 export { DocBackground } from './components/docs/doc-background';
+// TODO(@ai-review): Confirm DOCS_EXTENSION_TYPE remains the supported public contract for Pro document render extensions.
+export { DOCS_EXTENSION_TYPE } from './components/docs/doc-extension';
 export { Documents } from './components/docs/document';
 export type { IPageRenderConfig } from './components/docs/document';
 export type { IDocumentOffsetConfig } from './components/docs/document';

--- a/packages/engine-render/src/index.ts
+++ b/packages/engine-render/src/index.ts
@@ -46,7 +46,6 @@ export * from './components';
 export type { DocsCustomBlockRenderViewportProvider, IDocsCustomBlockRenderViewport, IDocsCustomBlockRenderViewportInput } from './components/docs/custom-block-render-viewport';
 export { getDocsCustomBlockRenderViewport, setDocsCustomBlockRenderViewportProvider } from './components/docs/custom-block-render-viewport';
 export { DocBackground } from './components/docs/doc-background';
-// TODO(@ai-review): Confirm DOCS_EXTENSION_TYPE remains the supported public contract for Pro document render extensions.
 export { DOCS_EXTENSION_TYPE } from './components/docs/doc-extension';
 export { Documents } from './components/docs/document';
 export type { IPageRenderConfig } from './components/docs/document';


### PR DESCRIPTION
Refs dream-num/univer-pro#5468

## Summary

- Export `DOCS_EXTENSION_TYPE` from the public `@univerjs/engine-render` entrypoint.
- Restore the public contract consumed by Univer Pro document callout extensions.

## Root cause

Univer Pro `dev` imports `DOCS_EXTENSION_TYPE` from `@univerjs/engine-render`, but the enum was only available from its internal defining module. Example and Playwright builds therefore failed during bundling.

## Validation

- `@univerjs/engine-render` typecheck passed.
- Univer Pro text-layout playground build passed.
- Univer Pro collaboration playground build passed.
- No runtime behavior or SDK dependency changed.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests are not applicable; downstream bundle builds verify the public export.
- [x] No breaking changes are introduced.