### PR TITLE
refactor(ui): standardize component registrations

### DIFF
--- a/packages/docs-ui/src/controllers/components.controller.ts
+++ b/packages/docs-ui/src/controllers/components.controller.ts
@@ -102,10 +102,9 @@ import {
 } from '../views/Icon';
 import {
     BULLET_LIST_TYPE_COMPONENT,
-    BulletListTypePicker,
     ORDER_LIST_TYPE_COMPONENT,
-    OrderListTypePicker,
 } from '../views/list-type-picker/index';
+import { BulletListTypePicker, OrderListTypePicker } from '../views/list-type-picker/Picker';
 import { PAGE_SETTING_COMPONENT_ID, PageSettings } from '../views/PageSettings';
 import {
     DOC_PARAGRAPH_MENU_COMPONENT_KEY,
@@ -118,6 +117,86 @@ import { SectionSettingIndex } from '../views/section-setting/index';
 import { COMPONENT_DOC_CREATE_TABLE_CONFIRM } from '../views/table/create/component-name';
 import { DocCreateTableConfirm } from '../views/table/create/TableCreate';
 
+const docUiIcons = {
+    AlignTextBothIcon,
+    AddImageIcon,
+    BoldIcon,
+    CopyDoubleIcon,
+    ColumnIcon,
+    CutIcon,
+    DeleteColumnDoubleIcon,
+    DeleteIcon,
+    DeleteRowDoubleIcon,
+    DeleteTableDoubleIcon,
+    DocSettingIcon,
+    FontColorDoubleIcon,
+    GridIcon,
+    H1Icon,
+    H2Icon,
+    H3Icon,
+    H4Icon,
+    H5Icon,
+    HeaderFooterIcon,
+    HorizontallyIcon,
+    InsertDoubleIcon,
+    InsertRowAboveDoubleIcon,
+    InsertRowBelowDoubleIcon,
+    ItalicIcon,
+    KeyboardIcon,
+    LeftInsertColumnDoubleIcon,
+    LeftJustifyingIcon,
+    LineIndentDecreaseIcon,
+    LineIndentIncreaseIcon,
+    MenuIcon,
+    TextTypeIcon,
+    NoColorDoubleIcon,
+    OrderIcon,
+    PaintBucketDoubleIcon,
+    PasteSpecialDoubleIcon,
+    ReduceDoubleIcon,
+    ReduceIcon,
+    RightInsertColumnDoubleIcon,
+    RightJustifyingIcon,
+    ShapeIcon,
+    SmileIcon,
+    StrikethroughIcon,
+    SubscriptIcon,
+    SuperscriptIcon,
+    SymbolsIcon,
+    TitleTypeIcon,
+    SubtitleTypeIcon,
+    TodoListDoubleIcon,
+    UnderlineIcon,
+    UnorderIcon,
+    DefaultTextColorIcon,
+    HeaderTextColorIcon,
+    MoreRightIcon,
+    MoreLeftIcon,
+    'DocParagraphTextColorSwatchIcon.0': DocParagraphTextColorSwatchIcon0,
+    'DocParagraphTextColorSwatchIcon.1': DocParagraphTextColorSwatchIcon1,
+    'DocParagraphTextColorSwatchIcon.2': DocParagraphTextColorSwatchIcon2,
+    'DocParagraphTextColorSwatchIcon.3': DocParagraphTextColorSwatchIcon3,
+    'DocParagraphTextColorSwatchIcon.4': DocParagraphTextColorSwatchIcon4,
+    'DocParagraphTextColorSwatchIcon.5': DocParagraphTextColorSwatchIcon5,
+    'DocParagraphTextColorSwatchIcon.6': DocParagraphTextColorSwatchIcon6,
+    'DocParagraphBackgroundColorSwatchIcon.0': DocParagraphBackgroundColorSwatchIcon0,
+    'DocParagraphBackgroundColorSwatchIcon.1': DocParagraphBackgroundColorSwatchIcon1,
+    'DocParagraphBackgroundColorSwatchIcon.2': DocParagraphBackgroundColorSwatchIcon2,
+    'DocParagraphBackgroundColorSwatchIcon.3': DocParagraphBackgroundColorSwatchIcon3,
+    'DocParagraphBackgroundColorSwatchIcon.4': DocParagraphBackgroundColorSwatchIcon4,
+    'DocParagraphBackgroundColorSwatchIcon.5': DocParagraphBackgroundColorSwatchIcon5,
+    'DocParagraphBackgroundColorSwatchIcon.6': DocParagraphBackgroundColorSwatchIcon6,
+    'DocParagraphBackgroundColorSwatchIcon.7': DocParagraphBackgroundColorSwatchIcon7,
+    'DocParagraphBackgroundColorSwatchIcon.8': DocParagraphBackgroundColorSwatchIcon8,
+    'DocParagraphBackgroundColorSwatchIcon.9': DocParagraphBackgroundColorSwatchIcon9,
+    'DocParagraphBackgroundColorSwatchIcon.10': DocParagraphBackgroundColorSwatchIcon10,
+    'DocParagraphBackgroundColorSwatchIcon.11': DocParagraphBackgroundColorSwatchIcon11,
+    'DocParagraphBackgroundColorSwatchIcon.12': DocParagraphBackgroundColorSwatchIcon12,
+    'DocParagraphBackgroundColorSwatchIcon.13': DocParagraphBackgroundColorSwatchIcon13,
+    'DocParagraphBackgroundColorSwatchIcon.14': DocParagraphBackgroundColorSwatchIcon14,
+    'DocParagraphBackgroundColorSwatchIcon.15': DocParagraphBackgroundColorSwatchIcon15,
+};
+
 const paragraphSettingIndexKey = 'doc_ui_paragraph-setting-panel';
 
 export class ComponentsController extends Disposable {
@@ -128,95 +207,11 @@ export class ComponentsController extends Disposable {
         super();
 
         this._registerComponents();
-        this._registerParts();
         this._registerIcons();
     }
 
-    private _registerParts(): void {
-        const componentManager = this._componentManager;
-        this.disposeWithMe(componentManager.register(COMPONENT_DOC_CREATE_TABLE_CONFIRM, DocCreateTableConfirm));
-    }
-
     private _registerIcons(): void {
-        this.disposeWithMe(this._iconManager.register({
-            AlignTextBothIcon,
-            AddImageIcon,
-            BoldIcon,
-            CopyDoubleIcon,
-            ColumnIcon,
-            CutIcon,
-            DeleteColumnDoubleIcon,
-            DeleteIcon,
-            DeleteRowDoubleIcon,
-            DeleteTableDoubleIcon,
-            DocSettingIcon,
-            FontColorDoubleIcon,
-            GridIcon,
-            H1Icon,
-            H2Icon,
-            H3Icon,
-            H4Icon,
-            H5Icon,
-            HeaderFooterIcon,
-            HorizontallyIcon,
-            InsertDoubleIcon,
-            InsertRowAboveDoubleIcon,
-            InsertRowBelowDoubleIcon,
-            ItalicIcon,
-            KeyboardIcon,
-            LeftInsertColumnDoubleIcon,
-            LeftJustifyingIcon,
-            LineIndentDecreaseIcon,
-            LineIndentIncreaseIcon,
-            MenuIcon,
-            TextTypeIcon,
-            NoColorDoubleIcon,
-            OrderIcon,
-            PaintBucketDoubleIcon,
-            PasteSpecialDoubleIcon,
-            ReduceDoubleIcon,
-            ReduceIcon,
-            RightInsertColumnDoubleIcon,
-            RightJustifyingIcon,
-            ShapeIcon,
-            SmileIcon,
-            StrikethroughIcon,
-            SubscriptIcon,
-            SuperscriptIcon,
-            SymbolsIcon,
-            TitleTypeIcon,
-            SubtitleTypeIcon,
-            TodoListDoubleIcon,
-            UnderlineIcon,
-            UnorderIcon,
-            DefaultTextColorIcon,
-            HeaderTextColorIcon,
-            MoreRightIcon,
-            MoreLeftIcon,
-            'DocParagraphTextColorSwatchIcon.0': DocParagraphTextColorSwatchIcon0,
-            'DocParagraphTextColorSwatchIcon.1': DocParagraphTextColorSwatchIcon1,
-            'DocParagraphTextColorSwatchIcon.2': DocParagraphTextColorSwatchIcon2,
-            'DocParagraphTextColorSwatchIcon.3': DocParagraphTextColorSwatchIcon3,
-            'DocParagraphTextColorSwatchIcon.4': DocParagraphTextColorSwatchIcon4,
-            'DocParagraphTextColorSwatchIcon.5': DocParagraphTextColorSwatchIcon5,
-            'DocParagraphTextColorSwatchIcon.6': DocParagraphTextColorSwatchIcon6,
-            'DocParagraphBackgroundColorSwatchIcon.0': DocParagraphBackgroundColorSwatchIcon0,
-            'DocParagraphBackgroundColorSwatchIcon.1': DocParagraphBackgroundColorSwatchIcon1,
-            'DocParagraphBackgroundColorSwatchIcon.2': DocParagraphBackgroundColorSwatchIcon2,
-            'DocParagraphBackgroundColorSwatchIcon.3': DocParagraphBackgroundColorSwatchIcon3,
-            'DocParagraphBackgroundColorSwatchIcon.4': DocParagraphBackgroundColorSwatchIcon4,
-            'DocParagraphBackgroundColorSwatchIcon.5': DocParagraphBackgroundColorSwatchIcon5,
-            'DocParagraphBackgroundColorSwatchIcon.6': DocParagraphBackgroundColorSwatchIcon6,
-            'DocParagraphBackgroundColorSwatchIcon.7': DocParagraphBackgroundColorSwatchIcon7,
-            'DocParagraphBackgroundColorSwatchIcon.8': DocParagraphBackgroundColorSwatchIcon8,
-            'DocParagraphBackgroundColorSwatchIcon.9': DocParagraphBackgroundColorSwatchIcon9,
-            'DocParagraphBackgroundColorSwatchIcon.10': DocParagraphBackgroundColorSwatchIcon10,
-            'DocParagraphBackgroundColorSwatchIcon.11': DocParagraphBackgroundColorSwatchIcon11,
-            'DocParagraphBackgroundColorSwatchIcon.12': DocParagraphBackgroundColorSwatchIcon12,
-            'DocParagraphBackgroundColorSwatchIcon.13': DocParagraphBackgroundColorSwatchIcon13,
-            'DocParagraphBackgroundColorSwatchIcon.14': DocParagraphBackgroundColorSwatchIcon14,
-            'DocParagraphBackgroundColorSwatchIcon.15': DocParagraphBackgroundColorSwatchIcon15,
-        }));
+        this.disposeWithMe(this._iconManager.register(docUiIcons));
     }
 
     private _registerComponents(): void {
@@ -238,5 +233,6 @@ export class ComponentsController extends Disposable {
                 this._componentManager.register(key, comp)
             );
         });
+        this.disposeWithMe(this._componentManager.register(COMPONENT_DOC_CREATE_TABLE_CONFIRM, DocCreateTableConfirm));
     }
 }

