### PR TITLE
feat(clipboard): support external rich content and images

### DIFF
--- a/packages/docs-ui/src/index.ts
+++ b/packages/docs-ui/src/index.ts
@@ -208,7 +208,11 @@ export {
 export { menuSchema as DocsUIMenuSchema } from './menu/schema';
 export { UniverDocsUIPlugin } from './plugin';
 export * from './services';
-export { IDocClipboardService } from './services/clipboard/clipboard.service';
+export {
+    convertClipboardHtmlToDocumentData,
+    IDocClipboardService,
+    removeClipboardHtmlImages,
+} from './services/clipboard/clipboard.service';
 export type {
     IDocClipboardCopyContentContext,
     IDocClipboardHook,
@@ -226,6 +230,7 @@ export type {
     IDocClipboardPasteMutationInfoParams,
     IDocClipboardPasteMutationInfos,
 } from './services/clipboard/doc-paste-mutation-adapter.service';
+export { convertClipboardRtfToPlainText } from './services/clipboard/rtf-to-plain-text';
 export { convertBodyToHtml } from './services/clipboard/udm-to-html/convertor';
 export { DocHtmlExportService } from './services/clipboard/udm-to-html/doc-html-export.service';
 export type { DocHtmlExportTransformer } from './services/clipboard/udm-to-html/doc-html-export.service';

--- a/packages/docs-ui/src/services/clipboard/__tests__/clipboard.service.spec.ts
+++ b/packages/docs-ui/src/services/clipboard/__tests__/clipboard.service.spec.ts
@@ -28,6 +28,7 @@ import {
     IUniverInstanceService,
     SliceBodyType,
     UniverInstanceType,
+    validateDocBodyStructure,
 } from '@univerjs/core';
 import {
     DocSelectionManagerService,
@@ -41,11 +42,18 @@ import { IClipboardInterfaceService } from '@univerjs/ui';
 import { describe, expect, it, vi } from 'vitest';
 import { createCommandTestBed } from '../../../commands/commands/__tests__/create-command-test-bed';
 import { CutContentCommand, InnerPasteCommand } from '../../../commands/commands/clipboard.inner.command';
-import { DocClipboardService, getTableClipboardBodySlice, IDocClipboardService } from '../clipboard.service';
+import {
+    convertClipboardHtmlToDocumentData,
+    DocClipboardService,
+    getTableClipboardBodySlice,
+    IDocClipboardService,
+    removeClipboardHtmlImages,
+} from '../clipboard.service';
 import {
     DocClipboardPasteAdapterService,
     IDocClipboardPasteAdapterService,
 } from '../doc-paste-mutation-adapter.service';
+import { HtmlToUDMService } from '../html-to-udm/converter';
 import {
     createInternalClipboardFragment,
     DOC_INTERNAL_FRAGMENT_MIME,
@@ -73,6 +81,80 @@ class RejectingClipboardInterfaceService extends TestClipboardInterfaceService {
         throw new Error('clipboard write failed');
     }
 }
+
+describe('clipboard HTML helpers', () => {
+    it('creates a standalone rich-text document that can be opened by shape editors', () => {
+        const documentData = convertClipboardHtmlToDocumentData('<p><strong>Rich</strong> text</p>');
+        const body = documentData.body!;
+
+        expect(body.dataStream).toBe('Rich text\r\n');
+        expect(body.paragraphs?.some((paragraph) => paragraph.startIndex === body.dataStream.length - 2)).toBe(true);
+        expect(body.sectionBreaks?.some((sectionBreak) => sectionBreak.startIndex === body.dataStream.length - 1)).toBe(true);
+        expect(body.textRuns).toContainEqual(expect.objectContaining({ st: 0, ed: 4 }));
+    });
+
+    it('creates structurally valid quote and code blocks for shape editors', () => {
+        const documentData = convertClipboardHtmlToDocumentData(`
+            <blockquote><p>Quoted documentation</p></blockquote>
+            <pre><code>const value = 1;</code></pre>
+        `);
+
+        expect(validateDocBodyStructure(documentData.body!)).toEqual([]);
+    });
+
+    it('falls back to plain text when converted HTML metadata is structurally invalid', () => {
+        const convert = vi.spyOn(HtmlToUDMService.prototype, 'convert').mockReturnValue({
+            id: 'invalid-html',
+            body: {
+                dataStream: 'Readable content',
+                blockRanges: [{
+                    blockId: 'broken-block',
+                    blockType: DocumentBlockRangeType.QUOTE,
+                    startIndex: 0,
+                    endIndex: 15,
+                }],
+            },
+            documentStyle: {},
+        });
+
+        try {
+            const documentData = convertClipboardHtmlToDocumentData('<blockquote>Readable content</blockquote>');
+
+            expect(documentData.body?.dataStream).toBe('Readable content\r\n');
+            expect(documentData.body?.blockRanges).toBeUndefined();
+            expect(validateDocBodyStructure(documentData.body!)).toEqual([]);
+        } finally {
+            convert.mockRestore();
+        }
+    });
+
+    it('ignores HTML content hidden from the source page', () => {
+        const documentData = convertClipboardHtmlToDocumentData(`
+            <p>Visible content</p>
+            <p aria-hidden="true">ARIA hidden</p>
+            <p class="sr-only">Screen reader only</p>
+            <p hidden>Hidden attribute</p>
+            <p style="display: none !important">Display none</p>
+            <p style="visibility: hidden">Visibility hidden</p>
+        `);
+
+        expect(documentData.body?.dataStream).toContain('Visible content');
+        expect(documentData.body?.dataStream).not.toMatch(/ARIA hidden|Screen reader only|Hidden attribute|Display none|Visibility hidden/);
+    });
+
+    it('removes image elements without dropping Word style metadata', () => {
+        const html = '<html><head><style>.word { font-weight: bold; }</style></head><body><p class="word">Text<img src="data:image/png;base64,AA=="></p></body></html>';
+        const sanitized = removeClipboardHtmlImages(html);
+
+        expect(sanitized).toContain('.word { font-weight: bold; }');
+        expect(sanitized).toContain('<p class="word">Text</p>');
+        expect(sanitized).not.toContain('<img');
+    });
+
+    it('keeps HTML fragments as fragments when removing images', () => {
+        expect(removeClipboardHtmlImages('<b>Text</b><img src="data:image/png;base64,AA==">')).toBe('<b>Text</b>');
+    });
+});
 
 describe('DocClipboardService table copy helpers', () => {
     it('should keep table metadata when copying an entire selected docs table', () => {
@@ -953,8 +1035,16 @@ describe('DocClipboardService table copy helpers', () => {
             naturalHeight = 10;
             private _onload: (() => void) | null = null;
 
+            get src(): string {
+                return '';
+            }
+
             set src(_value: string) {
                 queueMicrotask(() => this._onload?.());
+            }
+
+            get onload(): (() => void) | null {
+                return this._onload;
             }
 
             set onload(value: (() => void) | null) {

--- a/packages/docs-ui/src/services/clipboard/__tests__/html-and-udm-convert.spec.ts
+++ b/packages/docs-ui/src/services/clipboard/__tests__/html-and-udm-convert.spec.ts
@@ -183,6 +183,13 @@ describe('test case in html and udm convert', () => {
             expect(udm.body?.dataStream).toBe('Nové místo Plasy parkoviště u lékařského domu\r');
         });
 
+        it('should preserve collapsed spaces between inline formatting runs', () => {
+            const convertor = new HtmlToUDMService();
+            const udm = convertor.convert('<p><b>Bold</b> <i>Italic</i> <span>Plain</span></p>');
+
+            expect(udm.body?.dataStream).toBe('Bold Italic Plain\r');
+        });
+
         it('should preserve Word mso spacer and tab runs', () => {
             const convertor = new HtmlToUDMService();
             const udm = convertor.convert('<p class="MsoNormal"><span>New</span><span style="mso-spacerun:yes">&nbsp;&nbsp;&nbsp;</span><span>place</span><span style="mso-tab-count:1">&nbsp;&nbsp;&nbsp;&nbsp;</span><span>Plasy</span></p>');

--- a/packages/docs-ui/src/services/clipboard/__tests__/rtf-to-plain-text.spec.ts
+++ b/packages/docs-ui/src/services/clipboard/__tests__/rtf-to-plain-text.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { convertClipboardRtfToPlainText } from '../rtf-to-plain-text';
+
+describe('convertClipboardRtfToPlainText', () => {
+    it('preserves Word text, line breaks, tabs, unicode, and escaped punctuation', () => {
+        const rtf = String.raw`{\rtf1\ansi\uc1{\fonttbl{\f0 Calibri;}}Hello\tab Word\par \u20013?\u25991? \'93quote\'94 \\ \{ok\}}`;
+
+        expect(convertClipboardRtfToPlainText(rtf)).toBe('Hello\tWord\n中文 “quote” \\ {ok}');
+    });
+
+    it('ignores non-text destinations and rejects non-RTF input', () => {
+        expect(convertClipboardRtfToPlainText(String.raw`{\rtf1 Before{\pict abc123}After}`)).toBe('BeforeAfter');
+        expect(convertClipboardRtfToPlainText('plain text')).toBe('');
+    });
+});

--- a/packages/docs-ui/src/services/clipboard/clipboard.service.ts
+++ b/packages/docs-ui/src/services/clipboard/clipboard.service.ts
@@ -21,6 +21,7 @@ import {
     BuildTextUtils,
     createIdentifier,
     createParagraphId,
+    createSectionId,
     DataStreamTreeTokenType,
     Disposable,
     DOC_RANGE_TYPE,
@@ -42,6 +43,7 @@ import {
     toDisposable,
     Tools,
     UniverInstanceType,
+    validateDocBodyStructure,
 } from '@univerjs/core';
 import {
     canEditDocumentTargets,
@@ -83,6 +85,82 @@ import { DocHtmlExportService } from './udm-to-html/doc-html-export.service';
 HtmlToUDMService.use(LarkPastePlugin);
 HtmlToUDMService.use(UniverPastePlugin);
 HtmlToUDMService.use(WordPastePlugin);
+
+export function convertClipboardHtmlToDocumentData(html: string, unitId = ''): Partial<IDocumentData> {
+    const documentData = new HtmlToUDMService().convert(html, { unitId });
+    const body = finalizeClipboardDocumentBody(documentData.body);
+    if (!body?.dataStream) {
+        return documentData;
+    }
+
+    if (validateDocBodyStructure(body).length === 0) {
+        return documentData;
+    }
+
+    const plainText = [
+        DataStreamTreeTokenType.COLUMN_GROUP_START,
+        DataStreamTreeTokenType.COLUMN_START,
+        DataStreamTreeTokenType.COLUMN_END,
+        DataStreamTreeTokenType.COLUMN_GROUP_END,
+        DataStreamTreeTokenType.CUSTOM_RANGE_START,
+        DataStreamTreeTokenType.CUSTOM_RANGE_END,
+        DataStreamTreeTokenType.COLUMN_BREAK,
+        DataStreamTreeTokenType.PAGE_BREAK,
+        DataStreamTreeTokenType.DOCS_END,
+        DataStreamTreeTokenType.CUSTOM_BLOCK,
+    ].reduce(
+        (text, token) => text.replaceAll(token, ''),
+        BuildTextUtils.transform.getPlainText(body.dataStream)
+    );
+    return {
+        id: documentData.id,
+        body: finalizeClipboardDocumentBody(BuildTextUtils.transform.fromPlainText(plainText)),
+        documentStyle: documentData.documentStyle,
+    };
+}
+
+function finalizeClipboardDocumentBody(body: IDocumentBody | undefined): IDocumentBody | undefined {
+    if (!body?.dataStream) {
+        return body;
+    }
+
+    if (!body.dataStream.endsWith('\r\n')) {
+        if (!body.dataStream.endsWith('\r')) {
+            body.dataStream += '\r';
+        }
+        body.dataStream += '\n';
+    }
+
+    normalizeBody(body);
+
+    const paragraphs = body.paragraphs ?? [];
+    const paragraphIndex = body.dataStream.length - 2;
+    if (!paragraphs.some((paragraph) => paragraph.startIndex === paragraphIndex)) {
+        paragraphs.push({
+            paragraphId: createParagraphId(new Set(paragraphs.map((paragraph) => paragraph.paragraphId))),
+            startIndex: paragraphIndex,
+        });
+        body.paragraphs = paragraphs;
+    }
+
+    const sectionBreaks = body.sectionBreaks ?? [];
+    const sectionBreakIndex = body.dataStream.length - 1;
+    if (!sectionBreaks.some((sectionBreak) => sectionBreak.startIndex === sectionBreakIndex)) {
+        sectionBreaks.push({
+            sectionId: createSectionId(new Set(sectionBreaks.map((sectionBreak) => sectionBreak.sectionId))),
+            startIndex: sectionBreakIndex,
+        });
+        body.sectionBreaks = sectionBreaks;
+    }
+
+    return body;
+}
+
+export function removeClipboardHtmlImages(html: string): string {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    doc.querySelectorAll('img, svg').forEach((image) => image.remove());
+    return /<(?:html|head)\b/i.test(html) ? doc.documentElement.outerHTML : doc.body.innerHTML;
+}
 
 export interface IClipboardPropertyItem { }
 
@@ -468,7 +546,7 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
                 segmentId,
                 textRanges,
             });
-        } catch (_) {
+        } catch {
             this._logService.error('[DocClipboardController]', 'clipboard is empty.');
             return false;
         }
@@ -683,13 +761,9 @@ export class DocClipboardService extends Disposable implements IDocClipboardServ
             }
         }
 
-        if (!_unitId) {
-            const currentDocInstance = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC);
-            const docUnitId = currentDocInstance?.getUnitId() || '';
-            _unitId = docUnitId;
-        }
-
-        const doc = this._htmlToUDM.convert(html, { unitId: _unitId });
+        const currentDocInstance = this._univerInstanceService.getCurrentUnitOfType(UniverInstanceType.UNIVER_DOC);
+        const unitId = _unitId || currentDocInstance?.getUnitId() || '';
+        const doc = this._htmlToUDM.convert(html, { unitId });
 
         if (copyId) {
             copyContentCache.set(copyId, doc);

--- a/packages/docs-ui/src/services/clipboard/html-to-udm/converter.ts
+++ b/packages/docs-ui/src/services/clipboard/html-to-udm/converter.ts
@@ -173,6 +173,8 @@ export class HtmlToUDMService {
                         ts: style,
                     });
                 }
+            } else if (node instanceof HTMLElement && isHiddenClipboardElement(node)) {
+                continue;
             } else if (node.nodeName === 'IMG') {
                 const element = node as HTMLImageElement;
                 const imageSourceType = element.dataset.imageSourceType ?? (element.src ? inferImageSourceType(element.src) : undefined);
@@ -260,9 +262,11 @@ export class HtmlToUDMService {
 
         const body = doc.body!;
         const startIndex = body.dataStream.length;
+        body.dataStream += DataStreamTreeTokenType.BLOCK_START;
         const text = node.textContent ?? '';
         body.dataStream += text;
         this._appendParagraph(doc, node);
+        body.dataStream += DataStreamTreeTokenType.BLOCK_END;
         body.blockRanges ??= [];
         body.blockRanges.push({
             blockId: generateRandomId(6),
@@ -279,7 +283,10 @@ export class HtmlToUDMService {
             return null;
         }
 
-        return doc.body!.dataStream.length;
+        const body = doc.body!;
+        const startIndex = body.dataStream.length;
+        body.dataStream += DataStreamTreeTokenType.BLOCK_START;
+        return startIndex;
     }
 
     private _processAfterStructuredBlock(node: HTMLElement, doc: Partial<IDocumentData>, startIndex: number | null): void {
@@ -289,6 +296,7 @@ export class HtmlToUDMService {
             return;
         }
 
+        body.dataStream += DataStreamTreeTokenType.BLOCK_END;
         body.blockRanges ??= [];
         body.blockRanges.push({
             blockId: generateRandomId(6),
@@ -665,7 +673,11 @@ function normalizeTextNode(node: ChildNode): string {
     }
 
     if (!hasExplicitSpacing) {
-        return '';
+        return /[ \r\n]/.test(value) &&
+            hasInlineTextSibling(node.previousSibling, 'previous') &&
+            hasInlineTextSibling(node.nextSibling, 'next')
+            ? ' '
+            : '';
     }
 
     return hasTextSibling(node.previousSibling, 'previous') && hasTextSibling(node.nextSibling, 'next') ? ' ' : '';
@@ -684,6 +696,25 @@ function hasTextSibling(node: ChildNode | null, direction: 'previous' | 'next'):
 
         if (current.nodeType === Node.ELEMENT_NODE && (current.textContent ?? '').trim()) {
             return true;
+        }
+
+        current = direction === 'previous' ? current.previousSibling : current.nextSibling;
+    }
+
+    return false;
+}
+
+function hasInlineTextSibling(node: ChildNode | null, direction: 'previous' | 'next'): boolean {
+    let current = node;
+    while (current) {
+        if (current.nodeType === Node.TEXT_NODE && current.nodeValue?.trim()) {
+            return true;
+        }
+        if (current.nodeType === Node.ELEMENT_NODE) {
+            const element = current as HTMLElement;
+            return !isDefaultParagraphElement(element) &&
+                !['BR', 'OL', 'PRE', 'TABLE', 'UL'].includes(element.tagName) &&
+                Boolean(element.textContent?.trim());
         }
 
         current = direction === 'previous' ? current.previousSibling : current.nextSibling;
@@ -959,6 +990,21 @@ function getStructuredBlockType(node: HTMLElement): DocumentBlockRangeType | nul
     }
 
     return null;
+}
+
+function isHiddenClipboardElement(node: HTMLElement): boolean {
+    if (node.hidden || node.getAttribute('aria-hidden')?.toLowerCase() === 'true') {
+        return true;
+    }
+
+    const classes = node.classList;
+    if (classes.contains('sr-only') || classes.contains('visually-hidden') || classes.contains('screen-reader-only')) {
+        return true;
+    }
+
+    const style = node.getAttribute('style') ?? '';
+    return /(?:^|;)\s*display\s*:\s*none(?:\s*!important)?\s*(?:;|$)/i.test(style) ||
+        /(?:^|;)\s*visibility\s*:\s*(?:hidden|collapse)(?:\s*!important)?\s*(?:;|$)/i.test(style);
 }
 
 function isDefaultParagraphElement(node: HTMLElement): boolean {

--- a/packages/docs-ui/src/services/clipboard/rtf-to-plain-text.ts
+++ b/packages/docs-ui/src/services/clipboard/rtf-to-plain-text.ts
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const SKIPPED_DESTINATIONS = new Set([
+    'colortbl',
+    'datastore',
+    'filetbl',
+    'fonttbl',
+    'header',
+    'headerf',
+    'headerl',
+    'headerr',
+    'info',
+    'listtable',
+    'listoverridetable',
+    'object',
+    'pict',
+    'stylesheet',
+    'themedata',
+]);
+
+const SYMBOLS: Record<string, string> = {
+    bullet: '\u2022',
+    emdash: '\u2014',
+    endash: '\u2013',
+    line: '\n',
+    lquote: '\u2018',
+    par: '\n',
+    rdblquote: '\u201D',
+    rquote: '\u2019',
+    tab: '\t',
+    ldblquote: '\u201C',
+};
+
+interface IRtfState {
+    skip: boolean;
+    unicodeFallbackLength: number;
+}
+
+export function convertClipboardRtfToPlainText(rtf: string): string {
+    if (!/^\s*\{\\rtf\d?/i.test(rtf)) {
+        return '';
+    }
+
+    const states: IRtfState[] = [{ skip: false, unicodeFallbackLength: 1 }];
+    let state = states[0];
+    let output = '';
+    let index = 0;
+    let unicodeFallbackRemaining = 0;
+
+    while (index < rtf.length) {
+        const character = rtf[index];
+        if (character === '{') {
+            state = { ...state };
+            states.push(state);
+            index += 1;
+            continue;
+        }
+        if (character === '}') {
+            if (states.length > 1) {
+                states.pop();
+                state = states[states.length - 1];
+            }
+            unicodeFallbackRemaining = 0;
+            index += 1;
+            continue;
+        }
+        if (character !== '\\') {
+            if (!state.skip && unicodeFallbackRemaining === 0 && character !== '\r' && character !== '\n') {
+                output += character;
+            } else if (unicodeFallbackRemaining > 0) {
+                unicodeFallbackRemaining -= 1;
+            }
+            index += 1;
+            continue;
+        }
+
+        const escaped = rtf[index + 1];
+        if (escaped === '\\' || escaped === '{' || escaped === '}') {
+            if (!state.skip && unicodeFallbackRemaining === 0) {
+                output += escaped;
+            } else if (unicodeFallbackRemaining > 0) {
+                unicodeFallbackRemaining -= 1;
+            }
+            index += 2;
+            continue;
+        }
+        if (escaped === '~' || escaped === '-' || escaped === '_') {
+            if (!state.skip && unicodeFallbackRemaining === 0) {
+                output += escaped === '~' ? '\u00A0' : escaped === '_' ? '\u2011' : '';
+            } else if (unicodeFallbackRemaining > 0) {
+                unicodeFallbackRemaining -= 1;
+            }
+            index += 2;
+            continue;
+        }
+        if (escaped === '*') {
+            state.skip = true;
+            index += 2;
+            continue;
+        }
+        if (escaped === "'") {
+            const hex = rtf.slice(index + 2, index + 4);
+            if (!state.skip && unicodeFallbackRemaining === 0 && /^[0-9a-f]{2}$/i.test(hex)) {
+                output += decodeWindows1252(Number.parseInt(hex, 16));
+            } else if (unicodeFallbackRemaining > 0) {
+                unicodeFallbackRemaining -= 1;
+            }
+            index += 4;
+            continue;
+        }
+
+        const control = /^\\([a-z]+)(-?\d+)? ?/i.exec(rtf.slice(index));
+        if (!control) {
+            index += 2;
+            continue;
+        }
+        const word = control[1].toLowerCase();
+        const parameter = control[2] === undefined ? undefined : Number(control[2]);
+        index += control[0].length;
+
+        if (SKIPPED_DESTINATIONS.has(word)) {
+            state.skip = true;
+            continue;
+        }
+        if (word === 'uc' && parameter !== undefined) {
+            state.unicodeFallbackLength = Math.max(0, parameter);
+            continue;
+        }
+        if (word === 'u' && parameter !== undefined && !state.skip) {
+            output += String.fromCharCode(parameter < 0 ? parameter + 0x10000 : parameter);
+            unicodeFallbackRemaining = state.unicodeFallbackLength;
+            continue;
+        }
+        if (!state.skip && SYMBOLS[word]) {
+            output += SYMBOLS[word];
+        }
+    }
+
+    return output;
+}
+
+function decodeWindows1252(code: number): string {
+    const replacements: Record<number, string> = {
+        0x80: '\u20AC',
+        0x82: '\u201A',
+        0x83: '\u0192',
+        0x84: '\u201E',
+        0x85: '\u2026',
+        0x86: '\u2020',
+        0x87: '\u2021',
+        0x88: '\u02C6',
+        0x89: '\u2030',
+        0x8A: '\u0160',
+        0x8B: '\u2039',
+        0x8C: '\u0152',
+        0x8E: '\u017D',
+        0x91: '\u2018',
+        0x92: '\u2019',
+        0x93: '\u201C',
+        0x94: '\u201D',
+        0x95: '\u2022',
+        0x96: '\u2013',
+        0x97: '\u2014',
+        0x98: '\u02DC',
+        0x99: '\u2122',
+        0x9A: '\u0161',
+        0x9B: '\u203A',
+        0x9C: '\u0153',
+        0x9E: '\u017E',
+        0x9F: '\u0178',
+    };
+
+    return replacements[code] ?? String.fromCharCode(code);
+}

--- a/packages/drawing-ui/src/index.ts
+++ b/packages/drawing-ui/src/index.ts
@@ -48,6 +48,16 @@ export { UniverDrawingUIPlugin } from './plugin';
 export { DrawingImageClipService, IMAGE_CLIP_SHAPE_PICKER_COMPONENT } from './services/drawing-image-clip.service';
 export type { ImageShapeClipDelegate } from './services/drawing-image-clip.service';
 export { DrawingRenderService } from './services/drawing-render.service';
+export {
+    extractClipboardHtmlImageFiles,
+    extractClipboardImageFiles,
+    extractClipboardTextImageFile,
+    isClipboardTextImage,
+    isImageOnlyClipboardHtml,
+    normalizeClipboardImageFile,
+    svgImageFileToDataUrl,
+    writeImageSourceToClipboard,
+} from './utils/clipboard-image';
 export { getUpdateParams } from './utils/get-update-params';
 export { ImageCropperObject } from './views/crop/image-cropper-object';
 export { COMPONENT_IMAGE_POPUP_MENU } from './views/image-popup-menu/component-name';

--- a/packages/drawing-ui/src/utils/__tests__/clipboard-image.spec.ts
+++ b/packages/drawing-ui/src/utils/__tests__/clipboard-image.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    extractClipboardHtmlImageFiles,
+    extractClipboardImageFiles,
+    extractClipboardTextImageFile,
+    normalizeClipboardImageFile,
+    svgImageFileToDataUrl,
+    writeImageSourceToClipboard,
+} from '../clipboard-image';
+
+describe('writeImageSourceToClipboard', () => {
+    const originalClipboardItem = globalThis.ClipboardItem;
+    const originalFetch = globalThis.fetch;
+    const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(globalThis.navigator, 'clipboard');
+
+    afterEach(() => {
+        vi.useRealTimers();
+        globalThis.ClipboardItem = originalClipboardItem;
+        globalThis.fetch = originalFetch;
+        if (originalClipboardDescriptor) {
+            Object.defineProperty(globalThis.navigator, 'clipboard', originalClipboardDescriptor);
+        } else {
+            delete (globalThis.navigator as { clipboard?: Clipboard }).clipboard;
+        }
+    });
+
+    it('writes a PNG source through the browser clipboard API', async () => {
+        const blob = new Blob(['png'], { type: 'image/png' });
+        const write = vi.fn(async (_items: ClipboardItem[]) => undefined);
+        globalThis.fetch = vi.fn(async () => new Response(blob, { status: 200 })) as typeof fetch;
+        globalThis.ClipboardItem = class ClipboardItemMock {
+            readonly types = ['image/png'];
+            readonly presentationStyle = 'unspecified' as const;
+
+            constructor(readonly data: Record<string, Blob | Promise<Blob>>) {}
+
+            async getType(type: string): Promise<Blob> {
+                return this.data[type];
+            }
+        } as unknown as typeof ClipboardItem;
+        Object.defineProperty(globalThis.navigator, 'clipboard', {
+            configurable: true,
+            value: { write },
+        });
+
+        await expect(writeImageSourceToClipboard('data:image/png;base64,cG5n')).resolves.toBe(true);
+        const item = write.mock.calls[0][0][0] as unknown as { data: Record<string, Promise<Blob>> };
+        const copiedBlob = await item.data['image/png'];
+        expect(copiedBlob).toMatchObject({ size: blob.size, type: blob.type });
+    });
+
+    it('returns false when binary clipboard writing is unavailable', async () => {
+        Object.defineProperty(globalThis.navigator, 'clipboard', {
+            configurable: true,
+            value: undefined,
+        });
+
+        await expect(writeImageSourceToClipboard('data:image/png;base64,cG5n')).resolves.toBe(false);
+    });
+
+    it('prefers image item files over the fallback file list', () => {
+        const itemImage = new File(['item'], 'item.png', { type: 'image/png' });
+        const fallbackImage = new File(['fallback'], 'fallback.png', { type: 'image/png' });
+        const clipboardData = {
+            files: [fallbackImage],
+            items: [{ kind: 'file', type: 'image/png', getAsFile: () => itemImage }],
+        } as unknown as DataTransfer;
+
+        expect(extractClipboardImageFiles(clipboardData)).toEqual([itemImage]);
+    });
+
+    it('recognizes image files whose clipboard MIME type is missing', () => {
+        const image = new File(['image'], 'clipboard-image.PNG');
+        const clipboardData = {
+            files: [image],
+            items: [],
+        } as unknown as DataTransfer;
+
+        expect(extractClipboardImageFiles(clipboardData)).toEqual([image]);
+    });
+
+    it('deduplicates HTML images and ignores images from hidden content', async () => {
+        globalThis.fetch = vi.fn(async () => new Response(new Blob(['png'], { type: 'image/png' }), { status: 200 })) as typeof fetch;
+
+        const files = await extractClipboardHtmlImageFiles(`
+            <img src="https://example.com/visible.png">
+            <img src="https://example.com/visible.png">
+            <div aria-hidden="true"><img src="https://example.com/hidden.png"></div>
+        `);
+
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+        expect(files).toHaveLength(1);
+    });
+
+    it('extracts lazy HTML images and inline SVG as image files', async () => {
+        globalThis.fetch = vi.fn(async () => new Response(new Blob(['png'], { type: 'image/png' }), { status: 200 })) as typeof fetch;
+
+        const files = await extractClipboardHtmlImageFiles(`
+            <img data-src="https://example.com/lazy.png">
+            <picture><source srcset="https://example.com/picture.png 1x"><img></picture>
+            <svg viewBox="0 0 10 10"><path d="M0 0h10v10z"></path></svg>
+        `);
+
+        expect(globalThis.fetch).toHaveBeenCalledWith('https://example.com/lazy.png', expect.anything());
+        expect(globalThis.fetch).toHaveBeenCalledWith('https://example.com/picture.png', expect.anything());
+        expect(files).toEqual([
+            expect.objectContaining({ type: 'image/png' }),
+            expect.objectContaining({ type: 'image/png' }),
+            expect.objectContaining({ type: 'image/svg+xml' }),
+        ]);
+    });
+
+    it('stops waiting for inaccessible HTML images', async () => {
+        vi.useFakeTimers();
+        globalThis.fetch = vi.fn((_input, init) => new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        })) as typeof fetch;
+
+        const result = extractClipboardHtmlImageFiles('<img src="https://example.com/blocked.png">');
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        await expect(result).resolves.toEqual([]);
+    });
+
+    it('restores a missing MIME type before image insertion', async () => {
+        const image = new File(['image'], 'clipboard-image.png');
+
+        await expect(normalizeClipboardImageFile(image)).resolves.toMatchObject({ type: 'image/png' });
+    });
+
+    it('keeps sanitized SVG images as vectors during normalization', async () => {
+        const image = new File([
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24z"/></svg>',
+        ], 'clipboard-image.svg', { type: 'image/svg+xml' });
+
+        const normalized = await normalizeClipboardImageFile(image);
+
+        expect(normalized).toMatchObject({ name: 'clipboard-image.svg', type: 'image/svg+xml' });
+        await expect(normalized?.text()).resolves.toContain('viewBox="0 0 24 24"');
+        await expect(svgImageFileToDataUrl(normalized!)).resolves.toMatch(/^data:image\/svg\+xml;charset=utf-8,/);
+    });
+
+    it('converts a pasted image data URL into a file', async () => {
+        const file = await extractClipboardTextImageFile('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=');
+
+        expect(file).toMatchObject({ name: 'pasted-image.svg', type: 'image/svg+xml' });
+    });
+
+    it('converts complete SVG text into a sanitized file', async () => {
+        const file = await extractClipboardTextImageFile(`
+            <svg onload="alert(1)" viewBox="0 0 24 24">
+                <script>alert(1)</script>
+                <style>.remote { fill: url(https://example.com/pixel.svg) }</style>
+                <image href="https://example.com/tracker.png" />
+                <use href="#safe-path" />
+                <path id="safe-path" onclick="alert(1)" style="fill:url(javascript:alert(1))" d="M0 0h24v24z"/>
+            </svg>
+        `);
+
+        expect(file).toMatchObject({ name: 'pasted-image.svg', type: 'image/svg+xml' });
+        await expect(file?.text()).resolves.not.toMatch(/script|onclick|example\.com|javascript:/);
+        await expect(file?.text()).resolves.toContain('href="#safe-path"');
+    });
+
+    it('keeps ordinary text as text', async () => {
+        await expect(extractClipboardTextImageFile('Use <svg> in this sentence.')).resolves.toBeNull();
+    });
+
+    it('rejects oversized raw SVG before parsing it', async () => {
+        const oversized = `<svg>${' '.repeat(5_000_000)}</svg>`;
+
+        await expect(extractClipboardTextImageFile(oversized)).resolves.toBeNull();
+    });
+});

--- a/packages/drawing-ui/src/utils/clipboard-image.ts
+++ b/packages/drawing-ui/src/utils/clipboard-image.ts
@@ -1,0 +1,368 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IImageIoService } from '@univerjs/core';
+import { ImageSourceType } from '@univerjs/core';
+
+const IMAGE_PNG_MIME_TYPE = 'image/png';
+const IMAGE_SVG_MIME_TYPE = 'image/svg+xml';
+const CLIPBOARD_HTML_IMAGE_FETCH_TIMEOUT = 5_000;
+const MAX_CLIPBOARD_HTML_IMAGE_COUNT = 32;
+const MAX_CLIPBOARD_SVG_SOURCE_LENGTH = 5_000_000;
+const MAX_CLIPBOARD_SVG_ELEMENT_COUNT = 50_000;
+const PASSTHROUGH_IMAGE_MIME_TYPES = [
+    IMAGE_PNG_MIME_TYPE,
+    'image/jpeg',
+    'image/jpg',
+    'image/gif',
+    'image/bmp',
+];
+const IMAGE_MIME_TYPES_BY_EXTENSION: Record<string, string> = {
+    avif: 'image/avif',
+    bmp: 'image/bmp',
+    gif: 'image/gif',
+    heic: 'image/heic',
+    ico: 'image/x-icon',
+    jpeg: 'image/jpeg',
+    jpg: 'image/jpeg',
+    png: IMAGE_PNG_MIME_TYPE,
+    svg: 'image/svg+xml',
+    tif: 'image/tiff',
+    tiff: 'image/tiff',
+    webp: 'image/webp',
+};
+
+export function extractClipboardImageFiles(clipboardData: DataTransfer): File[] {
+    const itemFiles = Array.from(clipboardData.items ?? [])
+        .filter((item) => item.kind === 'file')
+        .map((item) => item.getAsFile())
+        .filter((file): file is File => file !== null && isClipboardImageFile(file));
+
+    return itemFiles.length > 0
+        ? itemFiles
+        : Array.from(clipboardData.files ?? []).filter(isClipboardImageFile);
+}
+
+export function isClipboardTextImage(text: string): boolean {
+    const source = text.trim();
+    return /^data:image\/[a-z0-9.+-]+(?:;[^,]*)?,/i.test(source) ||
+        (/^<svg(?:\s|>)/i.test(source) && /<\/svg>$/i.test(source));
+}
+
+export async function extractClipboardTextImageFile(text: string): Promise<File | null> {
+    const source = text.trim();
+    if (/^data:image\/[a-z0-9.+-]+(?:;[^,]*)?,/i.test(source)) {
+        try {
+            const response = await fetch(source);
+            const blob = await response.blob();
+            const type = blob.type.split(';')[0].toLowerCase();
+            if (type === IMAGE_SVG_MIME_TYPE) {
+                const svg = parseSvg(await blob.text());
+                return svg ? new File([svg], 'pasted-image.svg', { type }) : null;
+            }
+            return type.startsWith('image/')
+                ? new File([blob], `pasted-image.${imageExtension(type)}`, { type })
+                : null;
+        } catch {
+            return null;
+        }
+    }
+
+    const svg = parseSvg(source);
+    return svg ? new File([svg], 'pasted-image.svg', { type: IMAGE_SVG_MIME_TYPE }) : null;
+}
+
+export function isImageOnlyClipboardHtml(html: string): boolean {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const body = doc.body.cloneNode(true) as HTMLElement;
+    const hasImage = body.querySelector('img, svg') !== null;
+    body.querySelectorAll('img, svg').forEach((element) => element.remove());
+    return hasImage && !(body.textContent ?? '').trim() && !body.querySelector('table');
+}
+
+export async function extractClipboardHtmlImageFiles(html: string): Promise<File[]> {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const sources = Array.from(new Set(Array.from(doc.body.querySelectorAll('img'))
+        .filter((image) => !hasHiddenClipboardAncestor(image))
+        .map(resolveClipboardHtmlImageSource)
+        .filter((source) => /^(?:data|blob|https?):/i.test(source))))
+        .slice(0, MAX_CLIPBOARD_HTML_IMAGE_COUNT);
+    const fetchedFiles = await Promise.all(sources.map(fetchClipboardImageFile));
+    const svgFiles = Array.from(doc.body.querySelectorAll('svg'))
+        .filter((svg) => !hasHiddenClipboardAncestor(svg))
+        .map((svg, index) => {
+            const source = parseSvg(new XMLSerializer().serializeToString(svg));
+            return source ? new File([source], `pasted-image-${index + 1}.svg`, { type: IMAGE_SVG_MIME_TYPE }) : null;
+        });
+
+    return [...fetchedFiles, ...svgFiles]
+        .filter((file): file is File => file !== null)
+        .slice(0, MAX_CLIPBOARD_HTML_IMAGE_COUNT);
+}
+
+function resolveClipboardHtmlImageSource(image: HTMLImageElement): string {
+    const source = image.getAttribute('src') ||
+        image.getAttribute('data-src') ||
+        image.getAttribute('data-lazy-src') ||
+        image.getAttribute('data-original');
+    if (source) {
+        return source.trim();
+    }
+
+    const srcset = image.getAttribute('srcset') ||
+        image.closest('picture')?.querySelector('source[srcset]')?.getAttribute('srcset') ||
+        '';
+    return (srcset.trim().split(/\s+/)[0] ?? '').replace(/,$/, '');
+}
+
+async function fetchClipboardImageFile(source: string): Promise<File | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), CLIPBOARD_HTML_IMAGE_FETCH_TIMEOUT);
+    try {
+        const response = await fetch(source, { signal: controller.signal });
+        if (!response.ok) {
+            return null;
+        }
+        const blob = await response.blob();
+        return blob.type.startsWith('image/')
+            ? new File([blob], `pasted-image.${imageExtension(blob.type)}`, { type: blob.type })
+            : null;
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+function hasHiddenClipboardAncestor(element: Element): boolean {
+    let current: Element | null = element;
+    while (current) {
+        if (current.hasAttribute('hidden') || current.getAttribute('aria-hidden')?.toLowerCase() === 'true') {
+            return true;
+        }
+        const classes = current.classList;
+        if (classes.contains('sr-only') || classes.contains('visually-hidden') || classes.contains('screen-reader-only')) {
+            return true;
+        }
+        const style = current.getAttribute('style') ?? '';
+        if (/(?:^|;)\s*display\s*:\s*none(?:\s*!important)?\s*(?:;|$)/i.test(style) ||
+            /(?:^|;)\s*visibility\s*:\s*(?:hidden|collapse)(?:\s*!important)?\s*(?:;|$)/i.test(style)) {
+            return true;
+        }
+        current = current.parentElement;
+    }
+
+    return false;
+}
+
+export async function normalizeClipboardImageFile(file: File): Promise<File | null> {
+    const type = resolveClipboardImageMimeType(file);
+    if (!type) {
+        return null;
+    }
+    const typedFile = file.type.toLowerCase() === type ? file : new File([file], file.name, { type });
+    if (type === IMAGE_SVG_MIME_TYPE) {
+        const svg = parseSvg(await typedFile.text());
+        return svg ? new File([svg], typedFile.name || 'pasted-image.svg', { type }) : null;
+    }
+    if (PASSTHROUGH_IMAGE_MIME_TYPES.includes(type)) {
+        return typedFile;
+    }
+
+    try {
+        const blob = await rasterizeImageBlob(typedFile);
+        return blob ? new File([blob], 'pasted-image.png', { type: IMAGE_PNG_MIME_TYPE }) : null;
+    } catch {
+        return null;
+    }
+}
+
+export async function svgImageFileToDataUrl(file: File): Promise<string | null> {
+    if (resolveClipboardImageMimeType(file) !== IMAGE_SVG_MIME_TYPE) {
+        return null;
+    }
+
+    const svg = parseSvg(await file.text());
+    return svg ? `data:${IMAGE_SVG_MIME_TYPE};charset=utf-8,${encodeURIComponent(svg)}` : null;
+}
+
+export async function writeImageSourceToClipboard(
+    source: string,
+    imageSourceType?: ImageSourceType,
+    imageIoService?: IImageIoService
+): Promise<boolean> {
+    const clipboard = globalThis.navigator?.clipboard;
+    const ClipboardItemCtor = globalThis.ClipboardItem;
+    if (!source || !clipboard?.write || typeof ClipboardItemCtor === 'undefined') {
+        return false;
+    }
+
+    try {
+        const pngBlob = resolveImageClipboardPng(source, imageSourceType, imageIoService);
+        await clipboard.write([new ClipboardItemCtor({ [IMAGE_PNG_MIME_TYPE]: pngBlob })]);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function resolveImageClipboardPng(
+    source: string,
+    imageSourceType: ImageSourceType | undefined,
+    imageIoService: IImageIoService | undefined
+): Promise<Blob> {
+    const resolvedSource = await resolveImageSource(source, imageSourceType, imageIoService);
+    if (!resolvedSource) {
+        throw new Error('Clipboard image source could not be resolved.');
+    }
+    const response = await fetch(resolvedSource);
+    if (!response.ok) {
+        throw new Error('Clipboard image source could not be loaded.');
+    }
+    const imageBlob = await response.blob();
+    const pngBlob = imageBlob.type === IMAGE_PNG_MIME_TYPE
+        ? imageBlob
+        : await rasterizeImageBlob(imageBlob);
+    if (!pngBlob) {
+        throw new Error('Clipboard image could not be converted to PNG.');
+    }
+
+    return pngBlob;
+}
+
+async function resolveImageSource(
+    source: string,
+    imageSourceType: ImageSourceType | undefined,
+    imageIoService: IImageIoService | undefined
+): Promise<string | null> {
+    if (/^(?:data|blob|https?):/i.test(source) && imageSourceType !== ImageSourceType.UUID) {
+        return source;
+    }
+
+    return imageIoService ? imageIoService.getImage(source) : null;
+}
+
+async function rasterizeImageBlob(blob: Blob): Promise<Blob | null> {
+    if (!blob.type.startsWith('image/')) {
+        return null;
+    }
+
+    const objectUrl = URL.createObjectURL(blob);
+    try {
+        const image = await loadImage(objectUrl);
+        if (image.naturalWidth === 0 || image.naturalHeight === 0) {
+            return null;
+        }
+        const canvas = document.createElement('canvas');
+        canvas.width = image.naturalWidth;
+        canvas.height = image.naturalHeight;
+        const context = canvas.getContext('2d');
+        if (!context) {
+            return null;
+        }
+        context.drawImage(image, 0, 0);
+        return new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, IMAGE_PNG_MIME_TYPE));
+    } finally {
+        URL.revokeObjectURL(objectUrl);
+    }
+}
+
+function loadImage(source: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+        const image = new Image();
+        image.onload = () => resolve(image);
+        image.onerror = () => reject(new Error('Clipboard image could not be decoded.'));
+        image.src = source;
+    });
+}
+
+function parseSvg(source: string): string | null {
+    if (source.length > MAX_CLIPBOARD_SVG_SOURCE_LENGTH ||
+        !isClipboardTextImage(source) ||
+        !/^<svg(?:\s|>)/i.test(source)) {
+        return null;
+    }
+
+    const doc = new DOMParser().parseFromString(source, IMAGE_SVG_MIME_TYPE);
+    const root = doc.documentElement;
+    if (root.localName.toLowerCase() !== 'svg' || doc.querySelector('parsererror')) {
+        return null;
+    }
+
+    const descendants = root.querySelectorAll('*');
+    if (descendants.length > MAX_CLIPBOARD_SVG_ELEMENT_COUNT) {
+        return null;
+    }
+    root.querySelectorAll('script, foreignObject, iframe, object, embed, link').forEach((element) => element.remove());
+    root.querySelectorAll('style').forEach((element) => {
+        if (hasUnsafeSvgCssReference(element.textContent ?? '')) {
+            element.remove();
+        }
+    });
+    [root, ...Array.from(root.querySelectorAll('*'))].forEach((element) => {
+        Array.from(element.attributes).forEach((attribute) => {
+            if (/^on/i.test(attribute.name)) {
+                element.removeAttribute(attribute.name);
+                return;
+            }
+            if (/^(?:href|xlink:href)$/i.test(attribute.name) && !isSafeSvgReference(attribute.value)) {
+                element.removeAttribute(attribute.name);
+                return;
+            }
+            if (hasUnsafeSvgCssReference(attribute.value)) {
+                element.removeAttribute(attribute.name);
+            }
+        });
+    });
+    if (!root.hasAttribute('xmlns')) {
+        root.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    }
+
+    return new XMLSerializer().serializeToString(root);
+}
+
+function isSafeSvgReference(value: string): boolean {
+    const reference = value.trim();
+    return reference.startsWith('#') || /^data:image\/(?:png|jpe?g|gif|webp);base64,/i.test(reference);
+}
+
+function hasUnsafeSvgCssReference(value: string): boolean {
+    if (/@import/i.test(value)) {
+        return true;
+    }
+
+    const references = value.match(/url\([^)]*\)/gi) ?? [];
+    return references.some((reference) => !/^url\(\s*['"]?#/i.test(reference));
+}
+
+function imageExtension(type: string): string {
+    const extension = type.split('/')[1] ?? 'png';
+    return extension === 'svg+xml' ? 'svg' : extension;
+}
+
+function isClipboardImageFile(file: File): boolean {
+    return resolveClipboardImageMimeType(file) !== null;
+}
+
+function resolveClipboardImageMimeType(file: File): string | null {
+    const type = file.type.toLowerCase();
+    if (type.startsWith('image/')) {
+        return type;
+    }
+
+    const extension = file.name.split('.').pop()?.toLowerCase();
+    return extension ? IMAGE_MIME_TYPES_BY_EXTENSION[extension] ?? null : null;
+}


### PR DESCRIPTION
## Description

- Add reusable clipboard image parsing for data URLs, inline SVG, HTML images, and browser clipboard files.
- Preserve external HTML text structure while sanitizing invalid document ranges before editing.
- Add RTF plain-text fallback for clipboard sources that do not provide usable HTML.
- Keep SVG content as vector data and resolve supported external image sources without introducing new dependencies.

## How to test

- pnpm --filter @univerjs/docs-ui test -- src/services/clipboard/__tests__/clipboard.service.spec.ts src/services/clipboard/__tests__/html-and-udm-convert.spec.ts src/services/clipboard/__tests__/rtf-to-plain-text.spec.ts
- pnpm --filter @univerjs/drawing-ui test -- src/utils/__tests__/clipboard-image.spec.ts
- pnpm --filter @univerjs/docs-ui typecheck
- pnpm --filter @univerjs/drawing-ui typecheck
- ESLint on all changed TypeScript files

No breaking changes are introduced.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).