### PR TITLE
fix(docs): persist image crop changes

### DIFF
--- a/packages/docs-drawing-ui/src/commands/commands/__tests__/drawing-commands.spec.ts
+++ b/packages/docs-drawing-ui/src/commands/commands/__tests__/drawing-commands.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Dependency, DependencyIdentifier, DocumentDataModel, ICommand, IDocumentData } from '@univerjs/core';
-import type { IInsertDocDrawingCommandParams, ISetDocDrawingArrangeCommandParams, IUpdateDrawingDocTransformCommandParams } from '@univerjs/docs-drawing';
+import type { IDocImage, IInsertDocDrawingCommandParams, ISetDocDrawingArrangeCommandParams, IUpdateDrawingDocTransformCommandParams } from '@univerjs/docs-drawing';
 import {
     ArrangeTypeEnum,
     awaitTime,
@@ -30,6 +30,8 @@ import {
     ObjectRelativeFromH,
     ObjectRelativeFromV,
     PositionedObjectLayoutType,
+    RedoCommand,
+    UndoCommand,
     UniverInstanceType,
     WrapTextType,
 } from '@univerjs/core';
@@ -1012,6 +1014,71 @@ describe('docs drawing commands integration', () => {
         });
         expect(testBed.refreshControls).toHaveBeenCalled();
         expect(refreshDrawings).toHaveBeenCalledWith(skeleton);
+
+        testBed.univer.dispose();
+    });
+
+    it('persists image crop state as one undoable document change', async () => {
+        const docData = createDrawingDocData();
+        const initialDrawing = docData.drawings?.['shape-1'] as IDocImage;
+        delete initialDrawing.srcRect;
+        initialDrawing.docTransform = {
+            size: { width: 100, height: 80 },
+            positionH: { relativeFrom: ObjectRelativeFromH.PAGE, posOffset: 10 },
+            positionV: { relativeFrom: ObjectRelativeFromV.PARAGRAPH, posOffset: 20 },
+            angle: 0,
+        };
+        const testBed = setupDrawingTestBed(docData);
+        vi.spyOn(testBed.get(DocSkeletonManagerService), 'getSkeleton').mockReturnValue({} as never);
+
+        expect(await testBed.commandService.executeCommand<IUpdateDrawingDocTransformCommandParams>(UpdateDrawingDocTransformCommand.id, {
+            unitId: 'test-doc',
+            subUnitId: 'test-doc',
+            drawings: [
+                { drawingId: 'shape-1', key: 'srcRect', value: { left: 15, top: 6, right: 15, bottom: 14 } },
+                { drawingId: 'shape-1', key: 'size', value: { width: 70, height: 60 } },
+                { drawingId: 'shape-1', key: 'positionH', value: { relativeFrom: ObjectRelativeFromH.PAGE, posOffset: 25 } },
+                { drawingId: 'shape-1', key: 'positionV', value: { relativeFrom: ObjectRelativeFromV.PARAGRAPH, posOffset: 26 } },
+            ],
+        })).toBe(true);
+        await awaitTime(350);
+
+        const doc = testBed.get(IUniverInstanceService)
+            .getUnit<DocumentDataModel>('test-doc', UniverInstanceType.UNIVER_DOC)!;
+        const getDrawing = () => doc.getSnapshot().drawings?.['shape-1'] as IDocImage;
+
+        expect(getDrawing()).toMatchObject({
+            srcRect: { left: 15, top: 6, right: 15, bottom: 14 },
+            docTransform: {
+                size: { width: 70, height: 60 },
+                positionH: { relativeFrom: ObjectRelativeFromH.PAGE, posOffset: 25 },
+                positionV: { relativeFrom: ObjectRelativeFromV.PARAGRAPH, posOffset: 26 },
+            },
+        });
+        expect(testBed.get(IUndoRedoService).pitchTopUndoElement()).toMatchObject({
+            undoMutations: [{ id: RichTextEditingMutation.id }],
+            redoMutations: [{ id: RichTextEditingMutation.id }],
+        });
+
+        expect(await testBed.commandService.executeCommand(UndoCommand.id)).toBe(true);
+        expect(getDrawing().srcRect).toBeUndefined();
+        expect(getDrawing()).toMatchObject({
+            docTransform: {
+                size: { width: 100, height: 80 },
+                positionH: { relativeFrom: ObjectRelativeFromH.PAGE, posOffset: 10 },
+                positionV: { relativeFrom: ObjectRelativeFromV.PARAGRAPH, posOffset: 20 },
+            },
+        });
+
+        expect(await testBed.commandService.executeCommand(RedoCommand.id)).toBe(true);
+        expect(getDrawing()).toMatchObject({
+            srcRect: { left: 15, top: 6, right: 15, bottom: 14 },
+            docTransform: {
+                size: { width: 70, height: 60 },
+                positionH: { relativeFrom: ObjectRelativeFromH.PAGE, posOffset: 25 },
+                positionV: { relativeFrom: ObjectRelativeFromV.PARAGRAPH, posOffset: 26 },
+            },
+        });
 
         testBed.univer.dispose();
     });

