### PR TITLE
Forward ribbon layout to custom components

### DIFF
--- a/packages/ui/src/views/components/ribbon/ToolbarItem.tsx
+++ b/packages/ui/src/views/components/ribbon/ToolbarItem.tsx
@@ -203,6 +203,7 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IToolbarItemProps>((pr
 
     const { tooltip, shortcut, icon, title, label, id, commandId, type, slot, params, grid, large, showLabel, iconSize, iconColor, fullWidth } = props;
     const gridLabel = title ?? tooltip;
+    const ribbonLayout = grid ? 'grid' : 'toolbar';
 
     const shortcutDisplay = useToolbarShortcutDisplay({ id, commandId, shortcut });
     let tooltipTitle = tooltip ? localeService.t(tooltip) : '';
@@ -288,6 +289,7 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IToolbarItemProps>((pr
                         <CustomLabel
                             icon={iconToDisplay}
                             iconSize={iconSize}
+                            ribbonLayout={ribbonLayout}
                             title={titleToDisplay}
                             value={iconColor ?? value}
                             label={label}
@@ -337,7 +339,7 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IToolbarItemProps>((pr
                         {grid && large
                             ? (
                                 <>
-                                    <CustomLabel icon={iconToDisplay} iconSize={iconSize} />
+                                    <CustomLabel icon={iconToDisplay} iconSize={iconSize} ribbonLayout={ribbonLayout} />
                                     <div
                                         className={clsx(
                                             toolbarSelectorTriggerVariants({ disabled }),
@@ -345,6 +347,7 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IToolbarItemProps>((pr
                                         )}
                                     >
                                         <CustomLabel
+                                            ribbonLayout={ribbonLayout}
                                             title={titleToDisplay}
                                             value={value}
                                             label={label}
@@ -359,6 +362,7 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IToolbarItemProps>((pr
                                     <CustomLabel
                                         icon={iconToDisplay}
                                         iconSize={iconSize}
+                                        ribbonLayout={ribbonLayout}
                                         title={titleToDisplay}
                                         value={value}
                                         label={label}
@@ -414,6 +418,7 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IToolbarItemProps>((pr
                 >
                     <CustomLabel
                         className={grid && fullWidth ? '!univer-w-full' : undefined}
+                        ribbonLayout={ribbonLayout}
                         title={grid && showLabel ? gridLabel! : title!}
                         value={value}
                         label={label}
@@ -437,8 +442,8 @@ export const ToolbarItem = forwardRef<ITooltipWrapperRef, IToolbarItemProps>((pr
                 onDoubleClick={() => props.subId && executeCommand(props.subId)}
             >
                 {icon
-                    ? <CustomLabel icon={icon} iconSize={iconSize} title={grid && (large || showLabel) ? gridLabel : undefined} />
-                    : <CustomLabel title={title!} />}
+                    ? <CustomLabel icon={icon} iconSize={iconSize} ribbonLayout={ribbonLayout} title={grid && (large || showLabel) ? gridLabel : undefined} />
+                    : <CustomLabel ribbonLayout={ribbonLayout} title={title!} />}
             </ToolbarButton>
         );
     }

--- a/packages/ui/src/views/components/ribbon/__tests__/ToolbarItem.spec.tsx
+++ b/packages/ui/src/views/components/ribbon/__tests__/ToolbarItem.spec.tsx
@@ -77,8 +77,8 @@ function renderWithDependencies(element: ReactElement) {
     injector.add([ILogService, { useClass: TestLogService as never }]);
     injector.add([ComponentManager]);
     injector.add([IconManager]);
-    injector.get(ComponentManager).register('TestDynamicOption', ({ onChange, className }: { onChange: (value: string) => void; className?: string }) => (
-        <button type="button" className={className} onClick={() => onChange('dynamic-value')}>Choose dynamic value</button>
+    injector.get(ComponentManager).register('TestDynamicOption', ({ onChange, className, ribbonLayout }: { onChange: (value: string) => void; className?: string; ribbonLayout?: string }) => (
+        <button type="button" className={className} data-ribbon-layout={ribbonLayout} onClick={() => onChange('dynamic-value')}>Choose dynamic value</button>
     ));
 
     injector.get(IconManager).register({
@@ -195,7 +195,20 @@ describe('ToolbarItem', () => {
         );
 
         expect(container.querySelector('[data-u-command="test-custom-button"]')).toBeTruthy();
+        expect(container.querySelector('[data-ribbon-layout="grid"]')).toBeTruthy();
         expect(container.querySelector('button button')).toBeNull();
+    });
+
+    it('reports the toolbar layout to a regular custom button label', () => {
+        const { container } = renderWithDependencies(
+            <ToolbarItem
+                id="test-custom-button"
+                type={MenuItemType.BUTTON}
+                label={{ name: 'TestDynamicOption' }}
+            />
+        );
+
+        expect(container.querySelector('[data-ribbon-layout="toolbar"]')).toBeTruthy();
     });
 
     it('applies a configured Grid icon size', () => {

--- a/packages/ui/src/views/custom-label/CustomLabel.tsx
+++ b/packages/ui/src/views/custom-label/CustomLabel.tsx
@@ -23,10 +23,14 @@ import { isObservable } from 'rxjs';
 import { ComponentManager, IconManager } from '../../common';
 import { useDependency, useObservable } from '../../utils/di';
 
+export type RibbonCustomLayout = 'toolbar' | 'grid';
+
 export type ICustomLabelProps<T = undefined> = {
     className?: string;
 
     iconSize?: number;
+
+    ribbonLayout?: RibbonCustomLayout;
 
     value?: string | number | undefined;
 


### PR DESCRIPTION
﻿## Summary

- expose the active ribbon layout to registered custom label components
- forward `toolbar` for the classic ribbon and `grid` for the grid ribbon across button and selector render paths
- add regression coverage for both layouts

## Root cause

Custom ribbon components were rendered through `CustomLabel` without receiving the layout selected by `ToolbarItem`. Components that support both ribbon modes therefore had no host-level layout contract.

## Validation

- `vitest run src/views/components/ribbon/__tests__/ToolbarItem.spec.tsx` (15 tests passed)
- `git diff --check`
- Full UI test attempt: 67 files / 317 tests passed; 4 unrelated suites were blocked because generated emoji source files are not present in the clean worktree
- UI typecheck was likewise blocked only by those missing generated emoji source files

## Impact

This is an additive prop contract for custom labels. Existing components remain compatible because `ribbonLayout` is optional.

No SDK dependency changes. No behavior outside the currently pinned repository sources is required.

No architecture documentation update is needed because this is a local UI rendering contract, not a long-lived architecture change.

## Pull Request Checklist

- [x] Missing issue; this PR is linked from the dependent Univer Pro PR.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
