### PR TITLE
fix(sheets-ui): constrain drawing popups around frozen panes

### DIFF
--- a/packages/sheets-ui/src/services/__tests__/canvas-pop-manager.service.spec.ts
+++ b/packages/sheets-ui/src/services/__tests__/canvas-pop-manager.service.spec.ts
@@ -336,7 +336,7 @@ describe('SheetCanvasPopManagerService', () => {
     });
 
     it('adds scaled sheet header insets to a canvas-constrained drawing popup', () => {
-        const { service, popupService } = createSheetHarness();
+        const { service, popupService, viewport } = createSheetHarness();
         const targetObject = {
             left: 20,
             top: 10,
@@ -345,6 +345,8 @@ describe('SheetCanvasPopManagerService', () => {
             classType: RENDER_CLASS_TYPE.SHAPE,
             getPropByKey: () => 'image',
         };
+        viewport.left = 20;
+        viewport.top = 20;
 
         service.attachPopupToObject(targetObject as never, {
             componentKey: 'drawing-toolbar',
@@ -352,6 +354,27 @@ describe('SheetCanvasPopManagerService', () => {
         });
 
         expect(popupService.lastPopup()?.boundaryInsets).toEqual({ left: 40, top: 40 });
+    });
+
+    it('includes frozen panes in the boundary insets of a canvas-constrained drawing popup', () => {
+        const { service, popupService, viewport } = createSheetHarness();
+        const targetObject = {
+            left: 80,
+            top: 90,
+            width: 40,
+            height: 30,
+            classType: RENDER_CLASS_TYPE.SHAPE,
+            getPropByKey: () => 'image',
+        };
+        viewport.left = 80;
+        viewport.top = 100;
+
+        service.attachPopupToObject(targetObject as never, {
+            componentKey: 'drawing-toolbar',
+            constrainToCanvas: true,
+        });
+
+        expect(popupService.lastPopup()?.boundaryInsets).toEqual({ left: 160, top: 200 });
     });
 
     it('keeps absolute-position popups hidden while a selection is being dragged unless the popup opts in', () => {

--- a/packages/sheets-ui/src/services/canvas-pop-manager.service.ts
+++ b/packages/sheets-ui/src/services/canvas-pop-manager.service.ts
@@ -346,7 +346,7 @@ export class SheetCanvasPopManagerService extends Disposable {
         const canvasElement = currentRender.engine.getCanvasElement();
         const scaleAdjust = canvasElement.getBoundingClientRect().width / pxToNum(canvasElement.style.width);
         const { scaleX, scaleY } = currentRender.scene.getAncestorScale();
-
+        const viewMain = currentRender.scene.getViewport(SHEET_VIEWPORT_KEY.VIEW_MAIN);
         const id = this._globalPopupManagerService.addPopup({
             ...popup,
             unitId,
@@ -357,8 +357,8 @@ export class SheetCanvasPopManagerService extends Disposable {
             canvasElement,
             boundaryInsets: popup.constrainToCanvas
                 ? {
-                    left: skeleton.rowHeaderWidth * scaleAdjust * scaleX,
-                    top: skeleton.columnHeaderHeight * scaleAdjust * scaleY,
+                    left: (viewMain?.left ?? skeleton.rowHeaderWidth * scaleX) * scaleAdjust,
+                    top: (viewMain?.top ?? skeleton.columnHeaderHeight * scaleY) * scaleAdjust,
                 }
                 : popup.boundaryInsets,
         });

--- a/packages/ui/src/views/components/popup/CanvasPopup.tsx
+++ b/packages/ui/src/views/components/popup/CanvasPopup.tsx
@@ -45,13 +45,15 @@ export const SingleCanvasPopup = ({ popup, children }: ISingleCanvasPopupProps) 
     const hiddenRects$ = useMemo(() => popup.hiddenRects$?.pipe(throttleTime(0, animationFrameScheduler)) ?? of([]), [popup.hiddenRects$]);
     const excludeRects$ = useMemo(() => popup.excludeRects$?.pipe(throttleTime(0, animationFrameScheduler)), [popup.excludeRects$]);
     const excludeRectsRef = useObservableRef(excludeRects$, popup.excludeRects);
-    const { canvasElement, constrainToCanvas = false, hideOnInvisible = true, hiddenType = 'destroy' } = popup;
+    const { boundaryInsets, canvasElement, constrainToCanvas = false, hideOnInvisible = true, hiddenType = 'destroy' } = popup;
 
     const hidden = useObservable(
         hideOnInvisible
             ? () => combineLatest([anchorRect$, hiddenRects$]).pipe(map(([rectWithOffset, hiddenRects]) => {
                 const rect = canvasElement.getBoundingClientRect();
                 const { top, left, bottom, right } = rect;
+                const insetTop = constrainToCanvas ? boundaryInsets?.top ?? 0 : 0;
+                const insetLeft = constrainToCanvas ? boundaryInsets?.left ?? 0 : 0;
                 const rectHeight = rectWithOffset.bottom - rectWithOffset.top;
                 const rectWidth = rectWithOffset.right - rectWithOffset.left;
 
@@ -64,13 +66,13 @@ export const SingleCanvasPopup = ({ popup, children }: ISingleCanvasPopupProps) 
                         rectWithOffset.right <= (hiddenRect.right + bufferX);
                 });
 
-                return rectWithOffset.bottom < top || rectWithOffset.top > bottom ||
-                    rectWithOffset.right < left || rectWithOffset.left > right || isInHiddenRect;
+                return rectWithOffset.bottom < top + insetTop || rectWithOffset.top > bottom ||
+                    rectWithOffset.right < left + insetLeft || rectWithOffset.left > right || isInHiddenRect;
             }))
             : null,
         false,
         false,
-        [anchorRect$, canvasElement, hiddenRects$, hideOnInvisible]
+        [anchorRect$, boundaryInsets, canvasElement, constrainToCanvas, hiddenRects$, hideOnInvisible]
     );
 
     if ((hidden && hiddenType === 'destroy')) {


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #xxx

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
