### PR TITLE
fix(sheets-ui): ignore zero-width formula bar geometry

### DIFF
--- a/packages/sheets-ui/src/controllers/editor/__tests__/data-sync.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/editor/__tests__/data-sync.controller.spec.ts
@@ -67,7 +67,11 @@ describe('EditorDataSyncController', () => {
         controllers.splice(0).forEach((controller) => controller.dispose());
     });
 
-    function createController(options: { isFocusFxBar?: boolean; themeTextColor?: string } = {}) {
+    function createController(options: {
+        isFocusFxBar?: boolean;
+        themeTextColor?: string;
+        formulaBarPosition?: { width: number; height: number } | null;
+    } = {}) {
         const commandService = new TestCommandService();
         const editorBridgeService = {
             currentEditCellState$: new BehaviorSubject(null),
@@ -93,7 +97,9 @@ describe('EditorDataSyncController', () => {
         injector.add([RangeProtectionRuleModel, { useValue: { getRangeRuleInitState: () => true } as never }]);
         injector.add([WorksheetProtectionRuleModel, { useValue: { getSheetRuleInitState: () => true } as never }]);
         injector.add([FormulaEditorController, { useValue: { autoScroll: vi.fn() } as never }]);
-        injector.add([IFormulaEditorManagerService, { useValue: { getPosition: () => null } as never }]);
+        injector.add([IFormulaEditorManagerService, {
+            useValue: { getPosition: () => options.formulaBarPosition ?? null } as never,
+        }]);
         injector.add([IContextService, { useValue: contextService as never }]);
         injector.add([ThemeService, {
             useValue: {
@@ -121,6 +127,34 @@ describe('EditorDataSyncController', () => {
             getSnapshot: vi.fn(() => snapshot),
         });
     }
+
+    it('ignores a zero-width formula bar position', () => {
+        const { controller } = createController({ formulaBarPosition: { width: 0, height: 28 } });
+        const formulaBarSnapshot: IDocumentData = {
+            id: DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
+            body: {
+                dataStream: 'text\r\n',
+            },
+        };
+
+        checkAndSetRenderStyleConfig(controller, formulaBarSnapshot);
+
+        expect(formulaBarSnapshot.documentStyle?.pageSize?.width).toBe(Number.POSITIVE_INFINITY);
+    });
+
+    it('applies a measured formula bar width', () => {
+        const { controller } = createController({ formulaBarPosition: { width: 320, height: 28 } });
+        const formulaBarSnapshot: IDocumentData = {
+            id: DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
+            body: {
+                dataStream: 'text\r\n',
+            },
+        };
+
+        checkAndSetRenderStyleConfig(controller, formulaBarSnapshot);
+
+        expect(formulaBarSnapshot.documentStyle?.pageSize?.width).toBe(320);
+    });
 
     it('refreshes the current edit cell when set-values updates the edited cell', () => {
         const { commandService, editorBridgeService } = createController();

--- a/packages/sheets-ui/src/controllers/editor/__tests__/data-sync.controller.spec.ts
+++ b/packages/sheets-ui/src/controllers/editor/__tests__/data-sync.controller.spec.ts
@@ -132,6 +132,7 @@ describe('EditorDataSyncController', () => {
         const { controller } = createController({ formulaBarPosition: { width: 0, height: 28 } });
         const formulaBarSnapshot: IDocumentData = {
             id: DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
+            documentStyle: {},
             body: {
                 dataStream: 'text\r\n',
             },
@@ -146,6 +147,7 @@ describe('EditorDataSyncController', () => {
         const { controller } = createController({ formulaBarPosition: { width: 320, height: 28 } });
         const formulaBarSnapshot: IDocumentData = {
             id: DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
+            documentStyle: {},
             body: {
                 dataStream: 'text\r\n',
             },
@@ -154,6 +156,24 @@ describe('EditorDataSyncController', () => {
         checkAndSetRenderStyleConfig(controller, formulaBarSnapshot);
 
         expect(formulaBarSnapshot.documentStyle?.pageSize?.width).toBe(320);
+    });
+
+    it('keeps the previous formula bar width when the latest position has zero width', () => {
+        const formulaBarPosition = { width: 320, height: 28 };
+        const { controller } = createController({ formulaBarPosition });
+        const formulaBarSnapshot: IDocumentData = {
+            id: DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY,
+            documentStyle: {},
+            body: {
+                dataStream: 'text\r\n',
+            },
+        };
+
+        checkAndSetRenderStyleConfig(controller, formulaBarSnapshot);
+        formulaBarPosition.width = 0;
+        checkAndSetRenderStyleConfig(controller, formulaBarSnapshot);
+
+        expect(formulaBarSnapshot.documentStyle.pageSize?.width).toBe(320);
     });
 
     it('refreshes the current edit cell when set-values updates the edited cell', () => {

--- a/packages/sheets-ui/src/controllers/editor/data-sync.controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/data-sync.controller.ts
@@ -360,7 +360,9 @@ export class EditorDataSyncController extends Disposable {
             snapshot.documentStyle.renderConfig = renderConfig;
         }
         const position = isFormulaBar ? this._formulaEditorManagerService.getPosition() : null;
-        if (isFormulaBar && position) {
+        // A zero box means "not laid out yet" or "not on screen", not a real page width:
+        // keeping it would give doc layout a zero-width column.
+        if (isFormulaBar && position && position.width > 0) {
             const width = position.width;
             snapshot.documentStyle.pageSize = {
                 width,

--- a/packages/sheets-ui/src/controllers/editor/data-sync.controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/data-sync.controller.ts
@@ -341,6 +341,7 @@ export class EditorDataSyncController extends Disposable {
         }
 
         const isFormulaBar = snapshot.id === DOCS_FORMULA_BAR_EDITOR_UNIT_ID_KEY;
+        const previousPageWidth = snapshot.documentStyle?.pageSize?.width;
         if (isFormulaBar) {
             snapshot.documentStyle = {
                 ...formulaEditorStyle,
@@ -360,14 +361,15 @@ export class EditorDataSyncController extends Disposable {
             snapshot.documentStyle.renderConfig = renderConfig;
         }
         const position = isFormulaBar ? this._formulaEditorManagerService.getPosition() : null;
-        // A zero box means "not laid out yet" or "not on screen", not a real page width:
-        // keeping it would give doc layout a zero-width column.
-        if (isFormulaBar && position && position.width > 0) {
-            const width = position.width;
-            snapshot.documentStyle.pageSize = {
-                width,
-                height: Infinity,
-            };
+        if (isFormulaBar && position) {
+            // A non-positive width means the formula bar is not laid out, so keep the last valid width.
+            const width = position.width > 0 ? position.width : previousPageWidth;
+            if (width != null && width > 0) {
+                snapshot.documentStyle.pageSize = {
+                    width,
+                    height: Infinity,
+                };
+            }
         }
 
         const isFormula = (snapshot.body?.dataStream ?? '').startsWith('=');


### PR DESCRIPTION
close #7560

`EditorDataSyncController._checkAndSetRenderStyleConfig` copies the formula bar's measured box into the formula-bar document's `documentStyle.pageSize.width` without checking whether the box has real layout geometry.

`formulaEditorStyle` has zero left and right margins, so a measured width of `0` gives the docs layout a zero-width section column. `@univerjs/engine-render` then repeatedly logs:

```text
The column width is less than 0, need to adjust page width to make it great than 0
```

A zero box is transient geometry: `FormulaBar` measures its container with `getBoundingClientRect()` and can report `0` before layout, while hidden, or in an inactive tab. This change ignores non-positive widths, keeping the previous page width (or the `Number.POSITIVE_INFINITY` default before the first valid measurement) until the next `ResizeObserver` update supplies a positive width.

This also covers the symptom reported in #5869, which was closed for lack of a deterministic reproduction.

### How to test

```text
pnpm --filter @univerjs/sheets-ui test
pnpm exec eslint packages/sheets-ui/src/controllers/editor/data-sync.controller.ts packages/sheets-ui/src/controllers/editor/__tests__/data-sync.controller.spec.ts
```

The unit tests verify that:

- a zero-width formula-bar position leaves `pageSize.width` at the default `Number.POSITIVE_INFINITY`;
- a positive measured width is still applied.

Local result: 120 test files and 592 tests passed; ESLint passed for both changed files.

No breaking changes are introduced.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
