### PR TITLE
fix(core): expose NamedStyleType through FEnum

### DIFF
--- a/packages/core/src/facade/__tests__/f-enum.spec.ts
+++ b/packages/core/src/facade/__tests__/f-enum.spec.ts
@@ -39,6 +39,7 @@ import {
     LifecycleStages,
     LocaleType,
     MentionType,
+    NamedStyleType,
     NumberUnitType,
     PresetListType,
     ProtectionType,
@@ -75,6 +76,7 @@ describe('FEnum', () => {
         expect(facadeEnum.BaselineOffset).toBe(BaselineOffset);
         expect(facadeEnum.BooleanNumber).toBe(BooleanNumber);
         expect(facadeEnum.HorizontalAlign).toBe(HorizontalAlign);
+        expect(facadeEnum.NamedStyleType).toBe(NamedStyleType);
         expect(facadeEnum.SpacingRule).toBe(SpacingRule);
         expect(facadeEnum.NumberUnitType).toBe(NumberUnitType);
         expect(facadeEnum.PresetListType).toBe(PresetListType);

--- a/packages/core/src/facade/f-enum.ts
+++ b/packages/core/src/facade/f-enum.ts
@@ -40,6 +40,7 @@ import {
     LifecycleStages,
     LocaleType,
     MentionType,
+    NamedStyleType,
     NumberUnitType,
     PresetListType,
     ProtectionType,
@@ -241,6 +242,18 @@ export class FEnum {
      */
     get HorizontalAlign(): typeof HorizontalAlign {
         return HorizontalAlign;
+    }
+
+    /**
+     * Named paragraph style types
+     *
+     * @example
+     * ```ts
+     * console.log(univerAPI.Enum.NamedStyleType.HEADING_1);
+     * ```
+     */
+    get NamedStyleType(): typeof NamedStyleType {
+        return NamedStyleType;
     }
 
     /**


### PR DESCRIPTION
Related issue: [dream-num/univer-cli-sdk#20](https://github.com/dream-num/univer-cli-sdk/issues/20)

## Summary

- expose the existing `NamedStyleType` enum through `univerAPI.Enum`
- allow Facade-only execution environments to use values such as `univerAPI.Enum.NamedStyleType.HEADING_1` when setting `IParagraphStyle.namedStyleType`
- add a regression assertion to the core `FEnum` surface test

This does not change any `NamedStyleType` values or document-model behavior.

## Testing

- `pnpm --filter @univerjs/core test -- src/facade/__tests__/f-enum.spec.ts`
- `pnpm --filter @univerjs/core typecheck`
- `pnpm --filter @univerjs/core build`
- `pnpm lint`

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.