### PR TITLE
fix(ui): harden print preparation state

### DIFF
--- a/packages/docs-ui/src/controllers/ui.controller.ts
+++ b/packages/docs-ui/src/controllers/ui.controller.ts
@@ -128,7 +128,11 @@ export class DocUIController extends Disposable {
                 }
 
                 const renderManagerService = this._injector.get(IRenderManagerService);
-                const docSelectionRenderService = renderManagerService.getRenderUnitById(unitId)!.with(DocSelectionRenderService);
+                const renderUnit = renderManagerService.getRenderUnitById(unitId);
+                if (!renderUnit) {
+                    return;
+                }
+                const docSelectionRenderService = renderUnit.with(DocSelectionRenderService);
 
                 docSelectionRenderService.focus();
             })

--- a/packages/ui/src/views/hooks/virtual-list.ts
+++ b/packages/ui/src/views/hooks/virtual-list.ts
@@ -23,7 +23,7 @@ type ItemHeight<T> = (index: number, data: T) => number;
 const isNumber = (value: unknown): value is number => typeof value === 'number';
 
 export interface IVirtualListOptions<T> {
-    containerTarget: React.RefObject<HTMLElement>;
+    containerTarget: React.RefObject<HTMLElement | null>;
     itemHeight: number | ItemHeight<T>;
     overscan?: number;
 }

--- a/packages/ui/src/views/hooks/virtual-list.ts
+++ b/packages/ui/src/views/hooks/virtual-list.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Nullable } from '@univerjs/core';
+import type { RefObject } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useEvent } from './event';
 
@@ -23,7 +24,7 @@ type ItemHeight<T> = (index: number, data: T) => number;
 const isNumber = (value: unknown): value is number => typeof value === 'number';
 
 export interface IVirtualListOptions<T> {
-    containerTarget: React.RefObject<HTMLElement | null>;
+    containerTarget: RefObject<HTMLElement | null>;
     itemHeight: number | ItemHeight<T>;
     overscan?: number;
 }


### PR DESCRIPTION
Summary: guard document focus when the render unit is temporarily unavailable during print preparation, and allow nullable React DOM refs in the virtual list contract. Validation: docs-ui and ui typechecks, ESLint on both changed files, and git diff --check.