### PR TITLE
fix(docs): remove settings menu icons

### DIFF
--- a/packages/docs-ui/src/menu/__tests__/context-menu.spec.ts
+++ b/packages/docs-ui/src/menu/__tests__/context-menu.spec.ts
@@ -15,13 +15,20 @@
  */
 
 import { Injector, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
+import { DocSelectionManagerService } from '@univerjs/docs';
 import { of } from 'rxjs';
 import { describe, expect, it } from 'vitest';
-import { ParagraphSettingMenuFactory } from '../context-menu';
+import { ParagraphSettingMenuFactory, SectionSettingMenuFactory } from '../context-menu';
 
-describe('ParagraphSettingMenuFactory', () => {
-    it('does not show a leading icon in the context menu', () => {
+describe('settings context menu factories', () => {
+    it('does not show leading icons', () => {
         const accessor = new Injector([
+            [DocSelectionManagerService, {
+                useValue: {
+                    textSelection$: of(null),
+                    getActiveTextRange: () => null,
+                },
+            }],
             [IUniverInstanceService, {
                 useValue: {
                     focused$: of('doc-1'),
@@ -31,6 +38,7 @@ describe('ParagraphSettingMenuFactory', () => {
         ]);
 
         expect(ParagraphSettingMenuFactory(accessor).icon).toBeUndefined();
+        expect(SectionSettingMenuFactory(accessor).icon).toBeUndefined();
 
         accessor.dispose();
     });

--- a/packages/docs-ui/src/menu/__tests__/context-menu.spec.ts
+++ b/packages/docs-ui/src/menu/__tests__/context-menu.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injector, IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
+import { of } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { ParagraphSettingMenuFactory } from '../context-menu';
+
+describe('ParagraphSettingMenuFactory', () => {
+    it('does not show a leading icon in the context menu', () => {
+        const accessor = new Injector([
+            [IUniverInstanceService, {
+                useValue: {
+                    focused$: of('doc-1'),
+                    getUnitType: () => UniverInstanceType.UNIVER_DOC,
+                },
+            }],
+        ]);
+
+        expect(ParagraphSettingMenuFactory(accessor).icon).toBeUndefined();
+
+        accessor.dispose();
+    });
+});

--- a/packages/docs-ui/src/menu/context-menu.ts
+++ b/packages/docs-ui/src/menu/context-menu.ts
@@ -129,7 +129,6 @@ export function ParagraphSettingMenuFactory(accessor: IAccessor): IMenuButtonIte
     return {
         id: DocParagraphSettingPanelOperation.id,
         type: MenuItemType.BUTTON,
-        icon: 'MenuIcon',
         title: 'docs-ui.doc.menu.paragraphSetting',
         hidden$: getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_DOC),
     };

--- a/packages/docs-ui/src/menu/context-menu.ts
+++ b/packages/docs-ui/src/menu/context-menu.ts
@@ -206,7 +206,6 @@ export function SectionSettingMenuFactory(accessor: IAccessor): IMenuButtonItem<
     return {
         id: DocSectionSettingPanelOperation.id,
         type: MenuItemType.BUTTON,
-        icon: 'MenuIcon',
         title: 'docs-ui.doc.menu.sectionSetting',
         hidden$: combineLatest(
             getMenuHiddenObservable(accessor, UniverInstanceType.UNIVER_DOC),


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

## Description

- Remove the leading icons from the **Paragraph Settings** and **Section Settings** context-menu items.
- Keep their commands, titles, visibility behavior, and menu placement unchanged.
- Add a focused regression test for both menu item contracts.
- Companion Pro change for docs-table delete icons: https://github.com/dream-num/univer-pro/pull/5599

## How to test

- `pnpm --filter @univerjs/docs-ui exec vitest run src/menu/__tests__/context-menu.spec.ts`
- `pnpm --filter @univerjs/docs-ui typecheck`
- Right-click document content and confirm **Paragraph Settings** and **Section Settings** have no leading icons.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