--- a/packages/sheets-ui/src/controllers/components.controller.ts
+++ b/packages/sheets-ui/src/controllers/components.controller.ts
@@ -118,12 +118,102 @@ import { CellPopup } from '../views/CellPopup';
 import { DEFINED_NAME_CONTAINER } from '../views/defined-name/component-name';
 import { DefinedNameContainer } from '../views/defined-name/DefinedNameContainer';
 import { dropdownMap } from '../views/dropdown';
-import { MENU_ITEM_FROZEN_COMPONENT, MenuItemFrozen } from '../views/menu-item-frozen/index';
-import { MENU_ITEM_INPUT_COMPONENT, MenuItemInput } from '../views/menu-item-input/index';
-import { SheetPermissionDialog, SheetPermissionPanel, SheetPermissionUserDialog } from '../views/permission';
+import { MENU_ITEM_FROZEN_COMPONENT } from '../views/menu-item-frozen/interface';
+import { MenuItemFrozen } from '../views/menu-item-frozen/MenuItemFrozen';
+import { MENU_ITEM_INPUT_COMPONENT } from '../views/menu-item-input/interface';
+import { MenuItemInput } from '../views/menu-item-input/MenuItemInput';
 import { AlertDialog } from '../views/permission/AlertDialog';
 import { UNIVER_SHEET_PERMISSION_ALERT_DIALOG } from '../views/permission/error-msg-dialog/interface';
