### PR TITLE
feat(core): add fluent rich text link APIs

### DIFF
--- a/packages/core/src/docs/data-model/__tests__/rich-text-builder.test.ts
+++ b/packages/core/src/docs/data-model/__tests__/rich-text-builder.test.ts
@@ -825,6 +825,24 @@ describe('RichTextBuilder', () => {
     });
 
     describe('link management', () => {
+        it('should append, update, and remove links with agent-friendly methods', () => {
+            const builder = RichTextBuilder.create()
+                .text('Read ')
+                .link('Univer documentation', 'https://docs.univer.ai')
+                .text(' for details.');
+
+            expect(builder.toPlainText()).toBe('Read Univer documentation for details.');
+            const [link] = builder.getLinks();
+            expect(link.properties?.url).toBe('https://docs.univer.ai');
+
+            builder.updateLink(link.rangeId, 'https://univer.ai/docs');
+            expect(builder.getLinks()[0].properties?.url).toBe('https://univer.ai/docs');
+
+            expect(builder.removeLink(link.rangeId)).toBe(builder);
+            expect(builder.toPlainText()).toBe('Read Univer documentation for details.');
+            expect(builder.getLinks()).toEqual([]);
+        });
+
         it('should set link for text range', () => {
             const builder = RichTextBuilder.create()
                 .insertText('Hello World')

--- a/packages/core/src/docs/data-model/rich-text-builder.ts
+++ b/packages/core/src/docs/data-model/rich-text-builder.ts
@@ -16,26 +16,14 @@
 
 import type { Nullable } from '../../shared';
 import type { BaselineOffset, HorizontalAlign, TextDecoration, TextDirection, VerticalAlign } from '../../types/enum';
-import type {
-    IBorderData,
-    IColorStyle,
-    IDocumentBody,
-    IDocumentData,
-    INumberUnit,
-    IParagraphBorder,
-    IParagraphStyle,
-    ISectionColumnProperties,
-    IShading,
-    ITabStop,
-    ITextDecoration,
-    ITextStyle,
-    NamedStyleType,
-    SpacingRule,
-} from '../../types/interfaces';
+import type { IBorderData, IColorStyle, IDocumentBody, IDocumentData, INumberUnit, IParagraphBorder, IParagraphStyle, ISectionColumnProperties, IShading, ITabStop, ITextDecoration, ITextStyle, NamedStyleType, SpacingRule } from '../../types/interfaces';
 import { Tools } from '../../shared';
 import { generateRandomId } from '../../shared/random-id';
 import { BooleanNumber } from '../../types/enum';
-import { CustomRangeType } from '../../types/interfaces';
+import {
+    CustomRangeType,
+
+} from '../../types/interfaces';
 import { createParagraphId } from '../paragraph-id';
 import { createSectionId } from '../section-break-id';
 import { DocumentDataModel } from './document-data-model';
@@ -2446,6 +2434,27 @@ export class RichTextBuilder extends RichTextValue {
     }
 
     /**
+     * Appends linked text.
+     *
+     * This is the agent-friendly alias of `insertLink(text, url)`. Use `setLink(start, end, url)` only when applying a
+     * link to text that is already present and numeric offsets are unavoidable.
+     *
+     * @param text Visible link text to append. An empty string is ignored.
+     * @param url Link destination.
+     * @returns The current builder for chaining.
+     * @example
+     * ```ts
+     * const richText = univerAPI.newRichText()
+     *   .text('Read ')
+     *   .link('Univer documentation', 'https://docs.univer.ai')
+     *   .text(' for details.');
+     * ```
+     */
+    link(text: string, url: string): RichTextBuilder {
+        return text ? this.insertLink(text, url) : this;
+    }
+
+    /**
      * Appends one ordered, unordered, or checklist paragraph.
      *
      * Consecutive items with the same `type` automatically share a generated list id. Supply a semantic `listId` when
@@ -2873,6 +2882,31 @@ export class RichTextBuilder extends RichTextValue {
         return this;
     }
 
+    /**
+     * Removes a link while preserving its visible text.
+     *
+     * Link ids are available from `getLinks()`. This readable alias avoids exposing text offsets for the common case.
+     * Use `cancelLink(start, end)` only when removing every link in a known text range.
+     *
+     * @param id Link range id returned by `getLinks()`.
+     * @returns The current builder for chaining.
+     * @example
+     * ```ts
+     * const richText = univerAPI.newRichText().link('Univer', 'https://univer.ai');
+     * const [link] = richText.getLinks();
+     * if (link) richText.removeLink(link.rangeId);
+     * ```
+     */
+    removeLink(id: string): RichTextBuilder {
+        return this.cancelLink(id);
+    }
+
+    /**
+     * Updates a link destination while preserving its visible text.
+     * @param id Link range id returned by `getLinks()`.
+     * @param url New link destination.
+     * @returns The current builder for chaining.
+     */
     updateLink(id: string, url: string): RichTextBuilder {
         const current = this._data.body?.customRanges?.find((range) => range.rangeId === id);
         if (!current) {
@@ -2936,10 +2970,14 @@ export class RichTextBuilder extends RichTextValue {
     }
 
     /**
-     * Inserts a new link
-     * @param text
-     * @param url
-     * @returns
+     * Inserts linked text at the end of the builder or at an explicit text offset.
+     *
+     * Application and agent code should prefer `link(text, url)` for left-to-right construction. The positional
+     * overload remains available for advanced document-model integrations.
+     *
+     * @param text Visible link text to insert.
+     * @param url Link destination.
+     * @returns The current builder for chaining.
      */
     insertLink(text: string, url: string): RichTextBuilder;
     insertLink(start: number, text: string, url: string): RichTextBuilder;

--- a/packages/core/src/facade/f-univer.ts
+++ b/packages/core/src/facade/f-univer.ts
@@ -14,30 +14,24 @@
  * limitations under the License.
  */
 
-import type {
-    DocumentDataModel,
-    IDisposable,
-    IDocumentData,
-    IExecutionOptions,
-    ILanguagePack,
-    IParagraphStyle,
-    ITextDecoration,
-    ITextStyle,
-    LifecycleStages,
-    LocaleType,
-} from '@univerjs/core';
+import type { DocumentDataModel, IDisposable, IDocumentData, IExecutionOptions, ILanguagePack, IParagraphStyle, ITextDecoration, ITextStyle, LifecycleStages, LocaleType } from '@univerjs/core';
 import type { Theme } from '@univerjs/themes';
 import type { Subscription } from 'rxjs';
 import type { ICommandEvent, IEventParamConfig } from './f-event';
 import {
     CanceledError,
     Disposable,
+
     ICommandService,
+
     Inject,
     Injector,
+
     IUniverInstanceService,
     LifecycleService,
+
     LocaleService,
+
     ParagraphStyleBuilder,
     ParagraphStyleValue,
     RedoCommand,
@@ -605,9 +599,9 @@ export class FUniver extends Disposable {
      * @example
      * ```ts
      * const richText = univerAPI.newRichText()
-     *   .align({ horizontal: univerAPI.Enum.HorizontalAlign.CENTER })
-     *   .text('Status: ')
-     *   .span('Ready', { bold: true, color: '#16a34a' });
+     *   .text('Read ')
+     *   .link('Univer documentation', 'https://docs.univer.ai')
+     *   .text(' for details.');
      * ```
      */
     newRichText(): RichTextBuilder {


### PR DESCRIPTION
## Summary

- add an agent-friendly `RichTextBuilder.link(text, url)` fluent API
- add readable link update/removal semantics while preserving existing offset-based APIs
- document the recommended facade construction flow and cover it with regression tests

## Why

Shape text hyperlinks need a model-layer builder API that is easy for agents and application code to compose without manually managing document offsets.

## Validation

- `@univerjs/core` rich-text builder tests: 70 passed
- `packages/core` typecheck
- pre-commit checks