### PR TITLE
fix(docs): prevent text overlap after style changes

### DIFF
--- a/packages/docs-ui/src/commands/commands/__tests__/set-heading.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/set-heading.command.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DocumentDataModel, ICommand, IDocumentData, Injector, Univer } from '@univerjs/core';
-import { awaitTime, DataStreamTreeTokenType, DocumentBlockRangeType, ICommandService, IUniverInstanceService, NamedStyleType, UniverInstanceType, validateDocBodyStructure } from '@univerjs/core';
+import { awaitTime, DataStreamTreeTokenType, DocumentBlockRangeType, ICommandService, IUniverInstanceService, NamedStyleType, SpacingRule, UniverInstanceType, validateDocBodyStructure } from '@univerjs/core';
 import {
     DocContentInsertService,
     DocSelectionManagerService,
@@ -42,7 +42,14 @@ function getHeadingDocumentData(): IDocumentData {
         id: 'test-doc',
         body: {
             dataStream: 'Heading\r\n',
-            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_29', startIndex: 7 }],
+            paragraphs: [{
+                paragraphId: 'para_docs_ui_fixture_29',
+                startIndex: 7,
+                paragraphStyle: {
+                    lineSpacing: 24,
+                    spacingRule: SpacingRule.EXACT,
+                },
+            }],
         },
         documentStyle: {
             pageSize: {
@@ -62,7 +69,14 @@ function getQuickHeadingDocumentData(): IDocumentData {
         id: 'test-doc',
         body: {
             dataStream: '# Heading\r\n',
-            paragraphs: [{ paragraphId: 'para_docs_ui_fixture_30', startIndex: 9 }],
+            paragraphs: [{
+                paragraphId: 'para_docs_ui_fixture_30',
+                startIndex: 9,
+                paragraphStyle: {
+                    lineSpacing: 24,
+                    spacingRule: SpacingRule.EXACT,
+                },
+            }],
         },
         documentStyle: {
             pageSize: {
@@ -201,6 +215,8 @@ describe('set heading commands', () => {
 
         expect(getBody()?.paragraphs?.[0].paragraphStyle?.namedStyleType).toBe(NamedStyleType.HEADING_1);
         expect(getBody()?.paragraphs?.[0].paragraphStyle?.headingId?.length).toBe(6);
+        expect(getBody()?.paragraphs?.[0].paragraphStyle?.lineSpacing).toBeUndefined();
+        expect(getBody()?.paragraphs?.[0].paragraphStyle?.spacingRule).toBeUndefined();
     });
 
     it('applies heading levels and document title styles through public commands', async () => {
@@ -329,5 +345,7 @@ describe('set heading commands', () => {
 
         expect(getBody()?.dataStream.startsWith('Heading')).toBe(true);
         expect(getBody()?.paragraphs?.[0].paragraphStyle?.namedStyleType).toBe(NamedStyleType.HEADING_2);
+        expect(getBody()?.paragraphs?.[0].paragraphStyle?.lineSpacing).toBeUndefined();
+        expect(getBody()?.paragraphs?.[0].paragraphStyle?.spacingRule).toBeUndefined();
     });
 });

--- a/packages/docs-ui/src/commands/commands/set-heading.command.ts
+++ b/packages/docs-ui/src/commands/commands/set-heading.command.ts
@@ -85,6 +85,7 @@ export const SetParagraphNamedStyleCommand: ICommand<ISetParagraphNamedStyleComm
                 spaceAbove: undefined,
                 spaceBelow: undefined,
                 lineSpacing: undefined,
+                spacingRule: undefined,
             },
             paragraphTextRun: {},
 
@@ -223,6 +224,8 @@ export const QuickHeadingCommand: ICommand<ISetParagraphNamedStyleCommandParams>
                 ...paragraphStyle,
                 headingId: generateRandomId(6),
                 namedStyleType: value,
+                lineSpacing: undefined,
+                spacingRule: undefined,
             },
             cursor: startOffset,
             deleteLen: startOffset - paragraphStart,

--- a/packages/engine-render/src/components/docs/__tests__/document.spec.ts
+++ b/packages/engine-render/src/components/docs/__tests__/document.spec.ts
@@ -1529,6 +1529,58 @@ describe('documents render', () => {
         documents.dispose();
     });
 
+    it('offsets table cell paragraph backgrounds by parent page margins', () => {
+        const bodyPage = createPage(DocumentSkeletonPageType.BODY, '');
+        bodyPage.marginLeft = 30;
+        bodyPage.marginTop = 40;
+        const cell = createPage(DocumentSkeletonPageType.CELL, 'cell-seg');
+        const line = createLine(LineType.PARAGRAPH, 0);
+        line.backgroundColor = { rgb: '#ffeecc' };
+        const column = cell.sections[0].columns[0];
+        column.lines = [line];
+        line.parent = column;
+
+        const documents = new Documents('docs-table-cell-background');
+        (documents as any)._drawLiquid = {
+            x: 12,
+            y: 20,
+            translateSave: vi.fn(),
+            translateRestore: vi.fn(),
+            translateSection: vi.fn(),
+            translateColumn: vi.fn(),
+            translateLine: vi.fn(),
+            translateDivide: vi.fn(),
+        };
+        const drawLineBackground = vi.spyOn(documents as any, '_drawLineBackground').mockImplementation(() => {});
+        const ctx = {
+            beginPath: vi.fn(),
+            clip: vi.fn(),
+            closePath: vi.fn(),
+            rectByPrecision: vi.fn(),
+            restore: vi.fn(),
+            save: vi.fn(),
+        } as any;
+
+        (documents as any)._drawNestedPageContent(
+            ctx,
+            bodyPage,
+            cell,
+            [],
+            null,
+            [],
+            [],
+            { x: 0, y: 0 },
+            0,
+            0,
+            {},
+            { scaleX: 1, scaleY: 1 }
+        );
+
+        expect(drawLineBackground).toHaveBeenCalledWith(ctx, cell, line, column.width, 30, 40);
+
+        documents.dispose();
+    });
+
     it('clips column group nested page content with the column align offset', () => {
         const bodyPage = createPage(DocumentSkeletonPageType.BODY, '');
         bodyPage.marginLeft = 30;

--- a/packages/engine-render/src/components/docs/document.ts
+++ b/packages/engine-render/src/components/docs/document.ts
@@ -1169,7 +1169,14 @@ export class Documents extends DocComponent {
                     } else {
                         this._drawLiquid.translateSave();
                         this._drawLiquid.translateLine(line, true, true);
-                        this._drawLineBackground(ctx, nestedPage, line, column.width);
+                        this._drawLineBackground(
+                            ctx,
+                            nestedPage,
+                            line,
+                            column.width,
+                            parentPage.marginLeft,
+                            parentPage.marginTop
+                        );
 
                         const divideLength = divides.length;
 

--- a/packages/engine-render/src/components/docs/layout/__tests__/tools.spec.ts
+++ b/packages/engine-render/src/components/docs/layout/__tests__/tools.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IParagraphConfig, ISectionBreakConfig } from '../../../../basics/interfaces';
 import {
     AlignTypeH,
     AlignTypeV,
@@ -27,6 +28,7 @@ import {
     SectionType,
     SpacingRule,
 } from '@univerjs/core';
+
 import { describe, expect, it, vi } from 'vitest';
 import { GlyphType } from '../../../../basics/i-document-skeleton-cached';
 import { getDocumentCompatibilityPolicy } from '../../document-compatibility';
@@ -304,6 +306,22 @@ describe('docs layout tools extra', () => {
         expect(lineCfg.snapToGrid).toBe(BooleanNumber.FALSE);
         expect(lineCfg.lineSpacing).toBe(1);
     });
+
+    it.each([undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+        'falls back to automatic spacing for invalid fixed line spacing: %s',
+        (lineSpacing) => {
+            const lineCfg = getLineHeightConfig({} as ISectionBreakConfig, {
+                useWordStyleLineHeight: true,
+                paragraphStyle: {
+                    lineSpacing,
+                    spacingRule: SpacingRule.EXACT,
+                },
+            } as IParagraphConfig);
+
+            expect(lineCfg.lineSpacing).toBe(1);
+            expect(lineCfg.spacingRule).toBe(SpacingRule.AUTO);
+        }
+    );
 
     it('updates block index values and iterates skeleton blocks', () => {
         const { page, column } = createPageSkeleton();

--- a/packages/engine-render/src/components/docs/layout/tools.ts
+++ b/packages/engine-render/src/components/docs/layout/tools.ts
@@ -326,7 +326,10 @@ export function getLineHeightConfig(sectionBreakConfig: ISectionBreakConfig, par
     )
         ? BooleanNumber.FALSE
         : BooleanNumber.TRUE;
-    const { lineSpacing = 0, spacingRule = SpacingRule.AUTO, snapToGrid = defaultSnapToGrid } = paragraphStyle;
+    const { lineSpacing: requestedLineSpacing = 0, spacingRule: requestedSpacingRule = SpacingRule.AUTO, snapToGrid = defaultSnapToGrid } = paragraphStyle;
+    const hasValidLineSpacing = Number.isFinite(requestedLineSpacing) && requestedLineSpacing > 0;
+    const lineSpacing = hasValidLineSpacing ? requestedLineSpacing : 0;
+    const spacingRule = hasValidLineSpacing ? requestedSpacingRule : SpacingRule.AUTO;
 
     // Flavored docs use Word-style single spacing by default.
     // Embedded sheet/slides documents keep the legacy grid-based fallback.


### PR DESCRIPTION
## Description

Fix text overlap in document headings and shaded multi-line table cells.

The heading commands cleared the numeric line spacing but left `SpacingRule.EXACT` behind. The renderer then interpreted the missing value as zero-height exact spacing. This change clears both fields when applying standard or quick headings and makes the shared line-height calculation fall back to automatic spacing for invalid fixed values.

Nested table-cell paragraph backgrounds were also drawn without the parent page margins, allowing later line backgrounds to cover earlier text. This change applies the parent margins consistently.

No snapshot data, documentation, screenshots, generated fixtures, or temporary demo files are included.

## How to test

- `pnpm exec vitest run src/components/docs/__tests__/document.spec.ts src/components/docs/layout/__tests__/tools.spec.ts` in `packages/engine-render`
- `pnpm exec vitest run src/commands/commands/__tests__/set-heading.command.spec.ts` in `packages/docs-ui`
- `pnpm typecheck` in `packages/engine-render`
- `pnpm typecheck` in `packages/docs-ui`
- Run ESLint on the six changed source and regression-test files
- Load the Harbourline Q3 snapshot in the Docs demo and verify heading size changes in body text and table cells

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
