### PR TITLE
fix(sheets-ui): preserve empty cell text style

### DIFF
--- a/packages/docs-ui/src/index.ts
+++ b/packages/docs-ui/src/index.ts
@@ -242,6 +242,8 @@ export {
 } from './services/doc-event-manager.service';
 export type { IBulletBound, IMutiPageParagraphBound } from './services/doc-event-manager.service';
 export { DocIMEInputManagerService } from './services/doc-ime-input-manager.service';
+export { SetDocInputStyleCommand } from './services/doc-menu-style.service';
+export type { ISetDocInputStyleCommandParams } from './services/doc-menu-style.service';
 export { DocPageLayoutService } from './services/doc-page-layout.service';
 export { DocParagraphMenuService } from './services/doc-paragraph-menu.service';
 export { calcDocRangePositions, DocCanvasPopManagerService } from './services/doc-popup-manager.service';

--- a/packages/docs-ui/src/plugin.ts
+++ b/packages/docs-ui/src/plugin.ts
@@ -178,7 +178,7 @@ import { DocAutoFormatService } from './services/doc-auto-format.service';
 import { DocEventManagerService } from './services/doc-event-manager.service';
 import { DocIMEInputManagerService } from './services/doc-ime-input-manager.service';
 import { DocIMEStateChangeInterceptorService } from './services/doc-ime-state-change-interceptor.service';
-import { DocMenuStyleService } from './services/doc-menu-style.service';
+import { DocMenuStyleService, SetDocInputStyleCommand } from './services/doc-menu-style.service';
 import { DocPageLayoutService } from './services/doc-page-layout.service';
 import { DocParagraphMenuService } from './services/doc-paragraph-menu.service';
 import { DocCanvasPopManagerService } from './services/doc-popup-manager.service';