+import { SheetPermissionDialog } from '../views/permission/SheetPermissionDialog';
+import { SheetPermissionPanel } from '../views/permission/SheetPermissionPanel';
+import { SheetPermissionUserDialog } from '../views/permission/SheetPermissionUserDialog';
 import { SHEET_ZOOM_INPUT_COMPONENT, SheetZoomInput } from '../views/sheet-slider/SheetZoomInput';
+
+const sheetUiIcons = {
+    AdjustHeightDoubleIcon,
+    AdjustWidthDoubleIcon,
+    AddImageIcon,
+    AlignBottomIcon,
+    AlignTopIcon,
+    AllBorderIcon,
+    AutoHeightDoubleIcon,
+    AutoWidthDoubleIcon,
+    AutowrapIcon,
+    BackSlashDoubleIcon,
+    BoldIcon,
+    BrushIcon,
+    CancelFreezeIcon,
+    CancelMergeIcon,
+    CheckMarkIcon,
+    ClearFormatDoubleIcon,
+    CodeIcon,
+    ConvertToNumberIcon,
+    CopyDoubleIcon,
+    CutIcon,
+    DeleteCellShiftLeftDoubleIcon,
+    DeleteCellShiftUpDoubleIcon,
+    DeleteColumnDoubleIcon,
+    DeleteIcon,
+    DeleteRowDoubleIcon,
+    DownBorderDoubleIcon,
+    DownloadImageIcon,
+    EyeIcon,
+    FontColorDoubleIcon,
+    FontSizeIncreaseIcon,
+    FontSizeReduceIcon,
+    FreezeColumnIcon,
+    FreezeRowIcon,
+    FreezeToSelectedIcon,
+    HideDoubleIcon,
+    HideGridlinesIcon,
+    HorizontalBorderDoubleIcon,
+    HorizontalMergeIcon,
+    HorizontallyIcon,
+    InnerBorderDoubleIcon,
+    InsertCellDownDoubleIcon,
+    InsertCellShiftRightDoubleIcon,
+    InsertDoubleIcon,
+    InsertRowAboveDoubleIcon,
+    InsertRowBelowDoubleIcon,
+    ItalicIcon,
+    LeftBorderDoubleIcon,
+    LeftDoubleDiagonalDoubleIcon,
+    LeftInsertColumnDoubleIcon,
+    LeftJustifyingIcon,
+    LeftRotationFortyFiveDegreesIcon,
+    LeftRotationNinetyDegreesIcon,
+    LeftTridiagonalDoubleIcon,
+    LockIcon,
+    MergeAllIcon,
+    NoBorderIcon,
+    NoColorDoubleIcon,
+    NoRotationIcon,
+    OuterBorderDoubleIcon,
+    OverflowIcon,
+    PaintBucketDoubleIcon,
+    PasteSpecialDoubleIcon,
+    ProtectIcon,
+    ReduceDoubleIcon,
+    RightBorderDoubleIcon,
+    RightDoubleDiagonalDoubleIcon,
+    RightInsertColumnDoubleIcon,
+    RightJustifyingIcon,
+    RightRotationFortyFiveDegreesIcon,
+    RightRotationNinetyDegreesIcon,
+    ShrinkToFitIcon,
+    SlashDoubleIcon,
+    StrikethroughIcon,
+    SubscriptIcon,
+    SuperscriptIcon,
+    TruncationIcon,
+    UnderlineIcon,
+    UpBorderDoubleIcon,
+    VerticalBorderDoubleIcon,
+    VerticalCenterIcon,
+    VerticalIntegrationIcon,
+    VerticalTextIcon,
+    WriteIcon,
+};
 
 export class ComponentsController extends Disposable {
     constructor(
@@ -134,7 +224,6 @@ export class ComponentsController extends Disposable {
         super();
 
         this._registerComponents();
-        this._registerParts();
         this._registerIcons();
     }
 
@@ -166,114 +255,20 @@ export class ComponentsController extends Disposable {
                 })
             );
         }
