### PR TITLE
fix(embed): preserve sheet editing and calculation state

### DIFF
--- a/packages/sheets-formula/src/controllers/__tests__/update-formula.controller.spec.ts
+++ b/packages/sheets-formula/src/controllers/__tests__/update-formula.controller.spec.ts
@@ -84,12 +84,16 @@ function createWorkbookData(): IWorkbookData {
     };
 }
 
-function createControllerTestBed() {
+function createControllerTestBed(initialFormulaComputing?: CalculationMode) {
     const dependencies: Dependency[] = [
         [UpdateFormulaController],
     ];
 
-    return createFacadeTestBed(createWorkbookData(), dependencies);
+    const testBed = createFacadeTestBed(createWorkbookData(), dependencies);
+    if (initialFormulaComputing != null) {
+        testBed.injector.get(IConfigService).setConfig(PLUGIN_CONFIG_KEY_BASE, { initialFormulaComputing });
+    }
+    return testBed;
 }
 
 describe('UpdateFormulaController', () => {
@@ -132,6 +136,26 @@ describe('UpdateFormulaController', () => {
     afterEach(() => {
         vi.restoreAllMocks();
         testBed?.univer.dispose();
+    });
+
+    it('does not schedule workbook-added calculation in no-calculation mode', () => {
+        testBed.univer.dispose();
+        testBed = createControllerTestBed(CalculationMode.NO_CALCULATION);
+        commandService = testBed.injector.get(ICommandService);
+        commandService.registerCommand(SetFormulaDataMutation);
+        const executeCommand = vi.spyOn(commandService, 'executeCommand');
+
+        testBed.injector.get(UpdateFormulaController);
+        testBed.injector.get(IUniverInstanceService).createUnit(UniverInstanceType.UNIVER_SHEET, {
+            ...createWorkbookData(),
+            id: 'second',
+        });
+
+        expect(executeCommand).not.toHaveBeenCalledWith(
+            SetTriggerFormulaCalculationStartMutation.id,
+            expect.anything(),
+            expect.anything()
+        );
     });
 
     it('should update formula references when a referenced range moves', async () => {

--- a/packages/sheets-formula/src/controllers/update-formula.controller.ts
+++ b/packages/sheets-formula/src/controllers/update-formula.controller.ts
@@ -279,6 +279,7 @@ export class UpdateFormulaController extends Disposable {
 
         const config = this._configService.getConfig<IUniverSheetsFormulaBaseConfig>(PLUGIN_CONFIG_KEY_BASE);
         const calculationMode = config?.initialFormulaComputing ?? CalculationMode.WHEN_EMPTY;
+        if (calculationMode === CalculationMode.NO_CALCULATION) return;
         const params = this._getDirtyDataByCalculationMode(calculationMode);
 
         this._commandService.executeCommand(SetTriggerFormulaCalculationStartMutation.id, params, { onlyLocal: true });

--- a/packages/sheets-ui/src/controllers/permission/__tests__/sheet-permission-check-ui.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/permission/__tests__/sheet-permission-check-ui.controller.spec.ts
@@ -25,6 +25,7 @@ import { IMEInputCommand } from '@univerjs/docs-ui';
 import { EMPTY } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 import { SheetCopyCommand, SheetCutCommand, SheetPasteCommand } from '../../../commands/commands/clipboard.command';
+import { SetCellEditVisibleOperation } from '../../../commands/operations/cell-edit.operation';
 import { SheetPermissionCheckUIController } from '../sheet-permission-check-ui.controller';
 
 type ControllerConstructorArgs = ConstructorParameters<typeof SheetPermissionCheckUIController>;
@@ -80,6 +81,18 @@ describe('SheetPermissionCheckUIController', () => {
 
         expect(permissionCheckWithoutRange).not.toHaveBeenCalled();
         expect(blockExecuteWithoutPermission).not.toHaveBeenCalled();
+        controller.dispose();
+    });
+
+    it('checks the workbook identified by a cell editor visibility operation', () => {
+        const { controller, executeBefore, permissionCheckWithoutRange } = createController();
+
+        executeBefore({
+            id: SetCellEditVisibleOperation.id,
+            params: { visible: true, unitId: 'embedded-sheet' },
+        });
+
+        expect(permissionCheckWithoutRange).toHaveBeenCalledWith(expect.any(Object), 'embedded-sheet');
         controller.dispose();
     });
 

--- a/packages/sheets-ui/src/controllers/permission/sheet-permission-check-ui.controller.ts
+++ b/packages/sheets-ui/src/controllers/permission/sheet-permission-check-ui.controller.ts
@@ -138,7 +138,7 @@ export class SheetPermissionCheckUIController extends Disposable {
                     workbookTypes: [WorkbookEditablePermission],
                     worksheetTypes: [WorksheetSetCellValuePermission, WorksheetEditPermission],
                     rangeTypes: [RangeProtectionPermissionEditPoint],
-                });
+                }, params.unitId);
                 errorMsg = this._localeService.t<LocaleKey>('sheets-ui.permission.dialog.editErr');
                 break;
             case ApplyFormatPainterCommand.id:


### PR DESCRIPTION
﻿## Summary

- honor `NO_CALCULATION` when a workbook is added
- resolve embedded cell-edit permissions against the command's workbook unit

## Root cause

Embedded sheets execute UI operations while the host remains the global current unit. Permission checks therefore inspected the host workbook, and workbook creation still scheduled formula calculation even when initialization was explicitly disabled.

## Impact

Embedded sheets can enter cell editing without a false protected-range error, and snapshot values remain intact until a real user edit triggers calculation.

## Tests

- `pnpm test -- src/controllers/__tests__/update-formula.controller.spec.ts`
- `pnpm test -- src/controllers/permission/__tests__/sheet-permission-check-ui.controller.spec.ts`
