### PR TITLE
fix(engine-render): expose transform end notification

### DIFF
--- a/packages/engine-render/src/__tests__/scene.transformer.spec.ts
+++ b/packages/engine-render/src/__tests__/scene.transformer.spec.ts
@@ -77,4 +77,30 @@ describe('Transformer', () => {
         scene.dispose();
         engine.dispose();
     });
+
+    it('notifies change completion for external transforms', () => {
+        const engine = new Engine('transformer-notification-engine', { elementWidth: 100, elementHeight: 100, dpr: 1 });
+        const scene = new Scene('transformer-notification-scene', engine);
+        const rect = new Rect('transformer-notification-rect', { width: 10, height: 10 });
+        const transformer = new Transformer(scene);
+        const changeEnd = vi.fn();
+        const event = { offsetX: 12, offsetY: 34 } as Parameters<Transformer['changeEndNotification']>[0];
+        const changeEndSubscription = transformer.changeEnd$.subscribe(changeEnd);
+
+        transformer.setSelectedControl(rect);
+        transformer.changeEndNotification(event);
+
+        expect(changeEnd).toHaveBeenCalledWith(expect.objectContaining({
+            objects: new Map([[rect.oKey, rect]]),
+            offsetX: 12,
+            offsetY: 34,
+            event,
+        }));
+
+        changeEndSubscription.unsubscribe();
+        transformer.dispose();
+        rect.dispose();
+        scene.dispose();
+        engine.dispose();
+    });
 });

--- a/packages/engine-render/src/scene.transformer.ts
+++ b/packages/engine-render/src/scene.transformer.ts
@@ -291,6 +291,18 @@ export class Transformer extends Disposable implements ITransformerConfig {
         return this;
     }
 
+    changeEndNotification(event: IPointerEvent | IMouseEvent) {
+        this._changeEnd$.next({
+            objects: this._selectedObjectMap,
+            type: MoveObserverType.MOVE_END,
+            offsetX: event.offsetX,
+            offsetY: event.offsetY,
+            event,
+        });
+
+        return this;
+    }
+
     getSelectedObjectMap() {
         return this._selectedObjectMap;
     }


### PR DESCRIPTION
## Summary

- expose a public Transformer method for externally driven transforms to emit the standard change-end lifecycle event
- cover the event payload with a focused regression test

## Why

Board table handles drive object movement outside Transformer's built-in pointer flow. They can emit change notifications but previously had no supported way to complete the lifecycle, leaving subscribers such as alignment guides active.

## Testing

- `pnpm --filter @univerjs/engine-render exec vitest run src/__tests__/scene.transformer.spec.ts`
- `pnpm --filter @univerjs/engine-render typecheck`
- targeted ESLint (no new warnings)

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes introduced.