### PR TITLE
fix(docs-ui): preserve footer height with statistics

### DIFF
--- a/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
@@ -129,7 +129,7 @@ export function DocStatistics() {
                     noIcon
                     active={open}
                     className={`
-                      !univer-h-7 univer-px-2 univer-text-xs !univer-text-gray-600
+                      !univer-h-6 univer-px-2 univer-text-xs !univer-text-gray-600
                       focus-visible:univer-ring-2 focus-visible:univer-ring-primary-500
                       dark:!univer-text-gray-300
                     `}


### PR DESCRIPTION
## What changed

- align the document statistics button height with the existing document footer controls
- preserve the document workspace height when word count is enabled

## Why

The new statistics button used a 28px fixed height while the existing footer was 24px tall. This increased the footer height by 4px and reduced the document workspace, causing all Pro document text-layout snapshots to change from 559px to 555px.

## Validation

- `pnpm exec eslint packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx`
- `pnpm --filter @univerjs/docs-ui typecheck`
- local Playwright rendering restored the 4px workspace height without updating snapshot images
- `git diff --check`

The existing `DocStatistics.spec.tsx` tests currently fail on `dev` before reaching assertions because the component does not mount in the standalone test setup; this change does not affect that behavior.
