### PR TITLE
fix(docs): hide floating menus for locked selections

### DIFF
--- a/packages/docs-drawing-ui/src/menu/__tests__/drawing-popup-menu.controller.spec.ts
+++ b/packages/docs-drawing-ui/src/menu/__tests__/drawing-popup-menu.controller.spec.ts
@@ -26,10 +26,12 @@ import {
     PermissionService,
     toDisposable,
 } from '@univerjs/core';
+import { setDocumentPermissionValue } from '@univerjs/docs';
 import { IDocDrawingAdapterService } from '@univerjs/docs-drawing';
 import { DocCanvasPopManagerService } from '@univerjs/docs-ui';
 import { IDrawingManagerService } from '@univerjs/drawing';
 import { IRenderManagerService } from '@univerjs/engine-render';
+import { UnitAction } from '@univerjs/protocol';
 import { IMenuManagerService } from '@univerjs/ui';
 import { Subject } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
@@ -151,6 +153,23 @@ describe('DocDrawingPopupMenuController', () => {
 
             selectedObjects.clear();
             clearControl$.next(true);
+
+            expect(popupDisposable.dispose).toHaveBeenCalledOnce();
+        } finally {
+            controller.dispose();
+            injector.dispose();
+        }
+    });
+
+    it('removes an active popup when document editing is revoked even if drawing focus is empty', () => {
+        const { createControl$, injector, popupDisposable } = createControllerHarness();
+        const controller = injector.get(DocDrawingPopupMenuController);
+
+        try {
+            createControl$.next();
+            expect(popupDisposable.dispose).not.toHaveBeenCalled();
+
+            setDocumentPermissionValue(injector.get(IPermissionService), 'doc-1', 'doc-1', UnitAction.Edit, false);
 
             expect(popupDisposable.dispose).toHaveBeenCalledOnce();
         } finally {

--- a/packages/docs-drawing-ui/src/menu/drawing-popup-menu.controller.ts
+++ b/packages/docs-drawing-ui/src/menu/drawing-popup-menu.controller.ts
@@ -52,12 +52,18 @@ import { EditDocDrawingOperation } from '../commands/operations/edit-doc-drawing
 import { SidebarDocDrawingOperation } from '../commands/operations/open-drawing-panel.operation';
 import { DocDrawingFloatingToolbarAdapterService } from '../services/doc-drawing-floating-toolbar-adapter.service';
 
+interface IDrawingPopupTarget {
+    unitId: string;
+    subUnitId: string;
+    drawingId: string;
+}
+
 export class DocDrawingPopupMenuController extends RxDisposable {
     private _initImagePopupMenu = new Set<string>();
     private _embeddedRenderUnits = new Set<string>();
     private _popupMenuListeners = new Map<string, IDisposable>();
     private _disposePopupsByUnit = new Map<string, INeedCheckDisposable[]>();
-    private _popupTargetKeys = new Map<string, string>();
+    private _popupTargetsByUnit = new Map<string, IDrawingPopupTarget>();
     private _isDrawingPanelOpen = false;
 
     constructor(
@@ -101,11 +107,10 @@ export class DocDrawingPopupMenuController extends RxDisposable {
             })
         );
         this.disposeWithMe(this._permissionService.permissionPointUpdate$.subscribe(() => {
-            if (this._drawingManagerService.getFocusDrawings().some((drawing) =>
-                this._univerInstanceService.getUnitType(drawing.unitId) === UniverInstanceType.UNIVER_DOC &&
-                !this._canEditDrawing(drawing.unitId, drawing.drawingId)
-            )) {
-                this._clearPopups(undefined, true);
+            for (const [popupUnitId, drawing] of this._popupTargetsByUnit) {
+                if (!this._canEditDrawing(drawing.unitId, drawing.drawingId)) {
+                    this._clearPopups(popupUnitId, true);
+                }
             }
         }));
 
@@ -169,7 +174,7 @@ export class DocDrawingPopupMenuController extends RxDisposable {
 
         if (popups.length === 0) {
             this._disposePopupsByUnit.delete(unitId);
-            this._popupTargetKeys.delete(unitId);
+            this._popupTargetsByUnit.delete(unitId);
         }
     }
 
@@ -239,11 +244,11 @@ export class DocDrawingPopupMenuController extends RxDisposable {
     private _registerDrawingPopup(
         unitId: string,
         popup: INeedCheckDisposable,
-        drawing: { unitId: string; subUnitId: string; drawingId: string }
+        drawing: IDrawingPopupTarget
     ): void {
         this.disposeWithMe(popup);
         this._getDisposePopups(unitId).push(popup);
-        this._popupTargetKeys.set(unitId, `${drawing.unitId}:${drawing.subUnitId}:${drawing.drawingId}`);
+        this._popupTargetsByUnit.set(unitId, drawing);
 
         const focusDrawings = this._drawingManagerService.getFocusDrawings();
         const alreadyFocused = focusDrawings.find((focusedDrawing) =>
@@ -254,6 +259,12 @@ export class DocDrawingPopupMenuController extends RxDisposable {
         if (!alreadyFocused) {
             this._drawingManagerService.focusDrawing([drawing]);
         }
+    }
+
+    private _isSamePopupTarget(previous: IDrawingPopupTarget | undefined, next: IDrawingPopupTarget): boolean {
+        return previous?.unitId === next.unitId &&
+            previous.subUnitId === next.subUnitId &&
+            previous.drawingId === next.drawingId;
     }
 
     private _popupMenuListener(unitId: string): IDisposable | undefined {
@@ -298,13 +309,13 @@ export class DocDrawingPopupMenuController extends RxDisposable {
                     return;
                 }
                 const disposePopups = this._disposePopupsByUnit.get(unitId);
-                const popupTargetKey = `${drawingUnitId}:${subUnitId}:${drawingId}`;
-                const previousPopupTargetKey = this._popupTargetKeys.get(unitId);
-                if (previousPopupTargetKey === popupTargetKey && disposePopups && disposePopups.length > 0) {
+                const previousPopupTarget = this._popupTargetsByUnit.get(unitId);
+                const popupTarget = { unitId: drawingUnitId, subUnitId, drawingId };
+                if (this._isSamePopupTarget(previousPopupTarget, popupTarget) && disposePopups && disposePopups.length > 0) {
                     return;
                 }
 
-                this._clearPopups(unitId, previousPopupTargetKey != null);
+                this._clearPopups(unitId, previousPopupTarget != null);
                 const isImage = drawingType === DrawingTypeEnum.DRAWING_IMAGE;
                 // Charts use the document toolbar placement, while retaining chart-specific actions and controls.
                 const isChart = drawingType === DrawingTypeEnum.DRAWING_CHART;

--- a/packages/docs-ui/src/services/__tests__/float-menu.service.spec.ts
+++ b/packages/docs-ui/src/services/__tests__/float-menu.service.spec.ts
@@ -36,7 +36,13 @@ import {
     RANGE_DIRECTION,
     UniverInstanceService,
 } from '@univerjs/core';
-import { DocSelectionManagerService, setDocumentPermissionValue, SetTextSelectionsOperation } from '@univerjs/docs';
+import {
+    DocSelectionManagerService,
+    getDocumentEntityPermissionObjectId,
+    getDocumentParagraphPermissionObjectId,
+    setDocumentPermissionValue,
+    SetTextSelectionsOperation,
+} from '@univerjs/docs';
 import { NORMAL_TEXT_SELECTION_PLUGIN_STYLE } from '@univerjs/engine-render';
 import { UnitAction } from '@univerjs/protocol';
 import { ComponentManager } from '@univerjs/ui';
@@ -94,7 +100,8 @@ const ActiveDocSelectionRenderServiceCtor = ActiveDocSelectionRenderService as u
 function createActiveFloatMenuHarness(
     unitId: string,
     body: ConstructorParameters<typeof DocumentDataModel>[0]['body'],
-    runtimeFocusCoordinator?: EmbedRuntimeFocusCoordinator
+    runtimeFocusCoordinator?: EmbedRuntimeFocusCoordinator,
+    headers?: ConstructorParameters<typeof DocumentDataModel>[0]['headers']
 ) {
     const injector = new Injector();
     injector.add([IPermissionService, { useClass: PermissionService }]);
@@ -113,7 +120,7 @@ function createActiveFloatMenuHarness(
     }
     injector.get(ICommandService).registerCommand(SetTextSelectionsOperation);
     const univerInstanceService = injector.get(IUniverInstanceService) as UniverInstanceService;
-    univerInstanceService.__addUnit(new DocumentDataModel({ id: unitId, body }));
+    univerInstanceService.__addUnit(new DocumentDataModel({ id: unitId, body, headers }));
     const service = injector.createInstance(DocFloatMenuService, { unitId } as never);
     const selectionManager = injector.get(DocSelectionManagerService);
     selectionManager.__TEST_ONLY_setCurrentSelection({ unitId, subUnitId: unitId });
@@ -256,6 +263,132 @@ describe('DocFloatMenuService', () => {
             textRanges: [{ startOffset: 6, endOffset: 11, collapsed: false }],
         }, { unitId, subUnitId: unitId });
         expect(harness.popupService.ranges).toEqual(['0:5']);
+    });
+
+    it('hides the floating toolbar when the selected paragraph edit permission is revoked', () => {
+        const unitId = 'doc-read-only-paragraph-float-menu';
+        const paragraphId = 'paragraph-read-only-float-menu';
+        const harness = createActiveFloatMenuHarness(unitId, {
+            dataStream: 'Hello world\r\n',
+            paragraphs: [{ paragraphId, startIndex: 11 }],
+            sectionBreaks: [],
+            customRanges: [],
+            tables: [],
+            textRuns: [],
+        });
+        const selection = {
+            textRanges: [{ startOffset: 0, endOffset: 5, collapsed: false }],
+            rectRanges: [],
+            segmentId: '',
+            segmentPage: -1,
+            style: NORMAL_TEXT_SELECTION_PLUGIN_STYLE,
+            isEditing: true,
+        };
+        harness.selectionManager.__replaceTextRangesWithNoRefresh(selection, { unitId, subUnitId: unitId });
+        expect(harness.service.floatMenu).toMatchObject({ start: 0, end: 5 });
+
+        setDocumentPermissionValue(
+            harness.injector.get(IPermissionService),
+            unitId,
+            getDocumentParagraphPermissionObjectId('', paragraphId),
+            UnitAction.Edit,
+            false
+        );
+
+        expect(harness.service.floatMenu).toBeNull();
+        expect(harness.popupService.disposedCount).toBe(1);
+        harness.selectionManager.__replaceTextRangesWithNoRefresh({
+            ...selection,
+            textRanges: [{ startOffset: 6, endOffset: 11, collapsed: false }],
+        }, { unitId, subUnitId: unitId });
+        expect(harness.popupService.ranges).toEqual(['0:5']);
+    });
+
+    it('does not show the floating toolbar for a selection inside a read-only table', () => {
+        const unitId = 'doc-read-only-table-float-menu';
+        const harness = createActiveFloatMenuHarness(unitId, {
+            dataStream: 'TT\raa\r\n',
+            paragraphs: [
+                { startIndex: 2, paragraphId: 'paragraph-in-read-only-table' },
+                { startIndex: 5, paragraphId: 'paragraph-after-read-only-table' },
+            ],
+            sectionBreaks: [],
+            customRanges: [],
+            tables: [{ tableId: 'table-1', startIndex: 0, endIndex: 2 }],
+            textRuns: [],
+        });
+        setDocumentPermissionValue(
+            harness.injector.get(IPermissionService),
+            unitId,
+            getDocumentEntityPermissionObjectId('', 'table', 'table-1'),
+            UnitAction.Edit,
+            false
+        );
+
+        harness.selectionManager.__replaceTextRangesWithNoRefresh({
+            textRanges: [{ startOffset: 0, endOffset: 2, collapsed: false }],
+            rectRanges: [],
+            segmentId: '',
+            segmentPage: -1,
+            style: NORMAL_TEXT_SELECTION_PLUGIN_STYLE,
+            isEditing: true,
+        }, { unitId, subUnitId: unitId });
+
+        expect(harness.service.floatMenu).toBeNull();
+        expect(harness.popupService.ranges).toEqual([]);
+    });
+
+    it('rechecks permissions when the same offsets move to another document segment', () => {
+        const unitId = 'doc-read-only-header-float-menu';
+        const headerId = 'header-read-only-float-menu';
+        const headerParagraphId = 'header-paragraph-read-only-float-menu';
+        const harness = createActiveFloatMenuHarness(unitId, {
+            dataStream: 'Body text\r\n',
+            paragraphs: [{ paragraphId: 'body-paragraph-float-menu', startIndex: 9 }],
+            sectionBreaks: [],
+            customRanges: [],
+            tables: [],
+            textRuns: [],
+        }, undefined, {
+            [headerId]: {
+                headerId,
+                body: {
+                    dataStream: 'Header text\r\n',
+                    paragraphs: [{ paragraphId: headerParagraphId, startIndex: 11 }],
+                    sectionBreaks: [],
+                    customRanges: [],
+                    tables: [],
+                    textRuns: [],
+                },
+            },
+        });
+        const selection = {
+            textRanges: [{ startOffset: 0, endOffset: 5, collapsed: false, segmentId: '' }],
+            rectRanges: [],
+            segmentId: '',
+            segmentPage: -1,
+            style: NORMAL_TEXT_SELECTION_PLUGIN_STYLE,
+            isEditing: true,
+        };
+        harness.selectionManager.__replaceTextRangesWithNoRefresh(selection, { unitId, subUnitId: unitId });
+        expect(harness.service.floatMenu).toMatchObject({ start: 0, end: 5, segmentId: '' });
+
+        setDocumentPermissionValue(
+            harness.injector.get(IPermissionService),
+            unitId,
+            getDocumentParagraphPermissionObjectId(headerId, headerParagraphId),
+            UnitAction.Edit,
+            false
+        );
+        harness.selectionManager.__replaceTextRangesWithNoRefresh({
+            ...selection,
+            textRanges: [{ startOffset: 0, endOffset: 5, collapsed: false, segmentId: headerId }],
+            segmentId: headerId,
+        }, { unitId, subUnitId: unitId });
+
+        expect(harness.service.floatMenu).toBeNull();
+        expect(harness.popupService.ranges).toEqual(['0:5']);
+        expect(harness.popupService.disposedCount).toBe(1);
     });
 
     it('does not show the floating toolbar for selections inside code blocks', () => {

--- a/packages/docs-ui/src/services/float-menu.service.ts
+++ b/packages/docs-ui/src/services/float-menu.service.ts
@@ -31,8 +31,7 @@ import {
     toDisposable,
     UniverInstanceType,
 } from '@univerjs/core';
-import { DocSelectionManagerService, getDocumentPermissionValue } from '@univerjs/docs';
-import { UnitAction } from '@univerjs/protocol';
+import { canEditDocumentTargets, DocSelectionManagerService, getDocumentEditTargetObjectIds } from '@univerjs/docs';
 import { FLOAT_MENU_COMPONENT_KEY } from '../views/float-toolbar/FloatToolbar';
 import { IDocEmbedRuntimeFocusCoordinator } from './doc-embed-integration.service';
 import { DocLayoutInteractionService } from './doc-layout-interaction.service';
@@ -55,7 +54,7 @@ const SKIP_SYMBOLS: string[] = [
 ];
 
 export class DocFloatMenuService extends Disposable implements IRenderModule {
-    private _floatMenu: Nullable<{ disposable: IDisposable; start: number; end: number }> = null;
+    private _floatMenu: Nullable<{ disposable: IDisposable; start: number; end: number; segmentId: string }> = null;
     private _suppressed = false;
     private _embedSuppressed = false;
     private _invalidatedSelection: Nullable<string> = null;
@@ -129,7 +128,11 @@ export class DocFloatMenuService extends Disposable implements IRenderModule {
                     return;
                 }
                 this._invalidatedSelection = null;
-                if (range.startOffset === this._floatMenu?.start && range.endOffset === this._floatMenu?.end) {
+                if (
+                    range.startOffset === this._floatMenu?.start &&
+                    range.endOffset === this._floatMenu?.end &&
+                    (range.segmentId ?? '') === this._floatMenu?.segmentId
+                ) {
                     return;
                 }
                 this._hideFloatMenu();
@@ -144,18 +147,31 @@ export class DocFloatMenuService extends Disposable implements IRenderModule {
 
     private _initPermissionLifecycle(): void {
         this.disposeWithMe(this._permissionService.permissionPointUpdate$.subscribe(() => {
-            if (!this._canEditDocument()) {
+            if (this._floatMenu && !this._canEditDocument({
+                startOffset: this._floatMenu.start,
+                endOffset: this._floatMenu.end,
+            }, this._floatMenu.segmentId)) {
                 this._hideFloatMenu();
             }
         }));
     }
 
-    private _canEditDocument(): boolean {
-        return getDocumentPermissionValue(
+    private _canEditDocument(
+        range?: Pick<ITextRangeParam, 'startOffset' | 'endOffset'>,
+        segmentId = ''
+    ): boolean {
+        const documentDataModel = this._univerInstanceService.getUnit<DocumentDataModel>(
+            this._context.unitId,
+            UniverInstanceType.UNIVER_DOC
+        );
+        if (!documentDataModel) {
+            return false;
+        }
+
+        return canEditDocumentTargets(
             this._permissionService,
             this._context.unitId,
-            this._context.unitId,
-            UnitAction.Edit
+            range ? getDocumentEditTargetObjectIds(documentDataModel, segmentId, range) : []
         );
     }
 
@@ -180,7 +196,11 @@ export class DocFloatMenuService extends Disposable implements IRenderModule {
                 ?.find((range) => !range.collapsed);
             this._invalidatedSelection = expandedRange
                 ? this._getSelectionKey(expandedRange)
-                : this._floatMenu && `${this._floatMenu.start}:${this._floatMenu.end}`;
+                : this._floatMenu && this._getSelectionKey({
+                    startOffset: this._floatMenu.start,
+                    endOffset: this._floatMenu.end,
+                    segmentId: this._floatMenu.segmentId,
+                });
             this._hideFloatMenu();
         };
 
@@ -188,8 +208,8 @@ export class DocFloatMenuService extends Disposable implements IRenderModule {
         syncSuppressedState();
     }
 
-    private _getSelectionKey(range: Pick<ITextRangeParam, 'startOffset' | 'endOffset'>): string {
-        return `${range.startOffset}:${range.endOffset}`;
+    private _getSelectionKey(range: Pick<ITextRangeParam, 'startOffset' | 'endOffset' | 'segmentId'>): string {
+        return `${range.segmentId ?? ''}:${range.startOffset}:${range.endOffset}`;
     }
 
     private _hideFloatMenu() {
@@ -199,7 +219,8 @@ export class DocFloatMenuService extends Disposable implements IRenderModule {
 
     private _showFloatMenu(unitId: string, range: ITextRangeParam) {
         const documentDataModel = this._univerInstanceService.getUnit<DocumentDataModel>(unitId, UniverInstanceType.UNIVER_DOC);
-        if (!documentDataModel || documentDataModel.getDisabled() || !this._canEditDocument()) {
+        const segmentId = range.segmentId ?? '';
+        if (!documentDataModel || documentDataModel.getDisabled() || !this._canEditDocument(range, segmentId)) {
             return;
         }
 
@@ -233,6 +254,7 @@ export class DocFloatMenuService extends Disposable implements IRenderModule {
             }),
             start: range.startOffset,
             end: range.endOffset,
+            segmentId,
         };
 
         return toDisposable(() => this._hideFloatMenu());


### PR DESCRIPTION
## Summary

- hide the text floating toolbar when the selected Doc paragraph, table, or segment is read-only
- close active text and drawing floating menus immediately when target or document edit permission is revoked
- track drawing popup permission targets independently from transient drawing focus state
- keep segment identity in text-toolbar reuse and suppression checks

## Testing

- `vitest run packages/docs-ui/src/services/__tests__/float-menu.service.spec.ts` (13 passed)
- `vitest run packages/docs-drawing-ui/src/menu/__tests__/drawing-popup-menu.controller.spec.ts` (2 passed)
- TypeScript checks for `@univerjs/docs-ui` and `@univerjs/docs-drawing-ui`
- ESLint for all changed source and unit-test files
- packed-consumer Playwright coverage in https://github.com/dream-num/univer-e2e/pull/6 (2 passed)

## Pull Request Checklist

- [x] Related tickets or issues are linked. (No related issue.)
- [x] Naming conventions are followed.
- [x] Unit tests are added and passing.
- [x] Breaking changes are documented. (No breaking changes.)
