### PR TITLE
fix(docs): inherit list marker font size

### DIFF
--- a/packages/core/src/docs/data-model/text-x/build-utils/__tests__/paragraph.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/__tests__/paragraph.spec.ts
@@ -196,8 +196,8 @@ describe('paragraph build utils', () => {
         expect(body.paragraphs?.[2].bullet).toMatchObject({
             listType: PresetListType.ORDER_LIST,
             nestingLevel: 0,
-            textStyle: { fs: 20 },
         });
+        expect(body.paragraphs?.[2].bullet?.textStyle).toBeUndefined();
 
         const toggled = toggleChecklistParagraph({ paragraphIndex: secondParagraph.startIndex, document: doc });
         expect(toggleChecklistParagraph({ paragraphIndex: 999, document: doc })).toBe(false);

--- a/packages/core/src/docs/data-model/text-x/build-utils/paragraph.ts
+++ b/packages/core/src/docs/data-model/text-x/build-utils/paragraph.ts
@@ -102,9 +102,6 @@ export const switchParagraphBullet = (params: ISwitchParagraphBulletParams) => {
                             },
                             bullet: {
                                 nestingLevel: bullet?.nestingLevel ?? 0,
-                                textStyle: {
-                                    fs: 20,
-                                },
                                 listType,
                                 listId,
                             },
@@ -224,11 +221,9 @@ export const setParagraphBullet = (params: ISetParagraphBulletParams) => {
                         paragraphStyle,
                         bullet: {
                             nestingLevel: bullet?.nestingLevel ?? 0,
-                            textStyle: bullet?.listType === listType
-                                ? bullet.textStyle
-                                : {
-                                    fs: 20,
-                                },
+                            ...(bullet?.listType === listType && bullet.textStyle
+                                ? { textStyle: bullet.textStyle }
+                                : {}),
                             listType,
                             listId,
                         },

--- a/packages/docs-ui/src/commands/commands/__tests__/list.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/list.command.spec.ts
@@ -134,6 +134,21 @@ describe('list commands', () => {
         expect(paragraphs[0].bullet?.listId).toBe(paragraphs[1].bullet?.listId);
     });
 
+    it.each([
+        ['ordered', OrderListCommand.id, PresetListType.ORDER_LIST],
+        ['unordered', BulletListCommand.id, PresetListType.BULLET_LIST],
+        ['task', CheckListCommand.id, PresetListType.CHECK_LIST],
+    ])('does not assign an absolute marker font size to %s lists', async (_label, commandId, listType) => {
+        setSelections([{ startOffset: 0, endOffset: 4, collapsed: false }]);
+
+        await commandService.executeCommand(commandId);
+        await awaitTime(0);
+
+        const bullet = getBody()?.paragraphs?.[0].bullet;
+        expect(bullet?.listType).toBe(listType);
+        expect(bullet?.textStyle?.fs).toBeUndefined();
+    });
+
     it('changes checklist type and nesting level on an existing list', async () => {
         setSelections([
             { startOffset: 0, endOffset: 4, collapsed: false },
@@ -177,6 +192,7 @@ describe('list commands', () => {
 
         expect(getBody()?.paragraphs?.[0].bullet?.listType).toBe(PresetListType.ORDER_LIST);
         expect(getBody()?.paragraphs?.[0].bullet?.nestingLevel).toBe(0);
+        expect(getBody()?.paragraphs?.[0].bullet?.textStyle?.fs).toBeUndefined();
         expect(getBody()?.paragraphs?.[0].paragraphStyle?.textStyle).toMatchObject(
             PRESET_LIST_TYPE[PresetListType.ORDER_LIST].nestingLevel[0].paragraphProperties?.textStyle ?? {}
         );

--- a/packages/docs-ui/src/commands/commands/list.command.ts
+++ b/packages/docs-ui/src/commands/commands/list.command.ts
@@ -466,9 +466,6 @@ export const QuickListCommand: ICommand<IQuickListCommandParams> = {
                         bullet: {
                             ...(paragraph.bullet ?? {
                                 nestingLevel: 0,
-                                textStyle: {
-                                    fs: 20,
-                                },
                             }),
                             listType,
                             listId,

--- a/packages/engine-render/src/components/docs/layout/model/__tests__/glyph.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/model/__tests__/glyph.spec.ts
@@ -225,7 +225,7 @@ describe('Glyph utils test cases', () => {
             measureSpy.mockRestore();
         });
 
-        it('centers the custom checkbox shape on the measured marker metrics', () => {
+        it('inherits the paragraph font size when centering the custom checkbox shape', () => {
             const measureSpy = vi.spyOn(FontCache, 'getTextSize').mockReturnValue({
                 width: 16,
                 ba: 18,
@@ -247,12 +247,13 @@ describe('Glyph utils test cases', () => {
                 {
                     listId: 'check-list',
                     symbol: '\u2610',
-                    ts: { fs: 20 },
+                    ts: {},
                     startIndexItem: 1,
                 },
                 10
             );
 
+            expect(bulletGlyph.ts?.fs).toBe(20);
             expect(bulletGlyph.width).toBe(30);
             expect(bulletGlyph.bBox).toMatchObject({
                 width: 24,


### PR DESCRIPTION
## Summary

- Remove the hard-coded 20 pt marker font size from ordered, unordered, and task list creation paths.
- Let list markers inherit the effective paragraph font size when no marker style is explicitly configured.
- Preserve an existing explicit marker style when reapplying the same list type.
- Add regression coverage for toolbar commands, quick-list input, paragraph transforms, and checkbox marker rendering.

## Scope and non-goals

This PR only changes the default font-size behavior of newly created or retyped Docs list markers. It does not change explicitly imported marker styles, numbering semantics, indentation, or the list layout algorithm.

## Root cause

List creation commands persisted `bullet.textStyle.fs = 20`. The renderer already merges an unspecified marker style with the paragraph glyph style, so this absolute value bypassed the intended inheritance and made markers larger than normal body text.

## Validation

- `pnpm exec vitest run packages/core/src/docs/data-model/text-x/build-utils/__tests__/paragraph.spec.ts packages/docs-ui/src/commands/commands/__tests__/list.command.spec.ts packages/engine-render/src/components/docs/layout/model/__tests__/glyph.spec.ts`
  - 3 test files and 39 tests passed.
- `pnpm --filter @univerjs/core typecheck`
- `pnpm --filter @univerjs/docs-ui typecheck`
- `pnpm --filter @univerjs/engine-render typecheck`
- Targeted ESLint completed with no errors; two pre-existing `no-explicit-any` warnings remain in `glyph.spec.ts`.
- Built only the `docs-advanced` demo and visually verified 14 pt body text with ordered, unordered, and task list markers.

## SDK dependencies

- SDK dependencies changed: No.
- This is the upstream OSS SDK behavior change; no unpublished external SDK behavior is required.

## Architecture

No architecture or ADR update is needed because this is a localized correction to an existing rendering/style inheritance contract.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
