### PR TITLE
fix(docs): clear drawing popup after deletion

### DIFF
--- a/packages/docs-drawing-ui/src/menu/__tests__/drawing-popup-menu.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/menu/__tests__/drawing-popup-menu.controller.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ContextService,
+    DocumentDataModel,
+    DrawingTypeEnum,
+    ICommandService,
+    IContextService,
+    Injector,
+    IPermissionService,
+    IUniverInstanceService,
+    PermissionService,
+    toDisposable,
+} from '@univerjs/core';
+import { IDocDrawingAdapterService } from '@univerjs/docs-drawing';
+import { DocCanvasPopManagerService } from '@univerjs/docs-ui';
+import { IDrawingManagerService } from '@univerjs/drawing';
+import { IRenderManagerService } from '@univerjs/engine-render';
+import { IMenuManagerService } from '@univerjs/ui';
+import { Subject } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DocDrawingFloatingToolbarAdapterService } from '../../services/doc-drawing-floating-toolbar-adapter.service';
+import { DocDrawingPopupMenuController } from '../drawing-popup-menu.controller';
+
+function createControllerHarness() {
+    const unitId = 'doc-1';
+    const drawingId = 'drawing-1';
+    const injector = new Injector();
+    const createControl$ = new Subject<void>();
+    const clearControl$ = new Subject<boolean>();
+    const changing$ = new Subject<void>();
+    const focus$ = new Subject<never[]>();
+    const currentDocument$ = new Subject<never>();
+    const disposedDocument$ = new Subject<never>();
+    const renderCreated$ = new Subject<never>();
+    const renderDisposed$ = new Subject<never>();
+    const drawingObject = { oKey: drawingId };
+    const selectedObjects = new Map([[drawingId, drawingObject]]);
+    const popupDisposable = {
+        dispose: vi.fn(),
+        canDispose: () => false,
+    };
+    const drawing = {
+        unitId,
+        subUnitId: unitId,
+        drawingId,
+        drawingType: DrawingTypeEnum.DRAWING_IMAGE,
+    };
+    const documentDataModel = new DocumentDataModel({
+        id: unitId,
+        body: {
+            dataStream: '\b\r\n',
+            customBlocks: [{ startIndex: 0, blockId: drawingId }],
+        },
+    });
+    const transformer = {
+        createControl$,
+        clearControl$,
+        changing$,
+        getSelectedObjectMap: () => selectedObjects,
+    };
+    const scene = {
+        getAllObjects: () => [],
+        getTransformerByCreate: () => transformer,
+    };
+
+    injector.add([ICommandService, {
+        useValue: {
+            onCommandExecuted: () => toDisposable(() => undefined),
+        } as never,
+    }]);
+    injector.add([IContextService, { useValue: new ContextService() }]);
+    injector.add([IPermissionService, { useClass: PermissionService }]);
+    injector.add([IUniverInstanceService, {
+        useValue: {
+            getAllUnitsForType: () => [documentDataModel],
+            getCurrentTypeOfUnit$: () => currentDocument$,
+            getTypeOfUnitDisposed$: () => disposedDocument$,
+            getUnit: () => documentDataModel,
+            getUnitType: () => undefined,
+        } as never,
+    }]);
+    injector.add([IRenderManagerService, {
+        useValue: {
+            created$: renderCreated$,
+            disposed$: renderDisposed$,
+            getRenderUnitById: () => ({ scene }),
+            has: () => true,
+        } as never,
+    }]);
+    injector.add([IDrawingManagerService, {
+        useValue: {
+            focus$,
+            focusDrawing: vi.fn(),
+            getDrawingByParam: () => drawing,
+            getDrawingOKey: () => drawing,
+            getFocusDrawings: () => [],
+        } as never,
+    }]);
+    injector.add([IDocDrawingAdapterService, {
+        useValue: {
+            getEditDrawingCommandInfo: () => null,
+        } as never,
+    }]);
+    injector.add([DocCanvasPopManagerService, {
+        useValue: {
+            attachPopupToObject: () => popupDisposable,
+        } as never,
+    }]);
+    injector.add([IMenuManagerService, {
+        useValue: {
+            getFlatMenuByPositionKey: () => [],
+        } as never,
+    }]);
+    injector.add([DocDrawingFloatingToolbarAdapterService]);
+    injector.add([DocDrawingPopupMenuController]);
+
+    return {
+        clearControl$,
+        createControl$,
+        injector,
+        popupDisposable,
+        selectedObjects,
+    };
+}
+
+describe('DocDrawingPopupMenuController', () => {
+    it('keeps an active popup during refresh and removes it after the selected drawing is deleted', () => {
+        const { clearControl$, createControl$, injector, popupDisposable, selectedObjects } = createControllerHarness();
+        const controller = injector.get(DocDrawingPopupMenuController);
+
+        try {
+            createControl$.next();
+            clearControl$.next(false);
+            expect(popupDisposable.dispose).not.toHaveBeenCalled();
+
+            selectedObjects.clear();
+            clearControl$.next(true);
+
+            expect(popupDisposable.dispose).toHaveBeenCalledOnce();
+        } finally {
+            controller.dispose();
+            injector.dispose();
+        }
+    });
+});

