### PR TITLE
fix(sheets-ui): hide gridlines outside sheets

### DIFF
--- a/packages/sheets-ui/src/menu/__tests__/gridlines.menu.spec.ts
+++ b/packages/sheets-ui/src/menu/__tests__/gridlines.menu.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ICommandService,
+    IContextService,
+    Injector,
+    IUniverInstanceService,
+    UniverInstanceType,
+    UserManagerService,
+} from '@univerjs/core';
+import { of, Subject } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { ToggleGridlinesMenuFactory } from '../gridlines.menu';
+
+function createMenuAccessor(unitType: UniverInstanceType): Injector {
+    return new Injector([
+        [ICommandService, { useValue: {} }],
+        [IUniverInstanceService, {
+            useValue: {
+                focused$: new Subject<string | null>(),
+                getFocusedUnit: () => ({ getUnitId: () => 'unit-1' }),
+                getCurrentUnitOfType: () => null,
+                getCurrentTypeOfUnit$: () => of(null),
+                getUnitType: () => unitType,
+            },
+        }],
+        [UserManagerService, { useValue: { currentUser$: of(null) } }],
+        [IContextService, { useValue: { subscribeContextValue$: () => of(false) } }],
+    ]);
+}
+
+describe('gridlines menu visibility', () => {
+    it.each([
+        [UniverInstanceType.UNIVER_SHEET, false],
+        [UniverInstanceType.UNIVER_SLIDE, true],
+    ])('for focused unit type %s sets hidden to %s', (unitType, expectedHidden) => {
+        const accessor = createMenuAccessor(unitType);
+        const hiddenValues: boolean[] = [];
+        const subscription = ToggleGridlinesMenuFactory(accessor).hidden$?.subscribe((hidden) => hiddenValues.push(hidden));
+
+        expect(hiddenValues).toEqual([expectedHidden]);
+
+        subscription?.unsubscribe();
+        accessor.dispose();
+    });
+});

--- a/packages/sheets-ui/src/menu/gridlines.menu.ts
+++ b/packages/sheets-ui/src/menu/gridlines.menu.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
+import type { IAccessor, Workbook } from '@univerjs/core';
+import type { IMenuButtonItem } from '@univerjs/ui';
 import type { LocaleKey } from '../locale/types';
 import {
     BooleanNumber,
     DisposableCollection,
-    type IAccessor,
     ICommandService,
     IUniverInstanceService,
     UniverInstanceType,
-    type Workbook,
 } from '@univerjs/core';
 import {
     SetWorksheetActiveOperation,
@@ -31,7 +31,7 @@ import {
     WorkbookEditablePermission,
     WorksheetEditPermission,
 } from '@univerjs/sheets';
-import { getMenuHiddenObservable, type IMenuButtonItem, MenuItemType } from '@univerjs/ui';
+import { getMenuHiddenObservable, MenuItemType } from '@univerjs/ui';
 import { Observable } from 'rxjs';
 import { getCurrentRangeDisable$ } from './menu-util';
 

--- a/packages/sheets-ui/src/menu/gridlines.menu.ts
+++ b/packages/sheets-ui/src/menu/gridlines.menu.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import type { IAccessor, Workbook } from '@univerjs/core';
-import type { IMenuButtonItem } from '@univerjs/ui';
 import type { LocaleKey } from '../locale/types';
 import {
     BooleanNumber,
     DisposableCollection,
+    type IAccessor,
     ICommandService,
     IUniverInstanceService,
     UniverInstanceType,
+    type Workbook,
 } from '@univerjs/core';
 import {
     SetWorksheetActiveOperation,
@@ -31,7 +31,7 @@ import {
     WorkbookEditablePermission,
     WorksheetEditPermission,
 } from '@univerjs/sheets';
-import { MenuItemType } from '@univerjs/ui';
+import { getMenuHiddenObservable, type IMenuButtonItem, MenuItemType } from '@univerjs/ui';
 import { Observable } from 'rxjs';
 import { getCurrentRangeDisable$ } from './menu-util';
 
@@ -44,6 +44,7 @@ export function ToggleGridlinesMenuFactory(accessor: IAccessor): IMenuButtonItem
         type: MenuItemType.BUTTON,
         tooltip: 'sheets-ui.toolbar.toggleGridlines',
         icon: 'HideGridlinesIcon',
+        hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_SHEET),
         activated$: new Observable<boolean>((observer) => {
             const getValue = () => {
                 const workbook = instanceService.getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET);


### PR DESCRIPTION
## Summary

- Hide the Sheets gridlines ribbon item whenever the active unit is not a spreadsheet.
- Reuse `getMenuHiddenObservable` and `UniverInstanceType.UNIVER_SHEET` so embed hosts do not need demo-specific filtering.
- Add direct regression coverage for Sheet and Slide host contexts.

## Why

Embed hosts share the menu registry across child products. The gridlines item did not declare its product visibility, so it could leak into non-Sheet ribbons after another embedded product registered its menus.

## Impact

The gridlines command behavior is unchanged inside Sheets. The only behavior change is that the item is hidden outside Sheet contexts.

## Validation

- `vitest run packages/sheets-ui/src/menu/__tests__/gridlines.menu.spec.ts`
- `tsc --noEmit -p packages/sheets-ui/tsconfig.json`
- Repository ESLint rules passed locally for the changed files.
- GitHub Actions `eslint` passed after aligning the type-only imports with the repository convention.
- All five embed-local demos built successfully as part of the paired integration validation.

## Architecture and dependencies

- Architecture documentation: not updated; this is product visibility scoping through the existing menu API and introduces no long-lived structural decision.
- SDK dependency changes: none.
- Requires unpublished SDK behavior: no.
- Related issue: none.

## Pull Request Checklist

- [x] Naming convention followed.
- [x] Unit tests added for the changed behavior.
- [x] No breaking API change.
- [x] No demo code, process artifacts, images, or documentation included.
