### PR TITLE
fix(docs): defer incompatible continuous publications

### DIFF
--- a/packages/engine-render/src/__tests__/worker-layout.spec.ts
+++ b/packages/engine-render/src/__tests__/worker-layout.spec.ts
@@ -1530,7 +1530,7 @@ describe('worker document layout session', () => {
             },
         });
         let probeResult = session.step(probeGeneration, 0);
-        let deferredVerticalBoundaryMismatch = false;
+        let deferredBoundaryGeometryMismatch = false;
         for (let step = 0; step < 1_000 && !probeResult.progress.complete; step++) {
             const publication = probeResult.publication;
             if (publication?.kind === 'block') {
@@ -1541,17 +1541,19 @@ describe('worker document layout session', () => {
                 const workerBoundaryLine = transferredPublication.block.flow.lines[firstUnprotectedLineIndex - 1];
                 if (workerBoundaryLine != null) {
                     workerBoundaryLine.top += 1;
+                    workerBoundaryLine.lineHeight += 1;
+                    workerBoundaryLine.width = (workerBoundaryLine.width ?? 0) + 1;
                     expect(() => targetSkeleton.applyLayoutPublication(
                         transferredPublication,
                         probeResult.progress
                     )).not.toThrow();
-                    deferredVerticalBoundaryMismatch = true;
+                    deferredBoundaryGeometryMismatch = true;
                     break;
                 }
             }
             probeResult = session.step(probeGeneration, 0);
         }
-        expect(deferredVerticalBoundaryMismatch).toBe(true);
+        expect(deferredBoundaryGeometryMismatch).toBe(true);
         expect(targetSkeleton.getSkeletonData()?.pages[0]).toBe(protectedContinuousPage);
         targetSkeleton.cancelExternalLayout();
 

--- a/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
+++ b/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
@@ -2565,17 +2565,19 @@ export class DocumentSkeleton extends Skeleton {
             if (
                 mainBoundaryLine == null ||
                 mainBoundaryLine.st !== workerBoundaryLine.st ||
-                mainBoundaryLine.ed !== workerBoundaryLine.ed ||
-                mainBoundaryLine.lineHeight !== workerBoundaryLine.lineHeight ||
-                mainBoundaryLine.width !== workerBoundaryLine.width
+                mainBoundaryLine.ed !== workerBoundaryLine.ed
             ) {
                 throw new Error(`Continuous layout Main and Worker boundaries do not share the same continuation checkpoint: Main ${mainBoundaryLine?.st}:${mainBoundaryLine?.ed}@${mainBoundaryLine?.top}/${mainBoundaryLine?.lineHeight}/${mainBoundaryLine?.width}, Worker ${workerBoundaryLine.st}:${workerBoundaryLine.ed}@${workerBoundaryLine.top}/${workerBoundaryLine.lineHeight}/${workerBoundaryLine.width}.`);
             }
-            if (mainBoundaryLine.top !== workerBoundaryLine.top) {
-                // A Custom Block can finish measuring after Main publishes the
-                // interaction window but before Worker captures its viewport.
-                // The continuation identity still matches, while every absolute
-                // coordinate after it belongs to a different vertical geometry.
+            if (
+                mainBoundaryLine.top !== workerBoundaryLine.top ||
+                mainBoundaryLine.lineHeight !== workerBoundaryLine.lineHeight ||
+                mainBoundaryLine.width !== workerBoundaryLine.width
+            ) {
+                // A Custom Block, font, or host viewport can finish measuring
+                // after Main publishes the interaction window but before Worker
+                // captures its geometry. The continuation identity still matches,
+                // while every coordinate after it belongs to a different layout.
                 // Keep Main visible and commit the canonical Worker result only
                 // after completion instead of translating a partial collection of
                 // lines, tables, drawings, and column groups independently.


### PR DESCRIPTION
Refs dream-num/univer-cli#1188

When Main and Worker share the same continuous-layout text checkpoint but measure different geometry, keep the protected Main interaction window visible and defer the Worker publication until completion. This avoids treating late font, custom-block, or host-viewport measurements as fatal Worker failures. Text checkpoint mismatches remain fatal.

This is a follow-up required by dream-num/univer-pro#5461.

How to test:

- pnpm exec vitest run packages/engine-render/src/__tests__/worker-layout.spec.ts (10 passed)
- pnpm --filter @univerjs/engine-render typecheck
- pnpm exec eslint packages/engine-render/src/components/docs/layout/doc-skeleton.ts packages/engine-render/src/__tests__/worker-layout.spec.ts --max-warnings 0
- Pro embed smoke Doc Table peer-tab test repeated 10 times without retries (10 passed)

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes are introduced.