### PR TITLE
chore(docs): remove AI review annotations

### DIFF
--- a/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-transform-update.controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-transform-update.controller.ts
@@ -286,7 +286,6 @@ export class DocDrawingTransformUpdateController extends Disposable implements I
                         return;
                     }
 
-                    // TODO(@ai-review): Confirm the second microtask always follows the coalesced Doc layout refresh.
                     if (command.id === RichTextEditingMutation.id && options?.fromChangeset) {
                         this._scheduleChangesetDrawingRefresh();
                         return;

--- a/packages/docs-ui/src/controllers/__tests__/doc-render-controller.spec.ts
+++ b/packages/docs-ui/src/controllers/__tests__/doc-render-controller.spec.ts
@@ -267,7 +267,6 @@ describe('doc render controller', () => {
         expect(selectionManager.refreshSelection).toHaveBeenCalledTimes(1);
     });
 
-    // TODO(@ai-review): Confirm this test continues to model SnapshotService's synchronous changeset replay boundary.
     it('coalesces synchronous changeset mutations into one document render', async () => {
         const { commandCallbacks, pageLayoutService, selectionManager, skeletonManager } = createControllerFixture();
         const mutation = {

--- a/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/doc.render-controller.ts
@@ -233,7 +233,6 @@ export class DocRenderController extends RxDisposable implements IRenderModule {
                 return;
             }
 
-            // TODO(@ai-review): Verify this coalescing remains correct if changeset replay later yields between mutations.
             if (options?.fromChangeset) {
                 this._scheduleChangesetRender();
                 return;


### PR DESCRIPTION
## Summary

- remove three resolved `TODO(@ai-review)` annotations left by the merged Docs changeset rendering optimization
- keep the implementation and regression coverage unchanged
- include no Pro submodule, demo, asset, image, documentation, or generated-file changes

## Scope and architecture

The scope is limited to removing review-process markers from `docs-ui` and `docs-drawing-ui`. There is no behavior, command, mutation, Facade, dependency, package boundary, or long-term architecture change.

## Validation

- `@univerjs/docs-ui` targeted test: 8 passed
- `@univerjs/docs-drawing-ui` targeted test: 11 passed
- typecheck for `@univerjs/docs-ui` and `@univerjs/docs-drawing-ui`
- focused ESLint: 0 errors (existing function-length warnings only)
- `git diff --check`

## Pull Request Checklist

- [x] No related issue.
- [x] Naming convention is followed.
- [x] Existing focused regression coverage remains unchanged and passes.
- [x] No breaking changes are introduced.
