### PR TITLE
fix(docs-ui): insert images directly from the ribbon

### DIFF
--- a/packages/docs-drawing-ui/src/menu/image.menu.ts
+++ b/packages/docs-drawing-ui/src/menu/image.menu.ts
@@ -64,7 +64,8 @@ const getDisableWhenSelectionInTableObservable = (accessor: IAccessor) => {
 export function ImageMenuFactory(accessor: IAccessor): IMenuItem<LocaleKey> {
     return {
         id: DOCS_IMAGE_MENU_ID,
-        type: MenuItemType.SUBITEMS,
+        commandId: IMAGE_MENU_UPLOAD_FLOAT_ID,
+        type: MenuItemType.BUTTON,
         icon: 'AddImageIcon',
         tooltip: 'docs-drawing-ui.title',
         disabled$: getDisableWhenSelectionInTableObservable(accessor),

--- a/packages/docs-drawing-ui/src/menu/schema.ts
+++ b/packages/docs-drawing-ui/src/menu/schema.ts
@@ -41,10 +41,6 @@ export const menuSchema: MenuSchemaType = {
         [DOCS_IMAGE_MENU_ID]: {
             order: 0,
             menuItemFactory: ImageMenuFactory,
-            [IMAGE_MENU_UPLOAD_FLOAT_ID]: {
-                order: 0,
-                menuItemFactory: UploadFloatImageMenuFactory,
-            },
         },
     },
     [ContextMenuPosition.PARAGRAPH]: {


### PR DESCRIPTION
## Summary

- make the Docs image item in the Insert ribbon a direct button
- dispatch the existing image insertion command on the first click
- keep the stable Docs image menu ID and existing paragraph context-menu entries

## Root cause

The ribbon registered a `SUBITEMS` parent and nested the actual image command beneath it, so inserting an image required two clicks. The ribbon item now follows the direct `BUTTON + commandId` pattern used by the newer Slide UI.

## User impact

Users can open the image picker from the Docs ribbon with one click. Context-menu behavior is unchanged.

## Validation

- `pnpm --filter @univerjs/docs-drawing-ui typecheck`
- `pnpm exec eslint packages/docs-drawing-ui/src/menu/image.menu.ts packages/docs-drawing-ui/src/menu/schema.ts`
- `pnpm --filter @univerjs/docs-drawing-ui test` (17 files, 106 tests)
- `git diff --check`

No documentation, image assets, or process-only tests are included.

## Pull Request Checklist

- [x] No related issue was provided.
- [x] Naming conventions are followed.
- [x] No new test is needed for this declarative menu wiring change; the existing package suite passes.
- [x] No breaking changes are introduced.