@@ -309,6 +309,7 @@ export class UniverDocsUIPlugin extends Plugin {
             ResetInlineFormatTextBackgroundColorCommand,
             SetInlineFormatTextBackgroundColorCommand,
             SetInlineFormatCommand,
+            SetDocInputStyleCommand,
             BreakLineCommand,
             DeleteCustomBlockCommand,
             MoveDocBlockCommand,

--- a/packages/docs-ui/src/services/__tests__/doc-menu-style.service.spec.ts
+++ b/packages/docs-ui/src/services/__tests__/doc-menu-style.service.spec.ts
@@ -37,7 +37,7 @@ import {
     RenderManagerService,
 } from '@univerjs/engine-render';
 import { describe, expect, it } from 'vitest';
-import { DocMenuStyleService } from '../doc-menu-style.service';
+import { DocMenuStyleService, SetDocInputStyleCommand } from '../doc-menu-style.service';
 
 class TestRenderManagerService {
     editArea: DocumentEditArea | undefined;
@@ -127,6 +127,17 @@ describe('DocMenuStyleService', () => {
         service.setStyleCache({ it: 1 });
 
         expect(service.getStyleCache()).toEqual({ bl: 1, it: 1 });
+    });
+
+    it('sets the next input style through the command boundary', () => {
+        const { commandService, service } = createStyleTestBed();
+        commandService.registerCommand(SetDocInputStyleCommand);
+
+        commandService.syncExecuteCommand(SetDocInputStyleCommand.id, {
+            style: { fs: 20, cl: { rgb: '#f05252' } },
+        });
+
+        expect(service.getStyleCache()).toEqual({ fs: 20, cl: { rgb: '#f05252' } });
     });
 
     it('uses body text defaults when there is no focused document render', () => {

--- a/packages/docs-ui/src/services/doc-menu-style.service.ts
+++ b/packages/docs-ui/src/services/doc-menu-style.service.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import type { DocumentDataModel, ITextStyle, Nullable } from '@univerjs/core';
-import { Disposable, Inject, IUniverInstanceService, ThemeService, UniverInstanceType } from '@univerjs/core';
+import type { DocumentDataModel, ICommand, ITextStyle, Nullable } from '@univerjs/core';
+import { CommandType, Disposable, Inject, IUniverInstanceService, ThemeService, UniverInstanceType } from '@univerjs/core';
 import { DocSelectionManagerService, DocSkeletonManagerService } from '@univerjs/docs';
 import { DocumentEditArea, IRenderManagerService } from '@univerjs/engine-render';
 
@@ -113,3 +113,19 @@ export class DocMenuStyleService extends Disposable {
         this._cacheStyle = null;
     }
 }
+
+export interface ISetDocInputStyleCommandParams {
+    style: ITextStyle;
+}
+
+export const SetDocInputStyleCommand: ICommand<ISetDocInputStyleCommandParams> = {
+    id: 'doc.command.set-input-style',
+    type: CommandType.COMMAND,
+    handler: (accessor, params) => {
+        if (!params) {
+            return false;
+        }
+        accessor.get(DocMenuStyleService).setStyleCache(params.style);
+        return true;
+    },
+};

--- a/packages/sheets-ui/src/controllers/editor/__tests__/editing-render-business.spec.ts
+++ b/packages/sheets-ui/src/controllers/editor/__tests__/editing-render-business.spec.ts
@@ -24,7 +24,7 @@ import {
     LocaleType,
     UniverInstanceType,
 } from '@univerjs/core';
-import { MoveCursorOperation, MoveSelectionOperation, VIEWPORT_KEY } from '@univerjs/docs-ui';
+import { MoveCursorOperation, MoveSelectionOperation, SetDocInputStyleCommand, VIEWPORT_KEY } from '@univerjs/docs-ui';
 import { LexerTreeBuilder } from '@univerjs/engine-formula';
 import { DeviceInputEventType } from '@univerjs/engine-render';
 import { SetRangeValuesCommand } from '@univerjs/sheets';
@@ -92,6 +92,7 @@ function createController() {
     };
     const docModel = {
         getUnitId: vi.fn(() => DOCS_NORMAL_EDITOR_UNIT_ID_KEY),
+        getBody: vi.fn(() => normalSnapshot.body),
         getSnapshot: vi.fn(() => normalSnapshot),
         reset: vi.fn((snapshot) => {
             normalSnapshot = snapshot;
@@ -105,6 +106,7 @@ function createController() {
         }),
     };
     const documentModel = {
+        getBody: vi.fn((): IDocumentBody => ({ dataStream: 'new value\r\n' })),
         getSnapshot: vi.fn(() => ({
             body: { dataStream: 'new value\r\n' },
             documentStyle: {},
@@ -218,6 +220,7 @@ function createController() {
         controller,
         docModel,
         formulaBarEditor,
+        documentModel,
         getFormulaSnapshot: () => formulaSnapshot,
         getNormalSnapshot: () => normalSnapshot,
         workbook,
@@ -226,6 +229,23 @@ function createController() {
 }
 
 describe('EditingRenderController business methods', () => {
+    it('reuses an empty cell style for the next editor input', () => {
+        const { controller, documentModel } = createController();
+        documentModel.getBody.mockReturnValue({
+            dataStream: '\r\n',
+            textRuns: [{ st: 0, ed: 0, ts: { fs: 20, cl: { rgb: '#f05252' } } }],
+        });
+
+        controller._cacheEmptyCellTextStyle();
+
+        expect(controller._commandService.syncExecuteCommand).toHaveBeenCalledWith(SetDocInputStyleCommand.id, {
+            style: {
+                fs: 20,
+                cl: { rgb: '#f05252' },
+            },
+        });
+    });
+
     it('submits edited cell content and rolls back when validation rejects the value', async () => {
         const { controller } = createController();
         controller._sheetInterceptorService.onValidateCell.mockResolvedValue(false);

--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -73,6 +73,7 @@ import {
     MoveCursorOperation,
     MoveSelectionOperation,
     ReplaceSnapshotCommand,
+    SetDocInputStyleCommand,
     VIEWPORT_KEY,
 } from '@univerjs/docs-ui';
 import { IFunctionService, LexerTreeBuilder, matchToken } from '@univerjs/engine-formula';
@@ -258,6 +259,7 @@ export class EditingRenderController extends Disposable {
             if (!docSelectionRenderManager) return;
 
             docSelectionRenderManager.sync();
+            this._cacheEmptyCellTextStyle();
         }));
     }
 
@@ -542,6 +544,20 @@ export class EditingRenderController extends Disposable {
         }
 
         this._renderManagerService.getRenderUnitById(unitId)?.scene.resetCursor();
+    }
+
+    private _cacheEmptyCellTextStyle(): void {
+        const sourceBody = this._editorBridgeService.getEditLocation()?.documentLayoutObject.documentModel?.getBody();
+        const textRun = sourceBody?.textRuns?.length === 1 ? sourceBody.textRuns[0] : null;
+        if (
+            sourceBody?.dataStream === DEFAULT_EMPTY_DOCUMENT_VALUE
+            && textRun?.st === 0
+            && textRun.ed === 0
+        ) {
+            this._commandService.syncExecuteCommand(SetDocInputStyleCommand.id, {
+                style: Tools.deepClone(textRun.ts),
+            });
+        }
     }
 
     private _refreshCurrentSelections(sheetId: string) {


### PR DESCRIPTION
## Description

Preserve a formatted cell's font color and size when its last character is deleted in the sheet editor.

The empty editor document keeps the cell style on a zero-length text run, but the docs input-style cache was reset after the editor selection synchronized. Subsequent input therefore used the default style, and saving could overwrite the cell formatting. This change restores that empty-run style through the command boundary when edit mode is initialized.

## How to test

1. Set a cell's font color and font size.
2. Double-click the cell to edit it.
3. Delete the last character.
4. Press Enter or click another cell.
5. Confirm the cell keeps its font color and size, and double-click it again to confirm the editor reuses both.

Validation:

- `pnpm exec vitest run packages/docs-ui/src/services/__tests__/doc-menu-style.service.spec.ts packages/sheets-ui/src/controllers/editor/__tests__/editing-render-business.spec.ts`
- `pnpm --filter @univerjs/docs-ui typecheck`
- `pnpm --filter @univerjs/sheets-ui typecheck`
- ESLint on the six changed files (no errors; two pre-existing warnings)

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
