### PR TITLE
fix(docs-ui): follow theme for overlay and caret

### DIFF
--- a/packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts
+++ b/packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts
@@ -175,12 +175,12 @@ describe('DocHeaderFooterController', () => {
         expect(rectSpy.mock.calls[0][1]).toMatchObject({
             width: 200,
             height: 30,
-            fill: 'alpha(white, 0.5)',
+            fill: 'alpha(gray.0, 0.5)',
         });
         expect(rectSpy.mock.calls[1][1]).toMatchObject({
             width: 200,
             height: 40,
-            fill: 'alpha(white, 0.5)',
+            fill: 'alpha(gray.0, 0.5)',
         });
         expect(pathSpy).not.toHaveBeenCalled();
         expect(textSpy).not.toHaveBeenCalled();

--- a/packages/docs-ui/src/controllers/doc-header-footer.controller.ts
+++ b/packages/docs-ui/src/controllers/doc-header-footer.controller.ts
@@ -49,7 +49,7 @@ import { DocSelectionRenderService } from '../services/selection/doc-selection-r
 import { getDocPageSectionContext } from '../utils/section-header-footer';
 import { TextBubbleShape } from '../views/header-footer/text-bubble';
 
-const HEADER_FOOTER_COVER_COLOR = 'alpha(white, 0.5)';
+const HEADER_FOOTER_COVER_COLOR = 'alpha(gray.0, 0.5)';
 const HEADER_FOOTER_STROKE_COLOR = 'primary.600';
 const HEADER_FOOTER_LABEL_COLOR = 'alpha(primary.600, 0.08)';
 

--- a/packages/docs-ui/src/services/selection/__tests__/range-state.spec.ts
+++ b/packages/docs-ui/src/services/selection/__tests__/range-state.spec.ts
@@ -69,12 +69,17 @@ function createNodePosition(glyph = 0) {
     };
 }
 
-function createTextRangeHarness() {
+function createTextRangeHarness(textColor?: string, themeColors: Record<string, string> = {}) {
     const addedObjects: unknown[] = [];
     const scene = {
         addObject: (object: unknown) => {
             addedObjects.push(object);
         },
+        getEngine: () => ({
+            canvasColorService: {
+                getRenderColor: (color: string) => themeColors[color] ?? color,
+            },
+        }),
     };
     const document = {
         getOffsetConfig: () => ({
@@ -85,7 +90,7 @@ function createTextRangeHarness() {
     const skeleton = {
         findNodePositionByCharIndex: (index: number) => createNodePosition(index),
         findGlyphByPosition: () => ({
-            ts: {},
+            ts: textColor ? { cl: { rgb: textColor } } : {},
         }),
         getViewModel: () => ({
             getDataModel: () => ({
@@ -136,8 +141,41 @@ describe('selection range state', () => {
         });
         expect(addedObjects).toHaveLength(1);
         expect(range.getAnchor()).not.toBeNull();
+        expect(range.getAnchor()?.stroke).toBe('gray.1000');
 
         range.dispose();
+        rangePointSpy.mockRestore();
+    });
+
+    it('matches the caret endpoint to the current text color across theme directions', () => {
+        const rangePointSpy = vi.spyOn(NodePositionConvertToCursor.prototype, 'getRangePointData').mockImplementation(() => ({
+            contentBoxPointGroup: [[
+                { x: 10, y: 20 },
+                { x: 12, y: 20 },
+                { x: 12, y: 36 },
+                { x: 10, y: 36 },
+            ]],
+            borderBoxPointGroup: [],
+            cursorList: [{ startOffset: 1, endOffset: 1, collapsed: true }],
+        }) as never);
+
+        const createRange = (textColor: string, themeColors: Record<string, string>) => {
+            const { document, scene, skeleton } = createTextRangeHarness(textColor, themeColors);
+            return cursorConvertToTextRange(
+                scene as never,
+                { startOffset: 1, endOffset: 1, segmentId: '', segmentPage: -1 },
+                skeleton as never,
+                document as never
+            )!;
+        };
+        const lightThemeRange = createRange('#f5f7ff', { 'gray.0': '#ffffff', 'gray.1000': '#000000' });
+        const invertedThemeRange = createRange('#f5f7ff', { 'gray.0': '#070b19', 'gray.1000': '#f5f7ff' });
+
+        expect(lightThemeRange.getAnchor()?.stroke).toBe('gray.0');
+        expect(invertedThemeRange.getAnchor()?.stroke).toBe('gray.1000');
+
+        lightThemeRange.dispose();
+        invertedThemeRange.dispose();
         rangePointSpy.mockRestore();
     });
 

--- a/packages/docs-ui/src/services/selection/__tests__/range-state.spec.ts
+++ b/packages/docs-ui/src/services/selection/__tests__/range-state.spec.ts
@@ -69,7 +69,7 @@ function createNodePosition(glyph = 0) {
     };
 }
 
-function createTextRangeHarness(textColor?: string, themeColors: Record<string, string> = {}) {
+function createTextRangeHarness(backgroundColor?: string, themeColors: Record<string, string> = {}) {
     const addedObjects: unknown[] = [];
     const scene = {
         addObject: (object: unknown) => {
@@ -90,7 +90,7 @@ function createTextRangeHarness(textColor?: string, themeColors: Record<string, 
     const skeleton = {
         findNodePositionByCharIndex: (index: number) => createNodePosition(index),
         findGlyphByPosition: () => ({
-            ts: textColor ? { cl: { rgb: textColor } } : {},
+            ts: backgroundColor ? { bg: { rgb: backgroundColor } } : {},
         }),
         getViewModel: () => ({
             getDataModel: () => ({
@@ -147,7 +147,7 @@ describe('selection range state', () => {
         rangePointSpy.mockRestore();
     });
 
-    it('matches the caret endpoint to the current text color across theme directions', () => {
+    it('contrasts the caret endpoint with the effective text background across theme directions', () => {
         const rangePointSpy = vi.spyOn(NodePositionConvertToCursor.prototype, 'getRangePointData').mockImplementation(() => ({
             contentBoxPointGroup: [[
                 { x: 10, y: 20 },
@@ -159,8 +159,8 @@ describe('selection range state', () => {
             cursorList: [{ startOffset: 1, endOffset: 1, collapsed: true }],
         }) as never);
 
-        const createRange = (textColor: string, themeColors: Record<string, string>) => {
-            const { document, scene, skeleton } = createTextRangeHarness(textColor, themeColors);
+        const createRange = (backgroundColor: string | undefined, themeColors: Record<string, string>) => {
+            const { document, scene, skeleton } = createTextRangeHarness(backgroundColor, themeColors);
             return cursorConvertToTextRange(
                 scene as never,
                 { startOffset: 1, endOffset: 1, segmentId: '', segmentPage: -1 },
@@ -168,14 +168,17 @@ describe('selection range state', () => {
                 document as never
             )!;
         };
-        const lightThemeRange = createRange('#f5f7ff', { 'gray.0': '#ffffff', 'gray.1000': '#000000' });
-        const invertedThemeRange = createRange('#f5f7ff', { 'gray.0': '#070b19', 'gray.1000': '#f5f7ff' });
+        const lightBackgroundRange = createRange('#ffffff', { 'gray.0': '#ffffff', 'gray.1000': '#000000' });
+        const darkBackgroundRange = createRange('#070b19', { 'gray.0': '#ffffff', 'gray.1000': '#000000' });
+        const deepOceanRange = createRange(undefined, { 'gray.0': '#070b19', 'gray.1000': '#f5f7ff' });
 
-        expect(lightThemeRange.getAnchor()?.stroke).toBe('gray.0');
-        expect(invertedThemeRange.getAnchor()?.stroke).toBe('gray.1000');
+        expect(lightBackgroundRange.getAnchor()?.stroke).toBe('gray.1000');
+        expect(darkBackgroundRange.getAnchor()?.stroke).toBe('gray.0');
+        expect(deepOceanRange.getAnchor()?.stroke).toBe('gray.1000');
 
-        lightThemeRange.dispose();
-        invertedThemeRange.dispose();
+        lightBackgroundRange.dispose();
+        darkBackgroundRange.dispose();
+        deepOceanRange.dispose();
         rangePointSpy.mockRestore();
     });
 

--- a/packages/docs-ui/src/services/selection/text-range.ts
+++ b/packages/docs-ui/src/services/selection/text-range.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ITextRange, Nullable } from '@univerjs/core';
+import type { IColorStyle, ITextRange, Nullable } from '@univerjs/core';
 import type {
     Documents,
     DocumentSkeleton,
@@ -27,7 +27,7 @@ import type {
 } from '@univerjs/engine-render';
 import type { IDocRange } from './range-interface';
 import { BooleanNumber, ColorKit, COLORS, DOC_RANGE_TYPE, generateRandomId, getColorStyle, RANGE_DIRECTION } from '@univerjs/core';
-import { getColor, NORMAL_TEXT_SELECTION_PLUGIN_STYLE, Rect, RegularPolygon } from '@univerjs/engine-render';
+import { DocumentSkeletonPageType, getColor, NORMAL_TEXT_SELECTION_PLUGIN_STYLE, Rect, RegularPolygon } from '@univerjs/engine-render';
 import {
     compareNodePosition,
     compareNodePositionLogic,
@@ -514,27 +514,39 @@ export class TextRange implements IDocRange {
             return this.style.strokeActive;
         }
 
-        const textColor = glyph?.ts?.cl?.rgb ?? getColorStyle(glyph?.ts?.cl);
         const colorService = this._scene.getEngine?.()?.canvasColorService;
-        if (!textColor || !colorService) {
+        if (!colorService) {
             return DEFAULT_CARET_COLOR;
         }
 
         try {
-            const textColorKit = new ColorKit(colorService.getRenderColor(textColor));
+            const backgroundColorKit = new ColorKit(colorService.getRenderColor(this._getAnchorBackgroundColor(glyph)));
             const gray0 = new ColorKit(colorService.getRenderColor('gray.0'));
             const gray1000 = new ColorKit(colorService.getRenderColor(DEFAULT_CARET_COLOR));
-            if (!textColorKit.isValid || !gray0.isValid || !gray1000.isValid) {
+            if (!backgroundColorKit.isValid || !gray0.isValid || !gray1000.isValid) {
                 return DEFAULT_CARET_COLOR;
             }
 
-            const textLuminance = textColorKit.getLuminance();
-            return Math.abs(gray0.getLuminance() - textLuminance) < Math.abs(gray1000.getLuminance() - textLuminance)
+            return ColorKit.getContrastRatio(gray0, backgroundColorKit) > ColorKit.getContrastRatio(gray1000, backgroundColorKit)
                 ? 'gray.0'
                 : DEFAULT_CARET_COLOR;
         } catch {
             return DEFAULT_CARET_COLOR;
         }
+    }
+
+    private _getAnchorBackgroundColor(glyph: Nullable<IDocumentSkeletonGlyph>): string {
+        const line = glyph?.parent?.parent;
+        const page = line?.parent?.parent?.parent;
+        let cellBackground: IColorStyle | undefined;
+        if (page?.type === DocumentSkeletonPageType.CELL && page.parent && 'rowSource' in page.parent) {
+            const row = page.parent;
+            const cellIndex = row.cells.indexOf(page);
+            cellBackground = row.rowSource.tableCells[cellIndex]?.backgroundColor;
+        }
+
+        const background = glyph?.ts?.bg ?? line?.backgroundColor ?? cellBackground;
+        return background?.rgb ?? getColorStyle(background) ?? 'gray.0';
     }
 
     private _setCursorList(cursorList: ITextRange[]) {

--- a/packages/docs-ui/src/services/selection/text-range.ts
+++ b/packages/docs-ui/src/services/selection/text-range.ts
@@ -26,7 +26,7 @@ import type {
     Scene,
 } from '@univerjs/engine-render';
 import type { IDocRange } from './range-interface';
-import { BooleanNumber, COLORS, DOC_RANGE_TYPE, generateRandomId, RANGE_DIRECTION } from '@univerjs/core';
+import { BooleanNumber, ColorKit, COLORS, DOC_RANGE_TYPE, generateRandomId, getColorStyle, RANGE_DIRECTION } from '@univerjs/core';
 import { getColor, NORMAL_TEXT_SELECTION_PLUGIN_STYLE, Rect, RegularPolygon } from '@univerjs/engine-render';
 import {
     compareNodePosition,
@@ -42,6 +42,7 @@ const TEXT_ANCHOR_KEY_PREFIX = '__TestSelectionAnchor__';
 const ID_LENGTH = 6;
 const BLINK_ON = 500;
 const BLINK_OFF = 500;
+const DEFAULT_CARET_COLOR = 'gray.1000';
 
 export const TEXT_RANGE_LAYER_INDEX = 3;
 
@@ -120,6 +121,7 @@ export class TextRange implements IDocRange {
     private _cursorList: ITextRange[] = [];
 
     private _anchorBlinkTimer: Nullable<ReturnType<typeof setInterval>> = null;
+    private _anchorActiveStroke = DEFAULT_CARET_COLOR;
 
     constructor(
         private _scene: Scene,
@@ -301,7 +303,7 @@ export class TextRange implements IDocRange {
 
     activeStatic() {
         this._anchorShape?.setProps({
-            stroke: this.style?.strokeActive || getColor(COLORS.black, 1),
+            stroke: this._anchorActiveStroke,
         });
     }
 
@@ -469,6 +471,7 @@ export class TextRange implements IDocRange {
         let left = boundingLeft + docsLeft;
         const top = boundingTop + docsTop;
         const isItalic = glyph?.ts?.it === BooleanNumber.TRUE;
+        this._anchorActiveStroke = this._getAnchorActiveStroke(glyph);
 
         if (isItalic) {
             left += height * Math.tan((ITALIC_DEGREE * Math.PI) / 180) / 2;
@@ -483,6 +486,7 @@ export class TextRange implements IDocRange {
             } else {
                 this._anchorShape.skew(0, 0);
             }
+            this.activeStatic();
 
             return;
         }
@@ -492,7 +496,7 @@ export class TextRange implements IDocRange {
             top,
             height,
             strokeWidth: this.style?.strokeWidth || 1,
-            stroke: this.style?.strokeActive || getColor(COLORS.black, 1),
+            stroke: this._anchorActiveStroke,
             evented: false,
         });
 
@@ -503,6 +507,34 @@ export class TextRange implements IDocRange {
         this._anchorShape = anchor;
         this._scene.addObject(anchor, TEXT_RANGE_LAYER_INDEX);
         this.activeStatic();
+    }
+
+    private _getAnchorActiveStroke(glyph: Nullable<IDocumentSkeletonGlyph>): string {
+        if (this.style?.strokeActive && this.style.strokeActive !== NORMAL_TEXT_SELECTION_PLUGIN_STYLE.strokeActive) {
+            return this.style.strokeActive;
+        }
+
+        const textColor = glyph?.ts?.cl?.rgb ?? getColorStyle(glyph?.ts?.cl);
+        const colorService = this._scene.getEngine?.()?.canvasColorService;
+        if (!textColor || !colorService) {
+            return DEFAULT_CARET_COLOR;
+        }
+
+        try {
+            const textColorKit = new ColorKit(colorService.getRenderColor(textColor));
+            const gray0 = new ColorKit(colorService.getRenderColor('gray.0'));
+            const gray1000 = new ColorKit(colorService.getRenderColor(DEFAULT_CARET_COLOR));
+            if (!textColorKit.isValid || !gray0.isValid || !gray1000.isValid) {
+                return DEFAULT_CARET_COLOR;
+            }
+
+            const textLuminance = textColorKit.getLuminance();
+            return Math.abs(gray0.getLuminance() - textLuminance) < Math.abs(gray1000.getLuminance() - textLuminance)
+                ? 'gray.0'
+                : DEFAULT_CARET_COLOR;
+        } catch {
+            return DEFAULT_CARET_COLOR;
+        }
     }
 
     private _setCursorList(cursorList: ITextRange[]) {

--- a/packages/docs-ui/src/services/selection/text-range.ts
+++ b/packages/docs-ui/src/services/selection/text-range.ts
@@ -521,13 +521,11 @@ export class TextRange implements IDocRange {
 
         try {
             const backgroundColorKit = new ColorKit(colorService.getRenderColor(this._getAnchorBackgroundColor(glyph)));
-            const gray0 = new ColorKit(colorService.getRenderColor('gray.0'));
-            const gray1000 = new ColorKit(colorService.getRenderColor(DEFAULT_CARET_COLOR));
-            if (!backgroundColorKit.isValid || !gray0.isValid || !gray1000.isValid) {
+            if (!backgroundColorKit.isValid) {
                 return DEFAULT_CARET_COLOR;
             }
 
-            return ColorKit.getContrastRatio(gray0, backgroundColorKit) > ColorKit.getContrastRatio(gray1000, backgroundColorKit)
+            return ColorKit.getContrastRatio(colorService.getRenderColor('gray.0'), backgroundColorKit) > ColorKit.getContrastRatio(colorService.getRenderColor(DEFAULT_CARET_COLOR), backgroundColorKit)
                 ? 'gray.0'
                 : DEFAULT_CARET_COLOR;
         } catch {


### PR DESCRIPTION
## Summary

- Resolve the traditional Docs header/footer cover through the theme-aware `gray.0` token.
- Choose the default Docs caret endpoint with the highest contrast against the effective text background.
- Resolve text highlight, paragraph shading, and table-cell backgrounds before falling back to the document page background `gray.0`.
- Fall back to `gray.1000` when background or canvas colors are unavailable or invalid, while preserving explicitly customized caret colors.

## Root cause

The header/footer cover used `alpha(white, 0.5)`, and the default caret used a literal opaque black. Canvas color resolution treats CSS color names and RGBA values as literals, so custom themes could not control either visual consistently. Matching the caret to the text foreground also failed when a dark-themed document contained legacy fixed dark text colors.

## Impact

Light themes keep the expected appearance. Custom and inverted themes can control the header/footer cover and receive a caret that remains visible against the rendered text background. Pro receives the behavior from the shared OSS SDK; no Pro source or submodule pointer change is required.

## Validation

- `pnpm --filter @univerjs/docs-ui test -- doc-header-footer.controller.spec.ts` (3 passed)
- `pnpm --filter @univerjs/docs-ui exec vitest run src/services/selection/__tests__/range-state.spec.ts --pool=threads` (6 passed)
- `pnpm --filter @univerjs/docs-ui typecheck`
- `pnpm exec eslint packages/docs-ui/src/services/selection/text-range.ts packages/docs-ui/src/services/selection/__tests__/range-state.spec.ts`
- `git diff --check`
- Local Docs demo in traditional and modern modes; no runtime errors

## SDK dependencies

- No SDK dependency versions changed.
- The behavior is implemented directly in `@univerjs/docs-ui` and does not rely on unreleased external SDK behavior.

## Documentation

- No documentation or ADR update is needed because this is a localized visual token correction with no architecture change.

## Pull Request Checklist

- [x] No related issue was provided.
- [x] Naming conventions are followed.
- [x] Focused unit tests cover the behavior changes.
- [x] No breaking changes are introduced.
