### PR TITLE
fix(core): preserve custom range metadata when splitting

### DIFF
--- a/packages/core/src/docs/data-model/text-x/__tests__/apply.spec.ts
+++ b/packages/core/src/docs/data-model/text-x/__tests__/apply.spec.ts
@@ -157,6 +157,48 @@ describe('apply method', () => {
         expect(doc.paragraphs?.[0]).not.toBe(actions[0].body?.paragraphs?.[0]);
     });
 
+    it('preserves whole-entity metadata when inserting inside a custom range', () => {
+        const doc: IDocumentBody = {
+            dataStream: 'formula\r\n',
+            customRanges: [{
+                startIndex: 0,
+                endIndex: 6,
+                rangeId: 'formula-range',
+                rangeType: CustomRangeType.CUSTOM,
+                wholeEntity: true,
+                properties: { kind: 'formula' },
+            }],
+        };
+
+        TextX.apply(doc, [
+            { t: TextXActionType.RETAIN, len: 3 },
+            {
+                t: TextXActionType.INSERT,
+                len: 1,
+                body: {
+                    dataStream: 'X',
+                    customRanges: [{
+                        startIndex: 0,
+                        endIndex: 0,
+                        rangeId: 'formula-range',
+                        rangeType: CustomRangeType.CUSTOM,
+                        wholeEntity: true,
+                        properties: { kind: 'formula' },
+                    }],
+                },
+            },
+        ]);
+
+        expect(doc.customRanges).toEqual([{
+            startIndex: 0,
+            endIndex: 7,
+            rangeId: 'formula-range',
+            rangeType: CustomRangeType.CUSTOM,
+            wholeEntity: true,
+            properties: { kind: 'formula' },
+        }]);
+    });
+
     it('should get the same result when apply two actions by order OR composed first case 1', () => {
         const actionsA: TextXAction[] = [
             {

--- a/packages/core/src/docs/data-model/text-x/apply-utils/common.ts
+++ b/packages/core/src/docs/data-model/text-x/apply-utils/common.ts
@@ -646,14 +646,12 @@ export function splitCustomRangesByIndex(customRanges: ICustomRange[], currentIn
 
     if (matchedCustomRange) {
         customRanges.splice(matchedCustomRangeIndex, 1, {
-            rangeId: matchedCustomRange.rangeId,
-            rangeType: matchedCustomRange.rangeType,
+            ...matchedCustomRange,
             startIndex: matchedCustomRange.startIndex,
             endIndex: currentIndex - 1,
             properties: { ...matchedCustomRange.properties },
         }, {
-            rangeId: matchedCustomRange.rangeId,
-            rangeType: matchedCustomRange.rangeType,
+            ...matchedCustomRange,
             startIndex: currentIndex,
             endIndex: matchedCustomRange.endIndex,
             properties: { ...matchedCustomRange.properties },


### PR DESCRIPTION
## Summary

- Preserve `wholeEntity` and future custom-range metadata when TextX splits a range during an edit.
- Prevent atomic ranges such as Pro LaTeX formulas from being downgraded to ordinary text after a partial update.
- Add a focused regression test for split, insert, and merge behavior.

Related Pro fix: https://github.com/dream-num/univer-pro/pull/5603

## How to test

- `pnpm --filter @univerjs/core test`
- `pnpm --filter @univerjs/core typecheck`
- `pnpm exec eslint packages/core/src/docs/data-model/text-x/apply-utils/common.ts packages/core/src/docs/data-model/text-x/__tests__/apply.spec.ts`

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.