### PR TITLE
perf(engine-render): cache complex SVG image rasters

### DIFF
--- a/packages/engine-render/src/shape/__tests__/image.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/image.spec.ts
@@ -356,7 +356,7 @@ describe('image extra', () => {
         if (!(cacheCanvas instanceof HTMLCanvasElement)) {
             throw new TypeError('Expected the SVG raster cache canvas to be rendered');
         }
-        expect(cacheCanvas.width * cacheCanvas.height).toBeLessThanOrEqual(2_000_000);
+        expect(cacheCanvas.width * cacheCanvas.height).toBeLessThanOrEqual(4_000_000);
 
         drawImage.mockRestore();
         image.dispose();

--- a/packages/engine-render/src/shape/__tests__/image.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/image.spec.ts
@@ -347,6 +347,7 @@ describe('image extra', () => {
         const context = canvas.getContext();
         const drawImage = vi.spyOn(UniverRenderingContext.prototype, 'drawImage');
 
+        context.setTransform(0.5, 0, 0, 0.5, 0, 0);
         image.render(context);
         context.setTransform(2, 0, 0, 2, 0, 0);
         image.render(context);

--- a/packages/engine-render/src/shape/__tests__/image.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/image.spec.ts
@@ -232,7 +232,6 @@ describe('image extra', () => {
         expect(ctx.drawImage).toHaveBeenCalled();
     });
 
-    // TODO(@ai-review): Confirm this regression fails if Image stops reusing its fixed-resolution raster cache across zoom changes.
     it('reuses an opted-in raster cache across context scale changes', () => {
         const native = createNativeImage(2_000, 1_000);
         const image = new Image('cached-image', {

--- a/packages/engine-render/src/shape/__tests__/image.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/image.spec.ts
@@ -20,12 +20,19 @@ import { Canvas } from '../../canvas';
 import { UniverRenderingContext } from '../../context';
 import { Image } from '../image';
 
-function createNativeImage(width = 120, height = 80) {
+function createNativeImage(width = 120, height = 80, source?: string) {
     const img = document.createElement('img');
     Object.defineProperty(img, 'width', { value: width, configurable: true });
     Object.defineProperty(img, 'height', { value: height, configurable: true });
     Object.defineProperty(img, 'complete', { value: true, configurable: true });
+    if (source) {
+        img.src = source;
+    }
     return img;
+}
+
+function createSvgDataUrl(svg: string): string {
+    return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
 function createCtxMock() {
@@ -232,15 +239,55 @@ describe('image extra', () => {
         expect(ctx.drawImage).toHaveBeenCalled();
     });
 
-    it('reuses an opted-in raster cache across context scale changes', () => {
-        const native = createNativeImage(2_000, 1_000);
+    it('automatically raster caches only expensive inline SVG images', () => {
+        const filteredSvg = createSvgDataUrl(`
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <defs><filter id="noise"><feTurbulence /></filter></defs>
+                <rect width="10" height="10" filter="url(#noise)" />
+            </svg>
+        `);
+        const ordinarySvg = createSvgDataUrl('<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" /></svg>');
+        const filteredImage = new Image('filtered-svg', {
+            image: createNativeImage(10, 10, filteredSvg),
+            left: 0,
+            top: 0,
+            width: 10,
+            height: 10,
+        });
+        const ordinaryImage = new Image('ordinary-svg', {
+            image: createNativeImage(10, 10, ordinarySvg),
+            left: 0,
+            top: 0,
+            width: 10,
+            height: 10,
+        });
+        const optedOutImage = new Image('opted-out-svg', {
+            image: createNativeImage(10, 10, filteredSvg),
+            left: 0,
+            top: 0,
+            width: 10,
+            height: 10,
+            rasterCache: false,
+        });
+
+        expect(filteredImage.rasterCache).toBe(true);
+        expect(ordinaryImage.rasterCache).toBe(false);
+        expect(optedOutImage.rasterCache).toBe(false);
+    });
+
+    it('reuses an automatic SVG raster cache across context scale changes', () => {
+        const native = createNativeImage(4_000, 2_000, createSvgDataUrl(`
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <defs><filter id="blur"><feGaussianBlur stdDeviation="10" /></filter></defs>
+                <rect width="4000" height="2000" filter="url(#blur)" />
+            </svg>
+        `));
         const image = new Image('cached-image', {
             image: native,
             left: 0,
             top: 0,
-            width: 2_000,
-            height: 1_000,
-            rasterCache: true,
+            width: 4_000,
+            height: 2_000,
         });
         const canvas = new Canvas({ width: 200, height: 100, pixelRatio: 1 });
         const context = canvas.getContext();
@@ -251,6 +298,11 @@ describe('image extra', () => {
         image.render(context);
 
         expect(drawImage.mock.calls.filter(([source]) => source === native)).toHaveLength(1);
+        const cacheCanvas = drawImage.mock.calls.find(([source]) => source instanceof HTMLCanvasElement)?.[0];
+        if (!(cacheCanvas instanceof HTMLCanvasElement)) {
+            throw new TypeError('Expected the SVG raster cache canvas to be rendered');
+        }
+        expect(cacheCanvas.width * cacheCanvas.height).toBeLessThanOrEqual(2_000_000);
 
         drawImage.mockRestore();
         image.dispose();

--- a/packages/engine-render/src/shape/__tests__/image.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/image.spec.ts
@@ -239,7 +239,7 @@ describe('image extra', () => {
         expect(ctx.drawImage).toHaveBeenCalled();
     });
 
-    it('automatically raster caches only expensive inline SVG images', () => {
+    it('automatically raster caches only expensive static inline SVG images', () => {
         const filteredSvg = createSvgDataUrl(`
             <svg xmlns="http://www.w3.org/2000/svg">
                 <defs><filter id="noise"><feTurbulence /></filter></defs>
@@ -247,35 +247,89 @@ describe('image extra', () => {
             </svg>
         `);
         const ordinarySvg = createSvgDataUrl('<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" /></svg>');
+        const animatedSvg = createSvgDataUrl(`
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <defs><filter id="noise"><feTurbulence /></filter></defs>
+                <rect width="10" height="10" filter="url(#noise)"><animate attributeName="x" values="0;10" /></rect>
+            </svg>
+        `);
+        const filteredNative = createNativeImage(10, 10, filteredSvg);
+        const ordinaryNative = createNativeImage(10, 10, ordinarySvg);
+        const animatedNative = createNativeImage(10, 10, animatedSvg);
         const filteredImage = new Image('filtered-svg', {
-            image: createNativeImage(10, 10, filteredSvg),
+            image: filteredNative,
             left: 0,
             top: 0,
             width: 10,
             height: 10,
         });
         const ordinaryImage = new Image('ordinary-svg', {
-            image: createNativeImage(10, 10, ordinarySvg),
+            image: ordinaryNative,
             left: 0,
             top: 0,
             width: 10,
             height: 10,
         });
-        const optedOutImage = new Image('opted-out-svg', {
-            image: createNativeImage(10, 10, filteredSvg),
+        const animatedImage = new Image('animated-svg', {
+            image: animatedNative,
             left: 0,
             top: 0,
             width: 10,
             height: 10,
-            rasterCache: false,
         });
+        const canvas = new Canvas({ width: 20, height: 20, pixelRatio: 1 });
+        const context = canvas.getContext();
+        const drawImage = vi.spyOn(UniverRenderingContext.prototype, 'drawImage');
 
-        expect(filteredImage.rasterCache).toBe(true);
-        expect(ordinaryImage.rasterCache).toBe(false);
-        expect(optedOutImage.rasterCache).toBe(false);
+        for (const image of [filteredImage, ordinaryImage, animatedImage]) {
+            image.render(context);
+            image.render(context);
+        }
+
+        expect(drawImage.mock.calls.filter(([source]) => source === filteredNative)).toHaveLength(1);
+        expect(drawImage.mock.calls.filter(([source]) => source === ordinaryNative)).toHaveLength(2);
+        expect(drawImage.mock.calls.filter(([source]) => source === animatedNative)).toHaveLength(2);
+
+        drawImage.mockRestore();
+        filteredImage.dispose();
+        ordinaryImage.dispose();
+        animatedImage.dispose();
+        canvas.dispose();
     });
 
-    it('reuses an automatic SVG raster cache across context scale changes', () => {
+    it('reuses an automatic SVG raster cache within a scale bucket', () => {
+        const native = createNativeImage(100, 100, createSvgDataUrl(`
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <defs><filter id="blur"><feGaussianBlur stdDeviation="10" /></filter></defs>
+                <rect width="100" height="100" filter="url(#blur)" />
+            </svg>
+        `));
+        const image = new Image('cached-image', {
+            image: native,
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+        });
+        const canvas = new Canvas({ width: 200, height: 100, pixelRatio: 1 });
+        const context = canvas.getContext();
+        const drawImage = vi.spyOn(UniverRenderingContext.prototype, 'drawImage');
+
+        context.setTransform(1.1, 0, 0, 1.1, 0, 0);
+        image.render(context);
+        context.setTransform(1.4, 0, 0, 1.4, 0, 0);
+        image.render(context);
+        context.setTransform(1.6, 0, 0, 1.6, 0, 0);
+        image.render(context);
+
+        expect(drawImage.mock.calls.filter(([source]) => source === native)).toHaveLength(2);
+
+        drawImage.mockRestore();
+        image.dispose();
+        canvas.dispose();
+    });
+
+    it('draws the source SVG when the capped cache would be excessively upscaled', () => {
         const native = createNativeImage(4_000, 2_000, createSvgDataUrl(`
             <svg xmlns="http://www.w3.org/2000/svg">
                 <defs><filter id="blur"><feGaussianBlur stdDeviation="10" /></filter></defs>
@@ -297,7 +351,7 @@ describe('image extra', () => {
         context.setTransform(2, 0, 0, 2, 0, 0);
         image.render(context);
 
-        expect(drawImage.mock.calls.filter(([source]) => source === native)).toHaveLength(1);
+        expect(drawImage.mock.calls.filter(([source]) => source === native)).toHaveLength(2);
         const cacheCanvas = drawImage.mock.calls.find(([source]) => source instanceof HTMLCanvasElement)?.[0];
         if (!(cacheCanvas instanceof HTMLCanvasElement)) {
             throw new TypeError('Expected the SVG raster cache canvas to be rendered');

--- a/packages/engine-render/src/shape/__tests__/image.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/image.spec.ts
@@ -329,7 +329,7 @@ describe('image extra', () => {
         canvas.dispose();
     });
 
-    it('draws the source SVG when the capped cache would be excessively upscaled', () => {
+    it('keeps using the capped cache at high zoom', () => {
         const native = createNativeImage(4_000, 2_000, createSvgDataUrl(`
             <svg xmlns="http://www.w3.org/2000/svg">
                 <defs><filter id="blur"><feGaussianBlur stdDeviation="10" /></filter></defs>
@@ -351,12 +351,13 @@ describe('image extra', () => {
         context.setTransform(2, 0, 0, 2, 0, 0);
         image.render(context);
 
-        expect(drawImage.mock.calls.filter(([source]) => source === native)).toHaveLength(2);
+        expect(drawImage.mock.calls.filter(([source]) => source === native)).toHaveLength(1);
         const cacheCanvas = drawImage.mock.calls.find(([source]) => source instanceof HTMLCanvasElement)?.[0];
         if (!(cacheCanvas instanceof HTMLCanvasElement)) {
             throw new TypeError('Expected the SVG raster cache canvas to be rendered');
         }
         expect(cacheCanvas.width * cacheCanvas.height).toBeLessThanOrEqual(4_000_000);
+        expect(drawImage.mock.calls.filter(([source]) => source === cacheCanvas)).toHaveLength(2);
 
         drawImage.mockRestore();
         image.dispose();

--- a/packages/engine-render/src/shape/__tests__/image.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/image.spec.ts
@@ -16,6 +16,8 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { Vector2 } from '../../basics/vector2';
+import { Canvas } from '../../canvas';
+import { UniverRenderingContext } from '../../context';
 import { Image } from '../image';
 
 function createNativeImage(width = 120, height = 80) {
@@ -228,5 +230,31 @@ describe('image extra', () => {
         expect(ctx.rect).toHaveBeenCalledWith(0, 0, 80, 120);
         expect(ctx.clip).toHaveBeenCalledBefore(ctx.transform);
         expect(ctx.drawImage).toHaveBeenCalled();
+    });
+
+    // TODO(@ai-review): Confirm this regression fails if Image stops reusing its fixed-resolution raster cache across zoom changes.
+    it('reuses an opted-in raster cache across context scale changes', () => {
+        const native = createNativeImage(2_000, 1_000);
+        const image = new Image('cached-image', {
+            image: native,
+            left: 0,
+            top: 0,
+            width: 2_000,
+            height: 1_000,
+            rasterCache: true,
+        });
+        const canvas = new Canvas({ width: 200, height: 100, pixelRatio: 1 });
+        const context = canvas.getContext();
+        const drawImage = vi.spyOn(UniverRenderingContext.prototype, 'drawImage');
+
+        image.render(context);
+        context.setTransform(2, 0, 0, 2, 0, 0);
+        image.render(context);
+
+        expect(drawImage.mock.calls.filter(([source]) => source === native)).toHaveLength(1);
+
+        drawImage.mockRestore();
+        image.dispose();
+        canvas.dispose();
     });
 });

--- a/packages/engine-render/src/shape/image.ts
+++ b/packages/engine-render/src/shape/image.ts
@@ -31,7 +31,6 @@ const SVG_ANIMATION_PATTERN = /<(?:animate(?:Color|Motion|Transform)?|set)\b|@ke
 const RASTER_CACHE_MAX_PIXEL_COUNT = 4_000_000;
 const RASTER_CACHE_MAX_DIMENSION = 4_096;
 const RASTER_CACHE_PIXEL_RATIO_STEP = 0.5;
-const RASTER_CACHE_MAX_UPSCALE = 2;
 
 function shouldRasterCacheSvg(source?: string): boolean {
     const prefix = source && INLINE_SVG_DATA_URL_PATTERN.exec(source)?.[0];
@@ -459,15 +458,13 @@ export class Image extends Shape<IImageProps> {
                 h,
                 Math.ceil(requestedPixelRatio / RASTER_CACHE_PIXEL_RATIO_STEP) * RASTER_CACHE_PIXEL_RATIO_STEP
             );
-            if (requestedPixelRatio <= pixelRatio * RASTER_CACHE_MAX_UPSCALE) {
-                this._renderWithCache(
-                    ctx,
-                    { left: -w / 2, top: -h / 2, right: w / 2, bottom: h / 2 },
-                    (cacheContext) => this._drawNative(cacheContext, native, w, h),
-                    pixelRatio
-                );
-                return;
-            }
+            this._renderWithCache(
+                ctx,
+                { left: -w / 2, top: -h / 2, right: w / 2, bottom: h / 2 },
+                (cacheContext) => this._drawNative(cacheContext, native, w, h),
+                pixelRatio
+            );
+            return;
         }
 
         this._drawNative(ctx, native, w, h);

--- a/packages/engine-render/src/shape/image.ts
+++ b/packages/engine-render/src/shape/image.ts
@@ -54,19 +54,22 @@ function resolveRasterCachePixelRatio(width: number, height: number, requestedPi
         return requestedPixelRatio;
     }
 
-    const dimensionLimitedPixelRatio = Math.min(
-        requestedPixelRatio,
+    const dimensionPixelRatioLimit = Math.min(
         RASTER_CACHE_MAX_DIMENSION / width,
         RASTER_CACHE_MAX_DIMENSION / height
     );
     const pixelLimitedPixelRatio = Math.sqrt(RASTER_CACHE_MAX_PIXEL_COUNT / (width * height));
-    if (dimensionLimitedPixelRatio <= pixelLimitedPixelRatio) {
-        return dimensionLimitedPixelRatio;
+    const pixelRatioLimit = Math.min(dimensionPixelRatioLimit, pixelLimitedPixelRatio);
+    const pixelRatio = requestedPixelRatio + RASTER_CACHE_PIXEL_RATIO_STEP > pixelRatioLimit
+        ? pixelRatioLimit
+        : requestedPixelRatio;
+    if (pixelRatio < pixelLimitedPixelRatio) {
+        return pixelRatio;
     }
 
     const physicalWidth = Math.floor(width * pixelLimitedPixelRatio);
     const physicalHeight = Math.floor(RASTER_CACHE_MAX_PIXEL_COUNT / physicalWidth);
-    return Math.min((physicalWidth - 1) / width, (physicalHeight - 1) / height);
+    return Math.min(pixelRatio, (physicalWidth - 1) / width, (physicalHeight - 1) / height);
 }
 
 export interface IShapeClipBounds {

--- a/packages/engine-render/src/shape/image.ts
+++ b/packages/engine-render/src/shape/image.ts
@@ -400,7 +400,6 @@ export class Image extends Shape<IImageProps> {
         const w = renderWidth ?? this.width;
         const h = renderHeight ?? this.height;
 
-        // TODO(@ai-review): Verify raster caching remains opt-in because decoded bitmap images already have an efficient native draw path.
         if (this.rasterCache) {
             this._renderWithCache(
                 ctx,

--- a/packages/engine-render/src/shape/image.ts
+++ b/packages/engine-render/src/shape/image.ts
@@ -27,8 +27,11 @@ import { Shape } from './shape';
 const INLINE_SVG_DATA_URL_PATTERN = /^data:image\/svg\+xml(?:;[^,]*)?,/i;
 const SVG_FILTER_REFERENCE_PATTERN = /\bfilter\s*=/i;
 const SVG_EXPENSIVE_FILTER_PATTERN = /<fe(?:Turbulence|DisplacementMap|GaussianBlur)\b/i;
+const SVG_ANIMATION_PATTERN = /<(?:animate(?:Color|Motion|Transform)?|set)\b|@keyframes\b/i;
 const RASTER_CACHE_MAX_PIXEL_COUNT = 2_000_000;
 const RASTER_CACHE_MAX_DIMENSION = 4_096;
+const RASTER_CACHE_PIXEL_RATIO_STEP = 0.5;
+const RASTER_CACHE_MAX_UPSCALE = 2;
 
 function shouldRasterCacheSvg(source?: string): boolean {
     const prefix = source && INLINE_SVG_DATA_URL_PATTERN.exec(source)?.[0];
@@ -39,7 +42,9 @@ function shouldRasterCacheSvg(source?: string): boolean {
     try {
         const payload = source.slice(prefix.length);
         const svg = prefix.toLowerCase().includes(';base64,') ? atob(payload) : decodeURIComponent(payload);
-        return SVG_FILTER_REFERENCE_PATTERN.test(svg) && SVG_EXPENSIVE_FILTER_PATTERN.test(svg);
+        return !SVG_ANIMATION_PATTERN.test(svg) &&
+            SVG_FILTER_REFERENCE_PATTERN.test(svg) &&
+            SVG_EXPENSIVE_FILTER_PATTERN.test(svg);
     } catch {
         return false;
     }
@@ -100,8 +105,6 @@ export interface IImageProps extends IShapeProps {
     opacity?: number;
 
     clipBounds?: Nullable<IShapeClipBounds>;
-
-    rasterCache?: boolean;
 }
 
 export class Image extends Shape<IImageProps> {
@@ -171,11 +174,7 @@ export class Image extends Shape<IImageProps> {
         return this._props.clipBounds;
     }
 
-    get rasterCache() {
-        if (this._props.rasterCache !== undefined) {
-            return this._props.rasterCache;
-        }
-
+    private _shouldRasterCache(): boolean {
         const source = this._native?.src || this._props.url || '';
         if (source !== this._rasterCacheSource) {
             const previous = this._autoRasterCache;
@@ -442,19 +441,26 @@ export class Image extends Shape<IImageProps> {
         const w = renderWidth ?? this.width;
         const h = renderHeight ?? this.height;
 
-        if (this.rasterCache) {
+        if (this._shouldRasterCache()) {
+            const transform = ctx.getTransform();
+            const requestedPixelRatio = Math.max(
+                Math.hypot(transform.a, transform.b),
+                Math.hypot(transform.c, transform.d)
+            );
             const pixelRatio = resolveRasterCachePixelRatio(
                 w,
                 h,
-                this.getEngine()?.getCanvas().getPixelRatio() ?? 1
+                Math.ceil(requestedPixelRatio / RASTER_CACHE_PIXEL_RATIO_STEP) * RASTER_CACHE_PIXEL_RATIO_STEP
             );
-            this._renderWithCache(
-                ctx,
-                { left: -w / 2, top: -h / 2, right: w / 2, bottom: h / 2 },
-                (cacheContext) => this._drawNative(cacheContext, native, w, h),
-                pixelRatio
-            );
-            return;
+            if (requestedPixelRatio <= pixelRatio * RASTER_CACHE_MAX_UPSCALE) {
+                this._renderWithCache(
+                    ctx,
+                    { left: -w / 2, top: -h / 2, right: w / 2, bottom: h / 2 },
+                    (cacheContext) => this._drawNative(cacheContext, native, w, h),
+                    pixelRatio
+                );
+                return;
+            }
         }
 
         this._drawNative(ctx, native, w, h);

--- a/packages/engine-render/src/shape/image.ts
+++ b/packages/engine-render/src/shape/image.ts
@@ -28,7 +28,7 @@ const INLINE_SVG_DATA_URL_PATTERN = /^data:image\/svg\+xml(?:;[^,]*)?,/i;
 const SVG_FILTER_REFERENCE_PATTERN = /\bfilter\s*=/i;
 const SVG_EXPENSIVE_FILTER_PATTERN = /<fe(?:Turbulence|DisplacementMap|GaussianBlur)\b/i;
 const SVG_ANIMATION_PATTERN = /<(?:animate(?:Color|Motion|Transform)?|set)\b|@keyframes\b/i;
-const RASTER_CACHE_MAX_PIXEL_COUNT = 2_000_000;
+const RASTER_CACHE_MAX_PIXEL_COUNT = 4_000_000;
 const RASTER_CACHE_MAX_DIMENSION = 4_096;
 const RASTER_CACHE_PIXEL_RATIO_STEP = 0.5;
 const RASTER_CACHE_MAX_UPSCALE = 2;
@@ -55,12 +55,19 @@ function resolveRasterCachePixelRatio(width: number, height: number, requestedPi
         return requestedPixelRatio;
     }
 
-    return Math.min(
+    const dimensionLimitedPixelRatio = Math.min(
         requestedPixelRatio,
         RASTER_CACHE_MAX_DIMENSION / width,
-        RASTER_CACHE_MAX_DIMENSION / height,
-        Math.sqrt(RASTER_CACHE_MAX_PIXEL_COUNT / (width * height))
+        RASTER_CACHE_MAX_DIMENSION / height
     );
+    const pixelLimitedPixelRatio = Math.sqrt(RASTER_CACHE_MAX_PIXEL_COUNT / (width * height));
+    if (dimensionLimitedPixelRatio <= pixelLimitedPixelRatio) {
+        return dimensionLimitedPixelRatio;
+    }
+
+    const physicalWidth = Math.floor(width * pixelLimitedPixelRatio);
+    const physicalHeight = Math.floor(RASTER_CACHE_MAX_PIXEL_COUNT / physicalWidth);
+    return Math.min((physicalWidth - 1) / width, (physicalHeight - 1) / height);
 }
 
 export interface IShapeClipBounds {

--- a/packages/engine-render/src/shape/image.ts
+++ b/packages/engine-render/src/shape/image.ts
@@ -66,6 +66,8 @@ export interface IImageProps extends IShapeProps {
     opacity?: number;
 
     clipBounds?: Nullable<IShapeClipBounds>;
+
+    rasterCache?: boolean;
 }
 
 export class Image extends Shape<IImageProps> {
@@ -131,6 +133,10 @@ export class Image extends Shape<IImageProps> {
         return this._props.clipBounds;
     }
 
+    get rasterCache() {
+        return this._props.rasterCache ?? false;
+    }
+
     setOpacity(opacity: number) {
         this._props.opacity = opacity;
         this.makeDirty(true);
@@ -143,6 +149,16 @@ export class Image extends Shape<IImageProps> {
 
     setClipService(clipService: Nullable<IImageShapeClipService>) {
         this._clipService = clipService;
+    }
+
+    setRasterCacheEnabled(enabled: boolean): void {
+        if (this.rasterCache === enabled) {
+            return;
+        }
+
+        this._props.rasterCache = enabled;
+        this._releaseRenderCache();
+        this.makeDirty(true);
     }
 
     getClipService(): Nullable<IImageShapeClipService> {
@@ -377,12 +393,28 @@ export class Image extends Shape<IImageProps> {
     }
 
     protected override _draw(ctx: UniverRenderingContext, _bounds?: IViewportInfo, renderWidth?: number, renderHeight?: number) {
-        if (this._native == null) {
+        const native = this._native;
+        if (native == null) {
             return;
         }
         const w = renderWidth ?? this.width;
         const h = renderHeight ?? this.height;
 
+        // TODO(@ai-review): Verify raster caching remains opt-in because decoded bitmap images already have an efficient native draw path.
+        if (this.rasterCache) {
+            this._renderWithCache(
+                ctx,
+                { left: -w / 2, top: -h / 2, right: w / 2, bottom: h / 2 },
+                (cacheContext) => this._drawNative(cacheContext, native, w, h),
+                this.getEngine()?.getCanvas().getPixelRatio() ?? 1
+            );
+            return;
+        }
+
+        this._drawNative(ctx, native, w, h);
+    }
+
+    private _drawNative(ctx: UniverRenderingContext, native: HTMLImageElement, w: number, h: number): void {
         // Shape clip: when prstGeom is set and a clip service is available,
         // clip the image to the shape outline (e.g. ellipse, roundRect, etc.)
         if (this.prstGeom && this._clipService) {
@@ -409,14 +441,14 @@ export class Image extends Shape<IImageProps> {
                     const scaleW = this.width > 0 ? drawWidth / this.width : 1;
                     const scaleH = this.height > 0 ? drawHeight / this.height : 1;
                     ctx.drawImage(
-                        this._native,
+                        native,
                         drawLeft - left * scaleW,
                         drawTop - top * scaleH,
                         drawWidth + (right + left) * scaleW,
                         drawHeight + (bottom + top) * scaleH
                     );
                 } else {
-                    ctx.drawImage(this._native, drawLeft, drawTop, drawWidth, drawHeight);
+                    ctx.drawImage(native, drawLeft, drawTop, drawWidth, drawHeight);
                 }
                 ctx.restore();
                 return;
@@ -432,14 +464,14 @@ export class Image extends Shape<IImageProps> {
             ctx.rect(-w / 2, -h / 2, w, h);
             ctx.clip();
             ctx.drawImage(
-                this._native,
+                native,
                 -left * scaleW - w / 2,
                 -top * scaleH - h / 2,
                 w + (right + left) * scaleW,
                 h + (bottom + top) * scaleH
             );
         } else {
-            ctx.drawImage(this._native, -w / 2, -h / 2, w, h);
+            ctx.drawImage(native, -w / 2, -h / 2, w, h);
         }
     }
 

--- a/packages/engine-render/src/shape/image.ts
+++ b/packages/engine-render/src/shape/image.ts
@@ -24,6 +24,40 @@ import { RENDER_CLASS_TYPE, Transform, Vector2 } from '../basics';
 import { offsetRotationAxis } from '../basics/offset-rotation-axis';
 import { Shape } from './shape';
 
+const INLINE_SVG_DATA_URL_PATTERN = /^data:image\/svg\+xml(?:;[^,]*)?,/i;
+const SVG_FILTER_REFERENCE_PATTERN = /\bfilter\s*=/i;
+const SVG_EXPENSIVE_FILTER_PATTERN = /<fe(?:Turbulence|DisplacementMap|GaussianBlur)\b/i;
+const RASTER_CACHE_MAX_PIXEL_COUNT = 2_000_000;
+const RASTER_CACHE_MAX_DIMENSION = 4_096;
+
+function shouldRasterCacheSvg(source?: string): boolean {
+    const prefix = source && INLINE_SVG_DATA_URL_PATTERN.exec(source)?.[0];
+    if (!prefix) {
+        return false;
+    }
+
+    try {
+        const payload = source.slice(prefix.length);
+        const svg = prefix.toLowerCase().includes(';base64,') ? atob(payload) : decodeURIComponent(payload);
+        return SVG_FILTER_REFERENCE_PATTERN.test(svg) && SVG_EXPENSIVE_FILTER_PATTERN.test(svg);
+    } catch {
+        return false;
+    }
+}
+
+function resolveRasterCachePixelRatio(width: number, height: number, requestedPixelRatio: number): number {
+    if (width <= 0 || height <= 0) {
+        return requestedPixelRatio;
+    }
+
+    return Math.min(
+        requestedPixelRatio,
+        RASTER_CACHE_MAX_DIMENSION / width,
+        RASTER_CACHE_MAX_DIMENSION / height,
+        Math.sqrt(RASTER_CACHE_MAX_PIXEL_COUNT / (width * height))
+    );
+}
+
 export interface IShapeClipBounds {
     left: number;
     top: number;
@@ -81,6 +115,10 @@ export class Image extends Shape<IImageProps> {
 
     private _clipService: Nullable<IImageShapeClipService> = null;
 
+    private _rasterCacheSource = '';
+
+    private _autoRasterCache = false;
+
     override objectType = ObjectType.IMAGE;
 
     override isDrawingObject: boolean = true;
@@ -134,7 +172,21 @@ export class Image extends Shape<IImageProps> {
     }
 
     get rasterCache() {
-        return this._props.rasterCache ?? false;
+        if (this._props.rasterCache !== undefined) {
+            return this._props.rasterCache;
+        }
+
+        const source = this._native?.src || this._props.url || '';
+        if (source !== this._rasterCacheSource) {
+            const previous = this._autoRasterCache;
+            this._rasterCacheSource = source;
+            this._autoRasterCache = shouldRasterCacheSvg(source);
+            if (previous && !this._autoRasterCache) {
+                this._releaseRenderCache();
+            }
+        }
+
+        return this._autoRasterCache;
     }
 
     setOpacity(opacity: number) {
@@ -149,16 +201,6 @@ export class Image extends Shape<IImageProps> {
 
     setClipService(clipService: Nullable<IImageShapeClipService>) {
         this._clipService = clipService;
-    }
-
-    setRasterCacheEnabled(enabled: boolean): void {
-        if (this.rasterCache === enabled) {
-            return;
-        }
-
-        this._props.rasterCache = enabled;
-        this._releaseRenderCache();
-        this.makeDirty(true);
     }
 
     getClipService(): Nullable<IImageShapeClipService> {
@@ -401,11 +443,16 @@ export class Image extends Shape<IImageProps> {
         const h = renderHeight ?? this.height;
 
         if (this.rasterCache) {
+            const pixelRatio = resolveRasterCachePixelRatio(
+                w,
+                h,
+                this.getEngine()?.getCanvas().getPixelRatio() ?? 1
+            );
             this._renderWithCache(
                 ctx,
                 { left: -w / 2, top: -h / 2, right: w / 2, bottom: h / 2 },
                 (cacheContext) => this._drawNative(cacheContext, native, w, h),
-                this.getEngine()?.getCanvas().getPixelRatio() ?? 1
+                pixelRatio
             );
             return;
         }

--- a/packages/engine-render/src/shape/shape.ts
+++ b/packages/engine-render/src/shape/shape.ts
@@ -27,27 +27,14 @@ export type LineCap = 'butt' | 'round' | 'square';
 export type PaintFirst = 'fill' | 'stroke';
 
 const BASE_OBJECT_ARRAY_Set = new Set(BASE_OBJECT_ARRAY);
-const RENDER_CACHE_MAX_PIXEL_COUNT = 2_000_000;
-const RENDER_CACHE_MAX_DIMENSION = 4_096;
 
-function resolveRenderCacheMetrics(bounds: IBoundRectNoAngle, requestedPixelRatio: number) {
-    const boundsWidth = bounds.right - bounds.left;
-    const boundsHeight = bounds.bottom - bounds.top;
-    if (requestedPixelRatio <= Number.EPSILON || boundsWidth <= 0 || boundsHeight <= 0) {
-        return null;
+function resolveRenderCachePixelRatio(ctx: UniverRenderingContext, fixedPixelRatio?: number): number {
+    if (fixedPixelRatio !== undefined) {
+        return fixedPixelRatio;
     }
 
-    const pixelRatio = Math.min(
-        requestedPixelRatio,
-        RENDER_CACHE_MAX_DIMENSION / boundsWidth,
-        RENDER_CACHE_MAX_DIMENSION / boundsHeight,
-        Math.sqrt(RENDER_CACHE_MAX_PIXEL_COUNT / (boundsWidth * boundsHeight))
-    );
-    return {
-        pixelRatio,
-        width: Math.ceil(boundsWidth * pixelRatio) / pixelRatio,
-        height: Math.ceil(boundsHeight * pixelRatio) / pixelRatio,
-    };
+    const transform = ctx.getTransform();
+    return Math.max(Math.hypot(transform.a, transform.b), Math.hypot(transform.c, transform.d));
 }
 
 export interface IShapeProps extends IObjectFullState, ISize, IOffset, IScale {
@@ -421,16 +408,16 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
         draw: (cacheContext: UniverRenderingContext) => void,
         fixedPixelRatio?: number
     ): void {
-        const transform = ctx.getTransform();
-        const scaleX = Math.hypot(transform.a, transform.b);
-        const scaleY = Math.hypot(transform.c, transform.d);
-        const requestedPixelRatio = fixedPixelRatio ?? Math.max(scaleX, scaleY);
-        const metrics = resolveRenderCacheMetrics(bounds, requestedPixelRatio);
-        if (!metrics) {
+        const pixelRatio = resolveRenderCachePixelRatio(ctx, fixedPixelRatio);
+        if (pixelRatio <= Number.EPSILON) {
             return;
         }
 
-        const { width, height, pixelRatio } = metrics;
+        const width = Math.ceil((bounds.right - bounds.left) * pixelRatio) / pixelRatio;
+        const height = Math.ceil((bounds.bottom - bounds.top) * pixelRatio) / pixelRatio;
+        if (width <= 0 || height <= 0) {
+            return;
+        }
 
         const cacheBoundsChanged =
             this._renderCacheBounds?.left !== bounds.left ||

--- a/packages/engine-render/src/shape/shape.ts
+++ b/packages/engine-render/src/shape/shape.ts
@@ -27,6 +27,30 @@ export type LineCap = 'butt' | 'round' | 'square';
 export type PaintFirst = 'fill' | 'stroke';
 
 const BASE_OBJECT_ARRAY_Set = new Set(BASE_OBJECT_ARRAY);
+const RENDER_CACHE_MAX_PIXEL_COUNT = 2_000_000;
+const RENDER_CACHE_MAX_DIMENSION = 4_096;
+
+function resolveRenderCacheMetrics(bounds: IBoundRectNoAngle, requestedPixelRatio: number) {
+    const boundsWidth = bounds.right - bounds.left;
+    const boundsHeight = bounds.bottom - bounds.top;
+    if (requestedPixelRatio <= Number.EPSILON || boundsWidth <= 0 || boundsHeight <= 0) {
+        return null;
+    }
+
+    // TODO(@ai-review): Confirm the shared cache budget balances large SVG clarity and memory on the minimum supported browsers.
+    const pixelRatio = Math.min(
+        requestedPixelRatio,
+        RENDER_CACHE_MAX_DIMENSION / boundsWidth,
+        RENDER_CACHE_MAX_DIMENSION / boundsHeight,
+        Math.sqrt(RENDER_CACHE_MAX_PIXEL_COUNT / (boundsWidth * boundsHeight))
+    );
+    return {
+        pixelRatio,
+        width: Math.ceil(boundsWidth * pixelRatio) / pixelRatio,
+        height: Math.ceil(boundsHeight * pixelRatio) / pixelRatio,
+    };
+}
+
 export interface IShapeProps extends IObjectFullState, ISize, IOffset, IScale {
     rotateEnabled?: boolean;
     resizeEnabled?: boolean;
@@ -395,21 +419,19 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
     protected _renderWithCache(
         ctx: UniverRenderingContext,
         bounds: IBoundRectNoAngle,
-        draw: (cacheContext: UniverRenderingContext) => void
+        draw: (cacheContext: UniverRenderingContext) => void,
+        fixedPixelRatio?: number
     ): void {
         const transform = ctx.getTransform();
         const scaleX = Math.hypot(transform.a, transform.b);
         const scaleY = Math.hypot(transform.c, transform.d);
-        const pixelRatio = Math.max(scaleX, scaleY);
-        if (pixelRatio <= Number.EPSILON) {
+        const requestedPixelRatio = fixedPixelRatio ?? Math.max(scaleX, scaleY);
+        const metrics = resolveRenderCacheMetrics(bounds, requestedPixelRatio);
+        if (!metrics) {
             return;
         }
 
-        const width = Math.ceil((bounds.right - bounds.left) * pixelRatio) / pixelRatio;
-        const height = Math.ceil((bounds.bottom - bounds.top) * pixelRatio) / pixelRatio;
-        if (width <= 0 || height <= 0) {
-            return;
-        }
+        const { width, height, pixelRatio } = metrics;
 
         const cacheBoundsChanged =
             this._renderCacheBounds?.left !== bounds.left ||

--- a/packages/engine-render/src/shape/shape.ts
+++ b/packages/engine-render/src/shape/shape.ts
@@ -37,7 +37,6 @@ function resolveRenderCacheMetrics(bounds: IBoundRectNoAngle, requestedPixelRati
         return null;
     }
 
-    // TODO(@ai-review): Confirm the shared cache budget balances large SVG clarity and memory on the minimum supported browsers.
     const pixelRatio = Math.min(
         requestedPixelRatio,
         RENDER_CACHE_MAX_DIMENSION / boundsWidth,


### PR DESCRIPTION
## Summary

- automatically raster-cache inline SVG images that use expensive static filter primitives
- share the optimization across Sheet, Doc, Slide, and Board through the common `Image` render object
- reuse one bounded raster cache per image instead of drawing the source SVG during pan and high zoom
- build the final capped resolution early when the next 0.5 scale bucket would hit the cache limit

## Root cause

Canvas `drawImage` repeatedly rasterizes complex SVG filter graphs during pan and zoom. Viewport and layer texture caches do not eliminate that work when they are repaired or rebuilt.

The previous high-zoom safeguard fell back to the source SVG once the cached bitmap required more than 2x upscaling. In the Europa Board fixture, that made every pan at 98% spend roughly 0.9–1.2 seconds on the main thread.

## Impact

All products rendering through `@univerjs/engine-render` benefit from the shared path. PNG, JPEG, ordinary SVG, and animated SVG retain their existing direct rendering behavior.

The automatic policy only targets inline SVGs that reference a filter and contain `feTurbulence`, `feDisplacementMap`, or `feGaussianBlur`. Cache backing stores remain limited to 4,000,000 pixels and 4096 pixels per dimension. At high zoom, a capped bitmap can be softer than the source SVG; retaining it avoids the much larger repeated-rasterization cost.

No UI, facade, command, DI, i18n, demo, build-tool, dependency, or re-export changes are involved. Architecture documentation is not needed because this is an internal render-path optimization with no new public API or long-lived module boundary.

## Validation

- engine-render full suite: 95 files passed; 937 tests passed and 59 skipped
- engine-render typecheck passed
- targeted ESLint: 0 errors
- Europa Board fixture at 98% horizontal pan: main-thread work reduced from 905–1225 ms per action to 29–53 ms
- Europa Board fixture at 38% zoom: cache-upgrade work reduced from 893 ms to 83 ms
- GitHub build, test aggregate, Playwright aggregate, Codecov, CodeFactor, Semgrep, and Univer Merge Assistant succeeded