### PR TITLE
fix(render): resolve theme colors before canvas rendering

### DIFF
--- a/packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts
+++ b/packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts
@@ -20,6 +20,7 @@ import {
     Injector,
     IUniverInstanceService,
     LocaleService,
+    ThemeService,
 } from '@univerjs/core';
 import { DocSkeletonManagerService, RichTextEditingMutation } from '@univerjs/docs';
 import { DocumentEditArea, IRenderManagerService, Path, Rect } from '@univerjs/engine-render';
@@ -124,10 +125,11 @@ function createController(options: {
         [LocaleService, { useValue: {
             t: vi.fn((key: string) => key),
         } }],
+        [ThemeService],
     ]);
     const controller = injector.createInstance(DocHeaderFooterController, context);
 
-    return { controller, pageRender$, commandHandlers, commandService, document };
+    return { controller, pageRender$, commandHandlers, commandService, document, themeService: injector.get(ThemeService) };
 }
 
 describe('DocHeaderFooterController', () => {
@@ -152,11 +154,20 @@ describe('DocHeaderFooterController', () => {
     });
 
     it('covers header and footer areas while editing the document body', () => {
-        const { controller, pageRender$ } = createController({ editArea: DocumentEditArea.BODY });
+        const { controller, pageRender$, themeService } = createController({ editArea: DocumentEditArea.BODY });
         const rectSpy = vi.spyOn(Rect, 'drawWith').mockImplementation(() => undefined);
         const pathSpy = vi.spyOn(Path, 'drawWith').mockImplementation(() => undefined);
         const textSpy = vi.spyOn(TextBubbleShape, 'drawWith').mockImplementation(() => undefined);
         const ctx = createCtx();
+        const theme = themeService.getCurrentTheme();
+
+        themeService.setTheme({
+            ...theme,
+            gray: {
+                ...theme.gray,
+                0: '#123456',
+            },
+        });
 
         pageRender$.next({
             ctx,
@@ -175,12 +186,12 @@ describe('DocHeaderFooterController', () => {
         expect(rectSpy.mock.calls[0][1]).toMatchObject({
             width: 200,
             height: 30,
-            fill: 'alpha(gray.0, 0.5)',
+            fill: 'rgba(18,52,86,0.5)',
         });
         expect(rectSpy.mock.calls[1][1]).toMatchObject({
             width: 200,
             height: 40,
-            fill: 'alpha(gray.0, 0.5)',
+            fill: 'rgba(18,52,86,0.5)',
         });
         expect(pathSpy).not.toHaveBeenCalled();
         expect(textSpy).not.toHaveBeenCalled();
@@ -189,11 +200,20 @@ describe('DocHeaderFooterController', () => {
     });
 
     it('covers the body and draws header/footer guides while editing header or footer', () => {
-        const { controller, pageRender$ } = createController({ editArea: DocumentEditArea.HEADER });
+        const { controller, pageRender$, themeService } = createController({ editArea: DocumentEditArea.HEADER });
         const rectSpy = vi.spyOn(Rect, 'drawWith').mockImplementation(() => undefined);
         const pathSpy = vi.spyOn(Path, 'drawWith').mockImplementation(() => undefined);
         const textSpy = vi.spyOn(TextBubbleShape, 'drawWith').mockImplementation(() => undefined);
         const ctx = createCtx();
+        const theme = themeService.getCurrentTheme();
+
+        themeService.setTheme({
+            ...theme,
+            primary: {
+                ...theme.primary,
+                600: '#123456',
+            },
+        });
 
         pageRender$.next({
             ctx,
@@ -213,14 +233,14 @@ describe('DocHeaderFooterController', () => {
             height: 230,
         }));
         expect(pathSpy).toHaveBeenCalledTimes(2);
-        expect(pathSpy).toHaveBeenCalledWith(ctx, expect.objectContaining({ stroke: 'primary.600' }));
+        expect(pathSpy).toHaveBeenCalledWith(ctx, expect.objectContaining({ stroke: '#123456' }));
         expect(textSpy).toHaveBeenCalledWith(ctx, expect.objectContaining({
             text: 'docs-ui.headerFooter.header',
-            color: 'alpha(primary.600, 0.08)',
+            color: 'rgba(18,52,86,0.08)',
         }));
         expect(textSpy).toHaveBeenCalledWith(ctx, expect.objectContaining({
             text: 'docs-ui.headerFooter.footer',
-            color: 'alpha(primary.600, 0.08)',
+            color: 'rgba(18,52,86,0.08)',
         }));
 
         controller.dispose();

--- a/packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts
+++ b/packages/docs-ui/src/controllers/__tests__/doc-header-footer.controller.spec.ts
@@ -245,4 +245,38 @@ describe('DocHeaderFooterController', () => {
 
         controller.dispose();
     });
+
+    it('keeps theme color lookups out of the page render hot path', () => {
+        const { controller, pageRender$, themeService } = createController({ editArea: DocumentEditArea.BODY });
+        const getColorFromTheme = vi.spyOn(themeService, 'getColorFromTheme');
+        vi.spyOn(Rect, 'drawWith').mockImplementation(() => undefined);
+        const theme = themeService.getCurrentTheme();
+        const config = {
+            ctx: createCtx(),
+            pageLeft: 0,
+            pageTop: 0,
+            page: {
+                pageWidth: 200,
+                pageHeight: 300,
+                marginTop: 30,
+                marginBottom: 40,
+            },
+        };
+
+        themeService.setTheme({
+            ...theme,
+            gray: {
+                ...theme.gray,
+                0: '#123456',
+            },
+        });
+        getColorFromTheme.mockClear();
+
+        pageRender$.next(config);
+        pageRender$.next(config);
+
+        expect(getColorFromTheme).not.toHaveBeenCalled();
+
+        controller.dispose();
+    });
 });

--- a/packages/docs-ui/src/controllers/doc-header-footer.controller.ts
+++ b/packages/docs-ui/src/controllers/doc-header-footer.controller.ts
@@ -115,6 +115,11 @@ function checkCreateHeaderFooterType(
 
 export class DocHeaderFooterController extends Disposable implements IRenderModule {
     private _loadedMap = new WeakSet<RenderComponentType>();
+    private _headerFooterColors = {
+        primary: '',
+        cover: '',
+        label: '',
+    };
 
     constructor(
         private readonly _context: IRenderContext<DocumentDataModel>,
@@ -133,9 +138,26 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
     }
 
     private _initialize() {
+        this._initThemeColors();
         this._init();
         this._drawHeaderFooterLabel();
         this._listenSwitchMode();
+    }
+
+    private _initThemeColors(): void {
+        this.disposeWithMe(this._themeService.currentTheme$.subscribe(() => {
+            const primary = this._themeService.getColorFromTheme('primary.600');
+
+            this._headerFooterColors = {
+                primary,
+                cover: new ColorKit(this._themeService.getColorFromTheme('gray.0'))
+                    .setAlpha(HEADER_FOOTER_COVER_ALPHA)
+                    .toRgbString(),
+                label: new ColorKit(primary)
+                    .setAlpha(HEADER_FOOTER_LABEL_ALPHA)
+                    .toRgbString(),
+            };
+        }));
     }
 
     override dispose(): void {
@@ -283,11 +305,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
         return documentTransform.clone().invert().applyPoint(originCoord);
     }
 
-    // eslint-disable-next-line max-lines-per-function
     private _drawHeaderFooterLabel() {
-        const localeService = this._localeService;
-
-        // eslint-disable-next-line max-lines-per-function
         this.disposeWithMe(this._instanceSrv.getCurrentTypeOfUnit$(UniverInstanceType.UNIVER_DOC).subscribe((unit) => {
             if (unit == null) {
                 return;
@@ -309,110 +327,106 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
 
             this.disposeWithMe(
                 toDisposable(
-                    // eslint-disable-next-line max-lines-per-function
-                    docsComponent.pageRender$.subscribe((config: IPageRenderConfig) => {
-                        if (this._editorService.isEditor(unitId)) {
-                            return;
-                        }
-
-                        if (!this._isTraditionalMode()) {
-                            return;
-                        }
-
-                        const viewModel = this._docSkeletonManagerService.getViewModel();
-                        const editArea = viewModel.getEditArea();
-                        const isEditBody = editArea === DocumentEditArea.BODY;
-                        const { page, pageLeft, pageTop, ctx } = config;
-                        const { pageWidth, pageHeight, marginTop, marginBottom } = page;
-                        const primaryColor = this._themeService.getColorFromTheme('primary.600');
-                        const coverColor = new ColorKit(this._themeService.getColorFromTheme('gray.0'))
-                            .setAlpha(HEADER_FOOTER_COVER_ALPHA)
-                            .toRgbString();
-                        const labelColor = new ColorKit(primaryColor)
-                            .setAlpha(HEADER_FOOTER_LABEL_ALPHA)
-                            .toRgbString();
-
-                        // Draw header footer label.
-                        ctx.save();
-                        ctx.translate(pageLeft - 0.5, pageTop - 0.5);
-
-                        // Cover header and footer.
-                        if (isEditBody) {
-                            Rect.drawWith(ctx, {
-                                left: 0,
-                                top: 0,
-                                width: pageWidth,
-                                height: marginTop,
-                                fill: coverColor,
-                            });
-                            ctx.save();
-                            ctx.translate(0, pageHeight - marginBottom);
-                            Rect.drawWith(ctx, {
-                                left: 0,
-                                top: 0,
-                                width: pageWidth,
-                                height: marginBottom,
-                                fill: coverColor,
-                            });
-                            ctx.restore();
-                        } else { // Cover body.
-                            ctx.save();
-                            ctx.translate(0, marginTop);
-                            Rect.drawWith(ctx, {
-                                left: 0,
-                                top: marginTop,
-                                width: pageWidth,
-                                height: pageHeight - marginTop - marginBottom,
-                                fill: coverColor,
-                            });
-                            ctx.restore();
-                        }
-
-                        if (!isEditBody) {
-                            const headerPathConfigIPathProps = {
-                                dataArray: [{
-                                    command: 'M',
-                                    points: [0, marginTop],
-                                }, {
-                                    command: 'L',
-                                    points: [pageWidth, marginTop],
-                                }] as unknown as IPathProps['dataArray'],
-                                strokeWidth: 1,
-                                stroke: primaryColor,
-                            };
-
-                            const footerPathConfigIPathProps = {
-                                dataArray: [{
-                                    command: 'M',
-                                    points: [0, pageHeight - marginBottom],
-                                }, {
-                                    command: 'L',
-                                    points: [pageWidth, pageHeight - marginBottom],
-                                }] as unknown as IPathProps['dataArray'],
-                                strokeWidth: 1,
-                                stroke: primaryColor,
-                            };
-
-                            Path.drawWith(ctx, headerPathConfigIPathProps);
-                            Path.drawWith(ctx, footerPathConfigIPathProps);
-
-                            ctx.translate(0, marginTop + 1);
-                            TextBubbleShape.drawWith(ctx, {
-                                text: localeService.t<LocaleKey>('docs-ui.headerFooter.header'),
-                                color: labelColor,
-                            });
-                            ctx.translate(0, pageHeight - marginTop - marginBottom);
-                            TextBubbleShape.drawWith(ctx, {
-                                text: localeService.t<LocaleKey>('docs-ui.headerFooter.footer'),
-                                color: labelColor,
-                            });
-                        }
-                        ctx.restore();
-                    })
+                    docsComponent.pageRender$.subscribe((config: IPageRenderConfig) => this._drawHeaderFooterPage(config, unitId))
                 )
             );
-        })
-        );
+        }));
+    }
+
+    private _drawHeaderFooterPage(config: IPageRenderConfig, unitId: string): void {
+        if (this._editorService.isEditor(unitId) || !this._isTraditionalMode()) {
+            return;
+        }
+
+        const editArea = this._docSkeletonManagerService.getViewModel().getEditArea();
+        const isEditBody = editArea === DocumentEditArea.BODY;
+        const { pageLeft, pageTop, ctx } = config;
+
+        ctx.save();
+        ctx.translate(pageLeft - 0.5, pageTop - 0.5);
+        this._drawHeaderFooterCover(config, isEditBody);
+
+        if (!isEditBody) {
+            this._drawHeaderFooterGuides(config);
+        }
+
+        ctx.restore();
+    }
+
+    private _drawHeaderFooterCover({ page, ctx }: IPageRenderConfig, isEditBody: boolean): void {
+        const { pageWidth, pageHeight, marginTop, marginBottom } = page;
+
+        if (isEditBody) {
+            Rect.drawWith(ctx, {
+                left: 0,
+                top: 0,
+                width: pageWidth,
+                height: marginTop,
+                fill: this._headerFooterColors.cover,
+            });
+            ctx.save();
+            ctx.translate(0, pageHeight - marginBottom);
+            Rect.drawWith(ctx, {
+                left: 0,
+                top: 0,
+                width: pageWidth,
+                height: marginBottom,
+                fill: this._headerFooterColors.cover,
+            });
+            ctx.restore();
+            return;
+        }
+
+        ctx.save();
+        ctx.translate(0, marginTop);
+        Rect.drawWith(ctx, {
+            left: 0,
+            top: marginTop,
+            width: pageWidth,
+            height: pageHeight - marginTop - marginBottom,
+            fill: this._headerFooterColors.cover,
+        });
+        ctx.restore();
+    }
+
+    private _drawHeaderFooterGuides({ page, ctx }: IPageRenderConfig): void {
+        const { pageWidth, pageHeight, marginTop, marginBottom } = page;
+        const headerPathConfig = {
+            dataArray: [{
+                command: 'M',
+                points: [0, marginTop],
+            }, {
+                command: 'L',
+                points: [pageWidth, marginTop],
+            }] as unknown as IPathProps['dataArray'],
+            strokeWidth: 1,
+            stroke: this._headerFooterColors.primary,
+        };
+        const footerPathConfig = {
+            dataArray: [{
+                command: 'M',
+                points: [0, pageHeight - marginBottom],
+            }, {
+                command: 'L',
+                points: [pageWidth, pageHeight - marginBottom],
+            }] as unknown as IPathProps['dataArray'],
+            strokeWidth: 1,
+            stroke: this._headerFooterColors.primary,
+        };
+
+        Path.drawWith(ctx, headerPathConfig);
+        Path.drawWith(ctx, footerPathConfig);
+
+        ctx.translate(0, marginTop + 1);
+        TextBubbleShape.drawWith(ctx, {
+            text: this._localeService.t<LocaleKey>('docs-ui.headerFooter.header'),
+            color: this._headerFooterColors.label,
+        });
+        ctx.translate(0, pageHeight - marginTop - marginBottom);
+        TextBubbleShape.drawWith(ctx, {
+            text: this._localeService.t<LocaleKey>('docs-ui.headerFooter.footer'),
+            color: this._headerFooterColors.label,
+        });
     }
 
     private _isEditorReadOnly(unitId: string) {

--- a/packages/docs-ui/src/controllers/doc-header-footer.controller.ts
+++ b/packages/docs-ui/src/controllers/doc-header-footer.controller.ts
@@ -30,6 +30,7 @@ import type {
 import type { LocaleKey } from '../locale/types';
 import {
     BooleanNumber,
+    ColorKit,
     Disposable,
     DocumentFlavor,
     generateRandomId,
@@ -37,6 +38,7 @@ import {
     Inject,
     IUniverInstanceService,
     LocaleService,
+    ThemeService,
     toDisposable,
     UniverInstanceType,
 } from '@univerjs/core';
@@ -49,9 +51,8 @@ import { DocSelectionRenderService } from '../services/selection/doc-selection-r
 import { getDocPageSectionContext } from '../utils/section-header-footer';
 import { TextBubbleShape } from '../views/header-footer/text-bubble';
 
-const HEADER_FOOTER_COVER_COLOR = 'alpha(gray.0, 0.5)';
-const HEADER_FOOTER_STROKE_COLOR = 'primary.600';
-const HEADER_FOOTER_LABEL_COLOR = 'alpha(primary.600, 0.08)';
+const HEADER_FOOTER_COVER_ALPHA = 0.5;
+const HEADER_FOOTER_LABEL_ALPHA = 0.08;
 
 interface IHeaderFooterCreate {
     createType: Nullable<HeaderFooterType>;
@@ -123,7 +124,8 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
         @IRenderManagerService private readonly _renderManagerService: IRenderManagerService,
         @Inject(DocSkeletonManagerService) private readonly _docSkeletonManagerService: DocSkeletonManagerService,
         @Inject(DocSelectionRenderService) private readonly _docSelectionRenderService: DocSelectionRenderService,
-        @Inject(LocaleService) private readonly _localeService: LocaleService
+        @Inject(LocaleService) private readonly _localeService: LocaleService,
+        @Inject(ThemeService) private readonly _themeService: ThemeService
     ) {
         super();
 
@@ -322,6 +324,13 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                         const isEditBody = editArea === DocumentEditArea.BODY;
                         const { page, pageLeft, pageTop, ctx } = config;
                         const { pageWidth, pageHeight, marginTop, marginBottom } = page;
+                        const primaryColor = this._themeService.getColorFromTheme('primary.600');
+                        const coverColor = new ColorKit(this._themeService.getColorFromTheme('gray.0'))
+                            .setAlpha(HEADER_FOOTER_COVER_ALPHA)
+                            .toRgbString();
+                        const labelColor = new ColorKit(primaryColor)
+                            .setAlpha(HEADER_FOOTER_LABEL_ALPHA)
+                            .toRgbString();
 
                         // Draw header footer label.
                         ctx.save();
@@ -334,7 +343,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                 top: 0,
                                 width: pageWidth,
                                 height: marginTop,
-                                fill: HEADER_FOOTER_COVER_COLOR,
+                                fill: coverColor,
                             });
                             ctx.save();
                             ctx.translate(0, pageHeight - marginBottom);
@@ -343,7 +352,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                 top: 0,
                                 width: pageWidth,
                                 height: marginBottom,
-                                fill: HEADER_FOOTER_COVER_COLOR,
+                                fill: coverColor,
                             });
                             ctx.restore();
                         } else { // Cover body.
@@ -354,7 +363,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                 top: marginTop,
                                 width: pageWidth,
                                 height: pageHeight - marginTop - marginBottom,
-                                fill: HEADER_FOOTER_COVER_COLOR,
+                                fill: coverColor,
                             });
                             ctx.restore();
                         }
@@ -369,7 +378,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                     points: [pageWidth, marginTop],
                                 }] as unknown as IPathProps['dataArray'],
                                 strokeWidth: 1,
-                                stroke: HEADER_FOOTER_STROKE_COLOR,
+                                stroke: primaryColor,
                             };
 
                             const footerPathConfigIPathProps = {
@@ -381,7 +390,7 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                                     points: [pageWidth, pageHeight - marginBottom],
                                 }] as unknown as IPathProps['dataArray'],
                                 strokeWidth: 1,
-                                stroke: HEADER_FOOTER_STROKE_COLOR,
+                                stroke: primaryColor,
                             };
 
                             Path.drawWith(ctx, headerPathConfigIPathProps);
@@ -390,12 +399,12 @@ export class DocHeaderFooterController extends Disposable implements IRenderModu
                             ctx.translate(0, marginTop + 1);
                             TextBubbleShape.drawWith(ctx, {
                                 text: localeService.t<LocaleKey>('docs-ui.headerFooter.header'),
-                                color: HEADER_FOOTER_LABEL_COLOR,
+                                color: labelColor,
                             });
                             ctx.translate(0, pageHeight - marginTop - marginBottom);
                             TextBubbleShape.drawWith(ctx, {
                                 text: localeService.t<LocaleKey>('docs-ui.headerFooter.footer'),
-                                color: HEADER_FOOTER_LABEL_COLOR,
+                                color: labelColor,
                             });
                         }
                         ctx.restore();

