### PR TITLE
fix(sheets): preserve styles when replacing cell text

### DIFF
--- a/e2e/smoking/sheets-ime-input.spec.ts
+++ b/e2e/smoking/sheets-ime-input.spec.ts
@@ -74,6 +74,7 @@ test('preserves cell styles after deleting all text and entering new IME text', 
         range
             .setValue('A')
             .setHorizontalAlignment('center')
+            .setVerticalAlignment('middle')
             .setFontSize(20)
             .setFontColor('#f05252');
 
@@ -103,12 +104,14 @@ test('preserves cell styles after deleting all text and entering new IME text', 
         return {
             value: range.getValue(),
             horizontalAlignment: range.getHorizontalAlignment(),
+            verticalAlignment: range.getVerticalAlignment(),
             fontSize: style?.fs,
             fontColor: style?.cl?.rgb,
         };
     }, cell)).toEqual({
         value: '新',
         horizontalAlignment: 'center',
+        verticalAlignment: 'middle',
         fontSize: 20,
         fontColor: '#f05252',
     });

--- a/e2e/smoking/sheets-ime-input.spec.ts
+++ b/e2e/smoking/sheets-ime-input.spec.ts
@@ -60,9 +60,11 @@ test('preserves cell styles after deleting all text and entering new IME text', 
     const canvas = page.locator(SHEET_MAIN_CANVAS);
     await expect(canvas).toBeVisible();
     const canvasBox = await canvas.boundingBox();
-    expect(canvasBox).not.toBeNull();
+    if (!canvasBox) {
+        throw new Error('Expected the sheet canvas to have a bounding box');
+    }
 
-    await page.mouse.click(canvasBox!.x + 200, canvasBox!.y + 120);
+    await page.mouse.click(canvasBox.x + 200, canvasBox.y + 120);
     const cell = await page.evaluate(() => {
         const range = window.univerAPI.getActiveWorkbook().getActiveRange();
         if (!range) {
@@ -80,7 +82,7 @@ test('preserves cell styles after deleting all text and entering new IME text', 
 
     await page.keyboard.press('F2');
     const inputContainer = page.locator(SHEET_EDITOR_INPUT_CONTAINER);
-    await expect.poll(async () => (await inputContainer.boundingBox())?.x).toBeGreaterThanOrEqual(canvasBox!.x);
+    await expect.poll(async () => (await inputContainer.boundingBox())?.x).toBeGreaterThanOrEqual(canvasBox.x);
 
     await page.keyboard.press('Backspace');
 

--- a/e2e/smoking/sheets-ime-input.spec.ts
+++ b/e2e/smoking/sheets-ime-input.spec.ts
@@ -51,3 +51,63 @@ test('keeps the IME anchor on the active cell across edits', async ({ page }) =>
 
     expect(anchorPositions[1].y).toBeGreaterThan(anchorPositions[0].y);
 });
+
+test('preserves cell styles after deleting all text and entering new IME text', async ({ page }) => {
+    await page.goto('/sheets/');
+    await page.waitForFunction(() => !!window.univerAPI && !!window.E2EControllerAPI);
+    await page.evaluate(() => window.E2EControllerAPI.loadDefaultSheet());
+
+    const canvas = page.locator(SHEET_MAIN_CANVAS);
+    await expect(canvas).toBeVisible();
+    const canvasBox = await canvas.boundingBox();
+    expect(canvasBox).not.toBeNull();
+
+    await page.mouse.click(canvasBox!.x + 200, canvasBox!.y + 120);
+    const cell = await page.evaluate(() => {
+        const range = window.univerAPI.getActiveWorkbook().getActiveRange();
+        if (!range) {
+            throw new Error('Expected an active sheet range');
+        }
+
+        range
+            .setValue('A')
+            .setHorizontalAlignment('center')
+            .setFontSize(20)
+            .setFontColor('#f05252');
+
+        return range.getA1Notation();
+    });
+
+    await page.keyboard.press('F2');
+    const inputContainer = page.locator(SHEET_EDITOR_INPUT_CONTAINER);
+    await expect.poll(async () => (await inputContainer.boundingBox())?.x).toBeGreaterThanOrEqual(canvasBox!.x);
+
+    await page.keyboard.press('Backspace');
+
+    const client = await page.context().newCDPSession(page);
+    await client.send('Input.imeSetComposition', {
+        text: 'xin',
+        selectionStart: 3,
+        selectionEnd: 3,
+        replacementStart: 0,
+        replacementEnd: 0,
+    });
+    await client.send('Input.insertText', { text: '新' });
+    await page.keyboard.press('Enter');
+
+    await expect.poll(() => page.evaluate((a1Notation) => {
+        const range = window.univerAPI.getActiveWorkbook().getActiveSheet().getRange(a1Notation);
+        const style = range.getCellStyleData('cell');
+        return {
+            value: range.getValue(),
+            horizontalAlignment: range.getHorizontalAlignment(),
+            fontSize: style?.fs,
+            fontColor: style?.cl?.rgb,
+        };
+    }, cell)).toEqual({
+        value: '新',
+        horizontalAlignment: 'center',
+        fontSize: 20,
+        fontColor: '#f05252',
+    });
+});

--- a/packages/core/src/sheets/__tests__/util.spec.ts
+++ b/packages/core/src/sheets/__tests__/util.spec.ts
@@ -48,6 +48,8 @@ describe('sheet util helpers', () => {
             }],
         });
         expect(documentModel.getSnapshot().documentStyle).toMatchObject({
+            textStyle: { ff: 'Inter', fs: 12, va: BaselineOffset.SUPERSCRIPT },
+            defaultParagraphStyle: { horizontalAlign: HorizontalAlign.CENTER },
             marginTop: 1,
             marginRight: 4,
             marginBottom: 3,

--- a/packages/core/src/sheets/util.ts
+++ b/packages/core/src/sheets/util.ts
@@ -24,7 +24,7 @@ import { TextX } from '../docs/data-model/text-x/text-x';
 import { convertTextRotation } from '../docs/data-model/utils';
 import { createParagraphId } from '../docs/paragraph-id';
 import { createSectionId } from '../docs/section-break-id';
-import { Rectangle } from '../shared';
+import { Rectangle, Tools } from '../shared';
 import { HorizontalAlign, VerticalAlign, WrapStrategy } from '../types/enum';
 import { CustomRangeType, DocumentFlavor } from '../types/interfaces';
 
@@ -112,6 +112,10 @@ export function createDocumentModelWithStyle(content: string, textStyle: ITextSt
             }],
         },
         documentStyle: {
+            textStyle: Tools.deepClone(textStyle),
+            defaultParagraphStyle: {
+                horizontalAlign,
+            },
             pageSize: {
                 width: Number.POSITIVE_INFINITY,
                 height: Number.POSITIVE_INFINITY,

--- a/packages/docs-ui/src/commands/commands/__tests__/core-editing.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/core-editing.command.spec.ts
@@ -23,6 +23,7 @@ import {
     DataStreamTreeTokenType,
     DeleteDirection,
     DocumentBlockRangeType,
+    DocumentFlavor,
     HorizontalAlign,
     ICommandService,
     IUniverInstanceService,
@@ -203,7 +204,9 @@ describe('core editing commands', () => {
 
     function mockSkeleton() {
         const skeletonManager = get(DocSkeletonManagerService) as unknown as { getSkeleton: () => unknown };
-        skeletonManager.getSkeleton = () => ({});
+        skeletonManager.getSkeleton = () => ({
+            findNodeByCharIndex: () => null,
+        });
     }
 
     function registerDeleteKeyCommands() {
@@ -331,9 +334,11 @@ describe('core editing commands', () => {
         expect(getBody()?.paragraphs?.[0].paragraphStyle?.horizontalAlign).toBe(HorizontalAlign.LEFT);
     });
 
-    it('resets an empty centered paragraph to left alignment on a second backspace', async () => {
+    it('resets an empty centered paragraph to left alignment in a traditional document', async () => {
         univer.dispose();
-        const testBed = createCommandTestBed(getCenteredEmptyParagraphDocumentData());
+        const documentData = getCenteredEmptyParagraphDocumentData();
+        documentData.documentStyle.documentFlavor = DocumentFlavor.TRADITIONAL;
+        const testBed = createCommandTestBed(documentData);
         univer = testBed.univer;
         get = testBed.get;
         commandService = get(ICommandService);
@@ -347,6 +352,26 @@ describe('core editing commands', () => {
 
         expect(getDataStream()).toBe('\r\n');
         expect(getBody()?.paragraphs?.[0].paragraphStyle?.horizontalAlign).toBe(HorizontalAlign.LEFT);
+    });
+
+    it('keeps center alignment when deleting in an unspecified editor document', async () => {
+        univer.dispose();
+        const documentData = getCenteredEmptyParagraphDocumentData();
+        documentData.documentStyle.documentFlavor = DocumentFlavor.UNSPECIFIED;
+        const testBed = createCommandTestBed(documentData);
+        univer = testBed.univer;
+        get = testBed.get;
+        commandService = get(ICommandService);
+        registerDeleteKeyCommands();
+        mockSkeleton();
+        setActiveSelection(0);
+
+        await commandService.executeCommand(DeleteLeftCommand.id);
+        await commandService.executeCommand(DeleteRightCommand.id);
+        await awaitTime(0);
+
+        expect(getDataStream()).toBe('\r\n');
+        expect(getBody()?.paragraphs?.[0].paragraphStyle?.horizontalAlign).toBe(HorizontalAlign.CENTER);
     });
 
     it('detects delete offsets inside block ranges so backspace does not clear block paragraph indent', () => {

--- a/packages/docs-ui/src/commands/commands/__tests__/core-editing.command.spec.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/core-editing.command.spec.ts
@@ -22,6 +22,8 @@ import {
     CustomRangeType,
     DataStreamTreeTokenType,
     DeleteDirection,
+    DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
+    DOCS_NORMAL_EDITOR_UNIT_ID_KEY,
     DocumentBlockRangeType,
     DocumentFlavor,
     HorizontalAlign,
@@ -173,10 +175,11 @@ describe('core editing commands', () => {
     let univer: Univer;
     let get: Injector['get'];
     let commandService: ICommandService;
+    let unitId = 'test-doc';
 
     function getBody() {
         const univerInstanceService = get(IUniverInstanceService);
-        return univerInstanceService.getUnit<DocumentDataModel>('test-doc', UniverInstanceType.UNIVER_DOC)?.getBody();
+        return univerInstanceService.getUnit<DocumentDataModel>(unitId, UniverInstanceType.UNIVER_DOC)?.getBody();
     }
 
     function getDataStream() {
@@ -196,8 +199,8 @@ describe('core editing commands', () => {
     function setActiveSelection(offset: number) {
         const selectionManager = get(DocSelectionManagerService);
         selectionManager.__TEST_ONLY_setCurrentSelection({
-            unitId: 'test-doc',
-            subUnitId: 'test-doc',
+            unitId,
+            subUnitId: unitId,
         });
         selectionManager.__TEST_ONLY_add([{ startOffset: offset, endOffset: offset, collapsed: true, isActive: true, segmentId: '', style: null as never }]);
     }
@@ -218,6 +221,7 @@ describe('core editing commands', () => {
     }
 
     beforeEach(() => {
+        unitId = 'test-doc';
         const testBed = createCommandTestBed(getDocumentData());
         univer = testBed.univer;
         get = testBed.get;
@@ -354,7 +358,31 @@ describe('core editing commands', () => {
         expect(getBody()?.paragraphs?.[0].paragraphStyle?.horizontalAlign).toBe(HorizontalAlign.LEFT);
     });
 
-    it('keeps center alignment when deleting in an unspecified editor document', async () => {
+    it.each([
+        [DOCS_NORMAL_EDITOR_UNIT_ID_KEY, DeleteLeftCommand.id],
+        [DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY, DeleteRightCommand.id],
+    ])('keeps center alignment in Sheet editor %s', async (editorUnitId, commandId) => {
+        univer.dispose();
+        const documentData = getCenteredEmptyParagraphDocumentData();
+        documentData.id = editorUnitId;
+        documentData.documentStyle.documentFlavor = DocumentFlavor.UNSPECIFIED;
+        unitId = editorUnitId;
+        const testBed = createCommandTestBed(documentData);
+        univer = testBed.univer;
+        get = testBed.get;
+        commandService = get(ICommandService);
+        registerDeleteKeyCommands();
+        mockSkeleton();
+        setActiveSelection(0);
+
+        await commandService.executeCommand(commandId);
+        await awaitTime(0);
+
+        expect(getDataStream()).toBe('\r\n');
+        expect(getBody()?.paragraphs?.[0].paragraphStyle?.horizontalAlign).toBe(HorizontalAlign.CENTER);
+    });
+
+    it('resets center alignment in a non-Sheet unspecified document', async () => {
         univer.dispose();
         const documentData = getCenteredEmptyParagraphDocumentData();
         documentData.documentStyle.documentFlavor = DocumentFlavor.UNSPECIFIED;
@@ -367,11 +395,10 @@ describe('core editing commands', () => {
         setActiveSelection(0);
 
         await commandService.executeCommand(DeleteLeftCommand.id);
-        await commandService.executeCommand(DeleteRightCommand.id);
         await awaitTime(0);
 
         expect(getDataStream()).toBe('\r\n');
-        expect(getBody()?.paragraphs?.[0].paragraphStyle?.horizontalAlign).toBe(HorizontalAlign.CENTER);
+        expect(getBody()?.paragraphs?.[0].paragraphStyle?.horizontalAlign).toBe(HorizontalAlign.LEFT);
     });
 
     it('detects delete offsets inside block ranges so backspace does not clear block paragraph indent', () => {

--- a/packages/docs-ui/src/commands/commands/__tests__/create-command-test-bed.ts
+++ b/packages/docs-ui/src/commands/commands/__tests__/create-command-test-bed.ts
@@ -146,7 +146,7 @@ export function createCommandTestBed(docData?: IDocumentData, dependencies?: Dep
     // Refer to packages/sheets-ui/src/services/clipboard/__tests__/clipboard-test-bed.ts
     const fakeDocSkeletonManager = new MockDocSkeletonManagerService({
         unit: doc,
-        unitId: 'test-doc',
+        unitId: doc.getUnitId(),
         type: UniverInstanceType.UNIVER_DOC,
         engine: null as any,
         scene: null as any,
@@ -177,7 +177,7 @@ export function createCommandTestBed(docData?: IDocumentData, dependencies?: Dep
         });
     }
 
-    univerInstanceService.focusUnit('test-doc');
+    univerInstanceService.focusUnit(doc.getUnitId());
 
     const logService = get(ILogService);
     logService.setLogLevel(LogLevel.SILENT);

--- a/packages/docs-ui/src/commands/commands/doc-delete.command.ts
+++ b/packages/docs-ui/src/commands/commands/doc-delete.command.ts
@@ -23,7 +23,6 @@ import {
     CommandType,
     DataStreamTreeTokenType,
     DeleteDirection,
-    DocumentFlavor,
     getBlockRangeInterval,
     getRichTextEditPath,
     HorizontalAlign,
@@ -32,6 +31,7 @@ import {
     JSONX,
     PositionedObjectLayoutType,
     sequenceExecuteAsync,
+    SHEET_EDITOR_UNITS,
     TextX,
     TextXActionType,
     Tools,
@@ -845,8 +845,7 @@ function getEmptyCenteredParagraphAtOffset(body: IDocumentBody, offset: number) 
 }
 
 function shouldResetEmptyCenteredParagraphAlignment(docDataModel: DocumentDataModel) {
-    const documentFlavor = docDataModel.getDocumentStyle().documentFlavor;
-    return documentFlavor === DocumentFlavor.TRADITIONAL || documentFlavor === DocumentFlavor.MODERN;
+    return !SHEET_EDITOR_UNITS.includes(docDataModel.getUnitId());
 }
 
 function resetEmptyCenteredParagraphAlignment(

--- a/packages/docs-ui/src/commands/commands/doc-delete.command.ts
+++ b/packages/docs-ui/src/commands/commands/doc-delete.command.ts
@@ -23,6 +23,7 @@ import {
     CommandType,
     DataStreamTreeTokenType,
     DeleteDirection,
+    DocumentFlavor,
     getBlockRangeInterval,
     getRichTextEditPath,
     HorizontalAlign,
@@ -478,7 +479,7 @@ export const DeleteLeftCommand: ICommand = {
 
         const actualRange = activeRange;
         const { startOffset, collapsed } = actualRange;
-        if (collapsed) {
+        if (collapsed && shouldResetEmptyCenteredParagraphAlignment(docDataModel)) {
             const emptyCenteredParagraph = getEmptyCenteredParagraphAtOffset(body, startOffset);
             if (emptyCenteredParagraph != null) {
                 return resetEmptyCenteredParagraphAlignment(commandService, docDataModel, segmentId ?? '', emptyCenteredParagraph, style);
@@ -701,7 +702,7 @@ export const DeleteRightCommand: ICommand = {
 
         const actualRange = activeRange;
         const { startOffset, endOffset, collapsed } = actualRange;
-        if (collapsed) {
+        if (collapsed && shouldResetEmptyCenteredParagraphAlignment(docDataModel)) {
             const emptyCenteredParagraph = getEmptyCenteredParagraphAtOffset(body, startOffset);
             if (emptyCenteredParagraph != null) {
                 return resetEmptyCenteredParagraphAlignment(commandService, docDataModel, segmentId ?? '', emptyCenteredParagraph, style);
@@ -841,6 +842,11 @@ function getEmptyCenteredParagraphAtOffset(body: IDocumentBody, offset: number) 
             return paragraph;
         }
     }
+}
+
+function shouldResetEmptyCenteredParagraphAlignment(docDataModel: DocumentDataModel) {
+    const documentFlavor = docDataModel.getDocumentStyle().documentFlavor;
+    return documentFlavor === DocumentFlavor.TRADITIONAL || documentFlavor === DocumentFlavor.MODERN;
 }
 
 function resetEmptyCenteredParagraphAlignment(

--- a/packages/docs-ui/src/services/__tests__/doc-menu-style.service.spec.ts
+++ b/packages/docs-ui/src/services/__tests__/doc-menu-style.service.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ITextStyle } from '@univerjs/core';
 import {
     CommandService,
     ConfigService,
@@ -84,7 +85,7 @@ function createService(defaultTextColor?: string): DocMenuStyleService {
     return injector.get(DocMenuStyleService);
 }
 
-function createStyleTestBed() {
+function createStyleTestBed(textStyle?: ITextStyle) {
     const injector = new Injector();
     injector.add([ILogService, { useClass: DesktopLogService }]);
     injector.add([IConfigService, { useClass: ConfigService }]);
@@ -106,6 +107,9 @@ function createStyleTestBed() {
             customRanges: [],
             tables: [],
             textRuns: [],
+        },
+        documentStyle: {
+            textStyle,
         },
     }));
     univerInstanceService.setCurrentUnitForType('doc-menu-style');
@@ -154,6 +158,23 @@ describe('DocMenuStyleService', () => {
 
         renderManagerService.editArea = DocumentEditArea.FOOTER;
         expect(service.getDefaultStyle()).toEqual({ ff: 'Arial', fs: 9, cl: { rgb: '#1B1C1F' } });
+    });
+
+    it('uses active document text defaults for the next body input', () => {
+        const { service, renderManagerService } = createStyleTestBed({ fs: 20, cl: { rgb: '#f05252' } });
+
+        renderManagerService.editArea = DocumentEditArea.BODY;
+
+        expect(service.getDefaultStyle()).toEqual({ ff: 'Arial', fs: 20, cl: { rgb: '#f05252' } });
+
+        renderManagerService.editArea = DocumentEditArea.FOOTER;
+        expect(service.getDefaultStyle()).toEqual({ ff: 'Arial', fs: 9, cl: { rgb: '#f05252' } });
+    });
+
+    it('uses active document text defaults before its render is available', () => {
+        const { service } = createStyleTestBed({ fs: 20, cl: { rgb: '#f05252' } });
+
+        expect(service.getDefaultStyle()).toEqual({ ff: 'Arial', fs: 20, cl: { rgb: '#f05252' } });
     });
 
     it('clears cached input style when document selection changes', () => {

--- a/packages/docs-ui/src/services/doc-menu-style.service.ts
+++ b/packages/docs-ui/src/services/doc-menu-style.service.ts
@@ -78,13 +78,18 @@ export class DocMenuStyleService extends Disposable {
             };
         }
 
+        const documentDefaultTextStyle = {
+            ...defaultTextStyle,
+            ...docDataModel.getDocumentStyle().textStyle,
+        };
+
         const unitId = docDataModel?.getUnitId();
         const docSkeletonManagerService = this._renderManagerService.getRenderUnitById(unitId)?.with(DocSkeletonManagerService);
         const docViewModel = docSkeletonManagerService?.getViewModel();
 
         if (docViewModel == null) {
             return {
-                ...defaultTextStyle,
+                ...documentDefaultTextStyle,
             };
         }
 
@@ -92,11 +97,11 @@ export class DocMenuStyleService extends Disposable {
 
         if (editArea === DocumentEditArea.BODY) {
             return {
-                ...defaultTextStyle,
+                ...documentDefaultTextStyle,
             };
         } else {
             return {
-                ...defaultTextStyle,
+                ...documentDefaultTextStyle,
                 fs: HEADER_FOOTER_DEFAULT_FONTSIZE,
             };
         }


### PR DESCRIPTION
Follow-up to #7540.

## What is changed

- Preserve the cell text style and horizontal alignment as document defaults while editing a Sheet cell.
- Apply the active document's default text style when an input run no longer exists after deleting all text.
- Keep empty centered paragraphs unchanged for `UNSPECIFIED` editor documents while retaining the existing reset behavior for traditional and modern Docs.
- Add unit and Playwright regression coverage for deleting the last character, entering new IME text, and saving the cell.

## How to test

1. In Sheets, enter text in a cell and set center alignment, font size `20`, and font color `#f05252`.
2. Press `F2`, delete the last character, enter new IME text, and press Enter.
3. Verify that the value changes while center alignment, font size, and font color remain unchanged.

Automated checks:

- `pnpm exec vitest run packages/core/src/sheets/__tests__/util.spec.ts packages/docs-ui/src/services/__tests__/doc-menu-style.service.spec.ts packages/docs-ui/src/commands/commands/__tests__/core-editing.command.spec.ts` (22 tests passed)
- `pnpm --filter @univerjs/core typecheck`
- `pnpm --filter @univerjs/docs-ui typecheck`
- Targeted TypeScript check for `e2e/smoking/sheets-ime-input.spec.ts`
- Targeted ESLint check (0 errors)
- `HEADLESS=1 pnpm exec playwright test e2e/smoking/sheets-ime-input.spec.ts --project=chromium` (2 tests passed)

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