--- a/packages/docs-drawing-ui/src/menu/drawing-popup-menu.controller.ts
+++ b/packages/docs-drawing-ui/src/menu/drawing-popup-menu.controller.ts
@@ -221,16 +221,47 @@ export class DocDrawingPopupMenuController extends RxDisposable {
         return false;
     }
 
-    // eslint-disable-next-line max-lines-per-function
+    private _handleClearControl(
+        unitId: string,
+        transformer: ReturnType<Scene['getTransformerByCreate']>,
+        changeSelf: boolean
+    ): void {
+        this._clearPopups(unitId, changeSelf);
+        queueMicrotask(() => {
+            if (transformer.getSelectedObjectMap().size > 0) {
+                return;
+            }
+            this._contextService.setContextValue(FOCUSING_COMMON_DRAWINGS, false);
+            this._drawingManagerService.focusDrawing(null);
+        });
+    }
+
+    private _registerDrawingPopup(
+        unitId: string,
+        popup: INeedCheckDisposable,
+        drawing: { unitId: string; subUnitId: string; drawingId: string }
+    ): void {
+        this.disposeWithMe(popup);
+        this._getDisposePopups(unitId).push(popup);
+        this._popupTargetKeys.set(unitId, `${drawing.unitId}:${drawing.subUnitId}:${drawing.drawingId}`);
+
+        const focusDrawings = this._drawingManagerService.getFocusDrawings();
+        const alreadyFocused = focusDrawings.find((focusedDrawing) =>
+            focusedDrawing.unitId === drawing.unitId &&
+            focusedDrawing.subUnitId === drawing.subUnitId &&
+            focusedDrawing.drawingId === drawing.drawingId
+        );
+        if (!alreadyFocused) {
+            this._drawingManagerService.focusDrawing([drawing]);
+        }
+    }
+
     private _popupMenuListener(unitId: string): IDisposable | undefined {
         const scene = this._renderManagerService.getRenderUnitById(unitId)?.scene;
         if (!scene) {
             return;
         }
         const transformer = scene.getTransformerByCreate();
-        if (!transformer) {
-            return;
-        }
 
         const subscriptions = [
             transformer.createControl$.subscribe(() => {
@@ -294,26 +325,9 @@ export class DocDrawingPopupMenuController extends RxDisposable {
                     drawingUnitId
                 );
 
-                this.disposeWithMe(popup);
-                this._getDisposePopups(unitId).push(popup);
-                this._popupTargetKeys.set(unitId, popupTargetKey);
-
-                const focusDrawings = this._drawingManagerService.getFocusDrawings();
-                const alreadyFocused = focusDrawings.find((drawing) => drawing.unitId === drawingUnitId && drawing.subUnitId === subUnitId && drawing.drawingId === drawingId);
-                if (!alreadyFocused) {
-                    this._drawingManagerService.focusDrawing([{ unitId: drawingUnitId, subUnitId, drawingId }]);
-                }
+                this._registerDrawingPopup(unitId, popup, { unitId: drawingUnitId, subUnitId, drawingId });
             }),
-            transformer.clearControl$.subscribe(() => {
-                this._clearPopups(unitId);
-                queueMicrotask(() => {
-                    if (transformer.getSelectedObjectMap().size > 0) {
-                        return;
-                    }
-                    this._contextService.setContextValue(FOCUSING_COMMON_DRAWINGS, false);
-                    this._drawingManagerService.focusDrawing(null);
-                });
-            }),
+            transformer.clearControl$.subscribe((changeSelf) => this._handleClearControl(unitId, transformer, changeSelf)),
             transformer.changing$.subscribe(() => {
                 this._clearPopups(unitId, true);
             }),


### PR DESCRIPTION
## Summary

- force-dispose the Docs drawing popup when Transformer clears the selection itself
- keep the existing non-forced behavior for transient control refreshes
- remove the touched max-lines suppression by extracting the two focused lifecycle steps
- add an adjacent DI regression for active-popup deletion

## Validation

- docs-drawing-ui: 144 tests passed
- docs-drawing-ui typecheck passed
- focused ESLint passed with no warnings
- git diff check passed