-    }
-
-    private _registerParts(): void {
-        const componentManager = this._componentManager;
 
         // init custom components
-        this.disposeWithMe(componentManager.register(MENU_ITEM_INPUT_COMPONENT, MenuItemInput));
-        this.disposeWithMe(componentManager.register(MENU_ITEM_FROZEN_COMPONENT, MenuItemFrozen));
-        this.disposeWithMe(componentManager.register(SHEET_ZOOM_INPUT_COMPONENT, SheetZoomInput));
-        this.disposeWithMe(componentManager.register(BORDER_PANEL_COMPONENT, BorderPanel));
-        this.disposeWithMe(componentManager.register(DEFINED_NAME_CONTAINER, DefinedNameContainer));
-        this.disposeWithMe(componentManager.register(CELL_POPUP_COMPONENT_KEY, CellPopup));
+        this.disposeWithMe(this._componentManager.register(MENU_ITEM_INPUT_COMPONENT, MenuItemInput));
+        this.disposeWithMe(this._componentManager.register(MENU_ITEM_FROZEN_COMPONENT, MenuItemFrozen));
+        this.disposeWithMe(this._componentManager.register(SHEET_ZOOM_INPUT_COMPONENT, SheetZoomInput));
+        this.disposeWithMe(this._componentManager.register(BORDER_PANEL_COMPONENT, BorderPanel));
+        this.disposeWithMe(this._componentManager.register(DEFINED_NAME_CONTAINER, DefinedNameContainer));
+        this.disposeWithMe(this._componentManager.register(CELL_POPUP_COMPONENT_KEY, CellPopup));
         Object.values(dropdownMap).forEach((component) => {
-            this.disposeWithMe(componentManager.register(component.componentKey, component));
+            this.disposeWithMe(this._componentManager.register(component.componentKey, component));
         });
     }
 
