### PR TITLE
fix(docs): defer incompatible worker layout boundaries

### DIFF
--- a/packages/engine-render/src/__tests__/worker-layout.spec.ts
+++ b/packages/engine-render/src/__tests__/worker-layout.spec.ts
@@ -1687,6 +1687,50 @@ describe('worker document layout session', () => {
             protectedRange: {
                 mode: 'continuous',
                 startOffset: anchor,
+                endOffset: probeProtectedEndOffset,
+            },
+        });
+        const logicalMismatchGeneration = session.start({
+            reason: 'edit',
+            anchor,
+            invalidation: {
+                oldStart: anchor,
+                oldEnd: anchor,
+                newEnd: anchor + insertedText.length,
+            },
+        });
+        let logicalMismatchResult = session.step(logicalMismatchGeneration, 0);
+        let deferredBoundaryLogicalMismatch = false;
+        for (let step = 0; step < 1_000 && !logicalMismatchResult.progress.complete; step++) {
+            const publication = logicalMismatchResult.publication;
+            if (publication?.kind === 'block') {
+                const transferredPublication = structuredClone(publication);
+                const firstUnprotectedLineIndex = transferredPublication.block.flow.lines.findIndex(
+                    (line) => line.st > probeProtectedEndOffset
+                );
+                const workerBoundaryLine = transferredPublication.block.flow.lines[firstUnprotectedLineIndex - 1];
+                if (workerBoundaryLine != null) {
+                    workerBoundaryLine.st++;
+                    workerBoundaryLine.ed++;
+                    expect(() => targetSkeleton.applyLayoutPublication(
+                        transferredPublication,
+                        logicalMismatchResult.progress
+                    )).not.toThrow();
+                    deferredBoundaryLogicalMismatch = true;
+                    break;
+                }
+            }
+            logicalMismatchResult = session.step(logicalMismatchGeneration, 0);
+        }
+        expect(deferredBoundaryLogicalMismatch).toBe(true);
+        expect(targetSkeleton.getSkeletonData()?.pages[0]).toBe(protectedContinuousPage);
+        targetSkeleton.cancelExternalLayout();
+
+        targetSkeleton.beginExternalLayout({
+            reason: 'edit',
+            protectedRange: {
+                mode: 'continuous',
+                startOffset: anchor,
                 endOffset: mainEditProgress.stableLaidOutThrough,
             },
         });

--- a/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
+++ b/packages/engine-render/src/components/docs/layout/doc-skeleton.ts
@@ -2774,7 +2774,11 @@ export class DocumentSkeleton extends Skeleton {
                 mainBoundaryLine.st !== workerBoundaryLine.st ||
                 mainBoundaryLine.ed !== workerBoundaryLine.ed
             ) {
-                throw new Error(`Continuous layout Main and Worker boundaries do not share the same continuation checkpoint: Main ${mainBoundaryLine?.st}:${mainBoundaryLine?.ed}@${mainBoundaryLine?.top}/${mainBoundaryLine?.lineHeight}/${mainBoundaryLine?.width}, Worker ${workerBoundaryLine.st}:${workerBoundaryLine.ed}@${workerBoundaryLine.top}/${workerBoundaryLine.lineHeight}/${workerBoundaryLine.width}.`);
+                // Async Custom Block measurement can change wrapping while the
+                // Worker is already computing the suffix. A different logical
+                // boundary cannot be spliced safely, so retain Main's interaction
+                // window and apply the queued canonical Worker result at completion.
+                return null;
             }
             if (
                 mainBoundaryLine.top !== workerBoundaryLine.top ||


### PR DESCRIPTION
Related context: dream-num/univer-pro#5655

## Description

During progressive document layout, asynchronous Custom Block measurement can change line wrapping after Main has published the protected interaction window but while Worker is computing the suffix. The resulting logical continuation checkpoint differs from Main and cannot be spliced safely.

Defer these incompatible intermediate Worker publications instead of throwing. Main remains interactive, and the existing completion path atomically applies the queued canonical Worker publications.

## How to test

- Run `pnpm --filter @univerjs/engine-render typecheck`.
- Run `pnpm --filter @univerjs/engine-render test`.
- The worker layout regression test verifies that a logical boundary mismatch does not throw or replace the protected Main page.

## Pull Request Checklist

- [x] Related context has been linked in the PR description.
- [x] Naming convention is followed.
- [x] Unit tests have been added for the change.
- [x] No breaking changes are introduced.