### PR TITLE
fix(ui): support reliable base attachment previews

### DIFF
--- a/packages/core/src/bases/typedef.ts
+++ b/packages/core/src/bases/typedef.ts
@@ -889,27 +889,6 @@ export type BaseHitTestResult =
         value: number;
     }
     | {
-        type: 'grid-attachment-add' | 'grid-attachment-expand';
-        tableId: TableId;
-        viewId: ViewId;
-        recordId: RecordId;
-        fieldId: FieldId;
-        cellRect: IBaseRect;
-        virtual?: boolean;
-    }
-    | {
-        type: 'grid-attachment-item';
-        tableId: TableId;
-        viewId: ViewId;
-        recordId: RecordId;
-        fieldId: FieldId;
-        cellRect: IBaseRect;
-        attachmentIndex: number;
-        attachmentId?: string;
-        attachmentPreviewable: boolean;
-        virtual?: boolean;
-    }
-    | {
         type: 'grid-row-header' | 'grid-row-checkbox';
         tableId: TableId;
         viewId: ViewId;

--- a/packages/core/src/bases/typedef.ts
+++ b/packages/core/src/bases/typedef.ts
@@ -889,6 +889,27 @@ export type BaseHitTestResult =
         value: number;
     }
     | {
+        type: 'grid-attachment-add' | 'grid-attachment-expand';
+        tableId: TableId;
+        viewId: ViewId;
+        recordId: RecordId;
+        fieldId: FieldId;
+        cellRect: IBaseRect;
+        virtual?: boolean;
+    }
+    | {
+        type: 'grid-attachment-item';
+        tableId: TableId;
+        viewId: ViewId;
+        recordId: RecordId;
+        fieldId: FieldId;
+        cellRect: IBaseRect;
+        attachmentIndex: number;
+        attachmentId?: string;
+        attachmentPreviewable: boolean;
+        virtual?: boolean;
+    }
+    | {
         type: 'grid-row-header' | 'grid-row-checkbox';
         tableId: TableId;
         viewId: ViewId;

--- a/packages/ui/src/services/gallery/__tests__/desktop-gallery.service.spec.ts
+++ b/packages/ui/src/services/gallery/__tests__/desktop-gallery.service.spec.ts
@@ -44,6 +44,17 @@ describe('DesktopGalleryService', () => {
         sub.unsubscribe();
     });
 
+    it('replays the open state when the global gallery UI subscribes after the first open', () => {
+        const service = createService();
+        service.open({ images: ['a.png'] });
+        const snapshots: IGalleryProps[] = [];
+
+        const sub = service.gallery$.subscribe((value) => snapshots.push(value));
+
+        expect(snapshots).toEqual([{ open: true, images: ['a.png'] }]);
+        sub.unsubscribe();
+    });
+
     it('completes gallery state when the open handle is disposed', () => {
         const service = createService();
         let completed = false;

--- a/packages/ui/src/services/gallery/desktop-gallery.service.ts
+++ b/packages/ui/src/services/gallery/desktop-gallery.service.ts
@@ -18,7 +18,7 @@ import type { IDisposable } from '@univerjs/core';
 import type { IGalleryProps } from '@univerjs/design';
 import type { IGalleryService } from './gallery.service';
 import { Disposable, Inject, Injector, toDisposable } from '@univerjs/core';
-import { Subject } from 'rxjs';
+import { ReplaySubject } from 'rxjs';
 import { connectInjector } from '../../utils/di';
 import { GalleryPart } from '../../views/components/gallery-part/GalleryPart';
 import { BuiltInUIPart, IUIPartsService } from '../parts/parts.service';
@@ -33,7 +33,7 @@ export class DesktopGalleryService extends Disposable implements IGalleryService
         this._initUIPart();
     }
 
-    gallery$ = new Subject<IGalleryProps>();
+    gallery$ = new ReplaySubject<IGalleryProps>(1);
 
     override dispose(): void {
         super.dispose();


### PR DESCRIPTION
## Summary

- replay the Gallery open state so a lazily mounted global Gallery handles the first preview request
- cover the first-open regression with a focused UI service test

## Testing

- production UI typecheck with `tsc -p packages/ui/tsconfig.node.json --noEmit`
- `vitest run src/services/gallery/__tests__/desktop-gallery.service.spec.ts` (4 tests)
- `git diff --check`

No related GitHub issue. No breaking changes.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.