### PR TITLE
fix(engine-render): clip viewport copies during scrolling

### DIFF
--- a/common/debugger/src/controllers/e2e/e2e.controller.ts
+++ b/common/debugger/src/controllers/e2e/e2e.controller.ts
@@ -1,6 +1,8 @@
 import type { Univer } from '@univerjs/core';
 import type { FUniver } from '@univerjs/core/facade';
+import type { IBoundRectNoAngle, IScrollRenderInfo } from '@univerjs/engine-render';
 import { awaitTime, Disposable, DocumentFlavor, Inject, IUniverInstanceService, ThemeService, UniverInstanceType } from '@univerjs/core';
+import { scrollAndClearCanvas, UniverRenderingContext } from '@univerjs/engine-render';
 import { DEFAULT_WORKBOOK_DATA_DEMO, DEFAULT_WORKBOOK_DATA_DEMO_DEFAULT_STYLE } from '@univerjs/mockdata';
 import { getDefaultDocData } from './data/default-doc';
 import { getDefaultWorkbookData } from './data/default-sheet';
@@ -21,6 +23,12 @@ export interface IE2EControllerAPI {
     setDarkMode(darkMode: boolean): void;
     disposeUniver(): Promise<void>;
     disposeCurrSheetUnit(disposeTimeout?: number): Promise<void>;
+    scrollAndClearCanvas(
+        canvas: HTMLCanvasElement,
+        pixelRatio: number,
+        scrollRenderInfos: IScrollRenderInfo[],
+        dirtyBounds: IBoundRectNoAngle[]
+    ): void;
 }
 
 declare global {
@@ -62,7 +70,23 @@ export class E2EController extends Disposable {
             loadDefaultDoc: (loadTimeout) => this._loadDefaultDoc(loadTimeout),
             loadDocLayoutFixture: (documentFlavor, loadTimeout) => this._loadDocLayoutFixture(documentFlavor, loadTimeout),
             disposeUniver: () => this._disposeUniver(),
+            scrollAndClearCanvas: (canvas, pixelRatio, scrollRenderInfos, dirtyBounds) =>
+                this._scrollAndClearCanvas(canvas, pixelRatio, scrollRenderInfos, dirtyBounds),
         };
+    }
+
+    private _scrollAndClearCanvas(
+        canvas: HTMLCanvasElement,
+        pixelRatio: number,
+        scrollRenderInfos: IScrollRenderInfo[],
+        dirtyBounds: IBoundRectNoAngle[]
+    ): void {
+        const nativeContext = canvas.getContext('2d');
+        if (nativeContext == null) {
+            throw new Error('Canvas does not have a 2D context.');
+        }
+
+        scrollAndClearCanvas(new UniverRenderingContext(nativeContext), pixelRatio, scrollRenderInfos, dirtyBounds);
     }
 
     private _setDarkMode(darkMode: boolean): void {

--- a/e2e/e2e.d.ts
+++ b/e2e/e2e.d.ts
@@ -1,3 +1,5 @@
+import type { IBoundRectNoAngle, IScrollRenderInfo } from '@univerjs/engine-render';
+
 // The type definition is copied from:
 // common/debugger/src/controllers/e2e/e2e.controller.ts
 export interface IE2EControllerAPI {
@@ -11,6 +13,12 @@ export interface IE2EControllerAPI {
     setDarkMode(darkMode: boolean): void;
     disposeUniver(): Promise<void>;
     disposeCurrSheetUnit(disposeTimeout?: number): Promise<void>;
+    scrollAndClearCanvas(
+        canvas: HTMLCanvasElement,
+        pixelRatio: number,
+        scrollRenderInfos: IScrollRenderInfo[],
+        dirtyBounds: IBoundRectNoAngle[]
+    ): void;
 }
 
 declare global {

--- a/e2e/smoking/engine-render-scroll-copy.spec.ts
+++ b/e2e/smoking/engine-render-scroll-copy.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+
+test('preserves pixels across independent viewport copies on a short canvas', async ({ page }) => {
+    await page.goto('/sheets/');
+    await page.waitForFunction(() => window.E2EControllerAPI != null);
+
+    const pixelAlphaByRatio = await page.evaluate(() => [1, 2].map((pixelRatio) => {
+        const canvas = document.createElement('canvas');
+        canvas.width = 8 * pixelRatio;
+        canvas.height = 4 * pixelRatio;
+        const nativeContext = canvas.getContext('2d');
+        if (nativeContext == null) {
+            throw new Error('Failed to create the regression canvas.');
+        }
+
+        nativeContext.fillStyle = '#2563eb';
+        nativeContext.fillRect(0, 0, canvas.width, canvas.height);
+        window.E2EControllerAPI.scrollAndClearCanvas(canvas, pixelRatio, [
+            {
+                bounds: { left: 2, top: 0, right: 8, bottom: 4 },
+                offsetX: 0,
+                offsetY: -1,
+            },
+            {
+                bounds: { left: 0, top: 0, right: 2, bottom: 4 },
+                offsetX: 0,
+                offsetY: -1,
+            },
+        ], [{ left: 0, top: 3, right: 8, bottom: 4 }]);
+
+        const getAlpha = (x: number, y: number) =>
+            nativeContext.getImageData(x * pixelRatio, y * pixelRatio, 1, 1).data[3];
+        return {
+            main: getAlpha(4, 1),
+            header: getAlpha(1, 1),
+            dirty: getAlpha(4, 3),
+        };
+    }));
+
+    expect(pixelAlphaByRatio).toEqual([
+        { main: 255, header: 255, dirty: 0 },
+        { main: 255, header: 255, dirty: 0 },
+    ]);
+});

--- a/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
+++ b/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
@@ -333,6 +333,50 @@ describe('engine scene viewport extra', () => {
         engine.dispose();
     });
 
+    it('uses a full render after an after-render observer mutates the engine canvas', () => {
+        const { engine, scene, viewport } = createFixture();
+        const layer = scene.getLayer(1);
+        let shouldDrawOverlay = true;
+        const subscription = scene.afterRender$.subscribe((canvas) => {
+            if (canvas && shouldDrawOverlay) {
+                canvas.getContext().fillText('viewport overlay', 10, 10);
+            }
+        });
+
+        scene.render();
+        const renderSpy = vi.spyOn(layer, 'render');
+        const clearCanvasSpy = vi.spyOn(engine, 'clearCanvas');
+
+        viewport.scrollToViewportPos({ viewportScrollY: 16 });
+        scene.makeDirtyForScrolling();
+        scene.render();
+
+        expect(clearCanvasSpy).toHaveBeenCalledTimes(1);
+        expect(renderSpy).toHaveBeenLastCalledWith(undefined, false, undefined);
+
+        shouldDrawOverlay = false;
+        renderSpy.mockClear();
+        clearCanvasSpy.mockClear();
+        viewport.scrollToViewportPos({ viewportScrollY: 32 });
+        scene.makeDirtyForScrolling();
+        scene.render();
+        expect(clearCanvasSpy).toHaveBeenCalledTimes(1);
+
+        renderSpy.mockClear();
+        clearCanvasSpy.mockClear();
+        viewport.scrollToViewportPos({ viewportScrollY: 48 });
+        scene.makeDirtyForScrolling();
+        scene.render();
+        expect(clearCanvasSpy).not.toHaveBeenCalled();
+        expect(renderSpy).toHaveBeenLastCalledWith(undefined, false, expect.objectContaining({
+            preserveCache: true,
+        }));
+
+        subscription.unsubscribe();
+        scene.dispose();
+        engine.dispose();
+    });
+
     it('keeps cheap content live during a large scrollbar seek', () => {
         const { engine, scene, viewport } = createFixture();
         const layer = scene.getLayer(1);

--- a/packages/engine-render/src/context.ts
+++ b/packages/engine-render/src/context.ts
@@ -28,6 +28,8 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
     __mode = 'rendering';
 
     private _transformCache: Nullable<DOMMatrix>;
+    private _bitmapMutationId = 0;
+    private _bitmapMutationTrackingDepth = 0;
     readonly canvas: HTMLCanvasElement;
 
     _context: CanvasRenderingContext2D;
@@ -53,6 +55,23 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
 
     setId(id: string) {
         this._id = id;
+    }
+
+    detectBitmapMutation(callback: () => void) {
+        const mutationId = this._bitmapMutationId;
+        this._bitmapMutationTrackingDepth++;
+        try {
+            callback();
+        } finally {
+            this._bitmapMutationTrackingDepth--;
+        }
+        return mutationId !== this._bitmapMutationId;
+    }
+
+    private _markBitmapMutation() {
+        if (this._bitmapMutationTrackingDepth > 0) {
+            this._bitmapMutationId++;
+        }
     }
 
     isContextLost(): boolean {
@@ -421,7 +440,9 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
     drawFocusIfNeeded(element: Element): void;
     drawFocusIfNeeded(path: Path2D, element: Element): void;
     drawFocusIfNeeded(...args: [any]) {
-        return this._context.drawFocusIfNeeded(...args);
+        const result = this._context.drawFocusIfNeeded(...args);
+        this._markBitmapMutation();
+        return result;
     }
 
     /**
@@ -431,6 +452,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
     reset() {
         this._transformCache = null;
         this._context.reset();
+        this._markBitmapMutation();
     }
 
     /**
@@ -515,6 +537,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
      */
     clearRect(x: number, y: number, width: number, height: number) {
         this._context.clearRect(x, y, width, height);
+        this._markBitmapMutation();
     }
 
     /**
@@ -668,6 +691,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
         } else if (a.length === 9) {
             _context.drawImage(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]);
         }
+        this._markBitmapMutation();
     }
 
     /**
@@ -718,6 +742,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
         // this._context.fill();
 
         this._context.fill(...args);
+        this._markBitmapMutation();
     }
 
     /**
@@ -726,6 +751,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
      */
     fillRect(x: number, y: number, width: number, height: number) {
         this._context.fillRect(x, y, width, height);
+        this._markBitmapMutation();
     }
 
     /**
@@ -748,6 +774,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
      */
     strokeRect(x: number, y: number, width: number, height: number) {
         this._context.strokeRect(x, y, width, height);
+        this._markBitmapMutation();
     }
 
     /**
@@ -780,6 +807,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
         } else {
             this._context.fillText(text, x, y);
         }
+        this._markBitmapMutation();
     }
 
     /**
@@ -798,6 +826,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
         } else {
             this._context.fillText(text, x, y);
         }
+        this._markBitmapMutation();
     }
 
     /**
@@ -890,6 +919,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
      */
     putImageData(imageData: ImageData, dx: number, dy: number) {
         this._context.putImageData(imageData, dx, dy);
+        this._markBitmapMutation();
     }
 
     /**
@@ -989,6 +1019,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
         } else {
             this._context.stroke();
         }
+        this._markBitmapMutation();
     }
 
     /**
@@ -997,6 +1028,7 @@ export class UniverRenderingContext2D implements CanvasRenderingContext2D {
      */
     strokeText(text: string, x: number, y: number, maxWidth?: number) {
         this._context.strokeText(text, x, y, maxWidth);
+        this._markBitmapMutation();
     }
 
     /**

--- a/packages/engine-render/src/layer.ts
+++ b/packages/engine-render/src/layer.ts
@@ -69,6 +69,12 @@ export function scrollAndClearCanvas(
         const targetY = (bounds.top + Math.max(0, offsetY)) * pixelRatio;
         const pixelCopyWidth = copyWidth * pixelRatio;
         const pixelCopyHeight = copyHeight * pixelRatio;
+
+        // Keep each `copy` operation from clearing pixels retained by the other viewports.
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(targetX, targetY, pixelCopyWidth, pixelCopyHeight);
+        ctx.clip();
         ctx.drawImage(
             ctx.canvas,
             sourceX,
@@ -80,6 +86,7 @@ export function scrollAndClearCanvas(
             pixelCopyWidth,
             pixelCopyHeight
         );
+        ctx.restore();
     }
 
     clearCanvasBounds(ctx, pixelRatio, dirtyBounds);

--- a/packages/engine-render/src/scene.ts
+++ b/packages/engine-render/src/scene.ts
@@ -169,6 +169,7 @@ export class Scene extends Disposable {
     private _layers: Layer[] = [];
     private _viewports: Viewport[] = [];
     private _preserveEngineOnRender = false;
+    private _hasPostRenderCanvasMutation = false;
     private _scrollbarDragViewport: Nullable<Viewport> = null;
     private _isScrollbarSeeking = false;
     private _isScrollbarPreviewDirty = false;
@@ -954,6 +955,15 @@ export class Scene extends Disposable {
             (duration - this._estimatedFullRenderDuration) * SCROLLBAR_SEEK_RENDER_COST_SAMPLE_WEIGHT;
     }
 
+    private _notifyAfterRender(canvasInstance: Nullable<Canvas>) {
+        if (!canvasInstance) {
+            this._afterRender$.next(canvasInstance);
+            return false;
+        }
+
+        return canvasInstance.getContext().detectBitmapMutation(() => this._afterRender$.next(canvasInstance));
+    }
+
     render(parentCtx?: UniverRenderingContext) {
         if (!this.isDirty()) {
             return;
@@ -961,7 +971,10 @@ export class Scene extends Disposable {
 
         const layers = this._layers.sort(sortRules);
         const canvasInstance = this.getEngine()?.getCanvas();
-        const shouldTryPreservingEngine = this._preserveEngineOnRender && parentCtx == null && canvasInstance != null;
+        const shouldTryPreservingEngine = this._preserveEngineOnRender &&
+            !this._hasPostRenderCanvasMutation &&
+            parentCtx == null &&
+            canvasInstance != null;
         const isScrollbarSeekRender = this._isScrollbarSeeking && parentCtx == null && canvasInstance != null;
         const shouldMeasureFullRender = parentCtx == null && canvasInstance != null;
         const fullRenderStartedAt = Tools.now();
@@ -1003,7 +1016,7 @@ export class Scene extends Disposable {
         for (let i = 0, len = layers.length; i < len; i++) {
             layers[i].render(parentCtx, i === len - 1, layerRenderOptions);
         }
-        this._afterRender$.next(canvasInstance);
+        this._hasPostRenderCanvasMutation = this._notifyAfterRender(canvasInstance);
         this._recordRenderedViewportScrollPositions();
         if (shouldMeasureFullRender) {
             this._recordFullRenderDuration(Tools.now() - fullRenderStartedAt, isScrollbarSeekRender);


### PR DESCRIPTION
## Summary

- clip each canvas viewport copy to its destination rectangle before drawing
- expose the scrollAndClearCanvas helper through the debugger E2E API and its type declarations
- add a browser smoking regression test covering independent viewport copies at pixel ratios 1 and 2

## Related issue

No related issue.

## Testing

- pnpm --filter @univerjs/engine-render typecheck — passed
- pnpm --filter @univerjs/debugger typecheck — passed
- Added E2E regression coverage in e2e/smoking/engine-render-scroll-copy.spec.ts; browser execution was not run locally
- lint-staged ESLint passed for all changed files during commit

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (no related issue).
- [x] Naming convention is followed; no new plugins, commands, or resources were added.
- [x] Unit/E2E tests have been added for the rendering change.
- [x] Breaking changes have been documented (no breaking changes introduced).