### PR TITLE
fix(engine-formula): resolve cross-unit table references

### DIFF
--- a/packages/engine-formula/src/basics/__tests__/regex.spec.ts
+++ b/packages/engine-formula/src/basics/__tests__/regex.spec.ts
@@ -80,6 +80,7 @@ describe('Test ref regex', () => {
         expect(regexTestSingeRange('[1]Sheet1!A1')).toBe(true);
         expect(new RegExp(REFERENCE_TABLE_SINGLE_COLUMN_REGEX).test('[Book]Sheet1!A1')).toBe(false);
         expect(new RegExp(REFERENCE_TABLE_SINGLE_COLUMN_REGEX).test('[1]!SalesTable[Amount]')).toBe(true);
+        expect(new RegExp(REFERENCE_TABLE_SINGLE_COLUMN_REGEX).test('[Urban Nomad | Showcase]!Inventory[Safety stock]')).toBe(true);
         expect(new RegExp(REFERENCE_TABLE_SINGLE_COLUMN_REGEX).test('Sales.xlsx!SalesTable[Amount]')).toBe(true);
     });
 

--- a/packages/engine-formula/src/basics/regex.ts
+++ b/packages/engine-formula/src/basics/regex.ts
@@ -72,7 +72,10 @@ const TABLE_MULTIPLE_COLUMN_REGEX = `${TABLE_CONTENT_REGEX}${RANGE_SYMBOL}${TABL
 
 // Display formulas use Book!Table[Column], OOXML formulas use [n]!Table[Column],
 // and the legacy runtime-id form [unitId]Table[Column] remains accepted.
-const TABLE_UNIT_QUALIFIER_REGEX = `(?:(?:${UNIT_NAME_REGEX}|'(?:[^']|'')+'|[^\\s!\\[\\]]+)!)?(?:${UNIT_NAME_REGEX})?`;
+// Product Unit display names have their own character semantics. Base names may contain
+// characters such as `|` while still being wrapped by `[...]!`.
+const TABLE_DISPLAY_UNIT_QUALIFIER_REGEX = '\\[([^\\[\\]]+)\\]';
+const TABLE_UNIT_QUALIFIER_REGEX = `(?:(?:${TABLE_DISPLAY_UNIT_QUALIFIER_REGEX}|'(?:[^']|'')+'|[^\\s!\\[\\]]+)!)?(?:${UNIT_NAME_REGEX})?`;
 
 export const REFERENCE_TABLE_ALL_COLUMN_REGEX = `^${TABLE_UNIT_QUALIFIER_REGEX}${TABLE_NAME_REGEX}$`;
 

--- a/packages/engine-formula/src/engine/reference-object/__tests__/cell-reference-object.spec.ts
+++ b/packages/engine-formula/src/engine/reference-object/__tests__/cell-reference-object.spec.ts
@@ -20,6 +20,15 @@ import { CellReferenceObject } from '../cell-reference-object';
 import { RangeReferenceObject } from '../range-reference-object';
 
 describe('CellReferenceObject', () => {
+    it('preserves a directly assigned sheet ID when no sheet name needs resolution', () => {
+        const reference = new CellReferenceObject('A1');
+        reference.setForcedSheetIdDirect('base-table-id');
+
+        reference.setForcedSheetId({});
+
+        expect(reference.getForcedSheetId()).toBe('base-table-id');
+    });
+
     it('should allow blank cells inside the Excel grid even when they are outside snapshot row data', () => {
         const reference = new CellReferenceObject('Sheet2!A151');
 

--- a/packages/engine-formula/src/engine/reference-object/base-reference-object.ts
+++ b/packages/engine-formula/src/engine/reference-object/base-reference-object.ts
@@ -268,6 +268,9 @@ export class BaseReferenceObject extends ObjectClassType {
     }
 
     setForcedSheetId(sheetNameMap: IUnitSheetNameMap) {
+        if (!this._forcedSheetName) {
+            return;
+        }
         this._forcedSheetId = sheetNameMap[this.getUnitId()]?.[this._forcedSheetName];
     }
 


### PR DESCRIPTION
## Why

Cross-Unit Base table references failed in two consecutive ownership boundaries:

1. Product Unit display names may contain `|`, while the table-reference matcher reused the stricter Excel workbook-name character set. `[Urban Nomad | Showcase]!Table[Column]` was therefore not recognized and evaluated to `#NAME?`.
2. `INDEX` materializes a table-column item as a cell reference with a direct Base table ID. `FunctionNode` then calls `setForcedSheetId()`; the method resolved an empty sheet name and cleared that direct table ID. Non-Base hosts subsequently read the current Doc/Slide subUnit and returned an empty value.

Related to dream-num/univer-pro#5495.

## Correctness

- Parse bracketed product display Unit qualifiers with Unit-name semantics while preserving OOXML `[n]!Table[Column]`, quoted, unquoted, and legacy runtime-ID forms.
- Resolve a forced sheet name only when one exists, preserving a directly assigned sheet/table ID.
- Cover both boundaries with focused matcher and reference-object regressions.

## Long-term correctness

The parser owns textual Unit qualifier recognition. `BaseReferenceObject` owns the distinction between a sheet name that still needs resolution and a direct sheet/table ID that is already resolved. The fix applies once in these shared boundaries for Sheet formulas and non-Sheet other formulas.

## Validation

- `vitest run packages/engine-formula/src/basics/__tests__/regex.spec.ts packages/engine-formula/src/engine/reference-object/__tests__/cell-reference-object.spec.ts`: 83 passed.
- `pnpm --filter @univerjs/engine-formula typecheck`: passed.
- Pro integration: 84 `CalculateFormulaProService` tests passed, including the original `INDEX` + `MATCH` Shape/other-formula structure; expected result `8`.