### PR TITLE
fix(engine-render): resolve theme colors when printing

### DIFF
--- a/packages/engine-render/src/__tests__/canvas.spec.ts
+++ b/packages/engine-render/src/__tests__/canvas.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ICanvasColorService } from '../services/canvas-color.service';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Canvas, CanvasRenderMode, HitCanvas, SceneCanvas } from '../canvas';
 
@@ -23,12 +24,13 @@ describe('canvas wrapper', () => {
     });
 
     it('initializes rendering and printing contexts with sizing and ids', () => {
+        const colorService: ICanvasColorService = { getRenderColor: (color: string) => color };
         const canvas = new Canvas({
             id: 'ignored-by-constructor',
             width: 120,
             height: 80,
             pixelRatio: 2,
-            colorService: { getRenderColor: (color: string) => color } as any,
+            colorService,
         });
 
         canvas.setId('render-canvas');
@@ -50,6 +52,23 @@ describe('canvas wrapper', () => {
 
         const printing = new Canvas({ mode: CanvasRenderMode.Printing, width: 20, height: 10 });
         expect(printing.getContext().__mode).toBe('printing');
+        printing.dispose();
+    });
+
+    it('resolves theme colors in printing contexts', () => {
+        const getRenderColor = vi.fn((color: string) => color === 'primary.500' ? '#dfe5ff' : color);
+        const colorService: ICanvasColorService = { getRenderColor };
+        const printing = new Canvas({
+            mode: CanvasRenderMode.Printing,
+            width: 20,
+            height: 10,
+            colorService,
+        });
+
+        printing.getContext().fillStyle = 'primary.500';
+
+        expect(getRenderColor).toHaveBeenCalledWith('primary.500');
+        expect(printing.getContext().fillStyle).toBe('#dfe5ff');
         printing.dispose();
     });
 

--- a/packages/engine-render/src/canvas.ts
+++ b/packages/engine-render/src/canvas.ts
@@ -91,7 +91,9 @@ export class Canvas {
         }
 
         if (props.mode === CanvasRenderMode.Printing) {
-            this._context = new UniverPrintingContext(context);
+            this._context = new UniverPrintingContext(context, {
+                canvasColorService: props.colorService,
+            });
         } else {
             this._context = new UniverRenderingContext(context, {
                 canvasColorService: props.colorService,
@@ -161,10 +163,7 @@ export class Canvas {
         if (this._width === 0 || this._height === 0) {
             return;
         }
-        if (pixelRatio < 1) {
-            pixelRatio = 1;
-        }
-        this.setSize(this._width, this._height, pixelRatio);
+        this.setSize(this._width, this._height, Math.max(1, pixelRatio));
     }
 
     dispose() {
@@ -191,11 +190,11 @@ export class Canvas {
             // If this call fails (due to browser bug, like in Firefox 3.6),
             // then revert to previous no-parameter image/png behavior
             return this.getCanvasEle().toDataURL(mimeType, quality);
-        } catch (e) {
+        } catch {
             try {
                 return this.getCanvasEle().toDataURL();
             } catch (err: unknown) {
-                const { message } = err as Error;
+                const message = err instanceof Error ? err.message : String(err);
                 console.error(
                     `Unable to get data URL. ${message} For more info read https://universheet.net/docs/Canvas.html.`
                 );

--- a/packages/engine-render/src/canvas.ts
+++ b/packages/engine-render/src/canvas.ts
@@ -163,7 +163,10 @@ export class Canvas {
         if (this._width === 0 || this._height === 0) {
             return;
         }
-        this.setSize(this._width, this._height, Math.max(1, pixelRatio));
+        if (pixelRatio < 1) {
+            pixelRatio = 1;
+        }
+        this.setSize(this._width, this._height, pixelRatio);
     }
 
     dispose() {
@@ -190,11 +193,11 @@ export class Canvas {
             // If this call fails (due to browser bug, like in Firefox 3.6),
             // then revert to previous no-parameter image/png behavior
             return this.getCanvasEle().toDataURL(mimeType, quality);
-        } catch {
+        } catch (e) {
             try {
                 return this.getCanvasEle().toDataURL();
             } catch (err: unknown) {
-                const message = err instanceof Error ? err.message : String(err);
+                const { message } = err as Error;
                 console.error(
                     `Unable to get data URL. ${message} For more info read https://universheet.net/docs/Canvas.html.`
                 );


### PR DESCRIPTION
## Summary

- forward the canvas color service to printing contexts
- keep theme-token colors consistent between editing and printing
- add regression coverage for theme-color resolution in printing mode

## Context

Board print and image export use the dedicated printing canvas. Without the color service, theme color tokens were assigned directly to the native canvas context. Invalid color assignments retained the previous fill style, changing element backgrounds and hiding text in exported output.

## Validation

- `pnpm exec eslint packages/engine-render/src/canvas.ts packages/engine-render/src/__tests__/canvas.spec.ts`
- `pnpm --filter @univerjs/engine-render test -- canvas.spec.ts` (95 files, 962 tests)
- `pnpm --filter @univerjs/engine-render build:types`
- `git diff --check`