### PR TITLE
fix(ui): keep ribbon dropdowns open with disabled siblings

### DIFF
--- a/packages/ui/src/views/components/ribbon/TooltipButtonWrapper.tsx
+++ b/packages/ui/src/views/components/ribbon/TooltipButtonWrapper.tsx
@@ -47,6 +47,7 @@ const TooltipWrapperContext = createContext({
     setDropdownVisible: (_visible: boolean) => {},
 });
 
+// Ribbon dropdowns share one open key; disabled items must only clear it when they own it.
 const ToolbarDropdownContext = createContext<{
     openDropdownKey: string | null;
     setOpenDropdownKey: (key: string | null) => void;
@@ -158,10 +159,10 @@ export function DropdownWrapper(props: Omit<Partial<IDropdownProps>, 'overlay'> 
     const overlayRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        if (disabled) {
+        if (disabled && dropdownVisible) {
             setDropdownVisible(false);
         }
-    }, [disabled, setDropdownVisible]);
+    }, [disabled, dropdownVisible, setDropdownVisible]);
 
     useEffect(() => {
         const ownerDocument = triggerRef.current?.ownerDocument;
@@ -268,10 +269,10 @@ export function DropdownMenuWrapper({
     const { dropdownVisible, setDropdownVisible } = useContext(TooltipWrapperContext);
 
     useEffect(() => {
-        if (disabled) {
+        if (disabled && dropdownVisible) {
             setDropdownVisible(false);
         }
-    }, [disabled, setDropdownVisible]);
+    }, [disabled, dropdownVisible, setDropdownVisible]);
 
     const menuManagerService = useDependency(IMenuManagerService);
     const resolveMenuItems = () => menuId ? menuManagerService.getMenuByPositionKey(menuId) : [];

--- a/packages/ui/src/views/components/ribbon/__tests__/TooltipButtonWrapper.spec.tsx
+++ b/packages/ui/src/views/components/ribbon/__tests__/TooltipButtonWrapper.spec.tsx
@@ -135,6 +135,27 @@ describe('DropdownMenuLabel', () => {
 });
 
 describe('DropdownWrapper', () => {
+    it('keeps an enabled dropdown open when a sibling is disabled', () => {
+        const { getByRole, queryByText } = render(
+            <ToolbarDropdownProvider>
+                <TooltipWrapper dropdownKey="disabled-dropdown">
+                    <DropdownWrapper disabled overlay={<div>Disabled content</div>}>
+                        <button type="button">Disabled dropdown</button>
+                    </DropdownWrapper>
+                </TooltipWrapper>
+                <TooltipWrapper dropdownKey="enabled-dropdown">
+                    <DropdownWrapper overlay={<div>Enabled content</div>}>
+                        <button type="button">Enabled dropdown</button>
+                    </DropdownWrapper>
+                </TooltipWrapper>
+            </ToolbarDropdownProvider>
+        );
+
+        fireEvent.click(getByRole('button', { name: 'Enabled dropdown' }));
+
+        expect(queryByText('Enabled content')).not.toBeNull();
+    });
+
     it('opens toward the left in RTL layouts', async () => {
         const { findByText, getByRole } = render(
             <ConfigProvider direction="rtl" mountContainer={document.body}>


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #7596

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
