### PR TITLE
fix(docs-ui): preserve header footer overlay color

### DIFF
--- a/packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts
+++ b/packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts
@@ -20,7 +20,6 @@ import {
     Injector,
     IUniverInstanceService,
     LocaleService,
-    ThemeService,
 } from '@univerjs/core';
 import { DocSkeletonManagerService, RichTextEditingMutation } from '@univerjs/docs';
 import { DocumentEditArea, IRenderManagerService, Path, Rect } from '@univerjs/engine-render';
@@ -125,7 +124,6 @@ function createController(options: {
         [LocaleService, { useValue: {
             t: vi.fn((key: string) => key),
         } }],
-        [ThemeService],
     ]);
     const controller = injector.createInstance(DocHeaderFooterController, context);
 
@@ -174,8 +172,16 @@ describe('DocHeaderFooterController', () => {
 
         expect(ctx.translate).toHaveBeenCalledWith(11.5, 23.5);
         expect(rectSpy).toHaveBeenCalledTimes(2);
-        expect(rectSpy.mock.calls[0][1]).toMatchObject({ width: 200, height: 30 });
-        expect(rectSpy.mock.calls[1][1]).toMatchObject({ width: 200, height: 40 });
+        expect(rectSpy.mock.calls[0][1]).toMatchObject({
+            width: 200,
+            height: 30,
+            fill: 'alpha(white, 0.5)',
+        });
+        expect(rectSpy.mock.calls[1][1]).toMatchObject({
+            width: 200,
+            height: 40,
+            fill: 'alpha(white, 0.5)',
+        });
         expect(pathSpy).not.toHaveBeenCalled();
         expect(textSpy).not.toHaveBeenCalled();
 
@@ -207,8 +213,15 @@ describe('DocHeaderFooterController', () => {
             height: 230,
         }));
         expect(pathSpy).toHaveBeenCalledTimes(2);
-        expect(textSpy).toHaveBeenCalledWith(ctx, expect.objectContaining({ text: 'docs-ui.headerFooter.header' }));
-        expect(textSpy).toHaveBeenCalledWith(ctx, expect.objectContaining({ text: 'docs-ui.headerFooter.footer' }));
+        expect(pathSpy).toHaveBeenCalledWith(ctx, expect.objectContaining({ stroke: 'primary.600' }));
+        expect(textSpy).toHaveBeenCalledWith(ctx, expect.objectContaining({
+            text: 'docs-ui.headerFooter.header',
+            color: 'alpha(primary.600, 0.08)',
+        }));
+        expect(textSpy).toHaveBeenCalledWith(ctx, expect.objectContaining({
+            text: 'docs-ui.headerFooter.footer',
+            color: 'alpha(primary.600, 0.08)',
+        }));
 
         controller.dispose();
     });

