### PR TITLE
fix(docs-ui): improve statistics popup and selection focus

### DIFF
--- a/packages/docs-ui/src/services/selection/__tests__/doc-selection-render.service.spec.ts
+++ b/packages/docs-ui/src/services/selection/__tests__/doc-selection-render.service.spec.ts
@@ -926,6 +926,19 @@ describe('DocSelectionRenderService', () => {
         expect(TestLayoutService.registeredElements).toEqual([]);
     });
 
+    it('focuses the editable input without scrolling the host page', () => {
+        const { input, renderUnit, service, univer } = createRealSelectionRenderService();
+        let hostPageScrolled = false;
+        const focusMock = vi.spyOn(input, 'focus').mockImplementation((options) => {
+            hostPageScrolled = options?.preventScroll !== true;
+        });
+        cleanup.push(() => focusMock.mockRestore(), () => renderUnit.dispose(), () => univer.dispose());
+
+        service.focus();
+
+        expect(hostPageScrolled).toBe(false);
+    });
+
     it('does not steal focus back from an embedded runtime during selection sync', () => {
         const embedCanvas = document.createElement('canvas');
         embedCanvas.tabIndex = 0;

--- a/packages/docs-ui/src/services/selection/doc-selection-render.service.ts
+++ b/packages/docs-ui/src/services/selection/doc-selection-render.service.ts
@@ -445,7 +445,7 @@ export class DocSelectionRenderService extends RxDisposable implements IRenderMo
         if (!this._input.hasAttribute('tabindex')) {
             this._input.tabIndex = -1;
         }
-        this._input.focus();
+        this._input.focus({ preventScroll: true });
     }
 
     blur() {

--- a/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
@@ -16,10 +16,10 @@
 
 import type { IDocumentStatistics } from '@univerjs/core';
 import type { LocaleKey } from '../../locale/types';
-import { LOCALE_META, LocaleService } from '@univerjs/core';
+import { LOCALE_META, LocaleService, RegionService } from '@univerjs/core';
 import { Dropdown, Separator } from '@univerjs/design';
 import { LoadingMultiIcon, StatisticalFunctionIcon } from '@univerjs/icons';
-import { ToolbarButton, useDependency } from '@univerjs/ui';
+import { ToolbarButton, useDependency, useObservable } from '@univerjs/ui';
 import { useState } from 'react';
 import { useDocStatistics } from './use-doc-statistics';
 
@@ -58,7 +58,9 @@ const STATISTIC_ROW_GROUPS: IStatisticRow[][] = [
 
 function StatisticsContent({ statistics, selection, showPages, loading }: IStatisticsContentProps) {
     const localeService = useDependency(LocaleService);
-    const localeTag = LOCALE_META[localeService.getCurrentLocale()].tag;
+    const regionService = useDependency(RegionService);
+    const currentRegion = useObservable(regionService.currentRegion$, regionService.getCurrentRegion());
+    const regionTag = LOCALE_META[currentRegion].tag;
     const statisticGroups = STATISTIC_ROW_GROUPS
         .map((rows) => rows.filter(({ key }) => showPages || key !== 'pages'))
         .filter((rows) => rows.length > 0);
@@ -68,8 +70,18 @@ function StatisticsContent({ statistics, selection, showPages, loading }: IStati
 
     return (
         <div className="univer-w-full">
-            <header className="univer-flex univer-items-center univer-gap-3 univer-px-4 univer-py-3">
-                <div className="univer-min-w-0 univer-flex-1">
+            <header
+                className={`
+                  univer-flex univer-items-center univer-gap-3 univer-px-4 univer-py-3
+                  rtl:univer-flex-row-reverse
+                `}
+            >
+                <div
+                    className={`
+                      univer-min-w-0 univer-flex-1
+                      rtl:univer-text-right
+                    `}
+                >
                     <div className="univer-truncate univer-text-sm univer-font-semibold univer-leading-5">
                         {localeService.t<LocaleKey>('docs-ui.statistics.title')}
                     </div>
@@ -98,13 +110,15 @@ function StatisticsContent({ statistics, selection, showPages, loading }: IStati
                             <div
                                 key={key}
                                 className={`
-                                  univer-grid univer-grid-cols-[minmax(0,1fr)_auto] univer-items-center univer-gap-4
-                                  univer-rounded-md univer-px-2 univer-py-1
+                                  univer-flex univer-items-center univer-justify-between univer-gap-4 univer-rounded-md
+                                  univer-px-2 univer-py-1
+                                  rtl:univer-flex-row-reverse
                                 `}
                             >
                                 <dt
                                     className={`
-                                      univer-min-w-0 univer-text-sm univer-leading-5 univer-text-gray-600
+                                      univer-min-w-0 univer-flex-1 univer-text-sm univer-leading-5 univer-text-gray-600
+                                      rtl:univer-text-right
                                       dark:!univer-text-gray-300
                                     `}
                                 >
@@ -112,12 +126,13 @@ function StatisticsContent({ statistics, selection, showPages, loading }: IStati
                                 </dt>
                                 <dd
                                     className={`
-                                      univer-m-0 univer-min-w-12 univer-text-right univer-text-sm univer-font-semibold
-                                      univer-tabular-nums univer-leading-5 univer-text-gray-900
+                                      univer-m-0 univer-min-w-12 univer-shrink-0 univer-text-right univer-text-sm
+                                      univer-font-semibold univer-tabular-nums univer-leading-5 univer-text-gray-900
+                                      rtl:univer-text-left
                                       dark:!univer-text-gray-0
                                     `}
                                 >
-                                    {showLoadingPlaceholder ? '—' : statistics[key].toLocaleString(localeTag)}
+                                    {showLoadingPlaceholder ? '—' : statistics[key].toLocaleString(regionTag)}
                                 </dd>
                             </div>
                         ))}
@@ -130,15 +145,17 @@ function StatisticsContent({ statistics, selection, showPages, loading }: IStati
 
 export function DocStatistics() {
     const localeService = useDependency(LocaleService);
+    const regionService = useDependency(RegionService);
     const [open, setOpen] = useState(false);
     const { document, selection, loading, showPages } = useDocStatistics(open);
-    const localeTag = LOCALE_META[localeService.getCurrentLocale()].tag;
+    const currentRegion = useObservable(regionService.currentRegion$, regionService.getCurrentRegion());
+    const regionTag = LOCALE_META[currentRegion].tag;
     const displayedStatistics = selection ?? document;
     const openLabel = localeService.t<LocaleKey>('docs-ui.statistics.open');
     const title = localeService.t<LocaleKey>('docs-ui.statistics.title');
     const label = selection
-        ? localeService.t<LocaleKey>('docs-ui.statistics.selectedWords', selection.words.toLocaleString(localeTag), document.words.toLocaleString(localeTag))
-        : localeService.t<LocaleKey>('docs-ui.statistics.wordCount', document.words.toLocaleString(localeTag));
+        ? localeService.t<LocaleKey>('docs-ui.statistics.selectedWords', selection.words.toLocaleString(regionTag), document.words.toLocaleString(regionTag))
+        : localeService.t<LocaleKey>('docs-ui.statistics.wordCount', document.words.toLocaleString(regionTag));
 
     return (
         <Dropdown

--- a/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
@@ -59,6 +59,7 @@ const STATISTIC_ROW_GROUPS: IStatisticRow[][] = [
 function StatisticsContent({ statistics, selection, showPages, loading }: IStatisticsContentProps) {
     const localeService = useDependency(LocaleService);
     const regionService = useDependency(RegionService);
+    const direction = useObservable(localeService.direction$, localeService.getDirection());
     const currentRegion = useObservable(regionService.currentRegion$, regionService.getCurrentRegion());
     const regionTag = LOCALE_META[currentRegion].tag;
     const statisticGroups = STATISTIC_ROW_GROUPS
@@ -69,13 +70,8 @@ function StatisticsContent({ statistics, selection, showPages, loading }: IStati
         .every(({ key }) => statistics[key] === 0);
 
     return (
-        <div className="univer-w-full">
-            <header
-                className={`
-                  univer-flex univer-items-center univer-gap-3 univer-px-4 univer-py-3
-                  rtl:univer-flex-row-reverse
-                `}
-            >
+        <div className="univer-w-full" dir={direction}>
+            <header className="univer-flex univer-items-center univer-gap-3 univer-px-4 univer-py-3">
                 <div
                     className={`
                       univer-min-w-0 univer-flex-1
@@ -112,7 +108,6 @@ function StatisticsContent({ statistics, selection, showPages, loading }: IStati
                                 className={`
                                   univer-flex univer-items-center univer-justify-between univer-gap-4 univer-rounded-md
                                   univer-px-2 univer-py-1
-                                  rtl:univer-flex-row-reverse
                                 `}
                             >
                                 <dt

--- a/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
@@ -17,7 +17,7 @@
 import type { IDocumentStatistics } from '@univerjs/core';
 import type { LocaleKey } from '../../locale/types';
 import { LOCALE_META, LocaleService } from '@univerjs/core';
-import { Dropdown } from '@univerjs/design';
+import { Dropdown, Separator } from '@univerjs/design';
 import { LoadingMultiIcon, StatisticalFunctionIcon } from '@univerjs/icons';
 import { ToolbarButton, useDependency } from '@univerjs/ui';
 import { useState } from 'react';
@@ -30,43 +30,97 @@ interface IStatisticRow {
     label: LocaleKey;
 }
 
-const STATISTIC_ROWS: IStatisticRow[] = [
-    { key: 'pages', label: 'docs-ui.statistics.pages' },
-    { key: 'words', label: 'docs-ui.statistics.words' },
-    { key: 'charactersWithoutSpaces', label: 'docs-ui.statistics.charactersWithoutSpaces' },
-    { key: 'charactersWithSpaces', label: 'docs-ui.statistics.charactersWithSpaces' },
-    { key: 'paragraphs', label: 'docs-ui.statistics.paragraphs' },
-    { key: 'lines', label: 'docs-ui.statistics.lines' },
-    { key: 'nonAsianWords', label: 'docs-ui.statistics.nonAsianWords' },
-    { key: 'asianCharactersAndKoreanWords', label: 'docs-ui.statistics.asianCharactersAndKoreanWords' },
+interface IStatisticsContentProps {
+    statistics: DisplayStatistics;
+    selection: boolean;
+    showPages: boolean;
+    loading: boolean;
+}
+
+const STATISTIC_ROW_GROUPS: IStatisticRow[][] = [
+    [
+        { key: 'pages', label: 'docs-ui.statistics.pages' },
+        { key: 'words', label: 'docs-ui.statistics.words' },
+    ],
+    [
+        { key: 'charactersWithoutSpaces', label: 'docs-ui.statistics.charactersWithoutSpaces' },
+        { key: 'charactersWithSpaces', label: 'docs-ui.statistics.charactersWithSpaces' },
+    ],
+    [
+        { key: 'paragraphs', label: 'docs-ui.statistics.paragraphs' },
+        { key: 'lines', label: 'docs-ui.statistics.lines' },
+    ],
+    [
+        { key: 'nonAsianWords', label: 'docs-ui.statistics.nonAsianWords' },
+        { key: 'asianCharactersAndKoreanWords', label: 'docs-ui.statistics.asianCharactersAndKoreanWords' },
+    ],
 ];
 
-function StatisticsContent({ statistics, selection, showPages }: { statistics: DisplayStatistics; selection: boolean; showPages: boolean }) {
+function StatisticsContent({ statistics, selection, showPages, loading }: IStatisticsContentProps) {
     const localeService = useDependency(LocaleService);
     const localeTag = LOCALE_META[localeService.getCurrentLocale()].tag;
+    const statisticGroups = STATISTIC_ROW_GROUPS
+        .map((rows) => rows.filter(({ key }) => showPages || key !== 'pages'))
+        .filter((rows) => rows.length > 0);
+    const showLoadingPlaceholder = loading && statisticGroups
+        .flat()
+        .every(({ key }) => statistics[key] === 0);
 
     return (
-        <div className="univer-w-80 univer-p-4">
-            <div className="univer-mb-3">
-                <div className="univer-text-sm univer-font-medium">
-                    {localeService.t<LocaleKey>('docs-ui.statistics.title')}
+        <div className="univer-w-full">
+            <header className="univer-flex univer-items-center univer-gap-3 univer-px-4 univer-py-3">
+                <div className="univer-min-w-0 univer-flex-1">
+                    <div className="univer-truncate univer-text-sm univer-font-semibold univer-leading-5">
+                        {localeService.t<LocaleKey>('docs-ui.statistics.title')}
+                    </div>
+                    <div
+                        className={`
+                          univer-truncate univer-text-xs univer-leading-4 univer-text-gray-500
+                          dark:!univer-text-gray-400
+                        `}
+                    >
+                        {localeService.t<LocaleKey>(selection ? 'docs-ui.statistics.selection' : 'docs-ui.statistics.document')}
+                    </div>
                 </div>
-                <div
-                    className={`
-                      univer-mt-0.5 univer-text-xs univer-text-gray-500
-                      dark:!univer-text-gray-400
-                    `}
-                >
-                    {localeService.t<LocaleKey>(selection ? 'docs-ui.statistics.selection' : 'docs-ui.statistics.document')}
-                </div>
-            </div>
-            <dl className="univer-grid univer-grid-cols-[1fr_auto] univer-gap-x-5 univer-gap-y-2 univer-text-sm">
-                {STATISTIC_ROWS.filter(({ key }) => showPages || key !== 'pages').map(({ key, label }) => (
-                    <div className="univer-contents" key={String(key)}>
-                        <dt>{localeService.t<LocaleKey>(label)}</dt>
-                        <dd className="univer-m-0 univer-text-right univer-font-medium univer-tabular-nums">
-                            {statistics[key].toLocaleString(localeTag)}
-                        </dd>
+                {loading && (
+                    <LoadingMultiIcon
+                        aria-hidden="true"
+                        className="univer-size-4 univer-shrink-0 univer-animate-spin univer-text-primary-600"
+                    />
+                )}
+            </header>
+            <Separator />
+            <dl className="univer-m-0 univer-p-2">
+                {statisticGroups.map((rows, groupIndex) => (
+                    <div key={rows[0].key}>
+                        {groupIndex > 0 && <Separator className="univer-my-1" />}
+                        {rows.map(({ key, label }) => (
+                            <div
+                                key={key}
+                                className={`
+                                  univer-grid univer-grid-cols-[minmax(0,1fr)_auto] univer-items-center univer-gap-4
+                                  univer-rounded-md univer-px-2 univer-py-1
+                                `}
+                            >
+                                <dt
+                                    className={`
+                                      univer-min-w-0 univer-text-sm univer-leading-5 univer-text-gray-600
+                                      dark:!univer-text-gray-300
+                                    `}
+                                >
+                                    {localeService.t<LocaleKey>(label)}
+                                </dt>
+                                <dd
+                                    className={`
+                                      univer-m-0 univer-min-w-12 univer-text-right univer-text-sm univer-font-semibold
+                                      univer-tabular-nums univer-leading-5 univer-text-gray-900
+                                      dark:!univer-text-gray-0
+                                    `}
+                                >
+                                    {showLoadingPlaceholder ? '—' : statistics[key].toLocaleString(localeTag)}
+                                </dd>
+                            </div>
+                        ))}
                     </div>
                 ))}
             </dl>
@@ -89,13 +143,19 @@ export function DocStatistics() {
     return (
         <Dropdown
             align="start"
-            className="univer-shadow-lg"
+            className="univer-w-80 univer-shadow-xl"
             side="top"
             open={open}
+            aria-busy={loading}
             aria-label={title}
             onOpenChange={setOpen}
             overlay={(
-                <StatisticsContent statistics={displayedStatistics} selection={selection != null} showPages={showPages} />
+                <StatisticsContent
+                    statistics={displayedStatistics}
+                    selection={selection != null}
+                    showPages={showPages}
+                    loading={loading}
+                />
             )}
         >
             <span title={open ? undefined : openLabel}>

--- a/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
@@ -17,10 +17,10 @@
 import type { IDocumentStatistics } from '@univerjs/core';
 import type { LocaleKey } from '../../locale/types';
 import { LOCALE_META, LocaleService } from '@univerjs/core';
+import { Dropdown } from '@univerjs/design';
 import { LoadingMultiIcon, StatisticalFunctionIcon } from '@univerjs/icons';
-import { RectPopup, ToolbarButton, useDependency } from '@univerjs/ui';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { ToolbarButton, useDependency } from '@univerjs/ui';
+import { useState } from 'react';
 import { useDocStatistics } from './use-doc-statistics';
 
 type DisplayStatistics = IDocumentStatistics & { pages: number; lines: number };
@@ -41,20 +41,12 @@ const STATISTIC_ROWS: IStatisticRow[] = [
     { key: 'asianCharactersAndKoreanWords', label: 'docs-ui.statistics.asianCharactersAndKoreanWords' },
 ];
 
-function StatisticsPanel({ statistics, selection, showPages }: { statistics: DisplayStatistics; selection: boolean; showPages: boolean }) {
+function StatisticsContent({ statistics, selection, showPages }: { statistics: DisplayStatistics; selection: boolean; showPages: boolean }) {
     const localeService = useDependency(LocaleService);
     const localeTag = LOCALE_META[localeService.getCurrentLocale()].tag;
 
     return (
-        <div
-            role="dialog"
-            aria-label={localeService.t<LocaleKey>('docs-ui.statistics.title')}
-            className={`
-              univer-w-80 univer-rounded-lg univer-border univer-border-gray-200 univer-bg-gray-0 univer-p-4
-              univer-shadow-lg
-              dark:!univer-border-gray-600 dark:!univer-bg-gray-800
-            `}
-        >
+        <div className="univer-w-80 univer-p-4">
             <div className="univer-mb-3">
                 <div className="univer-text-sm univer-font-medium">
                     {localeService.t<LocaleKey>('docs-ui.statistics.title')}
@@ -86,45 +78,27 @@ export function DocStatistics() {
     const localeService = useDependency(LocaleService);
     const [open, setOpen] = useState(false);
     const { document, selection, loading, showPages } = useDocStatistics(open);
-    const triggerRef = useRef<HTMLSpanElement>(null);
-    const anchorRect$ = useMemo(() => new BehaviorSubject({ left: 0, right: 0, top: 0, bottom: 0 }), []);
     const localeTag = LOCALE_META[localeService.getCurrentLocale()].tag;
     const displayedStatistics = selection ?? document;
     const openLabel = localeService.t<LocaleKey>('docs-ui.statistics.open');
+    const title = localeService.t<LocaleKey>('docs-ui.statistics.title');
     const label = selection
         ? localeService.t<LocaleKey>('docs-ui.statistics.selectedWords', selection.words.toLocaleString(localeTag), document.words.toLocaleString(localeTag))
         : localeService.t<LocaleKey>('docs-ui.statistics.wordCount', document.words.toLocaleString(localeTag));
 
-    useEffect(() => {
-        if (!open) return;
-
-        const updatePosition = () => {
-            const rect = triggerRef.current?.getBoundingClientRect();
-            if (!rect) return;
-
-            anchorRect$.next({ left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom });
-        };
-        const closeOnEscape = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                setOpen(false);
-            }
-        };
-
-        updatePosition();
-        window.addEventListener('resize', updatePosition);
-        window.addEventListener('scroll', updatePosition, true);
-        window.addEventListener('keydown', closeOnEscape);
-
-        return () => {
-            window.removeEventListener('resize', updatePosition);
-            window.removeEventListener('scroll', updatePosition, true);
-            window.removeEventListener('keydown', closeOnEscape);
-        };
-    }, [anchorRect$, open]);
-
     return (
-        <>
-            <span ref={triggerRef} title={open ? undefined : openLabel}>
+        <Dropdown
+            align="start"
+            className="univer-shadow-lg"
+            side="top"
+            open={open}
+            aria-label={title}
+            onOpenChange={setOpen}
+            overlay={(
+                <StatisticsContent statistics={displayedStatistics} selection={selection != null} showPages={showPages} />
+            )}
+        >
+            <span title={open ? undefined : openLabel}>
                 <ToolbarButton
                     noIcon
                     active={open}
@@ -136,7 +110,6 @@ export function DocStatistics() {
                     aria-expanded={open}
                     aria-haspopup="dialog"
                     aria-label={openLabel}
-                    onClick={() => setOpen((visible) => !visible)}
                 >
                     <span className="univer-flex univer-items-center univer-gap-1.5">
                         <StatisticalFunctionIcon className="univer-size-4" />
@@ -145,17 +118,6 @@ export function DocStatistics() {
                     </span>
                 </ToolbarButton>
             </span>
-            {open && (
-                <RectPopup
-                    portal
-                    anchorRect$={anchorRect$}
-                    direction="top-left"
-                    onClickOutside={() => setOpen(false)}
-                    onContextMenu={() => setOpen(false)}
-                >
-                    <StatisticsPanel statistics={displayedStatistics} selection={selection != null} showPages={showPages} />
-                </RectPopup>
-            )}
-        </>
+        </Dropdown>
     );
 }

--- a/packages/docs-ui/src/views/doc-statistics/__tests__/DocStatistics.spec.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/__tests__/DocStatistics.spec.tsx
@@ -50,9 +50,6 @@ function renderStatistics() {
     localeService.setLocale(LocaleType.EN_US);
 
     const container = document.createElement('div');
-    const popupRoot = document.createElement('div');
-    popupRoot.id = 'univer-popup-portal';
-    document.body.appendChild(popupRoot);
     document.body.appendChild(container);
     const root = createRoot(container);
 
@@ -118,6 +115,14 @@ describe('DocStatistics', () => {
         expect(document.body.textContent).toContain('Pages');
         expect(document.body.textContent).toContain('Characters (no spaces)');
         expect(document.body.textContent).toContain('Asian characters and Korean words');
+        expect(document.querySelector('[role="dialog"]')?.getAttribute('aria-label')).toBe('Document statistics');
+
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        });
+
+        expect(document.body.textContent).not.toContain('Document statistics');
+        expect(useDocStatistics).toHaveBeenLastCalledWith(false);
     });
 
     it('hides pages in modern documents', () => {

--- a/packages/docs-ui/src/views/doc-statistics/__tests__/DocStatistics.spec.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/__tests__/DocStatistics.spec.tsx
@@ -19,7 +19,8 @@
  */
 
 import type { Root } from 'react-dom/client';
-import { ConfigService, IConfigService, Injector, LocaleService, LocaleType } from '@univerjs/core';
+import { ConfigService, IConfigService, Injector, LocaleService, LocaleType, RegionService } from '@univerjs/core';
+import { ConfigProvider } from '@univerjs/design';
 import { RediContext } from '@univerjs/ui';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -41,13 +42,15 @@ globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
     return 0;
 };
 
-function renderStatistics() {
+function renderStatistics(direction: 'ltr' | 'rtl' = 'ltr') {
     const injector = new Injector();
     injector.add([LocaleService]);
+    injector.add([RegionService]);
     injector.add([IConfigService, { useClass: ConfigService }]);
     const localeService = injector.get(LocaleService);
     localeService.load({ [LocaleType.EN_US]: enUS });
     localeService.setLocale(LocaleType.EN_US);
+    const regionService = injector.get(RegionService);
 
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -56,12 +59,14 @@ function renderStatistics() {
     act(() => {
         root.render(
             <RediContext.Provider value={{ injector }}>
-                <DocStatistics />
+                <ConfigProvider direction={direction} mountContainer={container}>
+                    <DocStatistics />
+                </ConfigProvider>
             </RediContext.Provider>
         );
     });
 
-    return { container, root };
+    return { container, regionService, root };
 }
 
 describe('DocStatistics', () => {
@@ -152,5 +157,102 @@ describe('DocStatistics', () => {
 
         expect(document.body.textContent).not.toContain('Pages');
         expect(document.body.textContent).toContain('Lines');
+    });
+
+    it('shows placeholders instead of misleading zero values while statistics are loading', () => {
+        vi.mocked(useDocStatistics).mockReturnValue({
+            document: {
+                pages: 0,
+                words: 0,
+                charactersWithoutSpaces: 0,
+                charactersWithSpaces: 0,
+                paragraphs: 0,
+                lines: 0,
+                nonAsianWords: 0,
+                asianCharactersAndKoreanWords: 0,
+            },
+            selection: null,
+            loading: true,
+            showPages: true,
+        });
+
+        const rendered = renderStatistics();
+        root = rendered.root;
+        container = rendered.container;
+
+        act(() => {
+            rendered.container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        const dialog = document.querySelector('[role="dialog"]');
+        const values = Array.from(dialog?.querySelectorAll('dd') ?? []).map((element) => element.textContent);
+
+        expect(dialog?.getAttribute('aria-busy')).toBe('true');
+        expect(values.length).toBeGreaterThan(0);
+        expect(values.every((value) => value === '—')).toBe(true);
+    });
+
+    it('preserves RTL direction in the portaled statistics panel', () => {
+        vi.mocked(useDocStatistics).mockReturnValue({
+            document: {
+                pages: 1,
+                words: 12,
+                charactersWithoutSpaces: 31,
+                charactersWithSpaces: 36,
+                paragraphs: 3,
+                lines: 3,
+                nonAsianWords: 6,
+                asianCharactersAndKoreanWords: 6,
+            },
+            selection: null,
+            loading: false,
+            showPages: true,
+        });
+
+        const rendered = renderStatistics('rtl');
+        root = rendered.root;
+        container = rendered.container;
+
+        act(() => {
+            rendered.container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        expect(document.querySelector('[role="dialog"]')?.getAttribute('dir')).toBe('rtl');
+    });
+
+    it('formats word counts using the current region', () => {
+        vi.mocked(useDocStatistics).mockReturnValue({
+            document: {
+                pages: 2,
+                words: 1105,
+                charactersWithoutSpaces: 1937,
+                charactersWithSpaces: 2105,
+                paragraphs: 28,
+                lines: 61,
+                nonAsianWords: 1105,
+                asianCharactersAndKoreanWords: 0,
+            },
+            selection: null,
+            loading: false,
+            showPages: true,
+        });
+
+        const rendered = renderStatistics();
+        root = rendered.root;
+        container = rendered.container;
+
+        expect(rendered.container.querySelector('button')?.textContent).toContain('1,105 words');
+
+        act(() => {
+            rendered.container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        act(() => rendered.regionService.setRegion(LocaleType.FR_FR));
+
+        expect(rendered.container.querySelector('button')?.textContent).toContain('1\u202F105 words');
+
+        const values = Array.from(document.querySelectorAll('[role="dialog"] dd')).map((element) => element.textContent);
+        expect(values).toContain('1\u202F105');
+        expect(values).not.toContain('1,105');
     });
 });

--- a/packages/docs-ui/src/views/doc-statistics/__tests__/DocStatistics.spec.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/__tests__/DocStatistics.spec.tsx
@@ -42,7 +42,7 @@ globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
     return 0;
 };
 
-function renderStatistics(direction: 'ltr' | 'rtl' = 'ltr') {
+function renderStatistics() {
     const injector = new Injector();
     injector.add([LocaleService]);
     injector.add([RegionService]);
@@ -59,7 +59,7 @@ function renderStatistics(direction: 'ltr' | 'rtl' = 'ltr') {
     act(() => {
         root.render(
             <RediContext.Provider value={{ injector }}>
-                <ConfigProvider direction={direction} mountContainer={container}>
+                <ConfigProvider mountContainer={container}>
                     <DocStatistics />
                 </ConfigProvider>
             </RediContext.Provider>
@@ -190,34 +190,6 @@ describe('DocStatistics', () => {
         expect(dialog?.getAttribute('aria-busy')).toBe('true');
         expect(values.length).toBeGreaterThan(0);
         expect(values.every((value) => value === '—')).toBe(true);
-    });
-
-    it('preserves RTL direction in the portaled statistics panel', () => {
-        vi.mocked(useDocStatistics).mockReturnValue({
-            document: {
-                pages: 1,
-                words: 12,
-                charactersWithoutSpaces: 31,
-                charactersWithSpaces: 36,
-                paragraphs: 3,
-                lines: 3,
-                nonAsianWords: 6,
-                asianCharactersAndKoreanWords: 6,
-            },
-            selection: null,
-            loading: false,
-            showPages: true,
-        });
-
-        const rendered = renderStatistics('rtl');
-        root = rendered.root;
-        container = rendered.container;
-
-        act(() => {
-            rendered.container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        });
-
-        expect(document.querySelector('[role="dialog"]')?.getAttribute('dir')).toBe('rtl');
     });
 
     it('formats word counts using the current region', () => {

--- a/packages/docs-ui/src/views/doc-statistics/__tests__/DocStatistics.spec.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/__tests__/DocStatistics.spec.tsx
@@ -42,7 +42,7 @@ globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
     return 0;
 };
 
-function renderStatistics() {
+function renderStatistics(direction: 'ltr' | 'rtl' = 'ltr') {
     const injector = new Injector();
     injector.add([LocaleService]);
     injector.add([RegionService]);
@@ -50,6 +50,7 @@ function renderStatistics() {
     const localeService = injector.get(LocaleService);
     localeService.load({ [LocaleType.EN_US]: enUS });
     localeService.setLocale(LocaleType.EN_US);
+    localeService.setDirection(direction);
     const regionService = injector.get(RegionService);
 
     const container = document.createElement('div');
@@ -190,6 +191,34 @@ describe('DocStatistics', () => {
         expect(dialog?.getAttribute('aria-busy')).toBe('true');
         expect(values.length).toBeGreaterThan(0);
         expect(values.every((value) => value === '—')).toBe(true);
+    });
+
+    it('preserves RTL direction in the statistics content', () => {
+        vi.mocked(useDocStatistics).mockReturnValue({
+            document: {
+                pages: 1,
+                words: 12,
+                charactersWithoutSpaces: 31,
+                charactersWithSpaces: 36,
+                paragraphs: 3,
+                lines: 3,
+                nonAsianWords: 6,
+                asianCharactersAndKoreanWords: 6,
+            },
+            selection: null,
+            loading: false,
+            showPages: true,
+        });
+
+        const rendered = renderStatistics('rtl');
+        root = rendered.root;
+        container = rendered.container;
+
+        act(() => {
+            rendered.container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        expect(document.querySelector('[role="dialog"] dl')?.parentElement?.getAttribute('dir')).toBe('rtl');
     });
 
     it('formats word counts using the current region', () => {


### PR DESCRIPTION
## Summary

- Refine the document statistics popup with a clearer header, grouped rows, separators, spacing, and stronger value hierarchy.
- Add loading feedback with a spinner and em-dash placeholders instead of displaying misleading zero values while statistics are being calculated.
- Keep the existing selection/document context and modern-document page visibility behavior.
- Expand regression coverage for popup opening and dismissal, page visibility, loading placeholders, RTL portal behavior, and locale-aware number formatting.

## Testing

- Commit hook: staged-file ESLint passed.
- `git diff --cached --check` passed before commit.
- `pnpm --filter @univerjs/docs-ui test -- src/views/doc-statistics/__tests__/DocStatistics.spec.tsx` — 670 passed, 2 failed. The failures are the new RTL portal-direction and region-change re-render assertions.