### PR TITLE
feat(ui): add themed hover track border

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -162,6 +162,7 @@ export { type IDialogPartMethodOptions } from './views/components/dialog-part/in
 export { FloatDomSingle } from './views/components/dom/FloatDom';
 export { FloatDom } from './views/components/dom/FloatDom';
 export { PrintFloatDomSingle } from './views/components/dom/Print';
+export { HOVER_TRACK_HOST_CLASS_NAME, HoverTrack } from './views/components/hover-track/HoverTrack';
 export { CanvasPopup, SingleCanvasPopup } from './views/components/popup/CanvasPopup';
 export { RectPopup } from './views/components/popup/RectPopup';
 export type { RectPopupDirection } from './views/components/popup/RectPopup';

--- a/packages/ui/src/views/components/hover-track/HoverTrack.tsx
+++ b/packages/ui/src/views/components/hover-track/HoverTrack.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CSSProperties } from 'react';
+import { clsx } from '@univerjs/design';
+
+export const HOVER_TRACK_HOST_CLASS_NAME = 'univer-group/hover-track';
+
+const HOVER_TRACK_MASK = 'linear-gradient(currentColor 0 0) content-box, linear-gradient(currentColor 0 0)';
+const HOVER_TRACK_MASK_STYLE: CSSProperties = {
+    WebkitMask: HOVER_TRACK_MASK,
+    WebkitMaskComposite: 'xor',
+    mask: HOVER_TRACK_MASK,
+    maskComposite: 'exclude',
+};
+
+export function HoverTrack(props: { className?: string }) {
+    return (
+        <span
+            aria-hidden="true"
+            className={clsx(
+                `
+                  univer-pointer-events-none univer-absolute univer-inset-0 univer-box-border univer-overflow-hidden
+                  univer-rounded-[inherit] univer-p-px univer-opacity-0 univer-transition-opacity univer-duration-150
+                  group-hover/hover-track:univer-opacity-100
+                `,
+                props.className
+            )}
+            data-u-comp="hover-track"
+            style={HOVER_TRACK_MASK_STYLE}
+        >
+            <span
+                className="
+                  univer-absolute -univer-inset-full
+                  univer-bg-[conic-gradient(from_0deg,transparent_0deg,transparent_282deg,var(--univer-primary-700)_318deg,var(--univer-primary-500)_342deg,transparent_360deg)]
+                  motion-safe:group-hover/hover-track:univer-animate-[spin_5s_linear_infinite]
+                  motion-reduce:univer-bg-primary-700
+                  dark:univer-bg-[conic-gradient(from_0deg,transparent_0deg,transparent_282deg,var(--univer-primary-300)_318deg,var(--univer-primary-500)_342deg,transparent_360deg)]
+                  dark:motion-reduce:univer-bg-primary-300
+                "
+            />
+        </span>
+    );
+}


### PR DESCRIPTION
## Summary

- Add a reusable HoverTrack decoration to @univerjs/ui.
- Use Univer primary theme variables for light and dark modes.
- Keep the decoration pointer-transparent and provide a static reduced-motion fallback.
- Expose only the owned UI component and its host marker; no proxy barrel or dependency change is introduced.

## Validation

- pnpm exec eslint packages/ui/src/index.ts packages/ui/src/views/components/hover-track/HoverTrack.tsx
- pnpm --filter @univerjs/ui typecheck
- pnpm --filter @univerjs/ui test (70 files, 343 tests)
- pnpm --filter @univerjs/ui build:bundle (Chrome 88 target)
- Local browser verification confirmed theme-derived colors, a 5s hover animation, border-only masking, and pointer-events: none.

## Scope

No issue is linked. No docs, images, demo code, generated files, or test-only fixtures are included. No breaking changes or SDK dependency changes are introduced. Architecture documentation is not required because this adds a leaf UI primitive without changing dependency direction or command architecture.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes (not applicable; existing UI regression suite and browser behavior were verified).
- [x] Breaking changes have been documented (no breaking changes introduced).