### PR TITLE
chore: migrate repository to pnpm 11

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -44,6 +44,7 @@ jobs:
               with:
                   node-version: 24.3.0
                   registry-url: https://registry.npmjs.org
+                  package-manager-cache: false
 
             - name: 🚚 Install dependencies and build
               run: |
@@ -52,12 +53,10 @@ jobs:
 
             - name: 🐙 Publish
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  NPM_CONFIG_PROVENANCE: true
                   REF_NAME: ${{ github.ref_name }}
               run: |
                   if [[ "$REF_NAME" =~ -(alpha|beta|rc)\. ]]; then
-                      pnpm publish --access public --tag "${BASH_REMATCH[1]}" -r --no-git-checks
+                      pnpm publish --access public --tag "${BASH_REMATCH[1]}" -r --no-git-checks --provenance
                   else
-                      pnpm publish --access public -r --no-git-checks
+                      pnpm publish --access public -r --no-git-checks --provenance
                   fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ To better assist you, we recommend:
 
 ### Install dependencies
 
-The development of Univer requires Node.js >= 22.18 and pnpm >= 10. Please make sure you have the correct versions installed.
+The development of Univer requires Node.js >= 22.18 and pnpm >= 11. Please make sure you have the correct versions installed.
 
 ```shell
 git clone https://github.com/dream-num/univer

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Package-level READMEs live beside each package under [`packages/`](./packages).
 Requirements:
 
 - Node.js `>=22.18`
-- pnpm `>=10`
+- pnpm `>=11`
 
 ```bash
 git clone https://github.com/dream-num/univer.git