--- a/packages/docs-ui/src/controllers/doc-header-footer.controller.ts
+++ b/packages/docs-ui/src/controllers/doc-header-footer.controller.ts
@@ -30,7 +30,6 @@ import type {
 import type { LocaleKey } from '../locale/types';
 import {
     BooleanNumber,
-    ColorKit,
     Disposable,
     DocumentFlavor,
     generateRandomId,
@@ -38,7 +37,6 @@ import {
     Inject,
     IUniverInstanceService,
     LocaleService,
-    ThemeService,
     toDisposable,
     UniverInstanceType,
 } from '@univerjs/core';
@@ -51,8 +49,9 @@ import { DocSelectionRenderService } from '../services/selection/doc-selection-r
 import { getDocPageSectionContext } from '../utils/section-header-footer';
 import { TextBubbleShape } from '../views/header-footer/text-bubble';
 
-const HEADER_FOOTER_COVER_ALPHA = 0.5;
-const HEADER_FOOTER_LABEL_ALPHA = 0.08;
+const HEADER_FOOTER_COVER_COLOR = 'alpha(white, 0.5)';
+const HEADER_FOOTER_STROKE_COLOR = 'primary.600';
+const HEADER_FOOTER_LABEL_COLOR = 'alpha(primary.600, 0.08)';
 
 interface IHeaderFooterCreate {
     createType: Nullable<HeaderFooterType>;
@@ -124,8 +123,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
         @IRenderManagerService private readonly _renderManagerService: IRenderManagerService,
         @Inject(DocSkeletonManagerService) private readonly _docSkeletonManagerService: DocSkeletonManagerService,
         @Inject(DocSelectionRenderService) private readonly _docSelectionRenderService: DocSelectionRenderService,
-        @Inject(LocaleService) private readonly _localeService: LocaleService,
-        @Inject(ThemeService) private readonly _themeService: ThemeService
+        @Inject(LocaleService) private readonly _localeService: LocaleService
     ) {
         super();
 
@@ -324,13 +322,6 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                         const isEditBody = editArea === DocumentEditArea.BODY;
                         const { page, pageLeft, pageTop, ctx } = config;
                         const { pageWidth, pageHeight, marginTop, marginBottom } = page;
-                        const primaryColor = this._themeService.getColorFromTheme('primary.600');
-                        const coverColor = new ColorKit(this._themeService.getColorFromTheme('gray.50'))
-                            .setAlpha(HEADER_FOOTER_COVER_ALPHA)
-                            .toRgbString();
-                        const labelColor = new ColorKit(primaryColor)
-                            .setAlpha(HEADER_FOOTER_LABEL_ALPHA)
-                            .toRgbString();
 
                         // Draw header footer label.
                         ctx.save();
@@ -343,7 +334,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                 top: 0,
                                 width: pageWidth,
                                 height: marginTop,
-                                fill: coverColor,
+                                fill: HEADER_FOOTER_COVER_COLOR,
                             });
                             ctx.save();
                             ctx.translate(0, pageHeight - marginBottom);
@@ -352,7 +343,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                 top: 0,
                                 width: pageWidth,
                                 height: marginBottom,
-                                fill: coverColor,
+                                fill: HEADER_FOOTER_COVER_COLOR,
                             });
                             ctx.restore();
                         } else { // Cover body.
@@ -363,7 +354,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                 top: marginTop,
                                 width: pageWidth,
                                 height: pageHeight - marginTop - marginBottom,
-                                fill: coverColor,
+                                fill: HEADER_FOOTER_COVER_COLOR,
                             });
                             ctx.restore();
                         }
@@ -378,7 +369,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                     points: [pageWidth, marginTop],
                                 }] as unknown as IPathProps['dataArray'],
                                 strokeWidth: 1,
-                                stroke: primaryColor,
+                                stroke: HEADER_FOOTER_STROKE_COLOR,
                             };
 
                             const footerPathConfigIPathProps = {
@@ -390,7 +381,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                     points: [pageWidth, pageHeight - marginBottom],
                                 }] as unknown as IPathProps['dataArray'],
                                 strokeWidth: 1,
-                                stroke: primaryColor,
+                                stroke: HEADER_FOOTER_STROKE_COLOR,
                             };
 
                             Path.drawWith(ctx, headerPathConfigIPathProps);
@@ -399,12 +390,12 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                             ctx.translate(0, marginTop + 1);
                             TextBubbleShape.drawWith(ctx, {
                                 text: localeService.t<LocaleKey>('docs-ui.headerFooter.header'),
-                                color: labelColor,
+                                color: HEADER_FOOTER_LABEL_COLOR,
                             });
                             ctx.translate(0, pageHeight - marginTop - marginBottom);
                             TextBubbleShape.drawWith(ctx, {
                                 text: localeService.t<LocaleKey>('docs-ui.headerFooter.footer'),
-                                color: labelColor,
+                                color: HEADER_FOOTER_LABEL_COLOR,
                             });
                         }
                         ctx.restore();


### PR DESCRIPTION
## Summary

- restore the traditional document header/footer cover to a translucent white canvas color
- keep header/footer guides and labels theme-aware through canvas color expressions
- cover the color expressions with focused controller tests

## Root cause

The header/footer cover changed from a fixed translucent white to `gray.50` resolved from the active theme. Dark themes resolve that token to a dark gray, which produced an opaque-looking gray band over the white document page.

## Impact

Inactive header/footer content remains visually de-emphasized while the overlay keeps the same translucent-white appearance as before, including when a dark theme palette is selected.

## Validation

- `pnpm vitest run packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts packages/engine-render/src/services/__tests__/canvas-color.service.spec.ts`
- `pnpm --filter @univerjs/docs-ui typecheck`
- `pnpm eslint packages/docs-ui/src/controllers/doc-header-footer.controller.ts packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts`
- `git diff --check`
