### PR TITLE
fix(sheets-drawing): preserve absolute anchor transforms

### DIFF
--- a/packages/sheets-drawing-ui/src/controllers/render-controllers/__tests__/sheet-drawing.render-controller.spec.ts
+++ b/packages/sheets-drawing-ui/src/controllers/render-controllers/__tests__/sheet-drawing.render-controller.spec.ts
@@ -16,7 +16,7 @@
 
 import type { ISheetDrawing } from '@univerjs/sheets-drawing';
 import { DrawingTypeEnum } from '@univerjs/core';
-import { drawingPositionToTransform } from '@univerjs/sheets-drawing';
+import { drawingPositionToTransform, SheetDrawingAnchorType } from '@univerjs/sheets-drawing';
 import { describe, expect, it, vi } from 'vitest';
 import { SheetsDrawingRenderController } from '../sheet-drawing.render-controller';
 
@@ -70,6 +70,17 @@ describe('SheetsDrawingRenderController', () => {
                 to: { row: 3, column: 4, rowOffset: 0, columnOffset: 0 },
             },
         };
+        const absoluteDrawing: Partial<ISheetDrawing> = {
+            unitId: 'unit-1',
+            subUnitId: 'sheet-1',
+            drawingId: 'drawing-6',
+            anchorType: SheetDrawingAnchorType.None,
+            transform: { left: 240, top: 96, width: 120, height: 80 },
+            sheetTransform: {
+                from: { row: 0, column: 0, rowOffset: 96, columnOffset: 240 },
+                to: { row: 0, column: 0, rowOffset: 176, columnOffset: 360 },
+            },
+        };
         const drawingData = {
             'sheet-1': {
                 data: {
@@ -77,6 +88,7 @@ describe('SheetsDrawingRenderController', () => {
                     'drawing-3': { unitId: 'unit-1', subUnitId: 'sheet-1', drawingId: 'drawing-3' },
                     'drawing-4': groupedDrawing,
                     'drawing-5': drawingGroup,
+                    'drawing-6': absoluteDrawing,
                 },
             },
             'missing-sheet': {
@@ -122,6 +134,8 @@ describe('SheetsDrawingRenderController', () => {
         expect(drawingWithSheetTransform.transform).toEqual({ left: 24, top: 36, width: 120, height: 80 });
         expect(drawingGroup.transform).toEqual({ left: 14, top: 16, width: 120, height: 80 });
         expect(groupedDrawing.transform).toEqual({ left: 2, top: 3, width: 40, height: 50 });
+        expect(absoluteDrawing.transform).toEqual({ left: 240, top: 96, width: 120, height: 80 });
+        expect(drawingPositionToTransform).not.toHaveBeenCalledWith(absoluteDrawing.sheetTransform, skeletonParam);
         expect(drawingWithoutSkeleton).not.toHaveProperty('transform');
         expect(drawingManagerService.registerDrawingData).toHaveBeenCalledWith('unit-1', drawingData);
         expect(drawingManagerService.initializeNotification).toHaveBeenCalledWith('unit-1');

--- a/packages/sheets-drawing-ui/src/controllers/render-controllers/sheet-drawing.render-controller.ts
+++ b/packages/sheets-drawing-ui/src/controllers/render-controllers/sheet-drawing.render-controller.ts
@@ -18,7 +18,7 @@ import type { IRenderContext, IRenderModule } from '@univerjs/engine-render';
 import { Disposable, DrawingTypeEnum, Inject } from '@univerjs/core';
 import { IDrawingManagerService } from '@univerjs/drawing';
 import { SheetSkeletonService } from '@univerjs/sheets';
-import { drawingPositionToTransform, ISheetDrawingService } from '@univerjs/sheets-drawing';
+import { drawingPositionToTransform, ISheetDrawingService, SheetDrawingAnchorType } from '@univerjs/sheets-drawing';
 
 export class SheetsDrawingRenderController extends Disposable implements IRenderModule {
     constructor(
@@ -47,7 +47,12 @@ export class SheetsDrawingRenderController extends Disposable implements IRender
                 const { unitId, subUnitId } = drawingData;
                 const skeletonParam = this._sheetSkeletonService.getSkeletonParam(unitId, subUnitId);
 
-                if (skeletonParam && drawingData.sheetTransform && !drawingData.groupId) {
+                if (
+                    skeletonParam &&
+                    drawingData.sheetTransform &&
+                    !drawingData.groupId &&
+                    drawingData.anchorType !== SheetDrawingAnchorType.None
+                ) {
                     const transform = drawingPositionToTransform(drawingData.sheetTransform, skeletonParam);
                     drawingData.transform = transform && drawingData.drawingType === DrawingTypeEnum.DRAWING_GROUP
                         ? {

--- a/packages/sheets-drawing-ui/src/controllers/sheet-drawing-active-render.controller.ts
+++ b/packages/sheets-drawing-ui/src/controllers/sheet-drawing-active-render.controller.ts
@@ -21,7 +21,7 @@ import type { ISheetDrawing } from '@univerjs/sheets-drawing';
 import { Disposable, ICommandService, Inject } from '@univerjs/core';
 import { IDrawingManagerService } from '@univerjs/drawing';
 import { SetWorksheetActiveOperation, SheetSkeletonService } from '@univerjs/sheets';
-import { drawingPositionToTransform, ISheetDrawingService } from '@univerjs/sheets-drawing';
+import { drawingPositionToTransform, ISheetDrawingService, SheetDrawingAnchorType } from '@univerjs/sheets-drawing';
 
 export class SheetDrawingActiveRenderController extends Disposable implements IRenderModule {
     constructor(
@@ -97,7 +97,7 @@ export class SheetDrawingActiveRenderController extends Disposable implements IR
                     Object.keys(drawingData).forEach((drawingId) => {
                         if (unitId === showUnitId && subUnitId === showSubunitId) {
                             const drawing = drawingData[drawingId] as ISheetDrawing;
-                            if (drawing.sheetTransform) {
+                            if (drawing.sheetTransform && drawing.anchorType !== SheetDrawingAnchorType.None) {
                                 drawing.transform = drawingPositionToTransform(drawing.sheetTransform, sheetSkeletonParam);
                             }
                             insertDrawings.push(drawingData[drawingId]);


### PR DESCRIPTION
## Summary

- keep absolute Sheet drawings unchanged during initial render registration
- keep absolute Sheet drawings unchanged when a worksheet becomes active
- cover the absolute-anchor initialization contract with a regression test

## Root cause

Both render lifecycle controllers reapplied the Sheet header offset to anchorType None drawings through drawingPositionToTransform. Depending on lifecycle timing, an absolute Float DOM moved by exactly the 46 x 20 header offset.

## Validation

- @univerjs/sheets-drawing-ui: 25 files, 136 tests passed
- @univerjs/sheets-drawing-ui typecheck passed
- targeted ESLint passed
- git diff --check passed

## Pull Request Checklist

- [x] Missing related issue
- [x] Naming convention is followed
- [x] Unit tests have been added
- [x] No breaking changes introduced