### PR TITLE
fix(docs-ui): reset overflow scroll to start

### DIFF
--- a/packages/docs-ui/src/services/__tests__/doc-page-layout.service.spec.ts
+++ b/packages/docs-ui/src/services/__tests__/doc-page-layout.service.spec.ts
@@ -180,7 +180,7 @@ describe('DocPageLayoutService', () => {
         expect(scene.viewport.scrollX).toBe(0);
     });
 
-    it('keeps the page margin and scrolls to the page center when the viewport is narrower than the page', () => {
+    it('keeps the page margin and resets horizontal scroll when the viewport is narrower than the page', () => {
         const { documentComponent, scene, service } = createLayoutService({
             documentWidth: 600,
             documentHeight: 900,
@@ -189,6 +189,7 @@ describe('DocPageLayoutService', () => {
             engineWidth: 500,
             engineHeight: 800,
         });
+        scene.viewport.scrollX = 90;
 
         service.calculatePagePosition();
 
@@ -196,7 +197,7 @@ describe('DocPageLayoutService', () => {
         expect(documentComponent.top).toBe(20);
         expect(scene.width).toBe(680);
         expect(scene.height).toBe(940);
-        expect(scene.viewport.scrollX).toBe(90);
+        expect(scene.viewport.scrollX).toBe(0);
     });
 
     it('uses fit-width start alignment padding instead of centering the page', () => {

--- a/packages/docs-ui/src/services/doc-page-layout.service.ts
+++ b/packages/docs-ui/src/services/doc-page-layout.service.ts
@@ -70,7 +70,7 @@ export class DocPageLayoutService extends Disposable implements IRenderModule {
             docsLeft = horizontalMargin;
             sceneWidth = docsWidth + horizontalMargin * 2;
 
-            scrollToX = isStartAlignedFit ? 0 : (sceneWidth - engineWidth / viewScale) / 2;
+            scrollToX = 0;
         }
 
         if (engineHeight > docsHeight) {


### PR DESCRIPTION
## Summary

- Keep document pages centered while they fit within the canvas.
- Reset horizontal scrolling to the start when a page overflows the canvas instead of automatically centering the overflow.
- Preserve the existing page margin and shared behavior for classic and modern documents.

## Test plan

- [x] `pnpm exec vitest run src/services/__tests__/doc-page-layout.service.spec.ts` (5 tests passed)
- [x] `pnpm --filter @univerjs/docs-ui typecheck`
- [x] `pnpm exec eslint packages/docs-ui/src/services/doc-page-layout.service.ts packages/docs-ui/src/services/__tests__/doc-page-layout.service.spec.ts`
- [x] `git diff --check`

## Pull Request Checklist

- [x] Related tickets or issues are missing for this change.
- [x] Naming conventions are followed.
- [x] A regression test covers resetting a non-zero horizontal scroll position.
- [x] No breaking changes are introduced.
