### PR TITLE
fix(docs): document table column styles on insert

### DIFF
--- a/packages/docs-ui/src/commands/commands/__tests__/doc-table-create.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/doc-table-create.command.spec.ts
@@ -488,8 +488,12 @@ describe('doc table create command helpers', () => {
         ]);
     });
 
-    it('executes column insertion and keeps table width distributed across all columns', async () => {
+    it('executes column insertion with the source cell style and keeps table width distributed', async () => {
         const fixture = createTableFixture();
+        const sourceColors = ['#101828', '#f8fafc', '#ffffff'];
+        fixture.documentData.tableSource![TABLE_ID].tableRows.forEach((row, rowIndex) => {
+            row.tableCells[1].backgroundColor = { rgb: sourceColors[rowIndex] };
+        });
         const testBed = createTableCommandBed(fixture);
         const commandService = testBed.get(ICommandService);
         setActiveTableRange(testBed, fixture.cellRanges[1].startIndex + 1);
@@ -500,6 +504,7 @@ describe('doc table create command helpers', () => {
         const tableSource = testBed.doc.getSnapshot().tableSource?.[TABLE_ID];
         expect(result).toBe(true);
         expect(tableSource?.tableRows.map((row) => row.tableCells.length)).toEqual([4, 4, 4]);
+        expect(tableSource?.tableRows.map((row) => [row.tableCells[1].backgroundColor?.rgb, row.tableCells[2].backgroundColor?.rgb])).toEqual(sourceColors.map((color) => [color, color]));
         expect(tableSource?.tableColumns.map((column) => column.size.width.v)).toEqual([90, 90, 90, 90]);
     });
 

--- a/packages/docs-ui/src/commands/commands/table/doc-table-insert.command.ts
+++ b/packages/docs-ui/src/commands/commands/table/doc-table-insert.command.ts
@@ -25,20 +25,19 @@ import {
     JSONX,
     TextX,
     TextXActionType,
+    Tools,
     UniverInstanceType,
 } from '@univerjs/core';
 import { DocSelectionManagerService, RichTextEditingMutation } from '@univerjs/docs';
 import { getCommandSkeleton } from '../../util';
 import {
     getColumnWidths,
-    getEmptyTableCell,
     getEmptyTableRow,
     getInsertColumnActionsParams,
     getInsertColumnBody,
     getInsertRowActionsParams,
     getInsertRowBody,
     getRangeInfoFromRanges,
-    getTableColumn,
     INSERT_COLUMN_POSITION,
     INSERT_ROW_POSITION,
 } from './table';
@@ -265,6 +264,14 @@ export const DocTableInsertColumnCommand: ICommand<IDocTableInsertColumnCommandP
         }
 
         const { offsets, columnIndex, tableId, rowCount } = actionParams;
+        const snapshot = docDataModel.getSnapshot();
+        const table = snapshot.tableSource?.[tableId];
+
+        if (!table) {
+            return false;
+        }
+
+        const insertColumnIndex = columnIndex + Number(position === INSERT_COLUMN_POSITION.RIGHT);
 
         const rawActions: JSONXActions = [];
 
@@ -305,22 +312,18 @@ export const DocTableInsertColumnCommand: ICommand<IDocTableInsertColumnCommandP
 
         // Step 3: Insert table cell;
         for (let i = 0; i < rowCount; i++) {
-            const insertCell = getEmptyTableCell();
-            const insertTableSource = jsonX.insertOp(['tableSource', tableId, 'tableRows', i, 'tableCells', columnIndex], insertCell);
+            const insertCell = Tools.deepClone(table.tableRows[i].tableCells[columnIndex]);
+            delete insertCell.rowSpan;
+            delete insertCell.columnSpan;
+            const insertTableSource = jsonX.insertOp(['tableSource', tableId, 'tableRows', i, 'tableCells', insertColumnIndex], insertCell);
             rawActions.push(insertTableSource!);
         }
-
-        const snapshot = docDataModel.getSnapshot();
 
         const documentStyle = snapshot.documentStyle;
 
         const { marginLeft = 0, marginRight = 0 } = documentStyle;
 
-        const tableColumns = snapshot?.tableSource?.[tableId]?.tableColumns;
-
-        if (!tableColumns) {
-            return false;
-        }
+        const tableColumns = table.tableColumns;
 
         const pageWidth = (documentStyle.pageSize?.width ?? 800) - marginLeft - marginRight;
         const tableWidth = tableColumns.reduce((sum, column) => sum + column.size.width.v, 0);
@@ -333,8 +336,9 @@ export const DocTableInsertColumnCommand: ICommand<IDocTableInsertColumnCommandP
             rawActions.push(action!);
         }
 
-        const insertCol = getTableColumn(newColWidth);
-        const insertTableColumn = jsonX.insertOp(['tableSource', tableId, 'tableColumns', columnIndex], insertCol);
+        const insertCol = Tools.deepClone(tableColumns[columnIndex]);
+        insertCol.size.width.v = newColWidth;
+        const insertTableColumn = jsonX.insertOp(['tableSource', tableId, 'tableColumns', insertColumnIndex], insertCol);
         rawActions.push(insertTableColumn!);
 
         doMutation.params.actions = rawActions.reduce((acc, cur) => {


### PR DESCRIPTION
## Summary

- insert the table-source column at the same left/right position as the document stream
- clone the adjacent column and cell styles for the new column
- clear copied merge-span markers from newly inserted cells
- extend the existing command regression test to cover style inheritance

## Root cause

The right-insert command wrote the new cell content after the selected column but inserted its table-source metadata at the selected column index. This shifted styles onto the wrong cells, and the new cells were created with default styling.

## User impact

Left and right column insertion now keep existing cell styles aligned and give the new column the adjacent column's style.

Companion Pro fix: https://github.com/dream-num/univer-pro/pull/5555

## Validation

- `pnpm --filter @univerjs/docs-ui exec vitest run src/commands/commands/__tests__/doc-table-create.command.spec.ts` (28 tests passed)
- `pnpm --filter @univerjs/docs-ui typecheck`
- `pnpm exec eslint packages/docs-ui/src/commands/commands/table/doc-table-insert.command.ts packages/docs-ui/src/commands/commands/__tests__/doc-table-create.command.spec.ts`
- `git diff HEAD^ --check`

## Pull Request Checklist

- [x] No related Issue was provided.
- [x] Naming conventions are unchanged.
- [x] Unit coverage protects the changed behavior.
- [x] No breaking changes are introduced.

No documentation, images, generated build output, or unrelated test artifacts are included.
