### PR TITLE
fix(formula): preserve external table references

### DIFF
--- a/packages/engine-formula/src/basics/__tests__/regex.spec.ts
+++ b/packages/engine-formula/src/basics/__tests__/regex.spec.ts
@@ -83,6 +83,13 @@ describe('Test ref regex', () => {
         expect(new RegExp(REFERENCE_TABLE_SINGLE_COLUMN_REGEX).test('Sales.xlsx!SalesTable[Amount]')).toBe(true);
     });
 
+    it('accepts escaped Univer display names as Table qualifiers', () => {
+        const regex = new RegExp(REFERENCE_TABLE_SINGLE_COLUMN_REGEX);
+
+        expect(regex.test('[Urban Nomad retail operations hub | Official showcase]!Inventory[Safety stock]')).toBe(true);
+        expect(regex.test('[Base name with ]] bracket]!Inventory[Safety stock]')).toBe(true);
+    });
+
     it('isReferenceString', () => {
         expect(isReferenceString('A1')).toBeTruthy();
         expect(isReferenceString('Sheet1!A1')).toBeTruthy();

--- a/packages/engine-formula/src/basics/regex.ts
+++ b/packages/engine-formula/src/basics/regex.ts
@@ -72,7 +72,10 @@ const TABLE_MULTIPLE_COLUMN_REGEX = `${TABLE_CONTENT_REGEX}${RANGE_SYMBOL}${TABL
 
 // Display formulas use Book!Table[Column], OOXML formulas use [n]!Table[Column],
 // and the legacy runtime-id form [unitId]Table[Column] remains accepted.
-const TABLE_UNIT_QUALIFIER_REGEX = `(?:(?:${UNIT_NAME_REGEX}|'(?:[^']|'')+'|[^\\s!\\[\\]]+)!)?(?:${UNIT_NAME_REGEX})?`;
+// Univer display names are not Excel file names: characters such as `|` are valid,
+// and `]` is escaped as `]]` by the Formula reference builder.
+const TABLE_BRACKETED_UNIT_QUALIFIER_REGEX = '\\[(?:[^\\]]|\\]\\])+\\]';
+const TABLE_UNIT_QUALIFIER_REGEX = `(?:(?:${TABLE_BRACKETED_UNIT_QUALIFIER_REGEX}|'(?:[^']|'')+'|[^\\s!\\[\\]]+)!)?(?:${TABLE_BRACKETED_UNIT_QUALIFIER_REGEX})?`;
 
 export const REFERENCE_TABLE_ALL_COLUMN_REGEX = `^${TABLE_UNIT_QUALIFIER_REGEX}${TABLE_NAME_REGEX}$`;
 

--- a/packages/engine-formula/src/engine/analysis/__tests__/parser.spec.ts
+++ b/packages/engine-formula/src/engine/analysis/__tests__/parser.spec.ts
@@ -16,6 +16,7 @@
 
 import type { Injector } from '@univerjs/core';
 import type { BaseAstNode } from '../../ast-node/base-ast-node';
+import type { BaseReferenceObject } from '../../reference-object/base-reference-object';
 import type { ArrayValueObject } from '../../value-object/array-value-object';
 import type { BaseValueObject } from '../../value-object/base-value-object';
 import type { LexerNode } from '../lexer-node';
@@ -31,6 +32,7 @@ import { Or } from '../../../functions/logical/or';
 import { Percentof } from '../../../functions/logical/percentof';
 import { FUNCTION_NAMES_LOOKUP } from '../../../functions/lookup/function-names';
 import { Hstack } from '../../../functions/lookup/hstack';
+import { Index } from '../../../functions/lookup/index';
 import { Indirect } from '../../../functions/lookup/indirect';
 import { Offset } from '../../../functions/lookup/offset';
 import { FUNCTION_NAMES_MATH } from '../../../functions/math/function-names';
@@ -166,6 +168,7 @@ describe('Test indirect', () => {
             new StdevP(FUNCTION_NAMES_STATISTICAL.STDEV_P),
             new Regexmatch(FUNCTION_NAMES_TEXT.REGEXMATCH),
             new Hstack(FUNCTION_NAMES_LOOKUP.HSTACK),
+            new Index(FUNCTION_NAMES_LOOKUP.INDEX),
             new Indirect(FUNCTION_NAMES_LOOKUP.INDIRECT),
             new Offset(FUNCTION_NAMES_LOOKUP.OFFSET),
             new Groupby(FUNCTION_NAMES_LOGICAL.GROUPBY),
@@ -311,6 +314,28 @@ describe('Test indirect', () => {
             const sectionAstNode = astTreeBuilder.parse(sectionLexerNode as LexerNode);
             const sectionResult = interpreter.execute(generateExecuteAstNodeData(sectionAstNode as BaseAstNode));
             expect((sectionResult as BaseValueObject).getValue()).toBe(30);
+        });
+
+        it('keeps external Table source data when INDEX returns a selected cell reference', () => {
+            const lexerNode = lexer.treeBuilder('=INDEX(Sales.xlsx!SalesTable[Amount],1)');
+            const astNode = astTreeBuilder.parse(lexerNode as LexerNode);
+            const result = interpreter.execute(generateExecuteAstNodeData(astNode as BaseAstNode));
+
+            const reference = result as BaseReferenceObject;
+            expect({
+                unitId: reference.getUnitId(),
+                sheetId: reference.getSheetId(),
+                forcedUnitId: reference.getForcedUnitId(),
+                forcedSheetId: reference.getForcedSheetId(),
+                forcedSheetName: reference.getForcedSheetName(),
+            }).toEqual({
+                unitId: 'sales-source',
+                sheetId: 'source-sheet',
+                forcedUnitId: 'sales-source',
+                forcedSheetId: 'source-sheet',
+                forcedSheetName: '',
+            });
+            expect(reference.getCellByPosition().getValue()).toBe(10);
         });
 
         it('stores the resolved source Unit in external Table dependency ranges', async () => {

--- a/packages/engine-formula/src/engine/reference-object/base-reference-object.ts
+++ b/packages/engine-formula/src/engine/reference-object/base-reference-object.ts
@@ -268,6 +268,9 @@ export class BaseReferenceObject extends ObjectClassType {
     }
 
     setForcedSheetId(sheetNameMap: IUnitSheetNameMap) {
+        if (!this._forcedSheetName) {
+            return;
+        }
         this._forcedSheetId = sheetNameMap[this.getUnitId()]?.[this._forcedSheetName];
     }
 

--- a/packages/engine-formula/src/engine/utils/__tests__/reference.spec.ts
+++ b/packages/engine-formula/src/engine/utils/__tests__/reference.spec.ts
@@ -56,6 +56,16 @@ describe('Test Reference', () => {
             tableName: 'SalesTable',
             columnStruct: '[Amount]',
         });
+        expect(splitTableStructuredRef('[Urban Nomad | Official showcase]!Inventory[Safety stock]')).toEqual({
+            unitQualifier: 'Urban Nomad | Official showcase',
+            tableName: 'Inventory',
+            columnStruct: '[Safety stock]',
+        });
+        expect(splitTableStructuredRef('[Base name with ]] bracket]!Inventory[Safety stock]')).toEqual({
+            unitQualifier: 'Base name with ] bracket',
+            tableName: 'Inventory',
+            columnStruct: '[Safety stock]',
+        });
     });
 
     it('getAbsoluteRefTypeWithSingleString', () => {

--- a/packages/engine-formula/src/engine/utils/__tests__/reference.spec.ts
+++ b/packages/engine-formula/src/engine/utils/__tests__/reference.spec.ts
@@ -66,6 +66,11 @@ describe('Test Reference', () => {
             tableName: 'Inventory',
             columnStruct: '[Safety stock]',
         });
+        expect(splitTableStructuredRef("'Base name with ]] bracket'!Inventory[Safety stock]")).toEqual({
+            unitQualifier: 'Base name with ]] bracket',
+            tableName: 'Inventory',
+            columnStruct: '[Safety stock]',
+        });
     });
 
     it('getAbsoluteRefTypeWithSingleString', () => {

--- a/packages/engine-formula/src/engine/utils/reference.ts
+++ b/packages/engine-formula/src/engine/utils/reference.ts
@@ -501,6 +501,10 @@ export function splitTableStructuredRef(ref: string) {
         } else if (!quoteOpen && char === '[') {
             bracketDepth++;
         } else if (!quoteOpen && char === ']') {
+            if (bracketDepth > 0 && tableRef[i + 1] === ']') {
+                i++;
+                continue;
+            }
             bracketDepth--;
         } else if (!quoteOpen && bracketDepth === 0 && char === '!') {
             qualifierEnd = i;
@@ -517,6 +521,7 @@ export function splitTableStructuredRef(ref: string) {
         if (unitQualifier.startsWith('[') && unitQualifier.endsWith(']')) {
             unitQualifier = unitQualifier.slice(1, -1);
         }
+        unitQualifier = unitQualifier.replaceAll(']]', ']');
         unitQualifier = unquoteSheetName(unitQualifier);
     } else if (tableRef.startsWith('[')) {
         const legacyQualifierEnd = tableRef.indexOf(']');

--- a/packages/engine-formula/src/engine/utils/reference.ts
+++ b/packages/engine-formula/src/engine/utils/reference.ts
@@ -515,13 +515,13 @@ export function splitTableStructuredRef(ref: string) {
     if (qualifierEnd >= 0) {
         unitQualifier = tableRef.slice(0, qualifierEnd).trim();
         tableRef = tableRef.slice(qualifierEnd + 1);
-        if (unitQualifier.startsWith("'") && unitQualifier.endsWith("'")) {
+        const isQuotedQualifier = unitQualifier.startsWith("'") && unitQualifier.endsWith("'");
+        const isBracketedQualifier = !isQuotedQualifier && unitQualifier.startsWith('[') && unitQualifier.endsWith(']');
+        if (isQuotedQualifier) {
             unitQualifier = unitQualifier.slice(1, -1);
+        } else if (isBracketedQualifier) {
+            unitQualifier = unitQualifier.slice(1, -1).replaceAll(']]', ']');
         }
-        if (unitQualifier.startsWith('[') && unitQualifier.endsWith(']')) {
-            unitQualifier = unitQualifier.slice(1, -1);
-        }
-        unitQualifier = unitQualifier.replaceAll(']]', ']');
         unitQualifier = unquoteSheetName(unitQualifier);
     } else if (tableRef.startsWith('[')) {
         const legacyQualifierEnd = tableRef.indexOf(']');


### PR DESCRIPTION
## Summary

- parse bracketed external Table qualifiers that contain `|` or escaped closing brackets
- preserve an already resolved sheet id when a function such as `INDEX` returns a derived reference
- cover external structured references and `INDEX` value selection with regression tests

## Validation

- `pnpm --filter @univerjs/engine-formula test` (562 files, 4108 tests)
- `pnpm --filter @univerjs/engine-formula typecheck`
- `pnpm --filter @univerjs/engine-formula build`
- locally validated the original Base Formula Shape sample through Univer CLI Viewer: result `8 units below safety`, calculated and non-stale on cold start

## Dependencies and rollout

This PR changes the OSS SDK formula engine. The Univer Pro Formula Shape materialization PR and the Univer CLI Base ResourceRef provider PR rely on this behavior, so this PR must be merged and released before those consumers update their pinned SDK artifacts.

No breaking changes are introduced. No architecture documentation is needed because this aligns existing external-reference parsing and reference identity behavior.

## Pull Request Checklist

- [x] No related issue is currently linked.
- [x] Naming convention is followed.
- [x] Unit tests have been added.
- [x] No breaking changes are introduced.
