### PR TITLE
perf(engine-render): reuse shape cache during transforms

### DIFF
--- a/packages/engine-render/src/shape/__tests__/shape-cache.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/shape-cache.spec.ts
@@ -52,4 +52,27 @@ describe('Shape render cache', () => {
         shape.dispose();
         mainCanvas.dispose();
     });
+
+    it('keeps the cached bitmap across drag translation but invalidates it for resize', () => {
+        const mainCanvas = new Canvas({ width: 200, height: 100, pixelRatio: 1 });
+        const shape = new CachedShape('translated-cached-shape', { width: 100, height: 50 });
+        const context = mainCanvas.getContext();
+        const bounds = { left: -10, top: -10, right: 110, bottom: 60 };
+
+        shape.drawCached(context, bounds);
+        shape.translate(24, 18);
+        shape.drawCached(context, bounds);
+        expect(shape.drawCount).toBe(1);
+
+        shape.transformByState({ left: 30, top: 20, width: 100, height: 50 });
+        shape.drawCached(context, bounds);
+        expect(shape.drawCount).toBe(1);
+
+        shape.transformByState({ width: 120 });
+        shape.drawCached(context, bounds);
+        expect(shape.drawCount).toBe(2);
+
+        shape.dispose();
+        mainCanvas.dispose();
+    });
 });

--- a/packages/engine-render/src/shape/shape.ts
+++ b/packages/engine-render/src/shape/shape.ts
@@ -102,6 +102,7 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
     private _renderCacheCanvas: Nullable<Canvas>;
     private _renderCacheBounds: Nullable<IBoundRectNoAngle>;
     private _renderCachePixelRatio = 0;
+    private _renderCacheTransformSize: Nullable<ISize>;
 
     private _hoverCursor: Nullable<string>;
 
@@ -402,6 +403,45 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
         };
     }
 
+    override transformByState(option: IObjectFullState): this | undefined {
+        const previousWidth = this.width;
+        const previousHeight = this.height;
+        const cachedSize = this._renderCacheTransformSize;
+        const hasReusableCache = Boolean(
+            this._renderCacheCanvas &&
+            this._renderCacheBounds &&
+            cachedSize?.width === this.width &&
+            cachedSize.height === this.height
+        );
+
+        const result = super.transformByState(option);
+        const geometryChanged = previousWidth !== this.width || previousHeight !== this.height;
+        if (hasReusableCache && !geometryChanged) {
+            // Translation and rotation only change the outer transform; the cached local pixels
+            // remain valid. Keep filters and 3D effects out of the per-frame drag path.
+            this.makeDirty(false);
+        } else if (geometryChanged) {
+            this._releaseRenderCache();
+        }
+        return result;
+    }
+
+    override translate(x?: number | string, y?: number | string): this {
+        const cachedSize = this._renderCacheTransformSize;
+        const hasReusableCache = Boolean(
+            this._renderCacheCanvas &&
+            this._renderCacheBounds &&
+            cachedSize?.width === this.width &&
+            cachedSize.height === this.height
+        );
+
+        super.translate(x, y);
+        if (hasReusableCache) {
+            this.makeDirty(false);
+        }
+        return this;
+    }
+
     protected _renderWithCache(
         ctx: UniverRenderingContext,
         bounds: IBoundRectNoAngle,
@@ -449,6 +489,7 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
             cacheContext.restore();
             this._renderCacheBounds = { ...bounds };
             this._renderCachePixelRatio = pixelRatio;
+            this._renderCacheTransformSize = { width: this.width, height: this.height };
         }
 
         ctx.drawImage(
@@ -465,6 +506,7 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
         this._renderCacheCanvas = null;
         this._renderCacheBounds = null;
         this._renderCachePixelRatio = 0;
+        this._renderCacheTransformSize = null;
     }
 
     protected _draw(ctx: UniverRenderingContext, bounds?: IViewportInfo) {


### PR DESCRIPTION
## Summary

- Reuse an existing offscreen shape render cache while translating or rotating a shape.
- Invalidate the cache when width or height changes so resize rendering remains correct.
- Add a regression test covering translation, transform-state movement, and resize invalidation.

## Root cause

Shape transforms mark the object dirty on every drag frame. Shapes with filters or 3D effects therefore rebuilt their offscreen bitmap continuously even though translation and rotation do not change the cached local pixels.

## Impact

Dragging effect-heavy shapes and SmartArt presentation shapes avoids repeating the expensive effect-rendering path while preserving correct resize invalidation.

## Validation

- `pnpm --filter @univerjs/engine-render exec vitest run src/shape/__tests__/shape-cache.spec.ts` — 2 tests passed.
- `pnpm --filter @univerjs/engine-render prepare`
- `pnpm --filter @univerjs/engine-render typecheck`
- ESLint on both changed files — 0 errors.
- `git diff --check`

## Scope

Only Engine Render source and its unit test are included. No images, documentation, demos, generated process artifacts, or breaking changes are part of this PR. No architecture documentation update is needed because this is a localized cache invalidation optimization.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
