### PR TITLE
perf(docs): coalesce changeset render refreshes

### DIFF
--- a/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-transform-update.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-transform-update.controller.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel, ICommandInfo, IDrawingParam, ITransformState } from '@univerjs/core';
+import type { DocumentDataModel, ICommandInfo, IDrawingParam, IExecutionOptions, ITransformState } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
 import type { Documents, DocumentSkeleton, IDocsCustomBlockRenderViewport, IDocsTableRenderViewport, IDocumentSkeletonHeaderFooter, IDocumentSkeletonPage, IDocumentSkeletonRow, IDocumentSkeletonTable, Image, IRenderContext, IRenderModule } from '@univerjs/engine-render';
 import {
@@ -224,6 +224,7 @@ function hasHorizontalTableViewport(viewport: IDocsTableRenderViewport | null | 
 
 export class DocDrawingTransformUpdateController extends Disposable implements IRenderModule {
     private _liquid = new Liquid();
+    private _changesetDrawingRefreshScheduled = false;
 
     constructor(
         private readonly _context: IRenderContext<DocumentDataModel>,
@@ -274,33 +275,61 @@ export class DocDrawingTransformUpdateController extends Disposable implements I
         const updateCommandList = [RichTextEditingMutation.id, SetDocZoomRatioOperation.id];
 
         this.disposeWithMe(
-            this._commandService.onCommandExecuted((command: ICommandInfo) => {
+            this._commandService.onCommandExecuted((command: ICommandInfo, options?: IExecutionOptions) => {
                 if (updateCommandList.includes(command.id)) {
                     const params = command.params as IRichTextEditingMutationParams;
                     const { unitId: commandUnitId } = params;
 
-                    const { unitId, mainComponent } = this._context;
+                    const { unitId } = this._context;
 
                     if (commandUnitId !== unitId) {
                         return;
                     }
 
-                    const skeleton = this._docSkeletonManagerService.getSkeleton();
-
-                    if (skeleton == null) {
+                    // TODO(@ai-review): Confirm the second microtask always follows the coalesced Doc layout refresh.
+                    if (command.id === RichTextEditingMutation.id && options?.fromChangeset) {
+                        this._scheduleChangesetDrawingRefresh();
                         return;
                     }
 
-                    // TODO: @JOCS, Do not use unitId to check if it's need to render images or isEditor. maybe need a config?
-                    if (this._editorService.isEditor(unitId)) {
-                        mainComponent?.makeDirty();
-                        return;
-                    }
-
-                    this._refreshDrawing(skeleton);
+                    this._refreshCurrentDrawing();
                 }
             })
         );
+    }
+
+    private _scheduleChangesetDrawingRefresh(): void {
+        if (this._changesetDrawingRefreshScheduled) {
+            return;
+        }
+
+        this._changesetDrawingRefreshScheduled = true;
+        queueMicrotask(() => {
+            queueMicrotask(() => {
+                this._changesetDrawingRefreshScheduled = false;
+                if (this._disposed) {
+                    return;
+                }
+
+                this._refreshCurrentDrawing();
+            });
+        });
+    }
+
+    private _refreshCurrentDrawing(): void {
+        const skeleton = this._docSkeletonManagerService.getSkeleton();
+        if (skeleton == null) {
+            return;
+        }
+
+        const { unitId, mainComponent } = this._context;
+        // TODO: @JOCS, Do not use unitId to check if it's need to render images or isEditor. maybe need a config?
+        if (this._editorService.isEditor(unitId)) {
+            mainComponent?.makeDirty();
+            return;
+        }
+
+        this._refreshDrawing(skeleton);
     }
 
     private _initTransformRefresh() {

--- a/packages/docs-ui/src/controllers/__tests__/doc-render-controller.spec.ts
+++ b/packages/docs-ui/src/controllers/__tests__/doc-render-controller.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ICommandInfo } from '@univerjs/core';
+import type { ICommandInfo, IExecutionOptions } from '@univerjs/core';
 import { DOCS_NORMAL_EDITOR_UNIT_ID_KEY, DocumentFlavor } from '@univerjs/core';
 import { RichTextEditingMutation } from '@univerjs/docs';
 import { Subject } from 'rxjs';
@@ -106,7 +106,7 @@ function createControllerFixture(options?: {
     unitId?: string;
 }) {
     mockScrollBarProps.length = 0;
-    const commandCallbacks: Array<(command: ICommandInfo) => void> = [];
+    const commandCallbacks: Array<(command: ICommandInfo, options?: IExecutionOptions) => void> = [];
     const darkMode$ = new Subject<boolean>();
     const canvasElement = { style: {} as Record<string, string> };
     const canvasColorService = {
@@ -263,6 +263,30 @@ describe('doc render controller', () => {
             },
         } as unknown as ICommandInfo);
 
+        expect(pageLayoutService.calculatePagePosition).toHaveBeenCalledTimes(1);
+        expect(selectionManager.refreshSelection).toHaveBeenCalledTimes(1);
+    });
+
+    // TODO(@ai-review): Confirm this test continues to model SnapshotService's synchronous changeset replay boundary.
+    it('coalesces synchronous changeset mutations into one document render', async () => {
+        const { commandCallbacks, pageLayoutService, selectionManager, skeletonManager } = createControllerFixture();
+        const mutation = {
+            id: RichTextEditingMutation.id,
+            params: {
+                unitId: 'doc-unit',
+                actions: [],
+            },
+        } as unknown as ICommandInfo;
+
+        commandCallbacks[0](mutation, { fromChangeset: true });
+        commandCallbacks[0](mutation, { fromChangeset: true });
+        commandCallbacks[0](mutation, { fromChangeset: true });
+
+        expect(skeletonManager.getSkeleton().calculate).not.toHaveBeenCalled();
+
+        await Promise.resolve();
+
+        expect(skeletonManager.getSkeleton().calculate).toHaveBeenCalledTimes(1);
         expect(pageLayoutService.calculatePagePosition).toHaveBeenCalledTimes(1);
         expect(selectionManager.refreshSelection).toHaveBeenCalledTimes(1);
     });

--- a/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel, EventState, ICommandInfo, Nullable } from '@univerjs/core';
+import type { DocumentDataModel, EventState, ICommandInfo, IExecutionOptions, Nullable } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
 import type { DocumentSkeleton, IDocumentSkeletonPage, IRenderContext, IRenderModule, IWheelEvent } from '@univerjs/engine-render';
 import { DocumentFlavor, ICommandService, Inject, isInternalEditorID, IUniverInstanceService, RxDisposable, ThemeService, UniverInstanceType } from '@univerjs/core';
@@ -29,6 +29,8 @@ import { IEditorService } from '../../services/editor/editor-manager.service';
 import { DocSelectionRenderService } from '../../services/selection/doc-selection-render.service';
 
 export class DocRenderController extends RxDisposable implements IRenderModule {
+    private _changesetRenderScheduled = false;
+
     constructor(
         private readonly _context: IRenderContext<DocumentDataModel>,
         @ICommandService private readonly _commandService: ICommandService,
@@ -220,15 +222,41 @@ export class DocRenderController extends RxDisposable implements IRenderModule {
     private _initCommandListener() {
         const updateCommandList = [RichTextEditingMutation.id];
 
-        this.disposeWithMe(this._commandService.onCommandExecuted((command: ICommandInfo) => {
-            // TODO@Jocs: performance, only update the skeleton when the command is related to the current unit.
-            if (updateCommandList.includes(command.id)) {
-                const params = command.params as IRichTextEditingMutationParams;
-                const { unitId } = params;
-
-                this.reRender(unitId);
+        this.disposeWithMe(this._commandService.onCommandExecuted((command: ICommandInfo, options?: IExecutionOptions) => {
+            if (!updateCommandList.includes(command.id)) {
+                return;
             }
+
+            const params = command.params as IRichTextEditingMutationParams;
+            const { unitId } = params;
+            if (unitId !== this._context.unitId) {
+                return;
+            }
+
+            // TODO(@ai-review): Verify this coalescing remains correct if changeset replay later yields between mutations.
+            if (options?.fromChangeset) {
+                this._scheduleChangesetRender();
+                return;
+            }
+
+            this.reRender(unitId);
         }));
+    }
+
+    private _scheduleChangesetRender(): void {
+        if (this._changesetRenderScheduled) {
+            return;
+        }
+
+        this._changesetRenderScheduled = true;
+        queueMicrotask(() => {
+            this._changesetRenderScheduled = false;
+            if (this._disposed) {
+                return;
+            }
+
+            this.reRender(this._context.unitId);
+        });
     }
 
     private _initThemeListener() {


### PR DESCRIPTION
## Summary

- coalesce synchronous changeset-driven document layout refreshes into one microtask
- schedule drawing refresh only after the coalesced document layout pass
- avoid repeated document layout and drawing work while embedded Slide thumbnails settle

## Why

Slide thumbnails can mount embedded documents while collaboration changesets are replayed. Refreshing layout and drawing for every synchronous changeset caused redundant work and delayed stable thumbnail capture.

## Paired Pro PR

- dream-num/univer-pro#5476

## Validation

- targeted Vitest coverage for the document render controller
- typecheck for `@univerjs/docs-ui` and `@univerjs/docs-drawing-ui`
- ESLint on all changed files (0 errors)
- outer repository convention checker
- `git diff --check`

## Scope

This PR contains only the Docs rendering changes created in the paired Slide thumbnail session. Sheet low-zoom rendering work from a separate task is not included.
