### PR TITLE
fix(docs-ui): expose custom block host viewport height

### DIFF
--- a/packages/docs-ui/src/__tests__/embed-host-anchor.spec.ts
+++ b/packages/docs-ui/src/__tests__/embed-host-anchor.spec.ts
@@ -162,6 +162,7 @@ describe('resolveDocsCustomBlockRenderViewport', () => {
         })).toEqual(expect.objectContaining({
             contentHeight: 720,
             height: 720,
+            visibleCanvasHeight: 900,
             viewportHeight: 720,
         }));
 
@@ -182,6 +183,7 @@ describe('resolveDocsCustomBlockRenderViewport', () => {
         })).toEqual(expect.objectContaining({
             contentHeight: 1200,
             height: 1200,
+            visibleCanvasHeight: 900,
             viewportHeight: 900,
         }));
     });

--- a/packages/docs-ui/src/embed-host-anchor.ts
+++ b/packages/docs-ui/src/embed-host-anchor.ts
@@ -47,6 +47,7 @@ export interface IDocsCustomBlockLayoutViewport {
     offsetLeft?: number;
     pageContentWidth?: number;
     viewScale?: number;
+    visibleCanvasHeight?: number;
     viewportHeight?: number;
     width: number;
 }
@@ -93,6 +94,7 @@ export function resolveDocsCustomBlockRenderViewport(params: IDocsCustomBlockRen
             offsetLeft: 0,
             pageContentWidth,
             viewScale,
+            visibleCanvasHeight,
             viewportHeight,
             width: layoutWidth,
         };
@@ -122,6 +124,7 @@ export function resolveDocsCustomBlockRenderViewport(params: IDocsCustomBlockRen
         offsetLeft: 0,
         pageContentWidth,
         viewScale,
+        visibleCanvasHeight,
         viewportHeight,
         width: layoutWidth,
     };


### PR DESCRIPTION
Paired Univer Pro change: https://github.com/dream-num/univer-pro/pull/5595

This PR preserves the host document canvas height in the custom-block layout viewport. Embed renderers can use that value to distinguish content that is shorter than the visible document area from content that needs sticky scroll handoff.

How to test:

- `pnpm --filter @univerjs/docs-ui exec vitest run src/__tests__/embed-host-anchor.spec.ts` (14 tests passed)
- `pnpm --filter @univerjs/docs-ui test` (664 tests passed)
- `pnpm --filter @univerjs/docs-ui typecheck`
- ESLint on the changed files (no errors)

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
