### PR TITLE
fix(drawing-ui): render chart option icons

### DIFF
--- a/packages/docs-drawing-ui/src/services/doc-drawing-floating-toolbar-adapter.service.ts
+++ b/packages/docs-drawing-ui/src/services/doc-drawing-floating-toolbar-adapter.service.ts
@@ -25,6 +25,7 @@ export interface IDocDrawingFloatingToolbarParams {
 }
 
 export interface IDocDrawingFloatingToolbarOption {
+    icon?: string;
     label: unknown;
     value: string;
 }

--- a/packages/drawing-ui/src/views/__tests__/DrawingPanelActions.spec.tsx
+++ b/packages/drawing-ui/src/views/__tests__/DrawingPanelActions.spec.tsx
@@ -343,4 +343,48 @@ describe('drawing panel actions', () => {
         expect(executedCommands.map((command) => command.id)).toEqual([chartEditCommandId]);
         expect(container.querySelector('[data-u-comp="doc-chart-floating-toolbar"]')).toBeNull();
     });
+
+    it('renders the icon provided by each chart toolbar option', () => {
+        const iconManager = univer.__getInjector().get(IconManager);
+        iconManager.register({
+            LineChartIcon: () => <span data-testid="line-chart-icon" />,
+            ColumnChartIcon: () => <span data-testid="column-chart-icon" />,
+        });
+
+        const rendered = renderWithRediContext(
+            univer.__getInjector(),
+            <ImagePopupMenu
+                popup={{
+                    extraProps: {
+                        variant: 'doc-chart-floating-toolbar',
+                        menuItems: [{
+                            type: 'select',
+                            label: 'chart.type',
+                            index: 0,
+                            commandId: chartEditCommandId,
+                            disable: false,
+                            value: 'line',
+                            options: [
+                                { label: 'Line', value: 'line', icon: 'LineChartIcon' },
+                                { label: 'Column', value: 'column', icon: 'ColumnChartIcon' },
+                            ],
+                            commandParamsFactory: (value) => ({ value }),
+                        }],
+                    },
+                }}
+            />
+        );
+        root = rendered.root;
+        container = rendered.container;
+
+        const chartTypeButton = container.querySelector<HTMLButtonElement>(
+            '[data-u-comp="doc-chart-floating-toolbar"] button'
+        );
+        expect(chartTypeButton?.querySelector('[data-testid="line-chart-icon"]')).not.toBeNull();
+
+        clickElement(chartTypeButton!);
+
+        expect(document.querySelector('[data-testid="line-chart-icon"]')).not.toBeNull();
+        expect(document.querySelector('[data-testid="column-chart-icon"]')).not.toBeNull();
+    });
 });

--- a/packages/drawing-ui/src/views/image-popup-menu/ImagePopupMenu.tsx
+++ b/packages/drawing-ui/src/views/image-popup-menu/ImagePopupMenu.tsx
@@ -43,7 +43,7 @@ export interface IImagePopupMenuItem {
     disable: boolean;
     type?: 'button' | 'select';
     value?: string;
-    options?: Array<{ label: unknown; value: string }>;
+    options?: Array<{ icon?: string; label: unknown; value: string }>;
     commandParamsFactory?: (value: string) => object;
     hideOnClick?: boolean;
     icon?: string;
@@ -423,11 +423,15 @@ function DocChartFloatingToolbar(props: Pick<IDocImageFloatingToolbarProps, 'men
     const actionItems = props.menuItems
         .filter((item) => item.type !== 'select' && item.icon)
         .sort((a, b) => a.index - b.index);
-    const chartTypeOptions = (chartTypeItem?.options ?? []).map((option) => ({
-        label: String(option.label),
-        value: option.value,
-        icon: <ChartIcon />,
-    }));
+    const chartTypeOptions = (chartTypeItem?.options ?? []).map((option) => {
+        const Icon = option.icon ? iconManager.get(option.icon) : ChartIcon;
+
+        return {
+            label: String(option.label),
+            value: option.value,
+            icon: <Icon />,
+        };
+    });
 
     const executeMenuItem = (item: IImagePopupMenuItem | undefined) => {
         if (!item || item.disable) {


### PR DESCRIPTION
## Summary

- extend document drawing floating-toolbar options with an optional icon name
- render each chart option through IconManager while retaining the generic ChartIcon fallback
- add regression coverage for distinct chart-type icons in the floating dropdown

## Root cause

The generic document chart floating toolbar reduced options to label and value, then hard-coded ChartIcon for every entry. Consumers therefore could not provide the chart-type icon already owned by their catalog.

## Verification

- pnpm -C packages/drawing-ui exec vitest run src/views/__tests__/DrawingPanelActions.spec.tsx (7 tests passed)
- pnpm --filter @univerjs/drawing-ui typecheck
- pnpm --filter @univerjs/docs-drawing-ui typecheck
- git diff --check origin/dev...HEAD

## Compatibility

The new icon field is optional, and existing consumers retain the generic chart icon fallback.

Persisted command or mutation schemas changed: no. Historical payload compatibility and migration: not applicable.