-    // eslint-disable-next-line max-lines-per-function
     private _registerIcons(): void {
-        this.disposeWithMe(this._iconManager.register({
-            ProtectIcon,
-            DeleteIcon,
-            WriteIcon,
-            CheckMarkIcon,
-            LockIcon,
-        }));
-
-        this.disposeWithMe(this._iconManager.register({
-            AdjustHeightDoubleIcon,
-            AdjustWidthDoubleIcon,
-            AddImageIcon,
-            AlignBottomIcon,
-            AlignTopIcon,
-            AllBorderIcon,
-            AutoHeightDoubleIcon,
-            AutoWidthDoubleIcon,
-            AutowrapIcon,
-            BackSlashDoubleIcon,
-            BoldIcon,
-            BrushIcon,
-            CancelFreezeIcon,
-            CancelMergeIcon,
-            ClearFormatDoubleIcon,
-            CodeIcon,
-            ConvertToNumberIcon,
-            CopyDoubleIcon,
-            CutIcon,
-            DeleteCellShiftLeftDoubleIcon,
-            DeleteCellShiftUpDoubleIcon,
-            DeleteColumnDoubleIcon,
-            DeleteRowDoubleIcon,
-            DownBorderDoubleIcon,
-            DownloadImageIcon,
-            EyeIcon,
-            FontColorDoubleIcon,
-            FontSizeIncreaseIcon,
-            FontSizeReduceIcon,
-            FreezeColumnIcon,
-            FreezeRowIcon,
-            FreezeToSelectedIcon,
-            HideDoubleIcon,
-            HideGridlinesIcon,
-            HorizontalBorderDoubleIcon,
-            HorizontalMergeIcon,
-            HorizontallyIcon,
-            InnerBorderDoubleIcon,
-            InsertCellDownDoubleIcon,
-            InsertCellShiftRightDoubleIcon,
-            InsertDoubleIcon,
-            InsertRowAboveDoubleIcon,
-            InsertRowBelowDoubleIcon,
-            ItalicIcon,
-            LeftBorderDoubleIcon,
-            LeftDoubleDiagonalDoubleIcon,
-            LeftInsertColumnDoubleIcon,
-            LeftJustifyingIcon,
-            LeftRotationFortyFiveDegreesIcon,
-            LeftRotationNinetyDegreesIcon,
-            LeftTridiagonalDoubleIcon,
-            LockIcon,
-            MergeAllIcon,
-            NoBorderIcon,
-            NoColorDoubleIcon,
-            NoRotationIcon,
-            OuterBorderDoubleIcon,
-            OverflowIcon,
-            PaintBucketDoubleIcon,
-            PasteSpecialDoubleIcon,
-            ProtectIcon,
-            ReduceDoubleIcon,
-            RightBorderDoubleIcon,
-            RightDoubleDiagonalDoubleIcon,
-            RightInsertColumnDoubleIcon,
-            RightJustifyingIcon,
-            RightRotationFortyFiveDegreesIcon,
-            RightRotationNinetyDegreesIcon,
-            ShrinkToFitIcon,
-            SlashDoubleIcon,
-            StrikethroughIcon,
-            SubscriptIcon,
-            SuperscriptIcon,
-            TruncationIcon,
-            UnderlineIcon,
-            UpBorderDoubleIcon,
-            VerticalBorderDoubleIcon,
-            VerticalCenterIcon,
-            VerticalIntegrationIcon,
-            VerticalTextIcon,
-        }));
+        this.disposeWithMe(this._iconManager.register(sheetUiIcons));
     }
 }