--- a/packages/docs-drawing-ui/src/controllers/render-controllers/__tests__/doc-drawing-update.render-controller.spec.ts
+++ b/packages/docs-drawing-ui/src/controllers/render-controllers/__tests__/doc-drawing-update.render-controller.spec.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { BooleanNumber, FOCUSING_COMMON_DRAWINGS } from '@univerjs/core';
+import { BooleanNumber, DrawingTypeEnum, FOCUSING_COMMON_DRAWINGS, ObjectRelativeFromH, ObjectRelativeFromV, PositionedObjectLayoutType } from '@univerjs/core';
 import { RichTextEditingMutation } from '@univerjs/docs';
-import { SetDocDrawingArrangeCommand } from '@univerjs/docs-drawing';
+import { SetDocDrawingArrangeCommand, UpdateDrawingDocTransformCommand } from '@univerjs/docs-drawing';
 import { DocumentEditArea } from '@univerjs/engine-render';
 import { Subject } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
@@ -30,6 +30,7 @@ function createController(options: {
     isFocusing?: boolean;
 } = {}) {
     const featurePluginOrderUpdate$ = new Subject<any>();
+    const featurePluginUpdate$ = new Subject<any[]>();
     const featurePluginGroupUpdate$ = new Subject<any>();
     const featurePluginUngroupUpdate$ = new Subject<any>();
     const focus$ = new Subject<any[] | null>();
@@ -100,6 +101,7 @@ function createController(options: {
     const context = {
         unitId: 'doc-1',
         unit: {
+            getDrawings: vi.fn(() => snapshot.drawings),
             getSnapshot: vi.fn(() => snapshot),
         },
         scene,
@@ -123,12 +125,15 @@ function createController(options: {
     };
     const docDrawingService = {
         focusDrawing: vi.fn(),
+        getDrawingByParam: vi.fn(({ drawingId }: { drawingId: string }) => options.drawings?.[drawingId]),
     };
     const drawingManagerService = {
+        featurePluginUpdate$,
         featurePluginOrderUpdate$,
         featurePluginGroupUpdate$,
         featurePluginUngroupUpdate$,
         focus$,
+        getDrawingByParam: vi.fn(({ drawingId }: { drawingId: string }) => options.drawings?.[drawingId]),
     };
     const contextService = {
         setContextValue: vi.fn(),
@@ -170,6 +175,7 @@ function createController(options: {
         docSelectionRenderService,
         drawingManagerService,
         editAreaChange$,
+        featurePluginUpdate$,
         focus$,
         getShape: (drawingId: string) => shapeByDrawingId.get(drawingId),
         onBlur$,
@@ -187,6 +193,112 @@ function createController(options: {
 }
 
 describe('DocDrawingUpdateRenderController', () => {
+    it('persists inline image crop data without moving its text anchor', () => {
+        const drawing = {
+            unitId: 'doc-1',
+            subUnitId: 'doc-1',
+            drawingId: 'body-drawing',
+            drawingType: DrawingTypeEnum.DRAWING_IMAGE,
+            layoutType: PositionedObjectLayoutType.INLINE,
+            transform: { left: 10, top: 20, width: 100, height: 80 },
+            docTransform: {
+                size: { width: 100, height: 80 },
+                positionH: { relativeFrom: ObjectRelativeFromH.PAGE, posOffset: 10 },
+                positionV: { relativeFrom: ObjectRelativeFromV.PAGE, posOffset: 20 },
+                angle: 0,
+            },
+        };
+        const { commandService, featurePluginUpdate$ } = createController({ drawings: { 'body-drawing': drawing } });
+
+        featurePluginUpdate$.next([{
+            ...drawing,
+            transform: { left: 25, top: 30, width: 70, height: 60 },
+            srcRect: { left: 15, top: 10, right: 15, bottom: 10 },
+        }]);
+
+        expect(commandService.executeCommand).toHaveBeenCalledWith(UpdateDrawingDocTransformCommand.id, {
+            unitId: 'doc-1',
+            subUnitId: 'doc-1',
+            drawings: [
+                { drawingId: 'body-drawing', key: 'srcRect', value: { left: 15, top: 10, right: 15, bottom: 10 } },
+                { drawingId: 'body-drawing', key: 'size', value: { width: 70, height: 60 } },
+            ],
+        });
+    });
+
+    it('persists floating crop position and ignores unrelated drawing updates', () => {
+        const drawing = {
+            unitId: 'doc-1',
+            subUnitId: 'doc-1',
+            drawingId: 'body-drawing',
+            drawingType: DrawingTypeEnum.DRAWING_IMAGE,
+            layoutType: PositionedObjectLayoutType.WRAP_SQUARE,
+            transform: { left: 10, top: 20, width: 100, height: 80 },
+            docTransform: {
+                size: { width: 100, height: 80 },
+                positionH: { relativeFrom: ObjectRelativeFromH.PAGE, posOffset: 40 },
+                positionV: { relativeFrom: ObjectRelativeFromV.PARAGRAPH, posOffset: 50 },
+                angle: 0,
+            },
+        };
+        const { commandService, featurePluginUpdate$ } = createController({ drawings: { 'body-drawing': drawing } });
+
+        featurePluginUpdate$.next([{ ...drawing, transform: { left: 12, top: 24, width: 90, height: 70 } }]);
+        featurePluginUpdate$.next([{ ...drawing, unitId: 'other-doc', srcRect: null }]);
+        expect(commandService.executeCommand).not.toHaveBeenCalled();
+
+        featurePluginUpdate$.next([{
+            ...drawing,
+            transform: { left: 25, top: 26, width: 70, height: 60 },
+            srcRect: { left: 15, top: 6, right: 15, bottom: 14 },
+        }]);
+
+        expect(commandService.executeCommand).toHaveBeenCalledWith(UpdateDrawingDocTransformCommand.id, {
+            unitId: 'doc-1',
+            subUnitId: 'doc-1',
+            drawings: [
+                { drawingId: 'body-drawing', key: 'srcRect', value: { left: 15, top: 6, right: 15, bottom: 14 } },
+                { drawingId: 'body-drawing', key: 'size', value: { width: 70, height: 60 } },
+                { drawingId: 'body-drawing', key: 'positionH', value: { relativeFrom: ObjectRelativeFromH.PAGE, posOffset: 55 } },
+                { drawingId: 'body-drawing', key: 'positionV', value: { relativeFrom: ObjectRelativeFromV.PARAGRAPH, posOffset: 56 } },
+            ],
+        });
+    });
+
+    it('persists shared crop data for repeated header and footer drawings without moving each occurrence', () => {
+        const drawing = {
+            unitId: 'doc-1',
+            subUnitId: 'doc-1',
+            drawingId: 'header-drawing',
+            drawingType: DrawingTypeEnum.DRAWING_IMAGE,
+            layoutType: PositionedObjectLayoutType.WRAP_SQUARE,
+            isMultiTransform: BooleanNumber.TRUE,
+            transform: { left: 10, top: 20, width: 100, height: 80 },
+            transforms: [
+                { left: 10, top: 20, width: 100, height: 80 },
+                { left: 10, top: 820, width: 100, height: 80 },
+            ],
+            docTransform: {
+                size: { width: 100, height: 80 },
+                positionH: { relativeFrom: ObjectRelativeFromH.PAGE, posOffset: 10 },
+                positionV: { relativeFrom: ObjectRelativeFromV.PAGE, posOffset: 20 },
+                angle: 0,
+            },
+        };
+        const { commandService, featurePluginUpdate$ } = createController({ drawings: { 'header-drawing': drawing } });
+
+        featurePluginUpdate$.next([{ ...drawing, srcRect: { left: 10, top: 0, right: 10, bottom: 0 } }]);
+
+        expect(commandService.executeCommand).toHaveBeenCalledWith(UpdateDrawingDocTransformCommand.id, {
+            unitId: 'doc-1',
+            subUnitId: 'doc-1',
+            drawings: [
+                { drawingId: 'header-drawing', key: 'srcRect', value: { left: 10, top: 0, right: 10, bottom: 0 } },
+                { drawingId: 'header-drawing', key: 'size', value: { width: 100, height: 80 } },
+            ],
+        });
+    });
+
     it('forwards drawing order and group events to doc drawing commands', () => {
         const { commandService, drawingManagerService } = createController();
 

--- a/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-update.render-controller.ts
+++ b/packages/docs-drawing-ui/src/controllers/render-controllers/doc-drawing-update.render-controller.ts
@@ -16,7 +16,8 @@
 
 import type { DocumentDataModel, ICommandInfo, IDocDrawingPosition, IDrawingParam, IImageIoServiceParam, Nullable } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
-import type { IDocDrawing, IInsertDocDrawingCommandParams, ISetDocDrawingArrangeCommandParams } from '@univerjs/docs-drawing';
+import type { IDocDrawing, IDrawingDocTransform, IInsertDocDrawingCommandParams, ISetDocDrawingArrangeCommandParams, IUpdateDrawingDocTransformCommandParams } from '@univerjs/docs-drawing';
+import type { IImageData } from '@univerjs/drawing';
 import type { Documents, Image, IRenderContext, IRenderModule } from '@univerjs/engine-render';
 import type { LocaleKey } from '../../locale/types';
 import {
@@ -35,7 +36,7 @@ import {
 } from '@univerjs/core';
 import { MessageType } from '@univerjs/design';
 import { buildDocTransform, docDrawingPositionToTransform, DocSelectionManagerService, DocSkeletonManagerService, RichTextEditingMutation } from '@univerjs/docs';
-import { IDocDrawingService, InsertDocDrawingCommand, SetDocDrawingArrangeCommand } from '@univerjs/docs-drawing';
+import { IDocDrawingService, InsertDocDrawingCommand, SetDocDrawingArrangeCommand, UpdateDrawingDocTransformCommand } from '@univerjs/docs-drawing';
 import { DocSelectionRenderService } from '@univerjs/docs-ui';
 import {
     DRAWING_IMAGE_ALLOW_IMAGE_LIST,
@@ -78,6 +79,7 @@ export class DocDrawingUpdateRenderController extends Disposable implements IRen
         super();
 
         this._updateOrderListener();
+        this._updateImageCropListener();
         this._groupDrawingListener();
         this._focusDrawingListener();
         this._transformDrawingListener();
@@ -266,6 +268,78 @@ export class DocDrawingUpdateRenderController extends Disposable implements IRen
                 });
             })
         );
+    }
+
+    private _updateImageCropListener() {
+        this.disposeWithMe(
+            this._drawingManagerService.featurePluginUpdate$.subscribe((params) => {
+                const drawings = (params as IImageData[]).flatMap((param) => this._getImageCropUpdates(param));
+
+                if (drawings.length > 0) {
+                    const { unitId } = this._context;
+                    this._commandService.executeCommand<IUpdateDrawingDocTransformCommandParams>(UpdateDrawingDocTransformCommand.id, {
+                        unitId,
+                        subUnitId: unitId,
+                        drawings,
+                    });
+                }
+            })
+        );
+    }
+
+    private _getImageCropUpdates(param: IImageData): IDrawingDocTransform[] {
+        const { unitId, subUnitId, drawingId, transform } = param;
+        if ([unitId, subUnitId].some((id) => id !== this._context.unitId)) {
+            return [];
+        }
+        if (transform == null || !Object.prototype.hasOwnProperty.call(param, 'srcRect')) {
+            return [];
+        }
+
+        const docDrawing = this._getDocDrawing(drawingId);
+        const renderDrawing = this._drawingManagerService.getDrawingByParam({ unitId, subUnitId, drawingId });
+        if (docDrawing?.drawingType !== DrawingTypeEnum.DRAWING_IMAGE || renderDrawing?.transform == null) {
+            return [];
+        }
+        const nextTransform = { ...renderDrawing.transform, ...transform };
+        const drawings: IDrawingDocTransform[] = [{ drawingId, key: 'srcRect', value: param.srcRect }];
+
+        if (nextTransform.width != null && nextTransform.height != null) {
+            drawings.push({
+                drawingId,
+                key: 'size',
+                value: { width: nextTransform.width, height: nextTransform.height },
+            });
+        }
+
+        if (docDrawing.layoutType === PositionedObjectLayoutType.INLINE || renderDrawing.isMultiTransform === BooleanNumber.TRUE) {
+            return drawings;
+        }
+
+        const horizontalDelta = (nextTransform.left ?? 0) - (renderDrawing.transform.left ?? 0);
+        const verticalDelta = (nextTransform.top ?? 0) - (renderDrawing.transform.top ?? 0);
+        const { positionH, positionV } = docDrawing.docTransform;
+
+        if (horizontalDelta !== 0 && positionH.posOffset != null) {
+            drawings.push({
+                drawingId,
+                key: 'positionH',
+                value: { relativeFrom: positionH.relativeFrom, posOffset: positionH.posOffset + horizontalDelta },
+            });
+        }
+        if (verticalDelta !== 0 && positionV.posOffset != null) {
+            drawings.push({
+                drawingId,
+                key: 'positionV',
+                value: { relativeFrom: positionV.relativeFrom, posOffset: positionV.posOffset + verticalDelta },
+            });
+        }
+
+        return drawings;
+    }
+
+    private _getDocDrawing(drawingId: string): IDocDrawing | undefined {
+        return this._context.unit.getDrawings()?.[drawingId] as IDocDrawing | undefined;
     }
 
     private _groupDrawingListener() {

--- a/packages/docs-drawing/src/commands/commands/update-doc-drawing-transform.command.ts
+++ b/packages/docs-drawing/src/commands/commands/update-doc-drawing-transform.command.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel, IAccessor, ICommand, IObjectPositionH, IObjectPositionV, ISize, JSONXActions } from '@univerjs/core';
+import type { DocumentDataModel, IAccessor, ICommand, IObjectPositionH, IObjectPositionV, ISize, ISrcRect, JSONXActions, Nullable } from '@univerjs/core';
 import type { IRichTextEditingMutationParams } from '@univerjs/docs';
+import type { IDocImage } from '../../services/doc-drawing.service';
 import {
     CommandType,
     ICommandService,
@@ -28,8 +29,8 @@ import { RichTextEditingMutation } from '@univerjs/docs';
 
 export interface IDrawingDocTransform {
     drawingId: string;
-    key: 'size' | 'angle' | 'positionH' | 'positionV' | 'flipX' | 'flipY';
-    value: ISize | number | boolean | IObjectPositionH | IObjectPositionV;
+    key: 'size' | 'angle' | 'positionH' | 'positionV' | 'flipX' | 'flipY' | 'srcRect';
+    value: ISize | number | boolean | IObjectPositionH | IObjectPositionV | Nullable<ISrcRect>;
 }
 
 export interface IUpdateDrawingDocTransformCommandParams {
@@ -60,9 +61,14 @@ export const UpdateDrawingDocTransformCommand: ICommand = {
         const actions: JSONXActions = [];
 
         for (const { drawingId, key, value } of drawings) {
-            const oldValue = oldDrawings[drawingId]?.docTransform?.[key];
+            const oldDrawing = oldDrawings[drawingId];
+            const oldValue = key === 'srcRect'
+                ? (oldDrawing as IDocImage | undefined)?.srcRect
+                : oldDrawing?.docTransform?.[key];
             if (!Tools.diffValue(oldValue, value)) {
-                const path = ['drawings', drawingId, 'docTransform', key];
+                const path = key === 'srcRect'
+                    ? ['drawings', drawingId, key]
+                    : ['drawings', drawingId, 'docTransform', key];
                 // Optional transform fields such as flips do not exist in older documents.
                 actions.push(oldValue === undefined
                     ? jsonX.insertOp(path, value)!


### PR DESCRIPTION
## Summary

- Persist Docs native image crop rectangles when crop mode updates the drawing.
- Persist the resulting size and floating position in the same document mutation.
- Keep inline anchors and repeated header/footer instances stable.
- Add focused regression coverage for crop event routing and atomic undo/redo.

## Scope and non-goals

This PR only fixes native image crop persistence in Docs. It does not change Sheets or Slides crop behavior, shape clipping, image rendering formats, or public command syntax.

The owning packages are `@univerjs/docs-drawing` and `@univerjs/docs-drawing-ui`. Univer Pro consumes the OSS repository through `submodules/univer`; no Pro source change or manual gitlink update is required.

## Root cause

The cropper emits `featurePluginUpdate$` with the image `srcRect` and transform. Docs no longer subscribed to that update after an earlier drawing-controller refactor, so the render object changed transiently but the Doc model did not. Leaving crop mode or reloading the document therefore discarded the crop.

## Implementation

- Subscribe to image crop updates only when the payload owns a `srcRect` property.
- Ignore updates for other documents, non-image drawings, and ordinary transform notifications.
- Persist `srcRect` at the drawing root together with size and applicable floating-position deltas.
- Route all crop fields through one `RichTextEditingMutation` so undo and redo remain atomic.
- Avoid moving inline anchors or individual repeated header/footer occurrences.

## Validation

- `pnpm --filter @univerjs/docs-drawing test` — 5 files, 16 tests passed.
- `pnpm --filter @univerjs/docs-drawing-ui test` — 17 files, 110 tests passed.
- `pnpm --filter @univerjs/docs-drawing typecheck` — passed.
- `pnpm --filter @univerjs/docs-drawing-ui typecheck` — passed.
- Targeted ESLint on the four changed files — 0 errors; 13 pre-existing warnings.
- `git diff --check` — passed.
- Manual editable-browser regression — crop remains after exiting crop mode and after reloading the document.

## SDK and integration impact

- SDK dependencies changed: No.
- Behavior absent from currently published SDK packages: Yes, this is the OSS fix itself.
- Merge/release order: merge this OSS PR first. Univer Pro should consume it through the existing automated `submodules/univer` sync workflow; do not manually commit the gitlink.

## Architecture and documentation

No ADR or architecture documentation update is needed because this restores existing behavior inside the current drawing command/controller boundaries.

## Pull Request Checklist

- [x] No related Issue was provided.
- [x] Naming conventions are followed.
- [x] Focused regression tests cover the change.
- [x] No breaking changes are introduced.
