### PR TITLE
fix(engine-render): repaint text during incremental scrolling

### DIFF
--- a/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
+++ b/packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts
@@ -45,6 +45,7 @@ import { Canvas } from '../../../canvas';
 import { Engine } from '../../../engine';
 import { MAIN_VIEW_PORT_KEY, Scene } from '../../../scene';
 import { Viewport } from '../../../viewport';
+import { Font } from '../extensions/font';
 import { SHEET_VIEWPORT_KEY } from '../interfaces';
 import {
     convertTransformToOffsetX,
@@ -707,6 +708,38 @@ describe('spreadsheet integration', () => {
             endY: 0,
         });
         noSkeletonSpreadsheet.dispose();
+    });
+
+    it('repaints text across the cleared incremental scroll bound', () => {
+        const { spreadsheet, skeleton, scene, cacheCanvas, mainCanvas } = fixture;
+        const context = mainCanvas.getContext();
+        const viewportInfo = createViewportInfo(scene, cacheCanvas, {
+            diffBounds: [createBound(46, 28, 118, 52)],
+            diffX: 0,
+            diffY: 24,
+            isDirty: 0,
+            isForceDirty: false,
+        });
+
+        skeleton.setStylesCache(createViewportInfo(scene, cacheCanvas));
+        const fontExtension = new Font();
+        spreadsheet.register(fontExtension);
+        Reflect.set(spreadsheet, '_fontExtension', fontExtension);
+        Reflect.set(skeleton, '_incrementalFontRenderRanges', [{
+            startRow: 10,
+            endRow: 10,
+            startColumn: 0,
+            endColumn: 0,
+        }]);
+        Reflect.set(spreadsheet, '_refreshIncrementalState', true);
+        const renderFontSpy = vi.spyOn(
+            fontExtension as unknown as { _renderFontEachCell: (...args: unknown[]) => void },
+            '_renderFontEachCell'
+        );
+
+        spreadsheet.draw(context, viewportInfo);
+
+        expect(renderFontSpy.mock.calls.some(([, row, column]) => row === 0 && column === 0)).toBe(true);
     });
 
     it('skips merge gridline cleanup during merge-free drawing', () => {

--- a/packages/engine-render/src/components/sheets/spreadsheet.ts
+++ b/packages/engine-render/src/components/sheets/spreadsheet.ts
@@ -383,9 +383,6 @@ export class Spreadsheet extends SheetComponent {
             extension.draw(ctx, parentScale, spreadsheetSkeleton, extensionDiffRanges, {
                 viewRanges: extensionViewRanges,
                 checkOutOfViewBound: true,
-                fontRenderRanges: extension === this._fontExtension && !isMergeRepair
-                    ? spreadsheetSkeleton.incrementalFontRenderRanges
-                    : undefined,
                 hasMergeData,
                 viewportKey: viewportInfo.viewportKey,
                 viewBound: viewportInfo.cacheBound,


### PR DESCRIPTION
## Summary

- Repaint text across the full cleared incremental scroll bound instead of restricting font drawing to the narrower style-cache update range.
- Preserve canvas and style-cache reuse without forcing a full refresh when scrollbar dragging ends.
- Add regression integration coverage for stale font ranges during incremental scrolling.

## How to test

- `pnpm test -- src/components/sheets/__tests__/spreadsheet.integration.spec.ts`
- `pnpm run typecheck`
- `pnpm exec eslint packages/engine-render/src/components/sheets/spreadsheet.ts packages/engine-render/src/components/sheets/__tests__/spreadsheet.integration.spec.ts`
- `pnpm --filter ./examples esbuild:demo -- --demo=sheets-local`
- Load the supplied snapshot, scroll to row 50, then drag the vertical scrollbar upward in 2 px steps and verify that text remains visible before releasing the pointer.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).