--- a/packages/slides-ui/src/controllers/components.controller.ts
+++ b/packages/slides-ui/src/controllers/components.controller.ts
@@ -28,11 +28,11 @@ export class ComponentsController extends Disposable {
     ) {
         super();
 
-        this._registerParts();
+        this._registerComponents();
         this._registerIcons();
     }
 
-    private _registerParts(): void {
+    private _registerComponents(): void {
         const componentManager = this._componentManager;
         this.disposeWithMe(componentManager.register(COMPONENT_SLIDE_IMAGE_POPUP_MENU, SlideImagePopupMenu));
         this.disposeWithMe(componentManager.register(COMPONENT_SLIDE_SIDEBAR, Sidebar));


### PR DESCRIPTION
## Summary

- keep all `ComponentManager` registrations in `_registerComponents`
- keep all `IconManager` registrations in `_registerIcons`
- move large static icon maps outside controller methods and use direct internal imports

## Testing

- `pnpm exec eslint packages/docs-ui/src/controllers/components.controller.ts packages/sheets-ui/src/controllers/components.controller.ts packages/slides-ui/src/controllers/components.controller.ts`
- `pnpm --filter @univerjs/docs-ui --filter @univerjs/sheets-ui --filter @univerjs/slides-ui typecheck`
- `git diff --check origin/dev...HEAD`

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).