### PR TITLE
perf(sheets): skip invisible text work in subpixel dimensions

### DIFF
--- a/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
+++ b/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
@@ -361,6 +361,43 @@ describe('spreadsheet integration', () => {
         expect(skeleton.stylesCache.fontMatrix.getSizeOf()).toBe(0);
     });
 
+    it('skips font cache for sub-four-pixel rows without dropping visible styles or merged text', () => {
+        const workbookData = workbookDataFactory();
+        workbookData.id = 'sheet-render-short-row-workbook';
+        workbookData.name = 'sheet-render-short-row-workbook';
+        workbookData.sheets['sheet-1'].rowData = {
+            ...workbookData.sheets['sheet-1'].rowData,
+            2: { h: 2 },
+            3: { h: 2 },
+            4: { h: 2 },
+        };
+        workbookData.sheets['sheet-1'].cellData = {
+            ...workbookData.sheets['sheet-1'].cellData,
+            4: { 0: { v: 'compressed', s: 'style-bg-border' } },
+        };
+
+        const workbook = fixture.univer.createUnit<IWorkbookData, Workbook>(UniverInstanceType.UNIVER_SHEET, workbookData);
+        const worksheet = workbook.getActiveSheet()!;
+        const skeleton = fixture.univer.__getInjector().createInstance(SpreadsheetSkeleton, worksheet, workbook.getStyles()).calculate() as SpreadsheetSkeleton;
+        skeleton.setScene(fixture.scene);
+        const viewportInfo = createViewportInfo(fixture.scene, fixture.cacheCanvas);
+
+        skeleton.setStylesCache(viewportInfo, { scaleY: 1 });
+
+        expect(skeleton.stylesCache.fontMatrix.getValue(4, 0)).toBeUndefined();
+        expect(skeleton.stylesCache.backgroundPositions?.getValue(4, 0)).toBeDefined();
+        expect(skeleton.stylesCache.border?.getValue(4, 0)).toBeDefined();
+        expect(skeleton.stylesCache.fontMatrix.getValue(2, 2)).toBeDefined();
+
+        skeleton.resetCache();
+        skeleton.setStylesCache(viewportInfo, { scaleY: 2 });
+        expect(skeleton.stylesCache.fontMatrix.getValue(4, 0)).toBeDefined();
+
+        skeleton.resetCache();
+        skeleton.setStylesCache(viewportInfo);
+        expect(skeleton.stylesCache.fontMatrix.getValue(4, 0)).toBeDefined();
+    });
+
     it('keeps the last printing row and column when the viewport ends on their exact boundaries', () => {
         const { skeleton, scene, cacheCanvas } = fixture;
         const endRow = 3;
@@ -442,8 +479,10 @@ describe('spreadsheet integration', () => {
             isDirty: 1,
             isForceDirty: false,
         });
+        const stylesCacheSpy = vi.spyOn(skeleton, 'setStylesCache');
 
         spreadsheet.render(mainCtx as any, baseVpInfo);
+        expect(stylesCacheSpy).toHaveBeenCalledWith(baseVpInfo, { scaleY: 1 });
         expect(spreadsheet.allowCache).toBe(true);
         expect(spreadsheet.getSelectionBounding(2, 2, 2, 2)).toEqual(expect.objectContaining({
             startRow: 2,

--- a/packages/engine-render/src/components/sheets/constants.ts
+++ b/packages/engine-render/src/components/sheets/constants.ts
@@ -22,6 +22,11 @@ export const BG_Z_INDEX = 21;
 export const PRINTING_BG_Z_INDEX = 21;
 
 export const EXPAND_SIZE_FOR_RENDER_OVERFLOW = 20;
+export const MIN_TEXT_RENDER_HEIGHT_IN_SCREEN_PX = 4;
+
+export function shouldRenderRowText(rowHeight: number, scaleY = 1): boolean {
+    return rowHeight * Math.abs(scaleY) >= MIN_TEXT_RENDER_HEIGHT_IN_SCREEN_PX;
+}
 
 export const sheetContentViewportKeys = [
     SHEET_VIEWPORT_KEY.VIEW_MAIN,

--- a/packages/engine-render/src/components/sheets/extensions/__tests__/column-header-layout.spec.ts
+++ b/packages/engine-render/src/components/sheets/extensions/__tests__/column-header-layout.spec.ts
@@ -119,6 +119,36 @@ describe('column header layout extension', () => {
         expect(ctx.fillText).toHaveBeenCalled();
     });
 
+    it('omits column labels that cannot occupy four screen pixels', () => {
+        const layout = new ColumnHeaderLayout();
+        const ctx = createCtx();
+        const compressedColumnCount = 228;
+        const skeleton = {
+            rowColumnSegment: { startRow: 0, endRow: 0, startColumn: 0, endColumn: compressedColumnCount },
+            columnHeaderHeight: 20,
+            rowHeightAccumulation: [20],
+            columnWidthAccumulation: Array.from(
+                { length: compressedColumnCount + 1 },
+                (_, column) => column < compressedColumnCount ? (column + 1) * 2 : compressedColumnCount * 2 + 20
+            ),
+            columnTotalWidth: compressedColumnCount * 2 + 20,
+            rowTotalHeight: 20,
+            worksheet: {
+                getSheetId: vi.fn(() => 'sheet-main'),
+            },
+        } as any;
+
+        layout.draw(ctx, { scaleX: 1, scaleY: 1 } as any, skeleton);
+
+        expect(ctx.fillText).toHaveBeenCalledOnce();
+        expect(ctx.fillText).toHaveBeenCalledWith('HU', expect.any(Number), expect.any(Number));
+        expect(ctx.stroke).toHaveBeenCalledTimes(compressedColumnCount + 2);
+
+        ctx.fillText.mockClear();
+        layout.draw(ctx, { scaleX: 2, scaleY: 1 } as any, skeleton);
+        expect(ctx.fillText).toHaveBeenCalledTimes(compressedColumnCount + 1);
+    });
+
     it('uses gapConfig default colors when drawing column gaps', () => {
         const layout = new ColumnHeaderLayout();
         const ctx = createCtx();

--- a/packages/engine-render/src/components/sheets/extensions/__tests__/font.spec.ts
+++ b/packages/engine-render/src/components/sheets/extensions/__tests__/font.spec.ts
@@ -849,6 +849,44 @@ describe('font extension', () => {
         expect(renderCellSpy).toHaveBeenCalledOnce();
     });
 
+    it('skips font work for rows that are too short to display text on screen', () => {
+        const font = new Font() as any;
+        const ctx = createCtx();
+        const spreadsheetSkeleton = createSpreadsheetSkeleton();
+        const fontMatrix = new ObjectMatrix<any>();
+        const compressedRowCount = 228;
+        for (let row = 0; row <= compressedRowCount; row++) {
+            fontMatrix.setValue(row, 0, createFontCache());
+        }
+        spreadsheetSkeleton.stylesCache = { fontMatrix };
+        spreadsheetSkeleton.rowHeightAccumulation = Array.from(
+            { length: compressedRowCount + 1 },
+            (_, row) => row < compressedRowCount ? (row + 1) * 2 : compressedRowCount * 2 + 20
+        );
+        spreadsheetSkeleton.getRowCount = vi.fn(() => compressedRowCount + 1);
+        spreadsheetSkeleton.columnTotalWidth = 120;
+        spreadsheetSkeleton.rowTotalHeight = compressedRowCount * 2 + 20;
+        const renderCellSpy = vi.spyOn(font, '_renderFontEachCell').mockReturnValue(true);
+
+        font.draw(ctx, { scaleX: 1, scaleY: 1 } as any, spreadsheetSkeleton, [], {
+            viewRanges: [{ startRow: 0, endRow: compressedRowCount, startColumn: 0, endColumn: 0 }],
+            checkOutOfViewBound: true,
+            viewportKey: 'viewMain',
+        } as any);
+
+        expect(renderCellSpy).toHaveBeenCalledOnce();
+        expect(renderCellSpy).toHaveBeenCalledWith(expect.anything(), compressedRowCount, 0, fontMatrix, expect.anything());
+
+        renderCellSpy.mockClear();
+        font.draw(ctx, { scaleX: 1, scaleY: 2 } as any, spreadsheetSkeleton, [], {
+            viewRanges: [{ startRow: 0, endRow: compressedRowCount, startColumn: 0, endColumn: 0 }],
+            checkOutOfViewBound: true,
+            viewportKey: 'viewMain',
+        } as any);
+
+        expect(renderCellSpy).toHaveBeenCalledTimes(compressedRowCount + 1);
+    });
+
     it('skips merge lookup work when the sheet has no merged cells', () => {
         const font = new Font() as any;
         const ctx = createCtx();

--- a/packages/engine-render/src/components/sheets/extensions/__tests__/row-header-layout.spec.ts
+++ b/packages/engine-render/src/components/sheets/extensions/__tests__/row-header-layout.spec.ts
@@ -119,6 +119,37 @@ describe('row header layout extension', () => {
         expect(ctx.fillText).toHaveBeenCalled();
     });
 
+    it('omits row labels that cannot occupy four screen pixels', () => {
+        const layout = new RowHeaderLayout();
+        const ctx = createCtx();
+        const compressedRowCount = 228;
+        const skeleton = {
+            rowColumnSegment: { startRow: 0, endRow: compressedRowCount, startColumn: 0, endColumn: 0 },
+            rowHeaderWidth: 30,
+            rowHeightAccumulation: Array.from(
+                { length: compressedRowCount + 1 },
+                (_, row) => row < compressedRowCount ? (row + 1) * 2 : compressedRowCount * 2 + 20
+            ),
+            columnWidthAccumulation: [30],
+            columnTotalWidth: 30,
+            rowTotalHeight: compressedRowCount * 2 + 20,
+            worksheet: {
+                getSheetId: vi.fn(() => 'sheet-main'),
+            },
+        } as any;
+
+        layout.draw(ctx, { scaleX: 1, scaleY: 1 } as any, skeleton);
+
+        expect(ctx.fillText).toHaveBeenCalledOnce();
+        expect(ctx.fillText).toHaveBeenCalledWith(`${compressedRowCount + 1}`, expect.any(Number), expect.any(Number));
+        expect(ctx.stroke).toHaveBeenCalledTimes(compressedRowCount + 2);
+
+        ctx.fillText.mockClear();
+        layout.draw(ctx, { scaleX: 1, scaleY: 2 } as any, skeleton);
+
+        expect(ctx.fillText).toHaveBeenCalledTimes(compressedRowCount + 1);
+    });
+
     it('uses gapConfig default colors when drawing row gaps', () => {
         const layout = new RowHeaderLayout();
         const ctx = createCtx();

--- a/packages/engine-render/src/components/sheets/extensions/column-header-layout.ts
+++ b/packages/engine-render/src/components/sheets/extensions/column-header-layout.ts
@@ -25,6 +25,7 @@ import { SheetColumnHeaderExtensionRegistry } from '../../extension';
 import { SheetExtension } from './sheet-extension';
 
 const UNIQUE_KEY = 'DefaultColumnHeaderLayoutExtension';
+const MIN_TEXT_RENDER_WIDTH_IN_SCREEN_PX = 4;
 
 export interface IColumnsHeaderCfgParam {
     headerStyle?: Partial<IHeaderStyleCfg>;
@@ -220,6 +221,12 @@ export class ColumnHeaderLayout extends SheetExtension {
             ctx.moveToByPrecision(cellBound.right, 0);
             ctx.lineToByPrecision(cellBound.right, cellBound.height);
             ctx.stroke();
+
+            if (cellBound.width * Math.abs(parentScale.scaleX ?? 1) < MIN_TEXT_RENDER_WIDTH_IN_SCREEN_PX) {
+                preColumnPosition = columnEndPosition;
+                continue;
+            }
+
             // column header text
             const textX = (() => {
                 switch (curColumnCfg.textAlign) {

--- a/packages/engine-render/src/components/sheets/extensions/font.ts
+++ b/packages/engine-render/src/components/sheets/extensions/font.ts
@@ -46,7 +46,7 @@ import { VERTICAL_ROTATE_ANGLE } from '../../../basics/text-rotation';
 import { clampRange, inViewRanges } from '../../../basics/tools';
 import { Text } from '../../../shape/text';
 import { SpreadsheetExtensionRegistry } from '../../extension';
-import { EXPAND_SIZE_FOR_RENDER_OVERFLOW, FONT_EXTENSION_Z_INDEX } from '../constants';
+import { EXPAND_SIZE_FOR_RENDER_OVERFLOW, FONT_EXTENSION_Z_INDEX, shouldRenderRowText } from '../constants';
 import { DEFAULT_PADDING_DATA, getDocsSkeletonPageSize } from '../sheet.render-skeleton';
 import { calculateCellImageRect } from '../util';
 import { SheetExtension } from './sheet-extension';
@@ -229,6 +229,14 @@ export class Font extends SheetExtension {
 
             const { startRow, endRow, startColumn, endColumn } = range;
             for (let row = startRow; row <= endRow; row++) {
+                const rowStartPosition = rowHeightAccumulation[row - 1] ?? 0;
+                const rowEndPosition = rowHeightAccumulation[row] ?? rowStartPosition;
+                const rowGap = spreadsheetSkeleton.gapConfig?.rowGaps?.[row]?.size ?? 0;
+                const rowHeight = Math.max(0, rowEndPosition - rowStartPosition - rowGap);
+                if (!shouldRenderRowText(rowHeight, parentScale.scaleY)) {
+                    continue;
+                }
+
                 for (let col = startColumn; col <= endColumn; col++) {
                     const fontCache = fontMatrix.getValue(row, col);
                     if (!fontCache) {

--- a/packages/engine-render/src/components/sheets/extensions/row-header-layout.ts
+++ b/packages/engine-render/src/components/sheets/extensions/row-header-layout.ts
@@ -24,6 +24,7 @@ import { SheetRowHeaderExtensionRegistry } from '../../extension';
 import { SheetExtension } from './sheet-extension';
 
 const UNIQUE_KEY = 'DefaultRowHeaderLayoutExtension';
+const MIN_TEXT_RENDER_HEIGHT_IN_SCREEN_PX = 4;
 
 export interface IRowsHeaderCfgParam {
     headerStyle?: Partial<IRowStyleCfg>;
@@ -223,6 +224,11 @@ export class RowHeaderLayout extends SheetExtension {
             ctx.moveToByPrecision(cellBound.left, cellBound.bottom);
             ctx.lineToByPrecision(cellBound.right, cellBound.bottom);
             ctx.stroke();
+
+            if (cellBound.height * Math.abs(parentScale.scaleY ?? 1) < MIN_TEXT_RENDER_HEIGHT_IN_SCREEN_PX) {
+                preRowPosition = rowEndPosition;
+                continue;
+            }
 
             // row header text
             const textX = (() => {

--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -66,7 +66,7 @@ import { DocSimpleSkeleton } from '../docs/layout/doc-simple-skeleton';
 import { DocumentSkeleton } from '../docs/layout/doc-skeleton';
 import { columnIterator } from '../docs/layout/tools';
 import { DocumentViewModel } from '../docs/view-model/document-view-model';
-import { EXPAND_SIZE_FOR_RENDER_OVERFLOW, MEASURE_EXTENT, MEASURE_EXTENT_FOR_PARAGRAPH } from './constants';
+import { EXPAND_SIZE_FOR_RENDER_OVERFLOW, MEASURE_EXTENT, MEASURE_EXTENT_FOR_PARAGRAPH, shouldRenderRowText } from './constants';
 import { SHEET_VIEWPORT_KEY } from './interfaces';
 
 interface IRowColumnRange extends IRowRange, IColumnRange { }
@@ -225,6 +225,11 @@ interface ISetStylesCacheForOneCellOptions {
     reuseExisting?: boolean;
     hasMergeData?: boolean;
     rowVisible?: boolean;
+    skipFontCache?: boolean;
+}
+
+export interface ISetStylesCacheOptions {
+    scaleY?: number;
 }
 
 export interface IGetPosByRowColOptions {
@@ -452,9 +457,10 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
     /**
      * Set border background and font to this._stylesCache by visible range, which derives from bounds)
      * @param vpInfo viewBounds
+     * @param options screen scale
      */
     // eslint-disable-next-line max-lines-per-function, complexity
-    setStylesCache(vpInfo?: IViewportInfo): Nullable<SpreadsheetSkeleton> {
+    setStylesCache(vpInfo?: IViewportInfo, options?: ISetStylesCacheOptions): Nullable<SpreadsheetSkeleton> {
         if (!this._worksheetData) return;
         if (!this.rowHeightAccumulation || !this.columnWidthAccumulation) return;
 
@@ -475,7 +481,10 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
             ? (vpInfo.shouldCacheUpdate ? (vpInfo.diffCacheBounds?.map((bound) => this.getRangeByViewBound(bound)) ?? []) : [])
             : [rowColumnSegment];
         const visibleCellOptions: ISetStylesCacheForOneCellOptions = { cacheItem: { bg: true, border: true }, reuseExisting: isIncrementalScroll, hasMergeData, rowVisible: true };
+        const shortRowVisibleCellOptions: ISetStylesCacheForOneCellOptions = { ...visibleCellOptions, skipFontCache: true };
         const overflowCellOptions: ISetStylesCacheForOneCellOptions = { cacheItem: { bg: false, border: false }, reuseExisting: isIncrementalScroll, hasMergeData, rowVisible: true };
+        const scaleY = options?.scaleY ?? 1;
+        const hasRenderContext = options !== undefined;
         this._incrementalFontRenderRanges = [];
 
         // clear cache out of visible range
@@ -515,11 +524,22 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
                     });
                 }
 
+                const rowStartPosition = this.rowHeightAccumulation[r - 1] ?? 0;
+                const rowEndPosition = this.rowHeightAccumulation[r] ?? rowStartPosition;
+                const rowGap = this.gapConfig?.rowGaps?.[r]?.size ?? 0;
+                const rowHeight = Math.max(0, rowEndPosition - rowStartPosition - rowGap);
+                // Merged-cell fonts are cached by the dedicated merge pass below.
+                const skipFontCacheForRow = hasRenderContext && !shouldRenderRowText(rowHeight, scaleY);
+                const cellOptions = skipFontCacheForRow ? shortRowVisibleCellOptions : visibleCellOptions;
                 for (let c = visibleStartColumn; c <= visibleEndColumn; c++) {
-                    this._setStylesCacheForOneCell(r, c, visibleCellOptions);
+                    this._setStylesCacheForOneCell(r, c, cellOptions);
                 }
-                if (shouldUseIncrementalStyleRange) {
+                if (shouldUseIncrementalStyleRange && !skipFontCacheForRow) {
                     pushRowRange(this._incrementalFontRenderRanges, r, visibleStartColumn, visibleEndColumn);
+                }
+
+                if (skipFontCacheForRow) {
+                    continue;
                 }
 
                 // Calculate text length for overflow cells just outside the visible range.
@@ -1536,7 +1556,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
         if (options.reuseExisting && cacheItem && !options.mergeRange) {
             const bgHandled = !cacheItem.bg || Tools.isDefine(this._handleBgMatrix.getValue(row, col));
             const borderHandled = !cacheItem.border || Tools.isDefine(this._handleBorderMatrix.getValue(row, col));
-            if (bgHandled && borderHandled && this._stylesCache.fontMatrix.getValue(row, col)) {
+            if (bgHandled && borderHandled && (options.skipFontCache || this._stylesCache.fontMatrix.getValue(row, col))) {
                 return;
             }
         }
@@ -1570,7 +1590,9 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
 
         this._setBgStylesCache(row, col, style, options);
         this._setBorderStylesCache(row, col, style, options);
-        this._setFontStylesCache(row, col, { ...cell, ...{ s: style } }, style, options.hasMergeData ?? true);
+        if (!options.skipFontCache) {
+            this._setFontStylesCache(row, col, { ...cell, s: style }, style, options.hasMergeData ?? true);
+        }
     }
 
     /**

--- a/packages/engine-render/src/components/sheets/spreadsheet.ts
+++ b/packages/engine-render/src/components/sheets/spreadsheet.ts
@@ -690,7 +690,9 @@ export class Spreadsheet extends SheetComponent {
             return this;
         }
 
-        spreadsheetSkeleton.setStylesCache(viewportInfo);
+        spreadsheetSkeleton.setStylesCache(viewportInfo, {
+            scaleY: this.getParentScale().scaleY,
+        });
 
         const segment = spreadsheetSkeleton.rowColumnSegment;
 


### PR DESCRIPTION
## Summary

- Skip cell text drawing when the effective row height is below 4 screen pixels.
- Skip row-header and column-header labels when their effective dimensions are below 4 screen pixels.
- Avoid preparing font, display, shrink, and overflow caches for invisible text while retaining backgrounds, borders, merged-cell handling, zoom behavior, and printing behavior.

Scope is limited to Sheet text rendering and text-cache preparation for subpixel row/column dimensions. It does not change row visibility, selection, borders, merged-cell geometry, or workbook data.

## Why

Workbooks can use very small row heights to approximate hidden data. Hundreds of rows can then enter one viewport at once, causing avoidable text measurement, cache preparation, overflow expansion, and header-label drawing even though the text is not visibly legible. This change applies an Excel-aligned screen-pixel threshold to the text paths while keeping non-text rendering intact.

## Validation

- `pnpm --filter @univerjs/engine-render test`
  - 95 test files passed
  - 934 tests passed, 59 skipped
- `pnpm --filter @univerjs/engine-render typecheck`
- `git diff --check origin/dev...HEAD`
- Local Univer Pro compatibility validation against this OSS commit:
  - `pnpm --filter @univerjs-pro/sheets-print test` (7 files, 8 tests passed)
  - `pnpm --filter @univerjs-pro/sheets-print typecheck`
- Reopened the Chart Gallery workbook with the local SDK build and verified that dense bottom rows no longer paint compressed cell/header text.

## Architecture and dependencies

- No architecture documentation or ADR update is needed because this is a localized rendering-performance behavior change with no new package or dependency edge.
- SDK dependencies do not change.
- No Univer Pro source change is required: the print renderer already sets `Spreadsheet.isPrinting`, so print output keeps text rendering below the interactive threshold. The fix should merge and ship from OSS; no submodule pointer is included in this PR.
- No breaking change is introduced.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (no related issue).
- [x] Naming convention is followed.
- [x] Unit and integration tests have been added for the changes.
- [x] No breaking changes are introduced.