--- a/docs/readme/es-ES.md
+++ b/docs/readme/es-ES.md
@@ -304,7 +304,7 @@ Los README de cada paquete están junto a sus paquetes dentro de [`packages/`](.
 Requisitos:
 
 - Node.js `>=22.18`
-- pnpm `>=10`
+- pnpm `>=11`
 
 ```bash
 git clone https://github.com/dream-num/univer.git

--- a/docs/readme/ja-JP.md
+++ b/docs/readme/ja-JP.md
@@ -305,7 +305,7 @@ Boundary principles:
 必要環境：
 
 - Node.js `>=22.18`
-- pnpm `>=10`
+- pnpm `>=11`
 
 ```bash
 git clone https://github.com/dream-num/univer.git

--- a/docs/readme/ko-KR.md
+++ b/docs/readme/ko-KR.md
@@ -305,7 +305,7 @@ Boundary principles:
 요구 사항:
 
 - Node.js `>=22.18`
-- pnpm `>=10`
+- pnpm `>=11`
 
 ```bash
 git clone https://github.com/dream-num/univer.git

--- a/docs/readme/zh-CN.md
+++ b/docs/readme/zh-CN.md
@@ -304,7 +304,7 @@ Pro 功能请参考 [Univer Pro 指南](https://docs.univer.ai/guides/pro)。这
 要求：
 
 - Node.js `>=22.18`
-- pnpm `>=10`
+- pnpm `>=11`
 
 ```bash
 git clone https://github.com/dream-num/univer.git

--- a/docs/readme/zh-TW.md
+++ b/docs/readme/zh-TW.md
@@ -304,7 +304,7 @@ Pro 功能請參考 [Univer Pro 指南](https://docs.univer.ai/guides/pro)。這
 要求：
 
 - Node.js `>=22.18`
-- pnpm `>=10`
+- pnpm `>=11`
 
 ```bash
 git clone https://github.com/dream-num/univer.git

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "version": "1.0.0-beta.1",
     "private": true,
-    "packageManager": "pnpm@10.33.4",
+    "packageManager": "pnpm@11.22.0",
     "author": "DreamNum Co., Ltd. <developer@univer.ai>",
     "license": "Apache-2.0",
     "funding": {
@@ -19,16 +19,10 @@
         "url": "https://github.com/dream-num/univer/issues"
     },
     "devEngines": {
-        "runtime": [
-            {
-                "name": "node",
-                "version": ">=22.18"
-            },
-            {
-                "name": "pnpm",
-                "version": ">=10"
-            }
-        ]
+        "runtime": {
+            "name": "node",
+            "version": ">=22.18"
+        }
     },
     "scripts": {
         "prepare": "husky",
@@ -84,14 +78,6 @@
         "turbo": "^2.10.8",
         "typescript": "^6.0.3",
         "vitest": "^4.1.10"
-    },
-    "pnpm": {
-        "overrides": {
-            "@types/react": "19.2.18",
-            "@types/react-dom": "19.2.4",
-            "react": "19.2.8",
-            "react-dom": "19.2.8"
-        }
     },
     "lint-staged": {
         "*": "eslint --fix"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,202 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 11.22.0
+        version: 11.22.0
+      pnpm:
+        specifier: 11.22.0
+        version: 11.22.0
+
+packages:
+
+  '@pnpm/exe@11.22.0':
+    resolution: {integrity: sha512-B1SGeKm+v9pX9YkzMmrnO2FbgBd8TDwzZ3jSj6J6ThxdyGvI4TsOfMeHARW4Wb25visPpmMDfIXrU76EZdJM4g==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@11.22.0':
+    resolution: {integrity: sha512-xzzn3jYG9QaiFZPaHcWM3yX4Fm9UGz5E42mzpbvUEvXYf5O9fwNolenOhGLpRl2qS5u35fjZSvDZbWlOwHMcug==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.22.0':
+    resolution: {integrity: sha512-isvaPctGinbsM2hsTtRsMarN8Sr5QhXDTNmn8Xv9Lp1PjincCvH2RBbhpo+xYIOxzgls1dtQSdgoORUbfRVALQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/linuxstatic-arm64@11.22.0':
+    resolution: {integrity: sha512-i4J+AQWW0T3JBdXaLsvxu8ZmMG1HLS6JZQESdOR9uBv8Zumb4yg8GYT83eWRLacr6ngVdhEBiC3W4eOG64MFbA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/linuxstatic-x64@11.22.0':
+    resolution: {integrity: sha512-QYzk8jhSuSbVthW/OxEOhU3f3zhjpw4HqgedrlwbVNb7btCWn5del2Hb5PsYYka2PbmKq5EtF5IzYN8Yp1CfxQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/macos-arm64@11.22.0':
+    resolution: {integrity: sha512-Io8Axk5kutPgMuAfOg1QGj3J0/KpLvH5iiPcmp7up8D4q7BNWT02ndQo3RyGWqrlkf5nwspM41GFpWTShrZ4Aw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.22.0':
+    resolution: {integrity: sha512-QgaRuKGQKov7xW2utPCgDT83fn/PU5cD6HFgib48oTslz7wv26E89d4jMCxL4GRmEL2YCfkYuj5ITj1oVWg5WQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.22.0':
+    resolution: {integrity: sha512-iWYsiSwpgxqur+TwsnSoPdOQaEfd4ygB84mb5tJUOgim6PHr1xhKJBndaQzH+At/WkLxLdYN+K8dYc4M7naezg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  pnpm@11.22.0:
+    resolution: {integrity: sha512-H/hwxMYTPf2I+yr8Rt0T1H8JyXlLQ4xv20fKmMrzvBY4HuC+k6CRuOOCTPAfiJ9G19niCRD7C+GrD7W6qA3WIQ==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@11.22.0':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@pnpm/linux-arm64': 11.22.0
+      '@pnpm/linux-x64': 11.22.0
+      '@pnpm/linuxstatic-arm64': 11.22.0
+      '@pnpm/linuxstatic-x64': 11.22.0
+      '@pnpm/macos-arm64': 11.22.0
+      '@pnpm/win-arm64': 11.22.0
+      '@pnpm/win-x64': 11.22.0
+
+  '@pnpm/linux-arm64@11.22.0':
+    optional: true
+
+  '@pnpm/linux-x64@11.22.0':
+    optional: true
+
+  '@pnpm/linuxstatic-arm64@11.22.0':
+    optional: true
+
+  '@pnpm/linuxstatic-x64@11.22.0':
+    optional: true
+
+  '@pnpm/macos-arm64@11.22.0':
+    optional: true
+
+  '@pnpm/win-arm64@11.22.0':
+    optional: true
+
+  '@pnpm/win-x64@11.22.0':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.22.0: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,9 +8,13 @@ packages:
     - tests/*
 publicHoistPattern:
     - '@storybook/react'
+allowBuilds:
+    '@parcel/watcher': false
+    '@swc/core': false
+    esbuild: false
+    protobufjs: false
 overrides:
-    '@types/react': 19.2.17
-    '@types/react-dom': 19.2.3
+    '@types/react': 19.2.18
+    '@types/react-dom': 19.2.4
     react: 19.2.8
     react-dom: 19.2.8
-# Before `pnpm >=11` in the packageManager, this file is not allowed to be modified.


### PR DESCRIPTION
## Summary

- migrate the repository package-manager configuration and workspace metadata to pnpm 11
- refresh the pnpm lockfile and update the release workflow
- update contributor and localized README documentation for the new package-manager requirements

## Related issue

No related issue.

## Testing

- pnpm install completed successfully with all workspace prepare scripts
- lint-staged ESLint passed for all changed files during commit

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (no related issue).
- [x] Naming convention is followed; no new plugins, commands, or resources were added.
- [ ] Unit tests have been added for the changes (not applicable to this package-manager/configuration migration).
- [x] Breaking changes have been documented (no runtime API breaking changes introduced).