### PR TITLE
fix(docs): preserve drawing selection during layout refresh

### DIFF
--- a/packages/docs-ui/src/controllers/render-controllers/__tests__/zoom.render-controller.spec.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/__tests__/zoom.render-controller.spec.ts
@@ -20,6 +20,7 @@ import { DocZoomRenderController, shouldHandleDocWheelZoom } from '../zoom.rende
 
 const mockSceneScale = vi.hoisted(() => vi.fn());
 const mockClearSelectedObjects = vi.hoisted(() => vi.fn());
+const mockSceneScaleState = vi.hoisted(() => ({ x: undefined as number | undefined, y: undefined as number | undefined }));
 
 vi.mock('../../../basics/component-tools', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../../basics/component-tools')>();
@@ -28,6 +29,12 @@ vi.mock('../../../basics/component-tools', async (importOriginal) => {
         ...actual,
         neoGetDocObject: () => ({
             scene: {
+                get scaleX() {
+                    return mockSceneScaleState.x;
+                },
+                get scaleY() {
+                    return mockSceneScaleState.y;
+                },
                 scale: mockSceneScale,
                 getTransformer: () => ({
                     clearSelectedObjects: mockClearSelectedObjects,
@@ -41,6 +48,8 @@ describe('DocZoomRenderController', () => {
     beforeEach(() => {
         mockSceneScale.mockClear();
         mockClearSelectedObjects.mockClear();
+        mockSceneScaleState.x = undefined;
+        mockSceneScaleState.y = undefined;
     });
 
     it('handles wheel zoom intent for focused modern docs', () => {
@@ -168,5 +177,77 @@ describe('DocZoomRenderController', () => {
         controller.updateViewZoom(1.25);
 
         expect(refreshSelection).not.toHaveBeenCalled();
+    });
+
+    it('preserves drawing selection during skeleton-only zoom refreshes', () => {
+        const controller = Object.create(DocZoomRenderController.prototype) as DocZoomRenderController;
+        Object.assign(controller, {
+            _context: {
+                unitId: 'doc-unit',
+                scene: {
+                    makeDirty: vi.fn(),
+                    render: vi.fn(),
+                },
+            },
+            _docViewScaleService: {
+                getViewScale: vi.fn(() => 1.875),
+            },
+            _editorService: {
+                isEditor: vi.fn(() => false),
+            },
+            _docPageLayoutService: {
+                calculatePagePosition: vi.fn(),
+            },
+            _textSelectionManagerService: {
+                refreshSelection: vi.fn(),
+            },
+            _embedInteractionBoundaryService: {
+                hasRecentInteraction: vi.fn(() => false),
+            },
+            _univerInstanceService: {
+                getUnitCreateOptions: vi.fn(() => undefined),
+            },
+        });
+
+        controller.updateViewZoom(1.25, false);
+
+        expect(mockClearSelectedObjects).not.toHaveBeenCalled();
+    });
+
+    it('preserves drawing selection when a repeated zoom operation keeps the same view scale', () => {
+        const controller = Object.create(DocZoomRenderController.prototype) as DocZoomRenderController;
+        mockSceneScaleState.x = 1.875;
+        mockSceneScaleState.y = 1.875;
+        Object.assign(controller, {
+            _context: {
+                unitId: 'doc-unit',
+                scene: {
+                    makeDirty: vi.fn(),
+                    render: vi.fn(),
+                },
+            },
+            _docViewScaleService: {
+                getViewScale: vi.fn(() => 1.875),
+            },
+            _editorService: {
+                isEditor: vi.fn(() => false),
+            },
+            _docPageLayoutService: {
+                calculatePagePosition: vi.fn(),
+            },
+            _textSelectionManagerService: {
+                refreshSelection: vi.fn(),
+            },
+            _embedInteractionBoundaryService: {
+                hasRecentInteraction: vi.fn(() => false),
+            },
+            _univerInstanceService: {
+                getUnitCreateOptions: vi.fn(() => undefined),
+            },
+        });
+
+        controller.updateViewZoom(1.25);
+
+        expect(mockClearSelectedObjects).not.toHaveBeenCalled();
     });
 });

--- a/packages/docs-ui/src/controllers/render-controllers/zoom.render-controller.ts
+++ b/packages/docs-ui/src/controllers/render-controllers/zoom.render-controller.ts
@@ -38,8 +38,8 @@ import { DocPageSetupCommand } from '../../commands/commands/doc-page-setup.comm
 import { SetDocZoomRatioCommand } from '../../commands/commands/set-doc-zoom-ratio.command';
 import { SwitchDocModeCommand } from '../../commands/commands/switch-doc-mode.command';
 import { SetDocZoomRatioOperation } from '../../commands/operations/set-doc-zoom-ratio.operation';
-import { DocPageLayoutService } from '../../services/doc-page-layout.service';
 import { IDocEmbedInteractionBoundaryService } from '../../services/doc-embed-integration.service';
+import { DocPageLayoutService } from '../../services/doc-page-layout.service';
 import { DocViewScaleService } from '../../services/doc-view-scale';
 import { DEFAULT_MODERN_DOC_ZOOM_RATIO, getDocEffectiveZoomRatio } from '../../services/doc-zoom';
 import { IEditorService } from '../../services/editor/editor-manager.service';
@@ -144,6 +144,7 @@ export class DocZoomRenderController extends Disposable implements IRenderModule
     updateViewZoom(zoomRatio: number, needRefreshSelection = true) {
         const docObject = neoGetDocObject(this._context);
         const viewScale = this._docViewScaleService.getViewScale(zoomRatio);
+        const viewScaleChanged = docObject.scene.scaleX !== viewScale || docObject.scene.scaleY !== viewScale;
         docObject.scene.scale(viewScale, viewScale);
 
         if (!this._editorService.isEditor(this._context.unitId)) {
@@ -158,7 +159,7 @@ export class DocZoomRenderController extends Disposable implements IRenderModule
             this._textSelectionManagerService.refreshSelection();
         }
 
-        if (!isInternalEditorID(this._context.unitId)) {
+        if (needRefreshSelection && viewScaleChanged && !isInternalEditorID(this._context.unitId)) {
             docObject.scene.getTransformer()?.clearSelectedObjects();
         }
 


### PR DESCRIPTION
Refs dream-num/univer-pro#5461

Preserve the active Doc drawing selection when a Worker skeleton publication only reapplies the current view scale. Repeated zoom operations that keep the same effective scale also leave the drawing selection intact, while real user zoom changes continue to clear and rebuild the controls.

Validation:
- `pnpm exec vitest run src/controllers/render-controllers/__tests__/zoom.render-controller.spec.ts --reporter=dot`
- `pnpm --filter @univerjs/docs-ui typecheck`
- `pnpm exec eslint packages/docs-ui/src/controllers/render-controllers/zoom.render-controller.ts packages/docs-ui/src/controllers/render-controllers/__tests__/zoom.render-controller.spec.ts`
- Pro embed E2E: Doc host Shape remains selected during layout publication and transfers toolbar ownership to an embedded Sheet runtime

No SDK dependency changes. This is the upstream SDK behavior required by dream-num/univer-pro#5461; merge this PR before the Pro PR receives the automated submodule update. No architecture documentation update is needed because this only narrows a destructive UI refresh side effect.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).