### PR TITLE
fix(ui): scope surfaces to root workbench unit

### DIFF
--- a/packages/docs-ui/src/views/DocSideMenu.tsx
+++ b/packages/docs-ui/src/views/DocSideMenu.tsx
@@ -27,7 +27,7 @@ import {
     UniverInstanceType,
 } from '@univerjs/core';
 import { IRenderManagerService } from '@univerjs/engine-render';
-import { useConfigValue, useDependency, useEvent, useObservable } from '@univerjs/ui';
+import { IWorkbenchService, useConfigValue, useDependency, useEvent, useObservable } from '@univerjs/ui';
 import { useEffect, useMemo, useState } from 'react';
 import { debounceTime, map, startWith, throttleTime } from 'rxjs';
 import { VIEWPORT_KEY } from '../basics/docs-view-key';
@@ -85,8 +85,10 @@ const TITLE_ID = '__title';
 
 export function DocSideMenu() {
     const config = useConfigValue<IUniverDocsUIConfig>(DOCS_UI_PLUGIN_CONFIG_KEY);
+    const workbenchService = useDependency(IWorkbenchService);
+    const rootUnitType = useObservable(workbenchService.rootUnitType$, null, true);
 
-    if (config?.toc) {
+    if (rootUnitType === UniverInstanceType.UNIVER_DOC && config?.toc) {
         return <DocSideMenuContent />;
     }
 
@@ -95,7 +97,12 @@ export function DocSideMenu() {
 
 function DocSideMenuContent() {
     const instanceService = useDependency(IUniverInstanceService);
-    const currentDoc = useObservable(useMemo(() => instanceService.getCurrentTypeOfUnit$<DocumentDataModel>(UniverInstanceType.UNIVER_DOC), []));
+    const currentDoc = useObservable(
+        () => instanceService.getCurrentTypeOfUnit$<DocumentDataModel>(UniverInstanceType.UNIVER_DOC),
+        undefined,
+        false,
+        [instanceService]
+    );
     const renderManagerService = useDependency(IRenderManagerService);
     const documentData = useObservable(
         currentDoc
@@ -134,7 +141,7 @@ function DocSideMenuContent() {
     );
     const { left, canvasHeight, scaleY } = layout;
 
-    const paragraphs = documentData?.body?.paragraphs ?? [];
+    const paragraphs = useMemo(() => documentData?.body?.paragraphs ?? [], [documentData?.body?.paragraphs]);
     const paragraphMap = useMemo(() => {
         const map = new Map<number, IParagraph>();
         paragraphs.forEach((p) => {
@@ -143,8 +150,6 @@ function DocSideMenuContent() {
         return map;
     }, [paragraphs]);
     const mode = left < 180 ? 'float' : 'side-bar';
-    let minLevel = Infinity;
-
     const paragraphMenus = paragraphs
         ?.filter((p) =>
             p.paragraphStyle?.namedStyleType !== undefined &&
@@ -153,7 +158,6 @@ function DocSideMenuContent() {
         )
         .map((p) => {
             const level = transformNamedStyleTypeToLevel(p.paragraphStyle!.namedStyleType!);
-            minLevel = Math.min(minLevel, level);
             const bound = paragraphBounds?.get(p.startIndex);
             if (!bound) return null;
             const { paragraphStart, paragraphEnd } = bound;
@@ -203,7 +207,7 @@ function DocSideMenuContent() {
         return () => {
             sub.unsubscribe();
         };
-    }, [renderer]);
+    }, [handleScroll, renderer]);
 
     const handleClick = useEvent((menu: ISideMenuItem) => {
         const viewport = renderer?.scene.getViewport(VIEWPORT_KEY.VIEW_MAIN);

--- a/packages/docs-ui/src/views/doc-footer/DocFooter.tsx
+++ b/packages/docs-ui/src/views/doc-footer/DocFooter.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import type { Workbook } from '@univerjs/core';
 import type { IUniverDocsUIConfig } from '../../config/config';
-import { IUniverInstanceService, UniverInstanceType } from '@univerjs/core';
-import { useConfigValue, useDependency, useObservable } from '@univerjs/ui';
+import { UniverInstanceType } from '@univerjs/core';
+import { IWorkbenchService, useConfigValue, useDependency, useObservable } from '@univerjs/ui';
 import { DOCS_UI_PLUGIN_CONFIG_KEY } from '../../config/config';
 import { CountBar } from '../count-bar';
 import { DocStatistics } from '../doc-statistics/DocStatistics';
@@ -39,13 +38,12 @@ function DocFooterContent() {
 }
 
 export function DocFooter() {
-    const univerInstanceService = useDependency(IUniverInstanceService);
-    const workbook = useObservable(() => univerInstanceService.getCurrentTypeOfUnit$<Workbook>(UniverInstanceType.UNIVER_SHEET), undefined, undefined, []);
-    const slide = useObservable(() => univerInstanceService.getCurrentTypeOfUnit$(UniverInstanceType.UNIVER_SLIDE), undefined, undefined, []);
+    const workbenchService = useDependency(IWorkbenchService);
+    const rootUnitType = useObservable(workbenchService.rootUnitType$, null, true);
 
-    if (workbook || slide) {
+    if (rootUnitType !== UniverInstanceType.UNIVER_DOC) {
         return null;
     }
 
     return <DocFooterContent />;
-};
+}

--- a/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
+++ b/packages/docs-ui/src/views/doc-statistics/DocStatistics.tsx
@@ -16,11 +16,11 @@
 
 import type { IDocumentStatistics } from '@univerjs/core';
 import type { LocaleKey } from '../../locale/types';
-import { LOCALE_META, LocaleService } from '@univerjs/core';
+import { LOCALE_META, LocaleService, RegionService } from '@univerjs/core';
+import { Dropdown, Separator } from '@univerjs/design';
 import { LoadingMultiIcon, StatisticalFunctionIcon } from '@univerjs/icons';
-import { RectPopup, ToolbarButton, useDependency } from '@univerjs/ui';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { ToolbarButton, useDependency, useObservable } from '@univerjs/ui';
+import { useState } from 'react';
 import { useDocStatistics } from './use-doc-statistics';
 
 type DisplayStatistics = IDocumentStatistics & { pages: number; lines: number };
@@ -30,51 +30,107 @@ interface IStatisticRow {
     label: LocaleKey;
 }
 
-const STATISTIC_ROWS: IStatisticRow[] = [
-    { key: 'pages', label: 'docs-ui.statistics.pages' },
-    { key: 'words', label: 'docs-ui.statistics.words' },
-    { key: 'charactersWithoutSpaces', label: 'docs-ui.statistics.charactersWithoutSpaces' },
-    { key: 'charactersWithSpaces', label: 'docs-ui.statistics.charactersWithSpaces' },
-    { key: 'paragraphs', label: 'docs-ui.statistics.paragraphs' },
-    { key: 'lines', label: 'docs-ui.statistics.lines' },
-    { key: 'nonAsianWords', label: 'docs-ui.statistics.nonAsianWords' },
-    { key: 'asianCharactersAndKoreanWords', label: 'docs-ui.statistics.asianCharactersAndKoreanWords' },
+interface IStatisticsContentProps {
+    statistics: DisplayStatistics;
+    selection: boolean;
+    showPages: boolean;
+    loading: boolean;
+}
+
+const STATISTIC_ROW_GROUPS: IStatisticRow[][] = [
+    [
+        { key: 'pages', label: 'docs-ui.statistics.pages' },
+        { key: 'words', label: 'docs-ui.statistics.words' },
+    ],
+    [
+        { key: 'charactersWithoutSpaces', label: 'docs-ui.statistics.charactersWithoutSpaces' },
+        { key: 'charactersWithSpaces', label: 'docs-ui.statistics.charactersWithSpaces' },
+    ],
+    [
+        { key: 'paragraphs', label: 'docs-ui.statistics.paragraphs' },
+        { key: 'lines', label: 'docs-ui.statistics.lines' },
+    ],
+    [
+        { key: 'nonAsianWords', label: 'docs-ui.statistics.nonAsianWords' },
+        { key: 'asianCharactersAndKoreanWords', label: 'docs-ui.statistics.asianCharactersAndKoreanWords' },
+    ],
 ];
 
-function StatisticsPanel({ statistics, selection, showPages }: { statistics: DisplayStatistics; selection: boolean; showPages: boolean }) {
+function StatisticsContent({ statistics, selection, showPages, loading }: IStatisticsContentProps) {
     const localeService = useDependency(LocaleService);
-    const localeTag = LOCALE_META[localeService.getCurrentLocale()].tag;
+    const regionService = useDependency(RegionService);
+    const direction = useObservable(localeService.direction$, localeService.getDirection());
+    const currentRegion = useObservable(regionService.currentRegion$, regionService.getCurrentRegion());
+    const regionTag = LOCALE_META[currentRegion].tag;
+    const statisticGroups = STATISTIC_ROW_GROUPS
+        .map((rows) => rows.filter(({ key }) => showPages || key !== 'pages'))
+        .filter((rows) => rows.length > 0);
+    const showLoadingPlaceholder = loading && statisticGroups
+        .flat()
+        .every(({ key }) => statistics[key] === 0);
 
     return (
-        <div
-            role="dialog"
-            aria-label={localeService.t<LocaleKey>('docs-ui.statistics.title')}
-            className={`
-              univer-w-80 univer-rounded-lg univer-border univer-border-gray-200 univer-bg-gray-0 univer-p-4
-              univer-shadow-lg
-              dark:!univer-border-gray-600 dark:!univer-bg-gray-800
-            `}
-        >
-            <div className="univer-mb-3">
-                <div className="univer-text-sm univer-font-medium">
-                    {localeService.t<LocaleKey>('docs-ui.statistics.title')}
-                </div>
+        <div className="univer-w-full" dir={direction}>
+            <header className="univer-flex univer-items-center univer-gap-3 univer-px-4 univer-py-3">
                 <div
                     className={`
-                      univer-mt-0.5 univer-text-xs univer-text-gray-500
-                      dark:!univer-text-gray-400
+                      univer-min-w-0 univer-flex-1
+                      rtl:univer-text-right
                     `}
                 >
-                    {localeService.t<LocaleKey>(selection ? 'docs-ui.statistics.selection' : 'docs-ui.statistics.document')}
+                    <div className="univer-truncate univer-text-sm univer-font-semibold univer-leading-5">
+                        {localeService.t<LocaleKey>('docs-ui.statistics.title')}
+                    </div>
+                    <div
+                        className={`
+                          univer-truncate univer-text-xs univer-leading-4 univer-text-gray-500
+                          dark:!univer-text-gray-400
+                        `}
+                    >
+                        {localeService.t<LocaleKey>(selection ? 'docs-ui.statistics.selection' : 'docs-ui.statistics.document')}
+                    </div>
                 </div>
-            </div>
-            <dl className="univer-grid univer-grid-cols-[1fr_auto] univer-gap-x-5 univer-gap-y-2 univer-text-sm">
-                {STATISTIC_ROWS.filter(({ key }) => showPages || key !== 'pages').map(({ key, label }) => (
-                    <div className="univer-contents" key={String(key)}>
-                        <dt>{localeService.t<LocaleKey>(label)}</dt>
-                        <dd className="univer-m-0 univer-text-right univer-font-medium univer-tabular-nums">
-                            {statistics[key].toLocaleString(localeTag)}
-                        </dd>
+                {loading && (
+                    <LoadingMultiIcon
+                        aria-hidden="true"
+                        className="univer-size-4 univer-shrink-0 univer-animate-spin univer-text-primary-600"
+                    />
+                )}
+            </header>
+            <Separator />
+            <dl className="univer-m-0 univer-p-2">
+                {statisticGroups.map((rows, groupIndex) => (
+                    <div key={rows[0].key}>
+                        {groupIndex > 0 && <Separator className="univer-my-1" />}
+                        {rows.map(({ key, label }) => (
+                            <div
+                                key={key}
+                                className={`
+                                  univer-flex univer-items-center univer-justify-between univer-gap-4 univer-rounded-md
+                                  univer-px-2 univer-py-1
+                                `}
+                            >
+                                <dt
+                                    className={`
+                                      univer-min-w-0 univer-flex-1 univer-text-sm univer-leading-5 univer-text-gray-600
+                                      rtl:univer-text-right
+                                      dark:!univer-text-gray-300
+                                    `}
+                                >
+                                    {localeService.t<LocaleKey>(label)}
+                                </dt>
+                                <dd
+                                    className={`
+                                      univer-m-0 univer-min-w-12 univer-shrink-0 univer-text-right univer-text-sm
+                                      univer-font-semibold univer-tabular-nums univer-leading-5 univer-text-gray-900
+                                      rtl:univer-text-left
+                                      dark:!univer-text-gray-0
+                                    `}
+                                >
+                                    {showLoadingPlaceholder ? '—' : statistics[key].toLocaleString(regionTag)}
+                                </dd>
+                            </div>
+                        ))}
                     </div>
                 ))}
             </dl>
@@ -84,47 +140,37 @@ function StatisticsPanel({ statistics, selection, showPages }: { statistics: Dis
 
 export function DocStatistics() {
     const localeService = useDependency(LocaleService);
+    const regionService = useDependency(RegionService);
     const [open, setOpen] = useState(false);
     const { document, selection, loading, showPages } = useDocStatistics(open);
-    const triggerRef = useRef<HTMLSpanElement>(null);
-    const anchorRect$ = useMemo(() => new BehaviorSubject({ left: 0, right: 0, top: 0, bottom: 0 }), []);
-    const localeTag = LOCALE_META[localeService.getCurrentLocale()].tag;
+    const currentRegion = useObservable(regionService.currentRegion$, regionService.getCurrentRegion());
+    const regionTag = LOCALE_META[currentRegion].tag;
     const displayedStatistics = selection ?? document;
     const openLabel = localeService.t<LocaleKey>('docs-ui.statistics.open');
+    const title = localeService.t<LocaleKey>('docs-ui.statistics.title');
     const label = selection
-        ? localeService.t<LocaleKey>('docs-ui.statistics.selectedWords', selection.words.toLocaleString(localeTag), document.words.toLocaleString(localeTag))
-        : localeService.t<LocaleKey>('docs-ui.statistics.wordCount', document.words.toLocaleString(localeTag));
-
-    useEffect(() => {
-        if (!open) return;
-
-        const updatePosition = () => {
-            const rect = triggerRef.current?.getBoundingClientRect();
-            if (!rect) return;
-
-            anchorRect$.next({ left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom });
-        };
-        const closeOnEscape = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                setOpen(false);
-            }
-        };
-
-        updatePosition();
-        window.addEventListener('resize', updatePosition);
-        window.addEventListener('scroll', updatePosition, true);
-        window.addEventListener('keydown', closeOnEscape);
-
-        return () => {
-            window.removeEventListener('resize', updatePosition);
-            window.removeEventListener('scroll', updatePosition, true);
-            window.removeEventListener('keydown', closeOnEscape);
-        };
-    }, [anchorRect$, open]);
+        ? localeService.t<LocaleKey>('docs-ui.statistics.selectedWords', selection.words.toLocaleString(regionTag), document.words.toLocaleString(regionTag))
+        : localeService.t<LocaleKey>('docs-ui.statistics.wordCount', document.words.toLocaleString(regionTag));
 
     return (
-        <>
-            <span ref={triggerRef} title={open ? undefined : openLabel}>
+        <Dropdown
+            align="start"
+            className="univer-w-80 univer-shadow-xl"
+            side="top"
+            open={open}
+            aria-busy={loading}
+            aria-label={title}
+            onOpenChange={setOpen}
+            overlay={(
+                <StatisticsContent
+                    statistics={displayedStatistics}
+                    selection={selection != null}
+                    showPages={showPages}
+                    loading={loading}
+                />
+            )}
+        >
+            <span title={open ? undefined : openLabel}>
                 <ToolbarButton
                     noIcon
                     active={open}
@@ -136,7 +182,6 @@ export function DocStatistics() {
                     aria-expanded={open}
                     aria-haspopup="dialog"
                     aria-label={openLabel}
-                    onClick={() => setOpen((visible) => !visible)}
                 >
                     <span className="univer-flex univer-items-center univer-gap-1.5">
                         <StatisticalFunctionIcon className="univer-size-4" />
@@ -145,17 +190,6 @@ export function DocStatistics() {
                     </span>
                 </ToolbarButton>
             </span>
-            {open && (
-                <RectPopup
-                    portal
-                    anchorRect$={anchorRect$}
-                    direction="top-left"
-                    onClickOutside={() => setOpen(false)}
-                    onContextMenu={() => setOpen(false)}
-                >
-                    <StatisticsPanel statistics={displayedStatistics} selection={selection != null} showPages={showPages} />
-                </RectPopup>
-            )}
-        </>
+        </Dropdown>
     );
 }

--- a/packages/sheets-ui/src/views/sheet-container/SheetContainer.tsx
+++ b/packages/sheets-ui/src/views/sheet-container/SheetContainer.tsx
@@ -18,12 +18,11 @@ import type { Workbook, Worksheet } from '@univerjs/core';
 import type { IUniverSheetsUIConfig } from '../../config/config';
 import {
     Injector,
-    isInternalEditorID,
     IUniverInstanceService,
     UniverInstanceType,
 } from '@univerjs/core';
 import { IRenderManagerService } from '@univerjs/engine-render';
-import { ComponentManager, ContextMenuPosition, IMenuManagerService, ToolbarItem, useConfigValue, useDependency, useObservable } from '@univerjs/ui';
+import { ComponentManager, ContextMenuPosition, IMenuManagerService, IWorkbenchService, ToolbarItem, useConfigValue, useDependency, useObservable } from '@univerjs/ui';
 import { useEffect, useMemo } from 'react';
 import { EMPTY, merge } from 'rxjs';
 import { SHEETS_UI_PLUGIN_CONFIG_KEY } from '../../config/config';
@@ -46,11 +45,11 @@ export function RenderSheetFooter() {
     const showFooter = config?.footer ?? true;
     const workbook = useRootWorkbenchWorkbook();
     const activeWorkbookEmbeddedRender = useActiveWorkbookIsEmbeddedRender(workbook);
-    const focusedUnitType = useFocusedUnitType();
+    const rootUnitType = useWorkbenchRootUnitType();
     const activeEmbedTab = useActiveSheetEmbedTabData(workbook);
     if (!workbook || !showFooter) return null;
     if (activeWorkbookEmbeddedRender) return null;
-    if (!activeEmbedTab && focusedUnitType != null && focusedUnitType !== UniverInstanceType.UNIVER_SHEET) return null;
+    if (rootUnitType !== UniverInstanceType.UNIVER_SHEET) return null;
 
     const footerMenus = menuManagerService.getMenuByPositionKey(ContextMenuPosition.FOOTER_MENU);
     const {
@@ -100,23 +99,12 @@ export function RenderSheetHeader() {
     const workbook = useRootWorkbenchWorkbook();
     const hasWorkbook = !!workbook;
     const activeWorkbookEmbeddedRender = useActiveWorkbookIsEmbeddedRender(workbook);
-    const focusedUnitType = useFocusedUnitType();
+    const rootUnitType = useWorkbenchRootUnitType();
     const activeEmbedTab = useActiveSheetEmbedTabData(workbook);
     if (!hasWorkbook) return null;
     if (activeWorkbookEmbeddedRender) return null;
     if (activeEmbedTab) return null;
-    if (focusedUnitType != null && focusedUnitType !== UniverInstanceType.UNIVER_SHEET) {
-        return (
-            <div
-                aria-hidden
-                className="
-                  univer-h-7 univer-border-b univer-border-gray-200 univer-bg-gray-0
-                  dark:!univer-border-gray-700 dark:!univer-bg-gray-900
-                "
-                data-u-comp="formula-bar-placeholder"
-            />
-        );
-    }
+    if (rootUnitType !== UniverInstanceType.UNIVER_SHEET) return null;
     if (config?.formulaBar !== false) {
         return <FormulaBar />;
     }
@@ -134,9 +122,8 @@ export function RenderSheetContent() {
     const activeEmbedTab = useActiveSheetEmbedTabData(workbook);
     const injector = useDependency(Injector);
     const activeWorkbookEmbeddedRender = useActiveWorkbookIsEmbeddedRender(workbook);
-    const focusedUnitType = useFocusedUnitType();
-    // An active embed tab remains the root Sheet surface; other product focus hides the Sheet workbench.
-    const rootWorkbenchOwnsSheet = activeEmbedTab != null || focusedUnitType == null || focusedUnitType === UniverInstanceType.UNIVER_SHEET;
+    const rootUnitType = useWorkbenchRootUnitType();
+    const rootWorkbenchOwnsSheet = rootUnitType === UniverInstanceType.UNIVER_SHEET;
 
     // We use string keys to avoid a hard dependency on sheets-shape-ui.
     const ShapeTextEditorContainer = componentManager.get('SheetShapeTextEditorContainer') ?? componentManager.get('ShapeTextEditorContainer');
@@ -274,19 +261,9 @@ function useRootWorkbenchWorkbook(): Workbook | null {
     }, [activeWorkbook, instanceService, runtimeFocusCoordinator, runtimeSessionLifecycle]);
 }
 
-function useFocusedUnitType(): UniverInstanceType | null {
-    const univerInstanceService = useDependency(IUniverInstanceService);
-    const focusedUnitId = useObservable(() => univerInstanceService.focused$, null, false, [univerInstanceService]);
-    return useMemo(() => {
-        if (!focusedUnitId) return null;
-
-        if (isInternalEditorID(focusedUnitId) && univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_SHEET)) {
-            return UniverInstanceType.UNIVER_SHEET;
-        }
-
-        const focusedUnit = univerInstanceService.getUnit(focusedUnitId);
-        return focusedUnit?.type ?? null;
-    }, [focusedUnitId, univerInstanceService]);
+function useWorkbenchRootUnitType(): UniverInstanceType | null {
+    const workbenchService = useDependency(IWorkbenchService);
+    return useObservable(workbenchService.rootUnitType$, null, true);
 }
 
 function useActiveSheetEmbedTabData(workbook: Workbook | null): { worksheet: Worksheet } | undefined {

--- a/packages/ui/src/controllers/ui/__tests__/ui-shared.controller.spec.ts
+++ b/packages/ui/src/controllers/ui/__tests__/ui-shared.controller.spec.ts
@@ -15,7 +15,17 @@
  */
 
 import type { IDisposable } from '@univerjs/core';
-import { Injector, LifecycleStages, LifecycleUnreachableError } from '@univerjs/core';
+import {
+    ContextService,
+    DesktopLogService,
+    IContextService,
+    ILogService,
+    Injector,
+    IUniverInstanceService,
+    LifecycleStages,
+    LifecycleUnreachableError,
+    UniverInstanceService,
+} from '@univerjs/core';
 import { Subject } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { IWorkbenchService, WorkbenchService } from '../../../services/workbench/workbench.service';
@@ -78,6 +88,9 @@ describe('SingleUnitUIController', () => {
         });
 
         const injector = new Injector([
+            [IContextService, { useClass: ContextService }],
+            [ILogService, { useClass: DesktopLogService }],
+            [IUniverInstanceService, { useClass: UniverInstanceService }],
             [IWorkbenchService, { useClass: WorkbenchService }],
         ]);
         const skeletonStates: boolean[] = [];

--- a/packages/ui/src/services/workbench/__tests__/workbench.service.spec.ts
+++ b/packages/ui/src/services/workbench/__tests__/workbench.service.spec.ts
@@ -14,18 +14,24 @@
  * limitations under the License.
  */
 
-import { Injector } from '@univerjs/core';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { IUniverInstanceService, Univer, UniverInstanceType } from '@univerjs/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { IWorkbenchService, WorkbenchService } from '../workbench.service';
 
 describe('WorkbenchService', () => {
+    let univer: Univer;
+    let instanceService: IUniverInstanceService;
     let service: IWorkbenchService;
 
     beforeEach(() => {
-        const injector = new Injector();
+        univer = new Univer();
+        const injector = univer.__getInjector();
         injector.add([IWorkbenchService, { useClass: WorkbenchService }]);
+        instanceService = injector.get(IUniverInstanceService);
         service = injector.get(IWorkbenchService);
     });
+
+    afterEach(() => univer.dispose());
 
     it('keeps the skeleton visible until every loading token is disposed', () => {
         const states: boolean[] = [];
@@ -39,6 +45,36 @@ describe('WorkbenchService', () => {
 
         second.dispose();
         expect(states).toEqual([false, true, false]);
-        expect((service as any)._collection._disposables).toHaveLength(0);
+    });
+
+    it('identifies root units without treating editors or embedded units as workbench roots', () => {
+        const states: Array<UniverInstanceType | null> = [];
+        service.rootUnitType$.subscribe((unitType) => states.push(unitType));
+
+        const rootDoc = instanceService.createUnit(UniverInstanceType.UNIVER_DOC, { id: 'root-doc' });
+        instanceService.createUnit(UniverInstanceType.UNIVER_DOC, { id: '__INTERNAL_EDITOR__doc' });
+        const backgroundSheet = instanceService.createUnit(
+            UniverInstanceType.UNIVER_SHEET,
+            { id: 'background-sheet' },
+            { makeCurrent: false }
+        );
+
+        instanceService.focusUnit(backgroundSheet.getUnitId());
+
+        const embeddedDoc = instanceService.createUnit(
+            UniverInstanceType.UNIVER_DOC,
+            { id: 'embedded-doc' },
+            { makeCurrent: false, skipAutoRender: true, embeddedRender: true }
+        );
+        instanceService.focusUnit(embeddedDoc.getUnitId());
+        instanceService.disposeUnit(backgroundSheet.getUnitId());
+
+        expect(rootDoc.getUnitId()).toBe('root-doc');
+        expect(states).toEqual([
+            null,
+            UniverInstanceType.UNIVER_DOC,
+            UniverInstanceType.UNIVER_SHEET,
+            null,
+        ]);
     });
 });

--- a/packages/ui/src/services/workbench/workbench.service.ts
+++ b/packages/ui/src/services/workbench/workbench.service.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import type { IDisposable } from '@univerjs/core';
+import type { ICreateUnitOptions, IDisposable, UniverInstanceType } from '@univerjs/core';
 import type { Observable } from 'rxjs';
-import { createIdentifier, Disposable, toDisposable } from '@univerjs/core';
-import { BehaviorSubject } from 'rxjs';
+import { createIdentifier, Disposable, Inject, isInternalEditorID, IUniverInstanceService, toDisposable } from '@univerjs/core';
+import { BehaviorSubject, Subscription } from 'rxjs';
 
 export interface IWorkbenchService {
+    readonly rootUnitType$: Observable<UniverInstanceType | null>;
     readonly skeletonVisible$: Observable<boolean>;
 
     acquireSkeleton(): IDisposable;
@@ -29,9 +30,51 @@ export const IWorkbenchService = createIdentifier<IWorkbenchService>('univer.ui.
 
 export class WorkbenchService extends Disposable implements IWorkbenchService {
     private readonly _tokens = new Set<symbol>();
+    private readonly _subscriptions = new Subscription();
+    private _rootUnitId: string | null = null;
+    private readonly _rootUnitType$ = new BehaviorSubject<UniverInstanceType | null>(null);
     private readonly _skeletonVisible$ = new BehaviorSubject(false);
 
+    readonly rootUnitType$ = this._rootUnitType$.asObservable();
     readonly skeletonVisible$ = this._skeletonVisible$.asObservable();
+
+    constructor(@Inject(IUniverInstanceService) univerInstanceService: IUniverInstanceService) {
+        super();
+
+        this._subscriptions.add(univerInstanceService.unitAdded$.subscribe(({ unit, options }) => {
+            const unitId = unit.getUnitId();
+            if (options?.makeCurrent === false || !isWorkbenchRootUnit(unitId, options)) {
+                return;
+            }
+
+            this._setRootUnit(unitId, unit.type);
+        }));
+
+        this._subscriptions.add(univerInstanceService.focused$.subscribe((unitId) => {
+            if (!unitId) {
+                return;
+            }
+
+            const unit = univerInstanceService.getUnit(unitId);
+            if (unit && isWorkbenchRootUnit(unitId, univerInstanceService.getUnitCreateOptions(unitId) ?? undefined)) {
+                this._setRootUnit(unitId, unit.type);
+            }
+        }));
+
+        this._subscriptions.add(univerInstanceService.unitDisposed$.subscribe((unit) => {
+            const unitId = unit.getUnitId();
+            if (this._rootUnitId === unitId) {
+                this._setRootUnit(null, null);
+            }
+        }));
+    }
+
+    private _setRootUnit(unitId: string | null, unitType: UniverInstanceType | null): void {
+        this._rootUnitId = unitId;
+        if (this._rootUnitType$.getValue() !== unitType) {
+            this._rootUnitType$.next(unitType);
+        }
+    }
 
     acquireSkeleton(): IDisposable {
         const token = Symbol('workbench-skeleton');
@@ -51,8 +94,15 @@ export class WorkbenchService extends Disposable implements IWorkbenchService {
     }
 
     override dispose(): void {
-        super.dispose();
+        this._subscriptions.unsubscribe();
         this._tokens.clear();
+        this._rootUnitId = null;
+        this._rootUnitType$.complete();
         this._skeletonVisible$.complete();
+        super.dispose();
     }
+}
+
+function isWorkbenchRootUnit(unitId: string, options?: ICreateUnitOptions): boolean {
+    return !isInternalEditorID(unitId) && !options?.skipAutoRender && !options?.embeddedRender;
 }

--- a/packages/ui/src/views/workbench/__tests__/Workbench.spec.tsx
+++ b/packages/ui/src/views/workbench/__tests__/Workbench.spec.tsx
@@ -22,12 +22,18 @@ import type { IDisposable } from '@univerjs/core';
 import type { ComponentType } from 'react';
 import { act, cleanup, render } from '@testing-library/react';
 import {
+    ContextService,
+    DesktopLogService,
     IConfigService,
+    IContextService,
+    ILogService,
     Injector,
+    IUniverInstanceService,
     LifecycleService,
     LifecycleStages,
     LocaleService,
     ThemeService,
+    UniverInstanceService,
 } from '@univerjs/core';
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -67,6 +73,9 @@ describe('DesktopWorkbenchContent lifecycle', () => {
             }],
             [ThemeSwitcherService, { useValue: { injectThemeToHead: () => {} } }],
             [IConfigService, { useValue: { getConfig: () => ({ popupRootId: 'test-popup-root' }) } }],
+            [IContextService, { useClass: ContextService }],
+            [ILogService, { useClass: DesktopLogService }],
+            [IUniverInstanceService, { useClass: UniverInstanceService }],
             [IUIPartsService, { useClass: UIPartsService }],
             [IWorkbenchService, { useClass: WorkbenchService }],
             [ISidebarService, {


### PR DESCRIPTION
## Summary
- track the root workbench unit type in `WorkbenchService`
- show document and sheet surfaces only for their root workbench unit
- replace the document statistics popup with the shared design dropdown
- add root-unit and lifecycle regression coverage

## Validation
- pre-commit: `eslint --fix` passed
- `git diff --check` passed