--- a/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
+++ b/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
@@ -30,6 +30,7 @@ import {
     LogLevel,
     ObjectMatrix,
     RANGE_TYPE,
+    ThemeService,
     Univer,
     UniverInstanceType,
     VerticalAlign,
@@ -264,6 +265,38 @@ describe('spreadsheet integration', () => {
         expect(getShrinkToFitScale(80, 100, 12)).toBe(1);
         expect(getShrinkToFitScale(200, 100, 12)).toBe(0.5);
         expect(getShrinkToFitScale(2400, 100, 12)).toBeCloseTo(1 / 12);
+    });
+
+    it('updates the mixed screen gridline color after theme changes', () => {
+        const { scene, skeleton, viewport } = fixture;
+        const themeService = fixture.univer.__getInjector().get(ThemeService);
+        const nativeContext = viewport.canvas!.getCanvasEle().getContext('2d') as CanvasRenderingContext2D & {
+            __getEvents: () => Array<{ type: string; props: Record<string, unknown> }>;
+            __clearEvents: () => void;
+        };
+        const getStrokeStyles = () => nativeContext.__getEvents()
+            .filter((event) => event.type === 'strokeStyle')
+            .map((event) => event.props.value);
+
+        nativeContext.__clearEvents();
+        skeleton.updateVisibleRange(viewport.calcViewportInfo());
+        scene.makeDirty(true);
+        scene.render();
+        expect(getStrokeStyles()).toContain('#d5d7dc');
+
+        const theme = themeService.getCurrentTheme();
+        themeService.setTheme({
+            ...theme,
+            gray: {
+                ...theme.gray,
+                200: '#ccddee',
+                900: '#112233',
+            },
+        });
+
+        nativeContext.__clearEvents();
+        scene.render();
+        expect(getStrokeStyles()).toContain('#bfd0e1');
     });
 
     it('scales cloned rich-text font sizes without mutating the stored document', () => {

--- a/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
+++ b/packages/engine-render/src/components/sheets/sheet.render-skeleton.ts
@@ -24,6 +24,7 @@ import {
     BooleanNumber,
 
     CellValueType,
+    ColorKit,
     DEFAULT_STYLES,
     DocumentDataModel,
     getColorStyle,
@@ -51,6 +52,7 @@ import {
     searchArray,
     SheetSkeleton,
 
+    ThemeService,
     Tools,
     VerticalAlign,
 
@@ -276,6 +278,7 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
     private _handleBorderMatrix = new ObjectMatrix<boolean>();
     private _showGridlines: BooleanNumber = BooleanNumber.TRUE;
     private _gridlinesColor: string | undefined = undefined;
+    private _defaultGridlinesColor!: string;
     private _scene: Nullable<Scene> = null;
 
     constructor(
@@ -287,6 +290,14 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
         @Inject(Injector) _injector: Injector
     ) {
         super(worksheet, _styles, _localeService, _contextService, _configService, _injector);
+        const themeService = _injector.get(ThemeService);
+        this.disposeWithMe(themeService.currentTheme$.subscribe(() => {
+            const gray200 = themeService.getColorFromTheme('gray.200');
+            const gray900 = themeService.getColorFromTheme('gray.900');
+            this._defaultGridlinesColor = ColorKit.mix(gray200, gray900, 0.07).toHexString();
+            this._scene?.getViewports().forEach((viewport) => viewport.markDirty(true));
+            this._scene?.makeDirty(true);
+        }));
         this._updateLayout();
         this.disposeWithMe(
             this._contextService.subscribeContextValue$(RENDER_RAW_FORMULA_KEY).pipe(
@@ -362,6 +373,10 @@ export class SpreadsheetSkeleton extends SheetSkeleton {
 
     get gridlinesColor(): string | undefined {
         return this._gridlinesColor;
+    }
+
+    get defaultGridlinesColor(): string {
+        return this._defaultGridlinesColor;
     }
 
     override dispose(): void {

--- a/packages/engine-render/src/components/sheets/spreadsheet.ts
+++ b/packages/engine-render/src/components/sheets/spreadsheet.ts
@@ -42,6 +42,7 @@ const CUSTOM_EXTENSION_KEY = 'DefaultCustomExtension';
 const MARKER_EXTENSION_KEY = 'DefaultMarkerExtension';
 const RANGE_PROTECTION_VIEW_EXTENSION_KEY = 'RANGE_PROTECTION_CAN_VIEW_RENDER_EXTENSION_KEY';
 const RANGE_PROTECTION_HIDDEN_EXTENSION_KEY = 'RANGE_PROTECTION_CAN_NOT_VIEW_RENDER_EXTENSION_KEY';
+const PRINTING_GRIDLINES_COLOR = getColor([214, 216, 219]);
 
 interface IRepaintBound {
     bound: IBoundRectNoAngle;
@@ -932,7 +933,9 @@ export class Spreadsheet extends SheetComponent {
 
         ctx.setLineWidthByPrecision(1);
 
-        const defaultGridlinesColor = ctx.__mode === 'printing' ? getColor([214, 216, 219]) : 'mix(gray.200, gray.900, 0.07)';
+        const defaultGridlinesColor = ctx.__mode === 'printing'
+            ? PRINTING_GRIDLINES_COLOR
+            : spreadsheetSkeleton.defaultGridlinesColor;
         ctx.strokeStyle = gridlinesColor ?? ctx.renderConfig.gridlinesColor ?? defaultGridlinesColor;
 
         const columnWidthAccumulationLength = columnWidthAccumulation.length;

--- a/packages/engine-render/src/render-manager/__tests__/render-manager.service.spec.ts
+++ b/packages/engine-render/src/render-manager/__tests__/render-manager.service.spec.ts
@@ -28,8 +28,9 @@ import {
 import { RenderUnit } from '../render-unit';
 
 describe('render manager service', () => {
-    it('covers render map lifecycle and dark mode listener', () => {
+    it('marks render components dirty when the theme changes', () => {
         const darkMode$ = new Subject<boolean>();
+        const currentTheme$ = new Subject();
         const injector = {
             createInstance: vi.fn(() => new Engine()),
         } as unknown as Injector;
@@ -38,7 +39,7 @@ describe('render manager service', () => {
             getUnitType: vi.fn(() => UniverInstanceType.UNIVER_SHEET),
             getCurrentUnitOfType: vi.fn(() => null),
         } as any;
-        const themeService = { darkMode$ } as any;
+        const themeService = { currentTheme$, darkMode$ } as any;
 
         const service = new RenderManagerService(injector, instanceService, themeService);
         const engine = new Engine('render-service-test', { elementWidth: 100, elementHeight: 80, dpr: 1 });
@@ -70,6 +71,11 @@ describe('render manager service', () => {
         expect(component.makeForceDirty).toHaveBeenCalledWith(true);
         expect(component.makeDirty).toHaveBeenCalledWith(true);
 
+        vi.clearAllMocks();
+        currentTheme$.next({});
+        expect(component.makeForceDirty).toHaveBeenCalledWith(true);
+        expect(component.makeDirty).toHaveBeenCalledWith(true);
+
         service.removeRender('u-1');
         expect(service.has('u-1')).toBe(false);
         service.dispose();
@@ -77,6 +83,7 @@ describe('render manager service', () => {
 
     it('covers dependency registration, render creation branches and helper funcs', () => {
         const darkMode$ = new Subject<boolean>();
+        const currentTheme$ = new Subject();
         const createdRenderUnit = {
             unitId: 'u-2',
             type: UniverInstanceType.UNIVER_SHEET,
@@ -109,7 +116,7 @@ describe('render manager service', () => {
             getUnitType: vi.fn(() => UniverInstanceType.UNIVER_SHEET),
             getCurrentUnitOfType: vi.fn(() => null),
         } as any;
-        const themeService = { darkMode$ } as any;
+        const themeService = { currentTheme$, darkMode$ } as any;
 
         const service = new RenderManagerService(injector, instanceService, themeService);
 
@@ -156,6 +163,7 @@ describe('render manager service', () => {
 
     it('deduplicates render dependencies by identifier', () => {
         const darkMode$ = new Subject<boolean>();
+        const currentTheme$ = new Subject();
         const injector = {
             createInstance: vi.fn(() => new Engine()),
         } as unknown as Injector;
@@ -164,7 +172,7 @@ describe('render manager service', () => {
             getUnitType: vi.fn(() => UniverInstanceType.UNIVER_SHEET),
             getCurrentUnitOfType: vi.fn(() => null),
         } as any;
-        const service = new RenderManagerService(injector, instanceService, { darkMode$ } as any);
+        const service = new RenderManagerService(injector, instanceService, { currentTheme$, darkMode$ } as any);
         const token = Symbol('render-dep') as any;
         const otherToken = Symbol('other-render-dep') as any;
         const firstDep = [token, { useClass: class FirstRenderModule {} }] as any;
@@ -189,6 +197,7 @@ describe('render manager service', () => {
 
     it('deduplicates identifier decorators by stable name across module copies', () => {
         const darkMode$ = new Subject<boolean>();
+        const currentTheme$ = new Subject();
         const injector = {
             createInstance: vi.fn(() => new Engine()),
         } as unknown as Injector;
@@ -197,7 +206,7 @@ describe('render manager service', () => {
             getUnitType: vi.fn(() => UniverInstanceType.UNIVER_SHEET),
             getCurrentUnitOfType: vi.fn(() => null),
         } as any;
-        const service = new RenderManagerService(injector, instanceService, { darkMode$ } as any);
+        const service = new RenderManagerService(injector, instanceService, { currentTheme$, darkMode$ } as any);
         const tokenA = Object.assign(() => undefined, { decoratorName: 'univer.sheet.selection-render-service' }) as any;
         const tokenB = Object.assign(() => undefined, { decoratorName: 'univer.sheet.selection-render-service' }) as any;
         const firstDep = [tokenA, { useClass: class FirstRenderModule {} }] as any;

--- a/packages/engine-render/src/render-manager/render-manager.service.ts
+++ b/packages/engine-render/src/render-manager/render-manager.service.ts
@@ -39,7 +39,7 @@ import {
     toDisposable,
     UniverInstanceType,
 } from '@univerjs/core';
-import { Subject } from 'rxjs';
+import { merge, Subject } from 'rxjs';
 import { Engine } from '../engine';
 import { Scene } from '../scene';
 import { RenderUnit } from './render-unit';
@@ -109,7 +109,7 @@ export class RenderManagerService extends Disposable implements IRenderManagerSe
     ) {
         super();
 
-        this._initDarkModeListener();
+        this._initThemeListener();
     }
 
     override dispose(): void {
@@ -179,8 +179,8 @@ export class RenderManagerService extends Disposable implements IRenderManagerSe
         return Array.from(this._renderDependencies.get(type) ?? []);
     }
 
-    private _initDarkModeListener(): void {
-        this.disposeWithMe(this._themeService.darkMode$.subscribe(() => {
+    private _initThemeListener(): void {
+        this.disposeWithMe(merge(this._themeService.currentTheme$, this._themeService.darkMode$).subscribe(() => {
             this.getRenderAll().forEach((renderer) => {
                 renderer.components.forEach((component) => {
                     component.makeForceDirty(true);

--- a/packages/engine-render/src/services/__tests__/canvas-color.service.spec.ts
+++ b/packages/engine-render/src/services/__tests__/canvas-color.service.spec.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import { ColorKit, Injector, ThemeService } from '@univerjs/core';
+import { Injector, invertColorByMatrix, ThemeService } from '@univerjs/core';
 import { describe, expect, it, vi } from 'vitest';
 import {
     CanvasColorService,
     DumbCanvasColorService,
-    getDarkRenderColorOverride,
     hexToRgb,
     ICanvasColorService,
     rgbToHex,
@@ -39,8 +38,13 @@ describe('CanvasColorService', () => {
         injector.add([ThemeService]);
         injector.add([ICanvasColorService, { useClass: CanvasColorService }]);
         const themeService = injector.get(ThemeService);
+        const getColorFromTheme = vi.spyOn(themeService, 'getColorFromTheme');
+        const isValidThemeColor = vi.spyOn(themeService, 'isValidThemeColor');
         const service = injector.get(ICanvasColorService);
         const theme = themeService.getCurrentTheme();
+
+        getColorFromTheme.mockClear();
+        isValidThemeColor.mockClear();
 
         themeService.setTheme({
             ...theme,
@@ -55,6 +59,9 @@ describe('CanvasColorService', () => {
         expect(service.getRenderColor('gray.50')).toBe('#0d1422');
         expect(service.getRenderColor('white')).toBe('white');
         expect(service.getRenderColor('black')).toBe('black');
+        expect(service.getRenderColor('rgba(37, 99, 235, 0.08)')).toBe('rgba(37, 99, 235, 0.08)');
+        expect(getColorFromTheme).not.toHaveBeenCalled();
+        expect(isValidThemeColor).not.toHaveBeenCalled();
 
         themeService.setTheme({
             ...theme,
@@ -67,6 +74,8 @@ describe('CanvasColorService', () => {
 
         expect(service.getRenderColor('gray.0')).toBe('#050914');
         expect(service.getRenderColor('gray.50')).toBe('#101827');
+        expect(getColorFromTheme).not.toHaveBeenCalled();
+        expect(isValidThemeColor).not.toHaveBeenCalled();
     });
 
     it('applies dark rendering to resolved design tokens', () => {
@@ -82,99 +91,29 @@ describe('CanvasColorService', () => {
         expect(service.getRenderColor('gray.900')).toBe(service.getRenderColor(gray900));
     });
 
-    it('resolves and caches mixed theme colors without becoming stale after theme changes', () => {
+    it('applies matrix inversion to current theme colors without fixed palette overrides', () => {
         const injector = new Injector();
         injector.add([ThemeService]);
         injector.add([ICanvasColorService, { useClass: CanvasColorService }]);
         const themeService = injector.get(ThemeService);
         const service = injector.get(ICanvasColorService);
-        const mixSpy = vi.spyOn(ColorKit, 'mix');
-        const expression = 'mix(gray.200, gray.900, 0.07)';
-
-        expect(service.getRenderColor(expression)).toBe('#d5d7dc');
-        expect(service.getRenderColor(expression)).toBe('#d5d7dc');
-        expect(mixSpy).toHaveBeenCalledTimes(1);
+        const theme = themeService.getCurrentTheme();
 
         themeService.setDarkMode(true);
-        expect(service.getRenderColor(expression)).toBe(service.getRenderColor('#d5d7dc'));
-        expect(mixSpy).toHaveBeenCalledTimes(1);
 
-        themeService.setDarkMode(false);
-        const theme = themeService.getCurrentTheme();
-        themeService.setTheme({
-            ...theme,
-            gray: {
-                ...theme.gray,
-                200: '#ccddee',
-                900: '#112233',
-            },
-        });
+        for (const color of ['#2563eb', '#0f766e']) {
+            themeService.setTheme({
+                ...theme,
+                primary: {
+                    ...theme.primary,
+                    300: color,
+                },
+            });
+            const expected = rgbToHex(invertColorByMatrix(hexToRgb(color)));
 
-        expect(service.getRenderColor(expression)).toBe('#bfd0e1');
-        expect(mixSpy).toHaveBeenCalledTimes(2);
-        mixSpy.mockRestore();
-    });
-
-    it('resolves and caches alpha theme colors without becoming stale after theme changes', () => {
-        const injector = new Injector();
-        injector.add([ThemeService]);
-        injector.add([ICanvasColorService, { useClass: CanvasColorService }]);
-        const themeService = injector.get(ThemeService);
-        const service = injector.get(ICanvasColorService);
-        const alphaSpy = vi.spyOn(ColorKit.prototype, 'setAlpha');
-        const expression = 'alpha(gray.50, 0.5)';
-
-        expect(service.getRenderColor(expression)).toBe('rgba(249,250,251,0.5)');
-        expect(service.getRenderColor(expression)).toBe('rgba(249,250,251,0.5)');
-        expect(alphaSpy).toHaveBeenCalledTimes(1);
-
-        themeService.setDarkMode(true);
-        expect(service.getRenderColor(expression)).toBe(service.getRenderColor('rgba(249,250,251,0.5)'));
-        expect(alphaSpy).toHaveBeenCalledTimes(1);
-
-        themeService.setDarkMode(false);
-        const theme = themeService.getCurrentTheme();
-        themeService.setTheme({
-            ...theme,
-            gray: {
-                ...theme.gray,
-                50: '#101827',
-            },
-        });
-
-        expect(service.getRenderColor(expression)).toBe('rgba(16,24,39,0.5)');
-        expect(alphaSpy).toHaveBeenCalledTimes(2);
-        alphaSpy.mockRestore();
-    });
-
-    it('resolves alpha CSS color names', () => {
-        const injector = new Injector();
-        injector.add([ThemeService]);
-        injector.add([ICanvasColorService, { useClass: CanvasColorService }]);
-        const service = injector.get(ICanvasColorService);
-
-        expect(service.getRenderColor('alpha(white, 0.5)')).toBe('rgba(255,255,255,0.5)');
-        expect(service.getRenderColor('alpha(white, 0.7)')).toBe('rgba(255,255,255,0.7)');
-    });
-
-    it('rejects invalid alpha color expressions', () => {
-        const injector = new Injector();
-        injector.add([ThemeService]);
-        injector.add([ICanvasColorService, { useClass: CanvasColorService }]);
-        const service = injector.get(ICanvasColorService);
-
-        expect(() => service.getRenderColor('alpha(gray.50, 1.1)')).toThrow('[CanvasColorService]: illegal color');
-        expect(() => service.getRenderColor('alpha(not-a-color, 0.5)')).toThrow('[CanvasColorService]: illegal color');
-    });
-
-    it('maps render colors for dark mode rendering', () => {
-        const injector = new Injector();
-        injector.add([ThemeService]);
-        injector.add([ICanvasColorService, { useClass: CanvasColorService }]);
-        injector.get(ThemeService).setDarkMode(true);
-
-        expect(injector.get(ICanvasColorService).getRenderColor('#17212b')).toBe('#e2e8f0');
-        expect(injector.get(ICanvasColorService).getRenderColor('rgba(37, 99, 235, 0.08)')).toBe('rgba(96,165,250,0.22)');
+            expect(service.getRenderColor('primary.300')).toBe(expected);
+            expect(service.getRenderColor(color)).toBe(expected);
+        }
     });
 
     it('inverts supported color syntaxes in dark mode and caches the render result', () => {
@@ -196,9 +135,7 @@ describe('CanvasColorService', () => {
         expect(service.getRenderColor('#abc')).toBe(shortHex);
     });
 
-    it('reports dark overrides and color conversion helpers used by renderers', () => {
-        expect(getDarkRenderColorOverride(' RGBA(37, 99, 235, 0.08) ')).toBe('rgba(96,165,250,0.22)');
-        expect(getDarkRenderColorOverride('#ffffff')).toBeNull();
+    it('converts colors used by renderers', () => {
         expect(hexToRgb('#abc')).toEqual([170, 187, 204]);
         expect(hexToRgb('#abcdef')).toEqual([171, 205, 239]);
         expect(rgbToHex([1.2, 15.5, 255])).toBe('#0110ff');

--- a/packages/engine-render/src/services/canvas-color.service.ts
+++ b/packages/engine-render/src/services/canvas-color.service.ts
@@ -32,52 +32,12 @@ export class DumbCanvasColorService implements ICanvasColorService {
     }
 }
 
-const DARK_RENDER_COLOR_OVERRIDES: Record<string, string> = {
-    '#17212b': '#e2e8f0',
-    '#64748b': '#94a3b8',
-    '#d9e0e7': '#253044',
-    '#edf1f5': '#1b2535',
-    '#eef2f6': '#1b2535',
-    '#f2f5f8': '#101827',
-    '#f3f6fa': '#18243a',
-    '#f4f8ff': '#172a46',
-    '#f5f9ff': '#12233a',
-    '#f7f9fb': '#0d1422',
-    '#f7f9fc': '#0d1422',
-    '#f8fafc': '#0f172a',
-    '#fbfcfd': '#07111f',
-    '#fcfdff': '#050914',
-    '#e8f1ff': '#173a69',
-    '#eaf5ff': '#12315a',
-    '#dbeafe': '#1e3a8a',
-    '#bfdbfe': '#60a5fa',
-    '#93c5fd': '#60a5fa',
-    '#8eb6f5': '#60a5fa',
-    '#60a5fa': '#60a5fa',
-    '#2563eb': '#60a5fa',
-    '#1d64d8': '#93c5fd',
-    '#1d5cff': '#60a5fa',
-    '#0f766e': '#2dd4bf',
-    '#d7f4ef': '#134e4a',
-    'rgba(37,99,235,0.05)': 'rgba(96,165,250,0.16)',
-    'rgba(37,99,235,0.06)': 'rgba(96,165,250,0.18)',
-    'rgba(37,99,235,0.08)': 'rgba(96,165,250,0.22)',
-    'rgba(37,99,235,0.12)': 'rgba(96,165,250,0.26)',
-    'rgba(37,99,235,0.18)': 'rgba(96,165,250,0.30)',
-    'rgba(37,99,235,0.28)': 'rgba(96,165,250,0.38)',
-    'rgba(239,246,255,0.88)': 'rgba(30,64,175,0.72)',
-    'rgba(148,163,184,0.45)': 'rgba(148,163,184,0.52)',
-};
-
-const COLOR_MIX_REGEXP = /^mix\(\s*([^,()]+)\s*,\s*([^,()]+)\s*,\s*(0(?:\.\d+)?|1(?:\.0+)?)\s*\)$/;
-const COLOR_ALPHA_REGEXP = /^alpha\(\s*([^,()]+)\s*,\s*(0(?:\.\d+)?|1(?:\.0+)?)\s*\)$/;
-
 /**
  * This service inverts a color for dark mode. This service is exposed
  */
 export class CanvasColorService extends Disposable implements ICanvasColorService {
     private readonly _darkModeCache = new Map<string, string>();
-    private readonly _resolvedColorCache = new Map<string, string>();
+    private readonly _resolvedThemeColors = new Map<string, string>();
     private _invertAlgo = invertColorByMatrix;
 
     constructor(
@@ -85,14 +45,14 @@ export class CanvasColorService extends Disposable implements ICanvasColorServic
     ) {
         super();
 
-        this.disposeWithMe(this._themeService.currentTheme$.subscribe(() => {
-            this._resolvedColorCache.clear();
+        this.disposeWithMe(this._themeService.currentTheme$.subscribe((theme) => {
+            this._cacheThemeColors(theme);
             this._darkModeCache.clear();
         }));
     }
 
     getRenderColor(inputColor: string): string {
-        const color = this._resolveColor(inputColor);
+        const color = this._resolvedThemeColors.get(inputColor) ?? inputColor;
 
         if (!this._themeService.darkMode) {
             return color;
@@ -102,16 +62,13 @@ export class CanvasColorService extends Disposable implements ICanvasColorServic
             return this._darkModeCache.get(color)!;
         }
 
-        if (normalizeRenderColor(color) === 'transparent') {
+        if (color.trim().toLowerCase() === 'transparent') {
             this._darkModeCache.set(color, 'transparent');
             return 'transparent';
         }
 
         let cachedColor = '';
-        const mappedColor = getDarkRenderColorOverride(color);
-        if (mappedColor) {
-            cachedColor = mappedColor;
-        } else if (color.startsWith('#')) {
+        if (color.startsWith('#')) {
             const invertedColor = this._invertAlgo(hexToRgb(color));
             cachedColor = rgbToHex(invertedColor);
 
@@ -145,74 +102,17 @@ export class CanvasColorService extends Disposable implements ICanvasColorServic
         return cachedColor;
     }
 
-    private _resolveColor(inputColor: string): string {
-        const cachedColor = this._resolvedColorCache.get(inputColor);
-        if (cachedColor !== undefined) {
-            return cachedColor;
-        }
+    private _cacheThemeColors(theme: ReturnType<ThemeService['getCurrentTheme']>): void {
+        this._resolvedThemeColors.clear();
 
-        const mixMatch = inputColor.match(COLOR_MIX_REGEXP);
-        if (mixMatch) {
-            const color1 = this._resolveThemeColor(mixMatch[1].trim());
-            const color2 = this._resolveThemeColor(mixMatch[2].trim());
-            const amount = Number(mixMatch[3]);
-            const color = ColorKit.mix(color1, color2, amount).toHexString();
-            this._resolvedColorCache.set(inputColor, color);
-            return color;
-        }
-
-        const alphaMatch = inputColor.match(COLOR_ALPHA_REGEXP);
-        if (alphaMatch) {
-            const baseColor = this._resolveThemeColor(alphaMatch[1].trim());
-            const colorKit = new ColorKit(baseColor);
-
-            if (!colorKit.isValid) {
-                throw new Error(`[CanvasColorService]: illegal color "${inputColor}"`);
-            }
-
-            const color = colorKit.setAlpha(Number(alphaMatch[2])).toRgbString();
-            this._resolvedColorCache.set(inputColor, color);
-            return color;
-        }
-
-        if (inputColor.trim().startsWith('alpha(')) {
-            throw new Error(`[CanvasColorService]: illegal color "${inputColor}"`);
-        }
-
-        const color = this._resolveThemeColor(inputColor);
-        if (color !== inputColor) {
-            this._resolvedColorCache.set(inputColor, color);
-        }
-
-        return color;
-    }
-
-    private _resolveThemeColor(inputColor: string): string {
-        let color = inputColor;
-
-        if (color.includes('.')) {
-            const themeColor = this._themeService.getColorFromTheme<unknown>(color);
-            if (typeof themeColor === 'string' && this._themeService.isValidThemeColor(color)) {
-                color = themeColor;
+        for (const [paletteName, palette] of Object.entries(theme)) {
+            for (const [tokenName, color] of Object.entries(palette)) {
+                if (typeof color === 'string') {
+                    this._resolvedThemeColors.set(`${paletteName}.${tokenName}`, color);
+                }
             }
         }
-
-        return color;
     }
-}
-
-export function getDarkRenderColorOverride(color: string): string | null {
-    const normalized = normalizeRenderColor(color);
-    return DARK_RENDER_COLOR_OVERRIDES[normalized] ?? null;
-}
-
-function normalizeRenderColor(color: string): string {
-    const trimmed = color.trim().toLowerCase();
-    if (trimmed.startsWith('rgb')) {
-        return trimmed.replace(/\s+/g, '');
-    }
-
-    return trimmed;
 }
 
 export function hexToRgb(_hex: string): RGBColorType {

--- a/packages/engine-render/src/shape/__tests__/basic-shapes-extra.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/basic-shapes-extra.spec.ts
@@ -25,7 +25,8 @@ import { ListItem } from '../dropdown-item';
 import { Rect } from '../rect';
 
 function createShapeCtx() {
-    return {
+    const alphaStack: number[] = [];
+    const ctx = {
         save: vi.fn(),
         restore: vi.fn(),
         transform: vi.fn(),
@@ -54,6 +55,13 @@ function createShapeCtx() {
         shadowOffsetX: 0,
         shadowOffsetY: 0,
     } as any;
+
+    ctx.save.mockImplementation(() => alphaStack.push(ctx.globalAlpha));
+    ctx.restore.mockImplementation(() => {
+        ctx.globalAlpha = alphaStack.pop() ?? 1;
+    });
+
+    return ctx;
 }
 
 describe('basic shape and position helpers', () => {
@@ -139,6 +147,25 @@ describe('basic shape and position helpers', () => {
         expect(ctx.arc).not.toHaveBeenCalled();
         expect(ctx.fill).toHaveBeenCalled();
         expect(ctx.restore).toHaveBeenCalled();
+    });
+
+    it('applies fill and stroke opacity independently', () => {
+        const ctx = createShapeCtx();
+        const paintAlpha: number[] = [];
+        ctx.fill.mockImplementation(() => paintAlpha.push(ctx.globalAlpha));
+        ctx.stroke.mockImplementation(() => paintAlpha.push(ctx.globalAlpha));
+
+        Rect.drawWith(ctx, {
+            width: 80,
+            height: 32,
+            fill: 'gray.0',
+            fillOpacity: 0.5,
+            stroke: 'gray.0',
+            strokeOpacity: 0.7,
+            strokeWidth: 1,
+        });
+
+        expect(paintAlpha).toEqual([0.5, 0.7]);
     });
 
     it('skips non-positive and non-finite stroke widths', () => {

--- a/packages/engine-render/src/shape/__tests__/scroll-bar.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/scroll-bar.spec.ts
@@ -132,12 +132,12 @@ describe('ScrollBar', () => {
     it('uses translucent white for default track colors', () => {
         const scrollBar = new ScrollBar(viewport);
 
-        expect(scrollBar.horizonScrollTrack?.fill).toBe('alpha(white, 0.5)');
-        expect(scrollBar.horizonScrollTrack?.stroke).toBe('alpha(white, 0.7)');
-        expect(scrollBar.verticalScrollTrack?.fill).toBe('alpha(white, 0.5)');
-        expect(scrollBar.verticalScrollTrack?.stroke).toBe('alpha(white, 0.7)');
-        expect(scrollBar.placeholderBarRect?.fill).toBe('alpha(white, 0.5)');
-        expect(scrollBar.placeholderBarRect?.stroke).toBe('alpha(white, 0.7)');
+        expect(scrollBar.horizonScrollTrack?.fill).toBe('rgba(255,255,255,0.5)');
+        expect(scrollBar.horizonScrollTrack?.stroke).toBe('rgba(255,255,255,0.7)');
+        expect(scrollBar.verticalScrollTrack?.fill).toBe('rgba(255,255,255,0.5)');
+        expect(scrollBar.verticalScrollTrack?.stroke).toBe('rgba(255,255,255,0.7)');
+        expect(scrollBar.placeholderBarRect?.fill).toBe('rgba(255,255,255,0.5)');
+        expect(scrollBar.placeholderBarRect?.stroke).toBe('rgba(255,255,255,0.7)');
 
         scrollBar.dispose();
     });

--- a/packages/engine-render/src/shape/__tests__/scroll-bar.spec.ts
+++ b/packages/engine-render/src/shape/__tests__/scroll-bar.spec.ts
@@ -129,15 +129,31 @@ describe('ScrollBar', () => {
         scrollBar.dispose();
     });
 
-    it('uses translucent white for default track colors', () => {
+    it('uses the theme surface color with distinct track opacities', () => {
         const scrollBar = new ScrollBar(viewport);
 
-        expect(scrollBar.horizonScrollTrack?.fill).toBe('rgba(255,255,255,0.5)');
-        expect(scrollBar.horizonScrollTrack?.stroke).toBe('rgba(255,255,255,0.7)');
-        expect(scrollBar.verticalScrollTrack?.fill).toBe('rgba(255,255,255,0.5)');
-        expect(scrollBar.verticalScrollTrack?.stroke).toBe('rgba(255,255,255,0.7)');
-        expect(scrollBar.placeholderBarRect?.fill).toBe('rgba(255,255,255,0.5)');
-        expect(scrollBar.placeholderBarRect?.stroke).toBe('rgba(255,255,255,0.7)');
+        for (const track of [
+            scrollBar.horizonScrollTrack,
+            scrollBar.verticalScrollTrack,
+            scrollBar.placeholderBarRect,
+        ]) {
+            expect(track?.fill).toBe('gray.0');
+            expect(track?.stroke).toBe('gray.0');
+            expect(track?.fillOpacity).toBe(0.5);
+            expect(track?.strokeOpacity).toBe(0.7);
+        }
+
+        scrollBar.dispose();
+    });
+
+    it('does not alter the opacity of custom track colors', () => {
+        const scrollBar = new ScrollBar(viewport, {
+            trackBackgroundColor: 'rgba(1,2,3,0.4)',
+            trackBorderColor: 'rgba(4,5,6,0.6)',
+        });
+
+        expect(scrollBar.horizonScrollTrack?.fillOpacity).toBe(1);
+        expect(scrollBar.horizonScrollTrack?.strokeOpacity).toBe(1);
 
         scrollBar.dispose();
     });

--- a/packages/engine-render/src/shape/scroll-bar.ts
+++ b/packages/engine-render/src/shape/scroll-bar.ts
@@ -105,8 +105,8 @@ export class ScrollBar extends Disposable {
     private _thumbDefaultBackgroundColor = 'gray.300';
     private _thumbHoverBackgroundColor = 'gray.400';
     private _thumbActiveBackgroundColor = 'gray.500';
-    private _trackBackgroundColor = 'alpha(white, 0.5)';
-    private _trackBorderColor = 'alpha(white, 0.7)';
+    private _trackBackgroundColor = 'rgba(255,255,255,0.5)';
+    private _trackBorderColor = 'rgba(255,255,255,0.7)';
 
     /**
      * The thickness of a scrolling track

--- a/packages/engine-render/src/shape/scroll-bar.ts
+++ b/packages/engine-render/src/shape/scroll-bar.ts
@@ -105,8 +105,10 @@ export class ScrollBar extends Disposable {
     private _thumbDefaultBackgroundColor = 'gray.300';
     private _thumbHoverBackgroundColor = 'gray.400';
     private _thumbActiveBackgroundColor = 'gray.500';
-    private _trackBackgroundColor = 'rgba(255,255,255,0.5)';
-    private _trackBorderColor = 'rgba(255,255,255,0.7)';
+    private _trackBackgroundColor = 'gray.0';
+    private _trackBorderColor = 'gray.0';
+    private _trackBackgroundOpacity = 0.5;
+    private _trackBorderOpacity = 0.7;
 
     /**
      * The thickness of a scrolling track
@@ -164,12 +166,20 @@ export class ScrollBar extends Disposable {
 
         themeKeys.forEach((key) => {
             if (props[key as keyof IScrollBarProps] !== undefined) {
-                (this as Record<string, any>)[`_${key}`] = props[key as keyof IScrollBarProps];
+                (this as unknown as Record<string, unknown>)[`_${key}`] = props[key as keyof IScrollBarProps];
             }
         });
 
         if (Tools.isDefine(props.thumbBackgroundColor)) {
             this._thumbDefaultBackgroundColor = props.thumbBackgroundColor;
+        }
+
+        if (Tools.isDefine(props.trackBackgroundColor)) {
+            this._trackBackgroundOpacity = 1;
+        }
+
+        if (Tools.isDefine(props.trackBorderColor)) {
+            this._trackBorderOpacity = 1;
         }
 
         if (Tools.isDefine(props.barSize)) {
@@ -635,8 +645,10 @@ export class ScrollBar extends Disposable {
         if (this._enableHorizontal) {
             this.horizonScrollTrack = new Rect('__horizonBarRect__', {
                 fill: this._trackBackgroundColor!,
+                fillOpacity: this._trackBackgroundOpacity,
                 strokeWidth: this._trackBorderThickness,
                 stroke: this._trackBorderColor!,
+                strokeOpacity: this._trackBorderOpacity,
             });
 
             this.horizonThumbRect = new Rect('__horizonThumbRect__', {
@@ -648,8 +660,10 @@ export class ScrollBar extends Disposable {
         if (this._enableVertical) {
             this.verticalScrollTrack = new Rect('__verticalBarRect__', {
                 fill: this._trackBackgroundColor!,
+                fillOpacity: this._trackBackgroundOpacity,
                 strokeWidth: this._trackBorderThickness,
                 stroke: this._trackBorderColor!,
+                strokeOpacity: this._trackBorderOpacity,
             });
 
             this.verticalThumbRect = new Rect('__verticalThumbRect__', {
@@ -661,8 +675,10 @@ export class ScrollBar extends Disposable {
         if (this._enableHorizontal && this._enableVertical) {
             this.placeholderBarRect = new Rect('__placeholderBarRect__', {
                 fill: this._trackBackgroundColor!,
+                fillOpacity: this._trackBackgroundOpacity,
                 strokeWidth: this._trackBorderThickness,
                 stroke: this._trackBorderColor!,
+                strokeOpacity: this._trackBorderOpacity,
             });
         }
     }

--- a/packages/engine-render/src/shape/shape.ts
+++ b/packages/engine-render/src/shape/shape.ts
@@ -50,8 +50,10 @@ export interface IShapeProps extends IObjectFullState, ISize, IOffset, IScale {
     paintFirst?: PaintFirst;
 
     stroke?: Nullable<string | CanvasGradient>;
+    strokeOpacity?: number;
     strokeScaleEnabled?: boolean; // strokeUniform: boolean;
     fill?: Nullable<string | CanvasGradient>;
+    fillOpacity?: number;
     fillAfterStrokeEnabled?: boolean;
     hitStrokeWidth?: number | string;
     strokeLineJoin?: LineJoin;
@@ -79,8 +81,10 @@ export const SHAPE_OBJECT_ARRAY = [
     'globalCompositeOperation',
     'paintFirst',
     'stroke',
+    'strokeOpacity',
     'strokeScaleEnabled',
     'fill',
+    'fillOpacity',
     'fillAfterStrokeEnabled',
     'hitStrokeWidth',
     'strokeLineJoin',
@@ -116,9 +120,13 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
 
     private _stroke: Nullable<string | CanvasGradient>;
 
+    private _strokeOpacity?: number;
+
     private _strokeScaleEnabled: boolean = false; // strokeUniform: boolean;
 
     private _fill: Nullable<string | CanvasGradient>;
+
+    private _fillOpacity?: number;
 
     private _fillAfterStrokeEnabled: boolean = false;
 
@@ -184,12 +192,20 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
         return this._stroke;
     }
 
+    get strokeOpacity() {
+        return this._strokeOpacity;
+    }
+
     get strokeScaleEnabled() {
         return this._strokeScaleEnabled;
     }
 
     get fill() {
         return this._fill;
+    }
+
+    get fillOpacity() {
+        return this._fillOpacity;
     }
 
     get fillAfterStrokeEnabled() {
@@ -277,6 +293,7 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
 
         ctx.save();
         this._setFillStyles(ctx, props);
+        ctx.globalAlpha *= props.fillOpacity ?? 1;
         if (props.fillRule === 'evenodd') {
             ctx.fill('evenodd');
         } else {
@@ -290,7 +307,7 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
      * @param {UniverRenderingContext} ctx SheetContext to render on
      */
     private static _renderStroke(ctx: UniverRenderingContext, props: IShapeProps) {
-        const { stroke, strokeWidth, strokeScaleEnabled } = props;
+        const { stroke, strokeWidth } = props;
 
         // let { scaleX, scaleY } = props;
         // const { scaleX = 1, scaleY = 1 } = ctx.getScale();
@@ -306,6 +323,7 @@ export abstract class Shape<T extends IShapeProps> extends BaseObject {
         // }
         // this._setLineDash(ctx);
         this._setStrokeStyles(ctx, props);
+        ctx.globalAlpha *= props.strokeOpacity ?? 1;
 
         ctx.stroke();
         ctx.restore();

--- a/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-menu.render-controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-menu.render-controller.spec.ts
@@ -21,7 +21,7 @@ import { HeaderMenuRenderController } from '../header-menu.render-controller';
 import { createRenderTestBed, createTestEvent } from './render-test-bed';
 
 describe('HeaderMenuRenderController', () => {
-    it('positions the column menu arrow in the base column header area when outline uses margins', () => {
+    it('renders a translucent hover state in the base column header area when outline uses margins', () => {
         const testBed = createRenderTestBed({
             dependencies: [
                 [IContextMenuService, { useValue: { triggerContextMenu: vi.fn() } }],
@@ -45,6 +45,7 @@ describe('HeaderMenuRenderController', () => {
 
         const hoverRect = (controller as any)._hoverRect;
         const hoverMenu = (controller as any)._hoverMenu;
+        expect(hoverRect.fill).toBe('alpha(gray.900, 0.1)');
         expect(hoverRect.top).toBe(40);
         expect(hoverRect.height).toBe(20);
         expect(hoverMenu.top).toBeCloseTo(40 + 20 / 2 - (20 * 0.8) / 2);

--- a/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-menu.render-controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/__tests__/header-menu.render-controller.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ThemeService } from '@univerjs/core';
 import { IContextMenuService } from '@univerjs/ui';
 import { describe, expect, it, vi } from 'vitest';
 import { SHEET_VIEW_KEY } from '../../../common/keys';
@@ -28,6 +29,16 @@ describe('HeaderMenuRenderController', () => {
             ],
         });
         const { context, injector, skeleton } = testBed;
+        const themeService = injector.get(ThemeService);
+        const theme = themeService.getCurrentTheme();
+
+        themeService.setTheme({
+            ...theme,
+            gray: {
+                ...theme.gray,
+                900: '#123456',
+            },
+        });
 
         skeleton.columnHeaderHeight = 20;
         skeleton.columnHeaderHeightAndMarginTop = 60;
@@ -45,10 +56,20 @@ describe('HeaderMenuRenderController', () => {
 
         const hoverRect = (controller as any)._hoverRect;
         const hoverMenu = (controller as any)._hoverMenu;
-        expect(hoverRect.fill).toBe('alpha(gray.900, 0.1)');
+        expect(hoverRect.fill).toBe('rgba(18,52,86,0.1)');
         expect(hoverRect.top).toBe(40);
         expect(hoverRect.height).toBe(20);
         expect(hoverMenu.top).toBeCloseTo(40 + 20 / 2 - (20 * 0.8) / 2);
+
+        themeService.setTheme({
+            ...theme,
+            gray: {
+                ...theme.gray,
+                900: '#345678',
+            },
+        });
+
+        expect(hoverRect.fill).toBe('rgba(52,86,120,0.1)');
 
         testBed.univer.dispose();
     });

--- a/packages/sheets-ui/src/controllers/render-controllers/__tests__/render-test-bed.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/__tests__/render-test-bed.ts
@@ -532,9 +532,9 @@ export function createRenderTestBed(options?: { workbookData?: IWorkbookData; de
     (engine as any).dispose ??= () => { };
 
     const components = new Map<any, any>();
-    components.set(SHEET_VIEW_KEY.ROW, { onPointerDown$: createTestEvent<any>(), onPointerMove$: createTestEvent<any>(), onPointerLeave$: createTestEvent<any>(), dispose: () => { } });
-    components.set(SHEET_VIEW_KEY.COLUMN, { onPointerDown$: createTestEvent<any>(), onPointerMove$: createTestEvent<any>(), onPointerLeave$: createTestEvent<any>(), dispose: () => { } });
-    components.set(SHEET_VIEW_KEY.LEFT_TOP, { onPointerDown$: createTestEvent<any>(), dispose: () => { } });
+    components.set(SHEET_VIEW_KEY.ROW, { onPointerDown$: createTestEvent<any>(), onPointerMove$: createTestEvent<any>(), onPointerLeave$: createTestEvent<any>(), makeForceDirty: () => { }, makeDirty: () => { }, dispose: () => { } });
+    components.set(SHEET_VIEW_KEY.COLUMN, { onPointerDown$: createTestEvent<any>(), onPointerMove$: createTestEvent<any>(), onPointerLeave$: createTestEvent<any>(), makeForceDirty: () => { }, makeDirty: () => { }, dispose: () => { } });
+    components.set(SHEET_VIEW_KEY.LEFT_TOP, { onPointerDown$: createTestEvent<any>(), makeForceDirty: () => { }, makeDirty: () => { }, dispose: () => { } });
 
     const mainComponent = {
         zIndex: 1,
@@ -542,6 +542,7 @@ export function createRenderTestBed(options?: { workbookData?: IWorkbookData; de
         isForceDirty: () => false,
         getSkeleton: () => ({ worksheet: { getMergeData: () => [] } }),
         makeForceDirty: () => { },
+        makeDirty: () => { },
         onPointerDown$: createTestEvent<any>(),
     };
 

--- a/packages/sheets-ui/src/controllers/render-controllers/header-menu.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/header-menu.render-controller.ts
@@ -18,10 +18,12 @@ import type { Nullable, Workbook } from '@univerjs/core';
 import type { IMouseEvent, IPointerEvent, IRenderContext, IRenderModule, SpreadsheetColumnHeader, SpreadsheetHeader } from '@univerjs/engine-render';
 import type { ISetSelectionsOperationParams } from '@univerjs/sheets';
 import {
+    ColorKit,
     Disposable,
     ICommandService,
     Inject,
     RANGE_TYPE,
+    ThemeService,
 } from '@univerjs/core';
 import { CURSOR_TYPE, Rect } from '@univerjs/engine-render';
 import { SetSelectionsOperation, SheetsSelectionsService } from '@univerjs/sheets';
@@ -37,7 +39,7 @@ const HEADER_MENU_CONTROLLER_SHAPE = '__SpreadsheetHeaderMenuSHAPEControllerShap
 
 const HEADER_MENU_CONTROLLER_MENU = '__SpreadsheetHeaderMenuMAINControllerShape__';
 
-const HEADER_MENU_CONTROLLER_SHAPE_COLOR = 'alpha(gray.900, 0.1)';
+const HEADER_MENU_CONTROLLER_SHAPE_ALPHA = 0.1;
 
 enum HEADER_HOVER_TYPE {
     ROW,
@@ -62,21 +64,15 @@ export class HeaderMenuRenderController extends Disposable implements IRenderMod
 
     private _currentColumn: number = Number.POSITIVE_INFINITY;
 
-    // private _rowHeaderPointerMoveSub: Subscription;
-    // private _colHeaderPointerMoveSub: Subscription;
-    // private _rowHeaderPointerLeaveSub: Subscription;
-    // private _colHeaderPointerLeaveSub: Subscription;
-    // private _rowHeaderPointerEnterSub: Subscription;
-    // private _colHeaderPointerEnterSub: Subscription;
-    private _headerPointerSubs: Nullable<Subscription>;
-    private _colHeaderPointerSubs: Nullable<Subscription>;
+    private readonly _headerPointerSubs = new Subscription();
 
     constructor(
         private readonly _context: IRenderContext<Workbook>,
         @Inject(SheetSkeletonManagerService) private readonly _sheetSkeletonManagerService: SheetSkeletonManagerService,
         @IContextMenuService private readonly _contextMenuService: IContextMenuService,
         @ICommandService private readonly _commandService: ICommandService,
-        @Inject(SheetsSelectionsService) private readonly _selectionManagerService: SheetsSelectionsService
+        @Inject(SheetsSelectionsService) private readonly _selectionManagerService: SheetsSelectionsService,
+        @Inject(ThemeService) private readonly _themeService: ThemeService
     ) {
         super();
 
@@ -84,32 +80,25 @@ export class HeaderMenuRenderController extends Disposable implements IRenderMod
     }
 
     override dispose(): void {
+        super.dispose();
         this._hoverRect?.dispose();
         this._hoverMenu?.dispose();
-
-        // const spreadsheetColumnHeader = this._context.components.get(SHEET_VIEW_KEY.COLUMN) as SpreadsheetColumnHeader;
-        // const spreadsheetRowHeader = this._context.components.get(SHEET_VIEW_KEY.ROW) as SpreadsheetHeader;
-
-        // [...this._headerPointerSubs, ...this._colHeaderPointerSubs].forEach((s) => {
-            // s.unsubscribe();
-            // spreadsheetRowHeader.onPointerEnterObserver.remove(observer);
-            // spreadsheetRowHeader.onPointerMoveObserver.remove(observer);
-            // spreadsheetRowHeader.onPointerLeaveObserver.remove(observer);
-            // spreadsheetColumnHeader.onPointerEnterObserver.remove(observer);
-            // spreadsheetColumnHeader.onPointerMoveObserver.remove(observer);
-            // spreadsheetColumnHeader.onPointerLeaveObserver.remove(observer);
-        // });
-        this._headerPointerSubs?.unsubscribe();
-        this._headerPointerSubs = null;
+        this._headerPointerSubs.unsubscribe();
     }
 
     private _initialize() {
         const scene = this._context.scene;
 
         this._hoverRect = new Rect(HEADER_MENU_CONTROLLER_SHAPE, {
-            fill: HEADER_MENU_CONTROLLER_SHAPE_COLOR,
             evented: false,
         });
+
+        this.disposeWithMe(this._themeService.currentTheme$.subscribe(() => {
+            const color = this._themeService.getColorFromTheme('gray.900');
+            this._hoverRect?.setProps({
+                fill: new ColorKit(color).setAlpha(HEADER_MENU_CONTROLLER_SHAPE_ALPHA).toRgbString(),
+            });
+        }));
 
         this._hoverMenu = new HeaderMenuShape(HEADER_MENU_CONTROLLER_MENU, { zIndex: 100, visible: false });
 
@@ -122,7 +111,6 @@ export class HeaderMenuRenderController extends Disposable implements IRenderMod
         this._initialHoverMenu();
     }
 
-    // eslint-disable-next-line max-lines-per-function
     private _initialHover(initialType: HEADER_HOVER_TYPE = HEADER_HOVER_TYPE.ROW) {
         const spreadsheetColumnHeader = this._context.components.get(SHEET_VIEW_KEY.COLUMN) as SpreadsheetColumnHeader;
         const spreadsheetRowHeader = this._context.components.get(SHEET_VIEW_KEY.ROW) as SpreadsheetHeader;
@@ -193,24 +181,12 @@ export class HeaderMenuRenderController extends Disposable implements IRenderMod
             this._hoverMenu?.hide();
         };
 
-        this._headerPointerSubs = new Subscription();
         const headerPointerMoveSub = eventBindingObject.onPointerMove$.subscribeEvent(pointerMoveHandler);
         const headerPointerEnterSub = eventBindingObject.onPointerEnter$.subscribeEvent(pointerEnterHandler);
         const headerPointerLeaveSub = eventBindingObject.onPointerLeave$.subscribeEvent(pointerLeaveHandler);
-        this._headerPointerSubs?.add(headerPointerMoveSub);
-        this._headerPointerSubs?.add(headerPointerEnterSub);
-        this._headerPointerSubs?.add(headerPointerLeaveSub);
-        // this._observers.push(
-        //     eventBindingObject?.onPointerEnter$.subscribeEvent(() => {
-        //     })
-        // );
-        // this._observers.push(
-        // eventBindingObject?.onPointerMoveObserver.add(
-        // );
-
-        // this._observers.push(
-        // eventBindingObject?.onPointerLeave$.subscribeEvent(})
-        // );
+        this._headerPointerSubs.add(headerPointerMoveSub);
+        this._headerPointerSubs.add(headerPointerEnterSub);
+        this._headerPointerSubs.add(headerPointerLeaveSub);
     }
 
     private _initialHoverMenu() {

--- a/packages/sheets-ui/src/controllers/render-controllers/header-menu.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/render-controllers/header-menu.render-controller.ts
@@ -37,7 +37,7 @@ const HEADER_MENU_CONTROLLER_SHAPE = '__SpreadsheetHeaderMenuSHAPEControllerShap
 
 const HEADER_MENU_CONTROLLER_MENU = '__SpreadsheetHeaderMenuMAINControllerShape__';
 
-const HEADER_MENU_CONTROLLER_SHAPE_COLOR = 'gray.100';
+const HEADER_MENU_CONTROLLER_SHAPE_COLOR = 'alpha(gray.900, 0.1)';
 
 enum HEADER_HOVER_TYPE {
     ROW,

--- a/packages/sheets-ui/src/services/__tests__/sheet-skeleton-manager.service.spec.ts
+++ b/packages/sheets-ui/src/services/__tests__/sheet-skeleton-manager.service.spec.ts
@@ -24,6 +24,7 @@ import {
     Injector,
     IUniverInstanceService,
     LocaleService,
+    ThemeService,
     UniverInstanceService,
     UniverInstanceType,
     Workbook,
@@ -69,6 +70,7 @@ describe('SheetSkeletonManagerService', () => {
         injector.add([IContextService, { useClass: ContextService }]);
         injector.add([ILogService, { useClass: DesktopLogService }]);
         injector.add([LocaleService]);
+        injector.add([ThemeService]);
         injector.add([IUniverInstanceService, { useClass: UniverInstanceService }]);
         injector.add([SheetSkeletonService]);
         const univerInstanceService = injector.get(IUniverInstanceService) as UniverInstanceService;

--- a/packages/slides/src/views/render/adaptors/spreadsheet-adaptor.ts
+++ b/packages/slides/src/views/render/adaptors/spreadsheet-adaptor.ts
@@ -124,9 +124,10 @@ export class SpreadsheetAdaptor extends ObjectAdaptor {
             width: allWidth,
             height: allHeight,
         });
+        spreadsheetSkeleton.setScene(scene);
+        scene.disposeWithMe(spreadsheetSkeleton);
 
         this._updateViewport(id, rowHeaderWidth, columnHeaderHeight, scene, mainScene);
-
         const spreadsheet = new Spreadsheet('testSheetViewer', spreadsheetSkeleton, false);
         const spreadsheetRowHeader = new SpreadsheetRowHeader(SHEET_VIEW_KEY.ROW, spreadsheetSkeleton);
         const spreadsheetColumnHeader = new SpreadsheetColumnHeader(SHEET_VIEW_KEY.COLUMN, spreadsheetSkeleton);
@@ -144,11 +145,9 @@ export class SpreadsheetAdaptor extends ObjectAdaptor {
         spreadsheet.zIndex = 10;
         scene.addObjects([spreadsheet], 1);
         scene.addObjects([spreadsheetRowHeader, spreadsheetColumnHeader, SpreadsheetLeftTopPlaceholder], 2);
-        // spreadsheet.enableSelection();
         return sv;
     }
 
-    // eslint-disable-next-line max-lines-per-function
     private _updateViewport(
         id: string,
         rowHeaderWidth: number,
@@ -188,15 +187,13 @@ export class SpreadsheetAdaptor extends ObjectAdaptor {
             isWheelPreventDefaultX: true,
         });
 
-        const VIEW_LEFT_TOP = new Viewport(SHEET_VIEW_KEY.VIEW_LEFT_TOP + id, scene, {
+        const _viewLeftTop = new Viewport(SHEET_VIEW_KEY.VIEW_LEFT_TOP + id, scene, {
             left: 0,
             top: 0,
             width: rowHeaderWidthScale,
             height: columnHeaderHeightScale,
             isWheelPreventDefaultX: true,
         });
-        // viewMain.linkToViewport(viewLeft, LINK_VIEW_PORT_TYPE.Y);
-        // viewMain.linkToViewport(viewTop, LINK_VIEW_PORT_TYPE.X);
         viewMain.onScrollAfter$.subscribeEvent((param: IScrollObserverParam) => {
             const { scrollX, scrollY, viewportScrollX, viewportScrollY } = param;
 
@@ -214,12 +211,13 @@ export class SpreadsheetAdaptor extends ObjectAdaptor {
         });
 
         scene.attachControl();
-
-        const scrollbar = new ScrollBar(viewMain, {
+        const _scrollbar = new ScrollBar(viewMain, {
             mainScene,
         });
+        this._bindWheel(scene, viewMain);
+    }
 
-        // Mouse wheel zoom
+    private _bindWheel(scene: Scene, viewMain: Viewport): void {
         scene.onMouseWheel$.subscribeEvent((evt: unknown, state: EventState) => {
             const e = evt as IWheelEvent;
             if (e.ctrlKey) {


### PR DESCRIPTION
No related issue.

## What changed

- Resolve theme tokens to concrete canvas colors before rendering.
- Update gridlines, document header/footer guides, and sheet header hover colors when the theme changes.
- Replace remaining alpha color expressions in scrollbar defaults and clean up render-resource disposal.
- Add regression coverage for theme-driven rendering updates.

## Why

Canvas rendering paths need concrete color values and must react to runtime theme changes. Keeping theme resolution at the rendering boundary prevents stale colors and preserves dynamic theme behavior.

## How to test

- Pre-commit hook: `eslint --fix` via lint-staged
- Focused Vitest coverage added for canvas colors, gridlines, document header/footer, and sheet header hover behavior

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changed behavior.
- [x] This change does not introduce breaking changes.