### PR TITLE
fix(engine-render): sample deferred scrollbar seek rendering

### DIFF
--- a/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
+++ b/packages/engine-render/src/__tests__/engine-scene-viewport.spec.ts
@@ -452,35 +452,145 @@ describe('engine scene viewport extra', () => {
         engine.dispose();
     });
 
-    it('keeps expensive content stable until a large scrollbar seek settles', () => {
+    it('samples main content and row-header detail while expensive scrollbar seeking is deferred', () => {
+        const { engine, scene, viewport } = createFixture();
+        viewport.setViewportSize({ left: 40, width: 260 });
+        const rowHeaderViewport = new Viewport('viewRowBottom', scene, {
+            left: 0,
+            top: 0,
+            width: 40,
+            height: 180,
+            active: true,
+        });
+        const layer = scene.getLayer(1);
+        const engineCtx = engine.getCanvas().getContext();
+        const drawImageSpy = vi.spyOn(engineCtx, 'drawImage');
+        const renderSpy = vi.spyOn(layer, 'render');
+        const mainViewportRenderSpy = vi.spyOn(viewport, 'render');
+        const rowHeaderViewportRenderSpy = vi.spyOn(rowHeaderViewport, 'render');
+        const mainViewportInfoSpy = vi.spyOn(viewport, 'calcViewportInfo');
+        const clearCanvasSpy = vi.spyOn(engine, 'clearCanvas');
+        const nowSpy = vi.spyOn(Tools, 'now');
+        vi.spyOn(engine, 'getEstimatedFrameInterval').mockReturnValue(1000 / 120);
+        const updateScrollbarDrag = (scrollY: number) => {
+            viewport.scrollToViewportPos({ viewportScrollY: scrollY });
+            rowHeaderViewport.updateScrollVal({
+                scrollX: 0,
+                scrollY,
+                viewportScrollX: 0,
+                viewportScrollY: scrollY,
+            });
+            scene.updateScrollbarDrag(viewport);
+        };
+
+        nowSpy.mockReturnValueOnce(0).mockReturnValueOnce(32);
+        scene.render();
+        drawImageSpy.mockClear();
+        renderSpy.mockClear();
+        mainViewportRenderSpy.mockClear();
+        rowHeaderViewportRenderSpy.mockClear();
+        clearCanvasSpy.mockClear();
+
+        let now = 50;
+        nowSpy.mockImplementation(() => now);
+        scene.beginScrollbarDrag(viewport);
+        updateScrollbarDrag(240);
+        scene.render();
+
+        expect(renderSpy).toHaveBeenCalledTimes(1);
+        expect(mainViewportRenderSpy).toHaveBeenCalled();
+        expect(rowHeaderViewportRenderSpy).toHaveBeenCalled();
+        expect(mainViewportRenderSpy.mock.calls.every(([, , , viewportInfo]) =>
+            viewportInfo?.preserveRenderState && viewportInfo.renderViewportScrollY === 240)).toBe(true);
+        expect(clearCanvasSpy).not.toHaveBeenCalled();
+
+        renderSpy.mockClear();
+        mainViewportRenderSpy.mockClear();
+        rowHeaderViewportRenderSpy.mockClear();
+
+        now = 58;
+        updateScrollbarDrag(260);
+        scene.render();
+
+        expect(drawImageSpy).not.toHaveBeenCalled();
+        expect(renderSpy).not.toHaveBeenCalled();
+        expect(mainViewportRenderSpy).not.toHaveBeenCalled();
+        expect(rowHeaderViewportRenderSpy).not.toHaveBeenCalled();
+        expect(clearCanvasSpy).not.toHaveBeenCalled();
+
+        for (const [sampleTime, scrollY] of [
+            [66, 280],
+            [82, 300],
+            [98, 320],
+            [114, 340],
+            [130, 360],
+        ]) {
+            now = sampleTime;
+            updateScrollbarDrag(scrollY);
+            scene.render();
+            if (sampleTime < 130) {
+                expect(drawImageSpy).not.toHaveBeenCalled();
+            }
+        }
+
+        expect(renderSpy).toHaveBeenCalledTimes(5);
+        expect(mainViewportRenderSpy).toHaveBeenCalled();
+        expect(rowHeaderViewportRenderSpy).toHaveBeenCalled();
+        expect(mainViewportRenderSpy.mock.calls.every(([, , , viewportInfo]) =>
+            viewportInfo?.preserveRenderState && viewportInfo.renderViewportScrollY === 240)).toBe(true);
+        expect(drawImageSpy).toHaveBeenCalledTimes(2);
+
+        renderSpy.mockClear();
+        mainViewportInfoSpy.mockClear();
+        now = 138;
+        updateScrollbarDrag(100);
+        scene.endScrollbarDrag(viewport);
+        scene.render();
+
+        expect(clearCanvasSpy).toHaveBeenCalledTimes(1);
+        expect(renderSpy).toHaveBeenCalledTimes(1);
+        expect(mainViewportInfoSpy.mock.results.some(({ value }) => value?.isForceDirty)).toBe(true);
+
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it('preserves after-render canvas mutations instead of replacing them with sampled frames', () => {
         const { engine, scene, viewport } = createFixture();
         const layer = scene.getLayer(1);
-        const renderSpy = vi.spyOn(layer, 'render');
+        const engineCtx = engine.getCanvas().getContext();
+        const subscription = scene.afterRender$.subscribe((canvas) => {
+            canvas?.getContext().fillText('viewport overlay', 10, 10);
+        });
         const nowSpy = vi.spyOn(Tools, 'now');
         vi.spyOn(engine, 'getEstimatedFrameInterval').mockReturnValue(1000 / 120);
 
-        nowSpy.mockReturnValueOnce(0).mockReturnValueOnce(40);
+        nowSpy.mockReturnValueOnce(0).mockReturnValueOnce(32);
         scene.render();
-        renderSpy.mockClear();
 
+        const drawImageSpy = vi.spyOn(engineCtx, 'drawImage');
+        const renderSpy = vi.spyOn(layer, 'render');
         let now = 50;
         nowSpy.mockImplementation(() => now);
         scene.beginScrollbarDrag(viewport);
         viewport.scrollToViewportPos({ viewportScrollY: 240 });
         scene.updateScrollbarDrag(viewport);
         scene.render();
-        expect(renderSpy).not.toHaveBeenCalled();
 
-        now = 220;
+        now = 114;
         viewport.scrollToViewportPos({ viewportScrollY: 300 });
         scene.updateScrollbarDrag(viewport);
         scene.render();
+
+        expect(drawImageSpy).not.toHaveBeenCalled();
         expect(renderSpy).not.toHaveBeenCalled();
 
-        now = 284;
+        now = 122;
+        scene.endScrollbarDrag(viewport);
         scene.render();
         expect(renderSpy).toHaveBeenCalledTimes(1);
 
+        subscription.unsubscribe();
         scene.dispose();
         engine.dispose();
     });

--- a/packages/engine-render/src/__tests__/layer.spec.ts
+++ b/packages/engine-render/src/__tests__/layer.spec.ts
@@ -183,6 +183,38 @@ describe('layer', () => {
         layer.dispose();
     });
 
+    it('renders only sampled viewports without consuming the pending full render', () => {
+        const scene = createScene();
+        const sampledViewport = {
+            viewportKey: 'sampled',
+            shouldIntoRender: vi.fn(() => true),
+            render: vi.fn(),
+        };
+        scene.getViewports = vi.fn(() => [scene.__viewport, sampledViewport]);
+        const object = new TestObject('sampled-object', 1);
+        const layer = new Layer(scene, [object], 1, true);
+        const ctx = createCtx();
+        scene.__resizeCache();
+
+        layer.render(ctx, false, {
+            dirtyBounds: [{ left: 0, top: 0, right: 40, bottom: 90 }],
+            preserveCache: true,
+            preserveDirty: true,
+            viewportKeys: new Set(['sampled']),
+        });
+
+        expect(scene.__viewport.render).not.toHaveBeenCalled();
+        expect(sampledViewport.render).toHaveBeenCalledTimes(1);
+        expect(layer.isDirty()).toBe(true);
+        expect(object.isDirty()).toBe(true);
+
+        layer.render(ctx);
+        expect(scene.__viewport.render).toHaveBeenCalledTimes(1);
+        expect(layer.isDirty()).toBe(false);
+
+        layer.dispose();
+    });
+
     it('uses cache canvas rendering, resizing and disposal paths', () => {
         const scene = createScene();
         const object = new TestObject('cached', 1);

--- a/packages/engine-render/src/basics/vector2.ts
+++ b/packages/engine-render/src/basics/vector2.ts
@@ -887,6 +887,11 @@ export interface IViewportInfo {
     sceneTrans: Transform;
     cacheCanvas?: Canvas;
 
+    // Snapshot render passes can override the live scroll offset without advancing viewport caches or dirty state.
+    preserveRenderState?: boolean;
+    renderViewportScrollX?: number;
+    renderViewportScrollY?: number;
+
     leftOrigin: number;
     topOrigin: number;
 

--- a/packages/engine-render/src/layer.ts
+++ b/packages/engine-render/src/layer.ts
@@ -33,7 +33,9 @@ export interface IScrollRenderInfo {
 export interface ILayerRenderOptions {
     dirtyBounds?: IBoundRectNoAngle[];
     preserveCache?: boolean;
+    preserveDirty?: boolean;
     viewportInfos?: Map<string, IViewportInfo>;
+    viewportKeys?: ReadonlySet<string>;
 }
 
 function clipContextToBounds(ctx: UniverRenderingContext, bounds: IBoundRectNoAngle[]) {
@@ -304,16 +306,18 @@ export class Layer extends Disposable {
     render(parentCtx?: UniverRenderingContext, isMaxLayer = false, options: ILayerRenderOptions = {}) {
         const mainCtx = parentCtx || this._scene.getEngine()?.getCanvas().getContext();
         if (mainCtx) {
-            const { dirtyBounds, preserveCache = false, viewportInfos } = options;
+            const { dirtyBounds, preserveCache = false, preserveDirty = false, viewportInfos, viewportKeys } = options;
             if (this._allowCache && this._cacheCanvas) {
                 if (preserveCache && dirtyBounds) {
                     mainCtx.save();
                     clipContextToBounds(mainCtx, dirtyBounds);
-                    this._draw(mainCtx, isMaxLayer, viewportInfos);
+                    this._draw(mainCtx, isMaxLayer, viewportInfos, viewportKeys, preserveDirty);
                     mainCtx.restore();
                     // The visible frame is current, but the offscreen layer cache still represents the pre-scroll frame.
                     this._cacheValid = false;
-                    this.makeDirty(false);
+                    if (!preserveDirty) {
+                        this.makeDirty(false);
+                    }
                     return this;
                 }
                 if (this.isDirty() || !this._cacheValid) {
@@ -324,7 +328,7 @@ export class Layer extends Disposable {
                     ctx.save();
 
                     ctx.setTransform(mainCtx.getTransform());
-                    this._draw(ctx, isMaxLayer, viewportInfos);
+                    this._draw(ctx, isMaxLayer, viewportInfos, viewportKeys, preserveDirty);
 
                     ctx.restore();
                     this._cacheValid = true;
@@ -335,12 +339,14 @@ export class Layer extends Disposable {
                 if (dirtyBounds) {
                     clipContextToBounds(mainCtx, dirtyBounds);
                 }
-                this._draw(mainCtx, isMaxLayer, viewportInfos);
+                this._draw(mainCtx, isMaxLayer, viewportInfos, viewportKeys, preserveDirty);
                 mainCtx.restore();
             }
         }
 
-        this.makeDirty(false);
+        if (!options.preserveDirty) {
+            this.makeDirty(false);
+        }
         return this;
     }
 
@@ -368,16 +374,26 @@ export class Layer extends Disposable {
         this._cacheValid = false;
     }
 
-    private _draw(mainCtx: UniverRenderingContext, isMaxLayer: boolean, viewportInfos?: Map<string, IViewportInfo>) {
-        const viewports = this._scene.getViewports().filter((vp) => vp.shouldIntoRender());
+    private _draw(
+        mainCtx: UniverRenderingContext,
+        isMaxLayer: boolean,
+        viewportInfos?: Map<string, IViewportInfo>,
+        viewportKeys?: ReadonlySet<string>,
+        preserveDirty = false
+    ) {
+        const viewports = this._scene
+            .getViewports()
+            .filter((viewport) => viewport.shouldIntoRender() && (viewportKeys == null || viewportKeys.has(viewport.viewportKey)));
         const objects = this.getObjectsByOrder();
         for (const [_index, vp] of viewports.entries()) {
             vp.render(mainCtx, objects, isMaxLayer, viewportInfos?.get(vp.viewportKey));
         }
-        objects.forEach((o) => {
-            o.makeDirty(false);
-            o.makeForceDirty?.(false);
-        });
+        if (!preserveDirty) {
+            objects.forEach((o) => {
+                o.makeDirty(false);
+                o.makeForceDirty?.(false);
+            });
+        }
     }
 
     private _applyCache(ctx?: UniverRenderingContext) {

--- a/packages/engine-render/src/scene.ts
+++ b/packages/engine-render/src/scene.ts
@@ -20,7 +20,6 @@ import type { IDragEvent, IMouseEvent, IPointerEvent, IWheelEvent } from './basi
 import type { ISceneTransformState, ITransformChangeState } from './basics/interfaces';
 import type { ITransformerConfig } from './basics/transformer-config';
 import type { IBoundRectNoAngle, IViewportInfo, Vector2 } from './basics/vector2';
-import type { Canvas } from './canvas';
 import type { UniverRenderingContext } from './context';
 import type { Engine } from './engine';
 import type { ILayerRenderOptions, IScrollRenderInfo } from './layer';
@@ -32,6 +31,7 @@ import { CURSOR_TYPE, RENDER_CLASS_TYPE } from './basics/const';
 import { TRANSFORM_CHANGE_OBSERVABLE_TYPE } from './basics/interfaces';
 import { precisionTo, requestNewFrame } from './basics/tools';
 import { Transform } from './basics/transform';
+import { Canvas } from './canvas';
 import { Layer, scrollAndClearCanvas } from './layer';
 import { InputManager } from './scene.input-manager';
 import { Transformer } from './scene.transformer';
@@ -42,6 +42,12 @@ const SCROLLBAR_SEEK_SETTLE_MS = 64;
 const SCROLLBAR_SEEK_EXPENSIVE_RENDER_MIN_MS = 32;
 const SCROLLBAR_SEEK_EXPENSIVE_RENDER_FRAME_INTERVALS = 2;
 const SCROLLBAR_SEEK_RENDER_COST_SAMPLE_WEIGHT = 0.25;
+// Keep seek previews visibly sampled while each tile stays within a 60 Hz frame budget.
+const SCROLLBAR_SEEK_SAMPLE_MIN_INTERVAL_MS = 16;
+const SCROLLBAR_SEEK_SAMPLE_COST_MULTIPLIER = 1;
+const SCROLLBAR_SEEK_SAMPLE_TARGET_DURATION_MS = 12;
+const SCROLLBAR_SEEK_SAMPLE_MIN_TILE_COUNT = 6;
+const SCROLLBAR_SEEK_SAMPLE_MAX_TILE_COUNT = 12;
 
 export interface ISceneInputControlOptions {
     enableDown: boolean;
@@ -69,6 +75,19 @@ interface IViewportScrollRenderState {
 interface IViewportScrollPosition {
     viewportScrollX: number;
     viewportScrollY: number;
+}
+
+interface IScrollbarSeekSampleViewportState {
+    bounds: IBoundRectNoAngle;
+    position: IViewportScrollPosition;
+    viewport: Viewport;
+    viewportInfo: IViewportInfo;
+}
+
+interface IScrollbarSeekSampleState {
+    tileCount: number;
+    tileIndex: number;
+    viewports: IScrollbarSeekSampleViewportState[];
 }
 
 function createExposedScrollBounds(bounds: IBoundRectNoAngle, offsetX: number, offsetY: number) {
@@ -151,6 +170,97 @@ function createViewportScrollRenderState(viewport: Viewport, scaleX: number, sca
     };
 }
 
+function createViewportRenderBounds(viewport: Viewport): IBoundRectNoAngle {
+    const scrollBar = viewport.getScrollBar();
+    return {
+        left: viewport.left,
+        top: viewport.top,
+        right: viewport.left + (viewport.width ?? 0) - (scrollBar?.enableVertical ? scrollBar.totalSize : 0),
+        bottom: viewport.top + (viewport.height ?? 0) - (scrollBar?.enableHorizontal ? scrollBar.totalSize : 0),
+    };
+}
+
+function copyCanvasBounds(source: Canvas, target: Canvas, bounds: IBoundRectNoAngle[]) {
+    const sourcePixelRatio = source.getPixelRatio();
+    const targetPixelRatio = target.getPixelRatio();
+    const targetCtx = target.getContext();
+    targetCtx.save();
+    targetCtx.setTransform(1, 0, 0, 1, 0, 0);
+    for (const bound of bounds) {
+        const width = bound.right - bound.left;
+        const height = bound.bottom - bound.top;
+        if (width <= 0 || height <= 0) {
+            continue;
+        }
+
+        targetCtx.save();
+        targetCtx.beginPath();
+        targetCtx.rect(
+            bound.left * targetPixelRatio,
+            bound.top * targetPixelRatio,
+            width * targetPixelRatio,
+            height * targetPixelRatio
+        );
+        targetCtx.clip();
+        targetCtx.drawImage(
+            source.getCanvasEle(),
+            bound.left * sourcePixelRatio,
+            bound.top * sourcePixelRatio,
+            width * sourcePixelRatio,
+            height * sourcePixelRatio,
+            bound.left * targetPixelRatio,
+            bound.top * targetPixelRatio,
+            width * targetPixelRatio,
+            height * targetPixelRatio
+        );
+        targetCtx.restore();
+    }
+    targetCtx.restore();
+}
+
+function createScrollbarSeekSampleTileBounds(bounds: IBoundRectNoAngle, tileIndex: number, tileCount: number) {
+    const height = bounds.bottom - bounds.top;
+    return {
+        ...bounds,
+        top: bounds.top + height * tileIndex / tileCount,
+        bottom: bounds.top + height * (tileIndex + 1) / tileCount,
+    };
+}
+
+function createScrollbarSeekSampleViewportInfo(
+    sampleViewport: IScrollbarSeekSampleViewportState,
+    tileBounds: IBoundRectNoAngle
+): IViewportInfo {
+    const { bounds, position, viewportInfo } = sampleViewport;
+    const height = bounds.bottom - bounds.top;
+    const topRatio = height === 0 ? 0 : (tileBounds.top - bounds.top) / height;
+    const bottomRatio = height === 0 ? 1 : (tileBounds.bottom - bounds.top) / height;
+    const viewBoundHeight = viewportInfo.viewBound.bottom - viewportInfo.viewBound.top;
+    const tileViewBound = {
+        ...viewportInfo.viewBound,
+        top: viewportInfo.viewBound.top + viewBoundHeight * topRatio,
+        bottom: viewportInfo.viewBound.top + viewBoundHeight * bottomRatio,
+    };
+
+    return {
+        ...viewportInfo,
+        allowCache: false,
+        cacheBound: tileViewBound,
+        cacheCanvas: undefined,
+        cacheViewPortPosition: tileBounds,
+        diffBounds: [tileViewBound],
+        diffCacheBounds: [tileViewBound],
+        isDirty: 0b10,
+        isForceDirty: true,
+        preserveRenderState: true,
+        renderViewportScrollX: position.viewportScrollX,
+        renderViewportScrollY: position.viewportScrollY,
+        shouldCacheUpdate: 0,
+        viewBound: tileViewBound,
+        viewPortPosition: tileBounds,
+    };
+}
+
 export class Scene extends Disposable {
     private _sceneKey: string = '';
     /**
@@ -175,7 +285,12 @@ export class Scene extends Disposable {
     private _isScrollbarPreviewDirty = false;
     private _lastScrollbarSeekInputAt = Number.NEGATIVE_INFINITY;
     private _estimatedFullRenderDuration = 0;
+    private _estimatedScrollbarSeekSampleDuration = 0;
+    private _lastScrollbarSeekSampleAt = Number.NEGATIVE_INFINITY;
     private _renderedViewportScrollPositions = new Map<string, IViewportScrollPosition>();
+    private _hasScrollbarSeekPartialRender = false;
+    private _scrollbarSeekSampleCanvas: Canvas | null = null;
+    private _scrollbarSeekSampleState: IScrollbarSeekSampleState | null = null;
 
     private _cursor: CURSOR_TYPE = CURSOR_TYPE.DEFAULT;
     private _defaultCursor: CURSOR_TYPE = CURSOR_TYPE.DEFAULT;
@@ -404,6 +519,8 @@ export class Scene extends Disposable {
         this._scrollbarDragViewport = viewport;
         this._isScrollbarSeeking = false;
         this._isScrollbarPreviewDirty = false;
+        this._lastScrollbarSeekSampleAt = Number.NEGATIVE_INFINITY;
+        this._disposeScrollbarSeekSample();
     }
 
     updateScrollbarDrag(viewport: Viewport) {
@@ -441,6 +558,7 @@ export class Scene extends Disposable {
         this._scrollbarDragViewport = null;
         this._isScrollbarSeeking = false;
         this._isScrollbarPreviewDirty = false;
+        this._disposeScrollbarSeekSample();
     }
 
     isScrollRenderPending() {
@@ -847,6 +965,7 @@ export class Scene extends Disposable {
             if (viewport.viewportKey === key) {
                 this._viewports.splice(i, 1);
                 this._renderedViewportScrollPositions.delete(key);
+                this._disposeScrollbarSeekSample();
                 if (viewport === this._scrollbarDragViewport) {
                     this._scrollbarDragViewport = null;
                     this._isScrollbarSeeking = false;
@@ -916,6 +1035,138 @@ export class Scene extends Disposable {
         this._isScrollbarPreviewDirty = false;
     }
 
+    private _getScrollbarSeekSampleViewports() {
+        return this._viewports.filter((viewport) => {
+            if (!viewport.shouldIntoRender()) {
+                return false;
+            }
+
+            const renderedPosition = this._renderedViewportScrollPositions.get(viewport.viewportKey);
+            return renderedPosition != null && (
+                renderedPosition.viewportScrollX !== viewport.viewportScrollX ||
+                renderedPosition.viewportScrollY !== viewport.viewportScrollY
+            );
+        });
+    }
+
+    private _shouldSampleDeferredScrollbarSeek(now: number) {
+        const sampleInterval = Math.max(
+            SCROLLBAR_SEEK_SAMPLE_MIN_INTERVAL_MS,
+            this._estimatedScrollbarSeekSampleDuration * SCROLLBAR_SEEK_SAMPLE_COST_MULTIPLIER
+        );
+        return now - this._lastScrollbarSeekSampleAt >= sampleInterval;
+    }
+
+    private _recordScrollbarSeekSampleDuration(duration: number) {
+        if (this._estimatedScrollbarSeekSampleDuration === 0) {
+            this._estimatedScrollbarSeekSampleDuration = duration;
+            return;
+        }
+
+        this._estimatedScrollbarSeekSampleDuration +=
+            (duration - this._estimatedScrollbarSeekSampleDuration) * SCROLLBAR_SEEK_RENDER_COST_SAMPLE_WEIGHT;
+    }
+
+    private _createScrollbarSeekSampleState(canvas: Canvas) {
+        const sampleViewports = this._getScrollbarSeekSampleViewports();
+        if (sampleViewports.length === 0) {
+            return;
+        }
+
+        const sampleCanvas = this._scrollbarSeekSampleCanvas ??= new Canvas({
+            colorService: this.getEngine()?.canvasColorService,
+        });
+        if (sampleCanvas.getWidth() !== canvas.getWidth() ||
+            sampleCanvas.getHeight() !== canvas.getHeight() ||
+            sampleCanvas.getPixelRatio() !== canvas.getPixelRatio()) {
+            sampleCanvas.setSize(canvas.getWidth(), canvas.getHeight(), canvas.getPixelRatio());
+        } else {
+            sampleCanvas.clear();
+        }
+
+        const tileCount = Tools.clamp(
+            Math.ceil(this._estimatedFullRenderDuration / SCROLLBAR_SEEK_SAMPLE_TARGET_DURATION_MS),
+            SCROLLBAR_SEEK_SAMPLE_MIN_TILE_COUNT,
+            SCROLLBAR_SEEK_SAMPLE_MAX_TILE_COUNT
+        );
+        return {
+            tileCount,
+            tileIndex: 0,
+            viewports: sampleViewports.map((viewport) => ({
+                bounds: createViewportRenderBounds(viewport),
+                position: {
+                    viewportScrollX: viewport.viewportScrollX,
+                    viewportScrollY: viewport.viewportScrollY,
+                },
+                viewport,
+                viewportInfo: viewport.calcViewportInfo(),
+            })),
+        } satisfies IScrollbarSeekSampleState;
+    }
+
+    private _recordCompletedScrollbarSeekSample(state: IScrollbarSeekSampleState) {
+        for (const { position, viewport } of state.viewports) {
+            this._renderedViewportScrollPositions.set(viewport.viewportKey, position);
+        }
+    }
+
+    private _disposeScrollbarSeekSample() {
+        this._scrollbarSeekSampleCanvas?.dispose();
+        this._scrollbarSeekSampleCanvas = null;
+        this._scrollbarSeekSampleState = null;
+    }
+
+    private _renderDeferredScrollbarSeekSample(canvas: Canvas, layers: Layer[], now: number) {
+        if (this._hasPostRenderCanvasMutation || !this._shouldSampleDeferredScrollbarSeek(now)) {
+            return;
+        }
+
+        const sampleState = this._scrollbarSeekSampleState ?? this._createScrollbarSeekSampleState(canvas);
+        if (!sampleState || !this._scrollbarSeekSampleCanvas) {
+            return;
+        }
+        this._scrollbarSeekSampleState = sampleState;
+
+        const sampleViewports = sampleState.viewports;
+        const dirtyBounds = sampleViewports.map(({ bounds }) => createScrollbarSeekSampleTileBounds(
+            bounds,
+            sampleState.tileIndex,
+            sampleState.tileCount
+        ));
+        const viewportKeys = new Set(sampleViewports.map(({ viewport }) => viewport.viewportKey));
+        const viewportInfos = new Map(sampleViewports.map((sampleViewport, index) => [
+            sampleViewport.viewport.viewportKey,
+            createScrollbarSeekSampleViewportInfo(sampleViewport, dirtyBounds[index]),
+        ]));
+        for (let i = 0, len = layers.length; i < len; i++) {
+            layers[i].render(this._scrollbarSeekSampleCanvas.getContext(), i === len - 1, {
+                dirtyBounds,
+                preserveCache: true,
+                preserveDirty: true,
+                viewportInfos,
+                viewportKeys,
+            });
+        }
+        sampleState.tileIndex += 1;
+        if (sampleState.tileIndex === sampleState.tileCount) {
+            const completedBounds = sampleViewports.map(({ bounds }) => bounds);
+            scrollAndClearCanvas(canvas.getContext(), canvas.getPixelRatio(), [], completedBounds);
+            copyCanvasBounds(this._scrollbarSeekSampleCanvas, canvas, completedBounds);
+            this._recordCompletedScrollbarSeekSample(sampleState);
+            this._scrollbarSeekSampleState = null;
+        }
+
+        const sampleFinishedAt = Tools.now();
+        this._lastScrollbarSeekSampleAt = sampleFinishedAt;
+        this._recordScrollbarSeekSampleDuration(sampleFinishedAt - now);
+        this._hasScrollbarSeekPartialRender = true;
+    }
+
+    private _renderDeferredScrollbarSeek(canvas: Canvas, layers: Layer[], now: number) {
+        this._renderDeferredScrollbarSeekSample(canvas, layers, now);
+        this.getEngine()?.renderFrameTags$.next(['scrollDetailDeferred', true]);
+    }
+
     private _shouldDeferScrollbarSeekRender(now: number) {
         if (!this._isScrollbarSeeking) {
             return false;
@@ -964,6 +1215,23 @@ export class Scene extends Disposable {
         return canvasInstance.getContext().detectBitmapMutation(() => this._afterRender$.next(canvasInstance));
     }
 
+    private _isEngineBitmapReusable() {
+        return !this._hasScrollbarSeekPartialRender && !this._hasPostRenderCanvasMutation;
+    }
+
+    private _forceRefreshAfterScrollbarSeekPreview() {
+        if (!this._hasScrollbarSeekPartialRender) {
+            return;
+        }
+
+        // The visible engine contains a sampled preview, so settling must rebuild the complete frame and caches.
+        for (const viewport of this._viewports) {
+            if (viewport.shouldIntoRender()) {
+                viewport.markForceDirty(true);
+            }
+        }
+    }
+
     render(parentCtx?: UniverRenderingContext) {
         if (!this.isDirty()) {
             return;
@@ -972,7 +1240,7 @@ export class Scene extends Disposable {
         const layers = this._layers.sort(sortRules);
         const canvasInstance = this.getEngine()?.getCanvas();
         const shouldTryPreservingEngine = this._preserveEngineOnRender &&
-            !this._hasPostRenderCanvasMutation &&
+            this._isEngineBitmapReusable() &&
             parentCtx == null &&
             canvasInstance != null;
         const isScrollbarSeekRender = this._isScrollbarSeeking && parentCtx == null && canvasInstance != null;
@@ -982,9 +1250,11 @@ export class Scene extends Disposable {
             this._renderScrollbarSeekPreview(canvasInstance);
         }
         if (isScrollbarSeekRender && this._shouldDeferScrollbarSeekRender(fullRenderStartedAt)) {
-            this.getEngine()?.renderFrameTags$.next(['scrollDetailDeferred', true]);
+            this._renderDeferredScrollbarSeek(canvasInstance, layers, fullRenderStartedAt);
             return;
         }
+
+        this._forceRefreshAfterScrollbarSeekPreview();
 
         this._preserveEngineOnRender = false;
         let layerRenderOptions: ILayerRenderOptions | undefined;
@@ -1018,6 +1288,8 @@ export class Scene extends Disposable {
         }
         this._hasPostRenderCanvasMutation = this._notifyAfterRender(canvasInstance);
         this._recordRenderedViewportScrollPositions();
+        this._disposeScrollbarSeekSample();
+        this._hasScrollbarSeekPartialRender = false;
         if (shouldMeasureFullRender) {
             this._recordFullRenderDuration(Tools.now() - fullRenderStartedAt, isScrollbarSeekRender);
         }
@@ -1195,6 +1467,7 @@ export class Scene extends Disposable {
         this.clearLayer();
         this.clearViewports();
         this._renderedViewportScrollPositions.clear();
+        this._disposeScrollbarSeekSample();
         this._scrollbarDragViewport = null;
         this.detachControl();
         this.onTransformChange$?.complete();

--- a/packages/engine-render/src/viewport.ts
+++ b/packages/engine-render/src/viewport.ts
@@ -767,7 +767,9 @@ export class Viewport {
         // this._scene.transform --> [scale, 0, 0, scale, - viewportScrollX * scaleX, - viewportScrollY * scaleY]
         // see transform.ts@multiply
         const sceneTrans = this._scene.transform.clone();
-        sceneTrans.multiply(Transform.create([1, 0, 0, 1, -this.viewportScrollX || 0, -this.viewportScrollY || 0]));
+        const viewportScrollX = viewportInfo?.renderViewportScrollX ?? this.viewportScrollX;
+        const viewportScrollY = viewportInfo?.renderViewportScrollY ?? this.viewportScrollY;
+        sceneTrans.multiply(Transform.create([1, 0, 0, 1, -viewportScrollX || 0, -viewportScrollY || 0]));
 
         // Logical translation & scaling, unrelated to dpr.
         const tm = sceneTrans.getMatrix();
@@ -790,13 +792,6 @@ export class Viewport {
             objects[i].render(mainCtx, viewPortInfo);
         }
 
-        this.markDirty(false);
-        this.markForceDirty(false);
-
-        this._preViewBound = this._viewBound;
-        if (viewPortInfo.shouldCacheUpdate) {
-            this.preCacheBound = this._cacheBound;
-        }
         mainCtx.restore();
 
         if (this._scrollBar && isMaxLayer) {
@@ -805,6 +800,20 @@ export class Viewport {
             mainCtx.transform(scrollbarTM[0], scrollbarTM[1], scrollbarTM[2], scrollbarTM[3], scrollbarTM[4], scrollbarTM[5]);
             this._drawScrollbar(mainCtx);
             mainCtx.restore();
+        }
+        this._updateRenderState(viewPortInfo);
+    }
+
+    private _updateRenderState(viewportInfo: IViewportInfo) {
+        if (viewportInfo.preserveRenderState) {
+            return;
+        }
+
+        this.markDirty(false);
+        this.markForceDirty(false);
+        this._preViewBound = this._viewBound;
+        if (viewportInfo.shouldCacheUpdate) {
+            this.preCacheBound = this._cacheBound;
         }
         // TODO @lumixraku, preScrollX is also handled by updateScroll(), this method is empty.
         this._afterRender();


### PR DESCRIPTION
## Summary
- sample deferred scrollbar-seek rendering in bounded tiles
- preserve render state until the full frame settles
- cover sampled viewports and after-render canvas mutations

## Validation
- pre-commit eslint --fix passed
- rebased onto origin/dev