### PR TITLE
fix(drawing): stabilize nested JSON1 updates

### DIFF
--- a/packages/drawing/src/services/__tests__/drawing-manager-impl.service.spec.ts
+++ b/packages/drawing/src/services/__tests__/drawing-manager-impl.service.spec.ts
@@ -22,17 +22,28 @@ import { UnitDrawingService } from '../drawing-manager-impl.service';
 const unitId = 'unit';
 const subUnitId = 'subUnit';
 
-type SlideDrawingTestParam = IDrawingParam & {
+type NestedDrawingTestParam = IDrawingParam & {
     element: {
         name: string;
-        shapeData: { text: string };
+        shapeData: {
+            text: string;
+            fontFamily?: string;
+            dataModel?: {
+                horizontalAlign?: number;
+                doc: { body: { dataStream: string } };
+            };
+        };
+        style?: {
+            dash?: number[];
+            stroke?: string;
+        };
     };
 };
 
-function createSlideDrawingService(): UnitDrawingService<SlideDrawingTestParam> {
+function createNestedDrawingService(): UnitDrawingService<NestedDrawingTestParam> {
     const injector = new Injector();
     injector.add([UnitDrawingService]);
-    return injector.get<UnitDrawingService<SlideDrawingTestParam>>(UnitDrawingService);
+    return injector.get<UnitDrawingService<NestedDrawingTestParam>>(UnitDrawingService);
 }
 
 function createDrawing(drawingId: string, overrides: Partial<IDrawingParam> = {}): IDrawingParam {
@@ -137,7 +148,7 @@ describe('UnitDrawingService', () => {
     });
 
     it('preserves disjoint nested fields across concurrent drawing updates', () => {
-        const base: SlideDrawingTestParam = {
+        const base: NestedDrawingTestParam = {
             ...createDrawing('shape-1'),
             element: {
                 name: 'before',
@@ -145,8 +156,8 @@ describe('UnitDrawingService', () => {
             },
             transform: { height: 80, left: 100, top: 100, width: 200 },
         };
-        const textService = createSlideDrawingService();
-        const nameService = createSlideDrawingService();
+        const textService = createNestedDrawingService();
+        const nameService = createNestedDrawingService();
         [textService, nameService].forEach((drawingService) => {
             drawingService.applyJson1(unitId, subUnitId, drawingService.getBatchAddOp([base]).redo);
         });
@@ -187,6 +198,122 @@ describe('UnitDrawingService', () => {
                 transform: { left: 360 },
             });
         });
+    });
+
+    it('inserts nested drawing data when optional properties are undefined', () => {
+        const drawingService = createNestedDrawingService();
+        const base: NestedDrawingTestParam = {
+            ...createDrawing('shape-with-text'),
+            element: {
+                name: 'shape',
+                shapeData: { text: 'before' },
+            },
+        };
+        drawingService.applyJson1(unitId, subUnitId, drawingService.getBatchAddOp([base]).redo);
+
+        const updated: NestedDrawingTestParam = {
+            ...base,
+            element: {
+                ...base.element,
+                shapeData: {
+                    text: 'after',
+                    dataModel: {
+                        horizontalAlign: undefined,
+                        doc: { body: { dataStream: 'after\r\n' } },
+                    },
+                },
+            },
+        };
+        const updateOp = drawingService.getBatchUpdateOp([updated]);
+        drawingService.applyJson1(unitId, subUnitId, updateOp.redo);
+
+        expect(drawingService.getDrawingByParam(createSearch('shape-with-text'))).toMatchObject({
+            element: {
+                shapeData: {
+                    text: 'after',
+                    dataModel: {
+                        doc: { body: { dataStream: 'after\r\n' } },
+                    },
+                },
+            },
+        });
+    });
+
+    it('treats undefined drawing properties as absent when updating nested data', () => {
+        const drawingService = createNestedDrawingService();
+        const base: NestedDrawingTestParam = {
+            ...createDrawing('connector'),
+            element: {
+                name: 'connector',
+                shapeData: { text: '' },
+                style: {
+                    dash: undefined,
+                    stroke: '#000000',
+                },
+            },
+        };
+        drawingService.applyJson1(unitId, subUnitId, drawingService.getBatchAddOp([base]).redo);
+
+        const updated: NestedDrawingTestParam = {
+            ...base,
+            element: {
+                ...base.element,
+                style: {
+                    dash: [1, 6],
+                    stroke: '#00aa55',
+                },
+            },
+        };
+        const updateOp = drawingService.getBatchUpdateOp([updated]);
+        drawingService.applyJson1(unitId, subUnitId, updateOp.redo);
+
+        expect(drawingService.getDrawingByParam(createSearch('connector'))).toMatchObject({
+            element: {
+                style: {
+                    dash: [1, 6],
+                    stroke: '#00aa55',
+                },
+            },
+        });
+    });
+
+    it('updates drawing objects with non-enumerable runtime defaults atomically', () => {
+        const drawingService = createNestedDrawingService();
+        const shapeData = { text: 'before' };
+        Object.defineProperty(shapeData, 'fontFamily', {
+            configurable: true,
+            value: 'Calibri',
+            writable: true,
+        });
+        const base: NestedDrawingTestParam = {
+            ...createDrawing('shape-with-defaults'),
+            element: {
+                name: 'shape',
+                shapeData,
+            },
+        };
+        drawingService.applyJson1(unitId, subUnitId, drawingService.getBatchAddOp([base]).redo);
+
+        const updatedShapeData = { fontFamily: 'Inter', text: 'after' };
+        const updateOp = drawingService.getBatchUpdateOp([{
+            ...base,
+            element: {
+                ...base.element,
+                shapeData: updatedShapeData,
+            },
+        }]);
+        drawingService.applyJson1(unitId, subUnitId, updateOp.redo);
+
+        const updatedDrawing = drawingService.getDrawingByParam(createSearch('shape-with-defaults'));
+        expect(updatedDrawing?.element.shapeData).toMatchObject({
+            fontFamily: 'Inter',
+            text: 'after',
+        });
+
+        drawingService.applyJson1(unitId, subUnitId, updateOp.undo);
+        const restoredShapeData = drawingService.getDrawingByParam(createSearch('shape-with-defaults'))?.element.shapeData;
+        expect(restoredShapeData).toMatchObject({ text: 'before' });
+        expect(restoredShapeData).not.toHaveProperty('fontFamily');
     });
 
     it('preserves previous drawing data when docs replace a subunit snapshot', () => {

--- a/packages/drawing/src/services/drawing-manager-impl.service.ts
+++ b/packages/drawing/src/services/drawing-manager-impl.service.ts
@@ -95,16 +95,39 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
     return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function isJsonDocument(value: unknown): value is json1.Doc {
+function hasOnlyEnumerableOwnProperties(value: Record<string, unknown>): boolean {
+    return Object.getOwnPropertyNames(value).every((key) => Object.prototype.propertyIsEnumerable.call(value, key));
+}
+
+function createJsonRemoveOp(path: Array<number | string>, value: json1.Doc): JSONOp {
+    return json1.type.writeCursor().writeAtPath(path, 'r', value).get();
+}
+
+function normalizeJsonDocument(value: unknown): json1.Doc | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
     if (value === null || typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string') {
-        return true;
+        return value;
     }
 
     if (Array.isArray(value)) {
-        return value.every(isJsonDocument);
+        return value.map((item) => normalizeJsonDocument(item) ?? null);
     }
 
-    return isPlainObject(value) && Object.values(value).every(isJsonDocument);
+    if (!isPlainObject(value)) {
+        return undefined;
+    }
+
+    const normalizedValue: Record<string, json1.Doc> = {};
+    Object.entries(value).forEach(([key, item]) => {
+        const normalizedItem = normalizeJsonDocument(item);
+        if (normalizedItem !== undefined) {
+            normalizedValue[key] = normalizedItem;
+        }
+    });
+    return normalizedValue;
 }
 
 function appendJsonUpdateOps(
@@ -114,16 +137,20 @@ function appendJsonUpdateOps(
     oldValue: unknown,
     hasOldValue: boolean
 ): void {
-    if (hasOldValue && isJsonValueEqual(oldValue, newValue)) {
+    const normalizedOldValue = normalizeJsonDocument(oldValue);
+    const normalizedNewValue = normalizeJsonDocument(newValue);
+    const hasNormalizedOldValue = hasOldValue && normalizedOldValue !== undefined;
+
+    if (hasNormalizedOldValue && isJsonValueEqual(normalizedOldValue, normalizedNewValue)) {
         return;
     }
 
     if (
-        hasOldValue &&
-        oldValue != null &&
-        newValue != null &&
+        hasNormalizedOldValue &&
         isPlainObject(oldValue) &&
-        isPlainObject(newValue)
+        isPlainObject(newValue) &&
+        hasOnlyEnumerableOwnProperties(oldValue) &&
+        hasOnlyEnumerableOwnProperties(newValue)
     ) {
         const keys = new Set([...Object.keys(oldValue), ...Object.keys(newValue)]);
         keys.forEach((key) => appendJsonUpdateOps(
@@ -131,18 +158,16 @@ function appendJsonUpdateOps(
             [...path, key],
             newValue[key],
             oldValue[key],
-            Object.prototype.hasOwnProperty.call(oldValue, key)
+            Object.prototype.hasOwnProperty.call(oldValue, key) && oldValue[key] !== undefined
         ));
         return;
     }
 
-    const op = !hasOldValue
-        ? newValue === undefined || !isJsonDocument(newValue) ? null : json1.insertOp(path, newValue)
-        : newValue === undefined
-            ? json1.removeOp(path, true)
-            : isJsonDocument(oldValue) && isJsonDocument(newValue)
-                ? json1.replaceOp(path, oldValue, newValue)
-                : null;
+    const op = !hasNormalizedOldValue
+        ? normalizedNewValue === undefined ? null : json1.insertOp(path, normalizedNewValue)
+        : normalizedNewValue === undefined
+            ? createJsonRemoveOp(path, normalizedOldValue)
+            : json1.replaceOp(path, normalizedOldValue, normalizedNewValue);
     if (op && isNonEmptyOp(op)) {
         ops.push(op);
     }
@@ -1046,7 +1071,7 @@ export class UnitDrawingService<T extends IDrawingParam> implements IUnitDrawing
 
         const op = ops.reduce(json1.type.compose, null);
 
-        const invertOp = json1.type.invertWithDoc(op, this.drawingManagerData as unknown as json1.Doc);
+        const invertOp = json1.type.invert(op);
 
         return { op, invertOp };
     }


### PR DESCRIPTION
## Description

- Normalize drawing values at the JSON1 boundary so optional `undefined` properties do not suppress nested updates.
- Keep objects with non-enumerable runtime defaults atomic while preserving concurrent updates across ordinary JSON object fields.
- Build self-invertible remove operations so undo/redo does not depend on non-JSON runtime properties.

## How to test

- `pnpm --filter @univerjs/drawing test -- --reporter=dot`
- `pnpm --filter @univerjs/drawing typecheck`
- `pnpm exec eslint packages/drawing/src/services/drawing-manager-impl.service.ts packages/drawing/src/services/__tests__/drawing-manager-impl.service.spec.ts`
- Consumer regression: Univer Pro Boards Mind, Slides, Sheets Shape, Sheets Drawing, and Sheets Drawing UI suites.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (no related issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.
