### PR TITLE
feat(core): export lodash setWith

### DIFF
--- a/packages/core/src/common/lodash.ts
+++ b/packages/core/src/common/lodash.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { debounce, get, merge, mergeWith, set } from 'lodash-es';
+export { debounce, get, merge, mergeWith, set, setWith } from 'lodash-es';


### PR DESCRIPTION
Related: dream-num/univer-pro#5095

## Summary

- Expose lodash-es setWith from the canonical @univerjs/core lodash utilities.
- Allow consumers to customize nested-container creation without importing lodash-es directly.

This is an additive public API change. No existing export or behavior is removed.

Persisted command or mutation schemas are unchanged; no migration is required.

## How to test

- pnpm -C packages/core test
- pnpm -C packages/core typecheck
- pnpm exec eslint packages/core/src/common/lodash.ts

## Pull Request Checklist

- [x] Related work is linked above.
- [x] Naming convention is followed.
- [x] Existing Core unit tests pass; no behavior-specific test is needed for the additive re-export.
- [x] No breaking changes are introduced.