### PR TITLE
fix(slides): improve thumbnail page index contrast

### DIFF
--- a/packages/slides-ui/src/views/slide-bar/SlideBar.tsx
+++ b/packages/slides-ui/src/views/slide-bar/SlideBar.tsx
@@ -109,19 +109,31 @@ export function SlideSideBar() {
                 {slideList.map((item, index) => (
                     <div
                         key={item.id}
-                        className={clsx('univer-my-4 univer-flex univer-gap-2', {
-                            '[&>div]:univer-border-primary-600 [&>span]:univer-text-primary-600': item.id === activatePageId,
-                        })}
+                        className="univer-my-4 univer-flex univer-justify-end"
                         onClick={() => activatePage(item.id)}
                     >
-                        <span>{index + 1}</span>
-                        <div
-                            ref={divRefs[index]}
-                            className={clsx(`
-                              univer-relative univer-box-border univer-h-32 univer-w-52 univer-bg-gray-0
-                              hover:univer-border-primary-600
-                            `, borderClassName)}
-                        />
+                        <div className="univer-relative univer-h-32 univer-w-52">
+                            <div
+                                ref={divRefs[index]}
+                                className={clsx(`
+                                  univer-box-border univer-h-full univer-w-full univer-bg-gray-0
+                                  hover:univer-border-primary-600
+                                `, borderClassName, {
+                                    'univer-border-primary-600': item.id === activatePageId,
+                                })}
+                            />
+                            <span
+                                className={clsx(`
+                                  univer-pointer-events-none univer-absolute univer-bottom-2 univer-left-2 univer-z-10
+                                  univer-inline-flex univer-h-6 univer-min-w-6 univer-items-center univer-justify-center
+                                  univer-rounded-md univer-px-1.5 univer-text-xs univer-font-medium univer-tabular-nums
+                                `, item.id === activatePageId
+                                    ? 'univer-bg-primary-100 univer-text-primary-800'
+                                    : 'univer-bg-gray-100 univer-text-gray-700')}
+                            >
+                                {index + 1}
+                            </span>
+                        </div>
                     </div>
                 ))}
             </div>


### PR DESCRIPTION
## Summary

- render slide page indexes as badges inside thumbnail previews
- use `gray.100` with `gray.700` for inactive indexes
- use `primary.100` with `primary.800` for the active index

## Why

The page index inherited the browser text color instead of using theme tokens. It could therefore disappear when a custom theme, such as a dark theme without dark mode enabled, changed the thumbnail surface to a dark color.

The badge surface keeps the index readable over arbitrary slide content, while the paired theme tokens maintain contrast in both the default theme and custom reversed-gray themes.

## Validation

- `pnpm --filter @univerjs/slides-ui typecheck`
- `pnpm exec eslint packages/slides-ui/src/views/slide-bar/SlideBar.tsx`
- `git diff --check`

## Compatibility

- No breaking changes
- No SDK dependency changes
- No tests added because this is a token-only presentation change

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes (if applicable).
- [x] No breaking changes are introduced.
