### PR TITLE
docs(core): define Base table name constraints

### DIFF
--- a/packages/core/src/bases/typedef.ts
+++ b/packages/core/src/bases/typedef.ts
@@ -315,7 +315,11 @@ export interface IBaseSnapshot {
 
 export interface ITableSnapshot {
     id: TableId;
-    /** Human-readable display name. Do not use it as a structured-reference identifier. */
+    /**
+     * Human-readable display name, subject to Excel worksheet name rules because
+     * each Base table is exported as a worksheet. Names must be unique within the
+     * Base, ignoring case. Do not use this value as a structured-reference identifier.
+     */
     name: string;
     /**
      * Persisted stable identifier used by formulas and exported structured references.

--- a/packages/core/src/bases/typedef.ts
+++ b/packages/core/src/bases/typedef.ts
@@ -315,8 +315,14 @@ export interface IBaseSnapshot {
 
 export interface ITableSnapshot {
     id: TableId;
+    /** Human-readable display name. Do not use it as a structured-reference identifier. */
     name: string;
-    /** Stable canonical name used by formulas and exported structured references. */
+    /**
+     * Persisted stable identifier used by formulas and exported structured references.
+     *
+     * Historical snapshots may omit this field. Use `getBaseFormulaTableName()` when a
+     * resolved formula identifier is required.
+     */
     formulaName?: string;
     fields: Record<FieldId, IFieldSnapshot>;
     fieldOrder: FieldId[];


### PR DESCRIPTION
## Summary

- clarify that Base table display names follow Excel worksheet name rules because each table is exported as a worksheet
- document case-insensitive uniqueness within a Base
- keep `formulaName` documented as the persisted structured-reference identifier
- direct historical snapshot consumers to `getBaseFormulaTableName()`

## Why

Base snapshots expose both a display name and a stable formula identifier. The display name is not unrestricted: exporting a Base maps each table to an Excel worksheet, so `table.name` must satisfy the worksheet naming contract. `formulaName` remains the value used for structured references.

## Validation

- `pnpm --filter @univerjs/core typecheck`
- `pnpm exec eslint packages/core/src/bases/typedef.ts`
- `git diff --check`
- pre-commit ESLint hook

No runtime behavior changed in this OSS PR, so no new test was added.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes (not applicable: type documentation only).
- [x] No breaking changes are introduced.