### PR TITLE
fix(sheets): preserve previous worksheet name in rename mutations

### DIFF
--- a/packages/sheets/src/commands/commands/__tests__/set-worksheet-name.command.spec.ts
+++ b/packages/sheets/src/commands/commands/__tests__/set-worksheet-name.command.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Injector, Univer, Workbook } from '@univerjs/core';
+import type { ICommandInfo, Injector, Univer, Workbook } from '@univerjs/core';
 import { ICommandService, IUniverInstanceService, RedoCommand, UndoCommand, UniverInstanceType } from '@univerjs/core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SetWorksheetNameMutation } from '../../mutations/set-worksheet-name.mutation';
@@ -44,7 +44,9 @@ describe('Test set worksheet name commands', () => {
         describe('set worksheet name', async () => {
             it('correct situation: ', async () => {
                 const workbook = get(IUniverInstanceService).getCurrentUnitOfType<Workbook>(UniverInstanceType.UNIVER_SHEET)!;
-                if (!workbook) throw new Error('This is an error');
+                if (!workbook) {
+                    throw new Error('This is an error');
+                }
 
                 expect(
                     await commandService.executeCommand(SetWorksheetNameCommand.id, {
@@ -62,6 +64,33 @@ describe('Test set worksheet name commands', () => {
                 // redo
                 expect(await commandService.executeCommand(RedoCommand.id)).toBeTruthy();
                 expect(workbook.getSheetBySheetId('sheet1')?.getConfig().name).toEqual('new name');
+            });
+
+            it('carries the previous name through rename and undo/redo', async () => {
+                const mutations: ICommandInfo[] = [];
+                const listener = commandService.onMutationExecutedForCollab((mutation) => {
+                    if (mutation.id === SetWorksheetNameMutation.id) {
+                        mutations.push({ ...mutation, params: { ...mutation.params } });
+                    }
+                });
+                try {
+                    expect(await commandService.executeCommand(SetWorksheetNameCommand.id, {
+                        unitId: 'test',
+                        subUnitId: 'sheet1',
+                        name: 'Sheet2',
+                    })).toBe(true);
+                    expect(await commandService.executeCommand(UndoCommand.id)).toBe(true);
+                    expect(await commandService.executeCommand(RedoCommand.id)).toBe(true);
+                    expect(mutations.map((mutation) => mutation.params)).toMatchObject([
+                        { oldName: 'sheet1', name: 'Sheet2' },
+                        // Undo the rename: Sheet2 -> sheet1.
+                        { oldName: 'Sheet2', name: 'sheet1' },
+                        // Redo the rename: sheet1 -> Sheet2.
+                        { oldName: 'sheet1', name: 'Sheet2' },
+                    ]);
+                } finally {
+                    listener.dispose();
+                }
             });
         });
     });

--- a/packages/sheets/src/commands/commands/set-worksheet-name.command.ts
+++ b/packages/sheets/src/commands/commands/set-worksheet-name.command.ts
@@ -24,7 +24,10 @@ import {
     sequenceExecute,
 } from '@univerjs/core';
 import { SheetInterceptorService } from '../../services/sheet-interceptor/sheet-interceptor.service';
-import { SetWorksheetNameMutation, SetWorksheetNameMutationFactory } from '../mutations/set-worksheet-name.mutation';
+import {
+    SetWorksheetNameMutation,
+    SetWorksheetNameUndoMutationFactory,
+} from '../mutations/set-worksheet-name.mutation';
 import { getSheetCommandTarget } from './utils/target-util';
 
 export interface ISetWorksheetNameCommandParams {
@@ -46,15 +49,18 @@ export const SetWorksheetNameCommand: ICommand = {
         const sheetInterceptorService = accessor.get(SheetInterceptorService);
 
         const target = getSheetCommandTarget(accessor.get(IUniverInstanceService), params);
-        if (!target) return false;
+        if (!target) {
+            return false;
+        }
 
-        const { unitId, subUnitId } = target;
+        const { unitId, subUnitId, worksheet } = target;
         const redoMutationParams: ISetWorksheetNameMutationParams = {
             subUnitId,
             name: params.name,
+            oldName: worksheet.getName(),
             unitId,
         };
-        const undoMutationParams: ISetWorksheetNameMutationParams = SetWorksheetNameMutationFactory(
+        const undoMutationParams: ISetWorksheetNameMutationParams = SetWorksheetNameUndoMutationFactory(
             accessor,
             redoMutationParams
         );

--- a/packages/sheets/src/commands/mutations/__tests__/worksheet-meta.mutation.spec.ts
+++ b/packages/sheets/src/commands/mutations/__tests__/worksheet-meta.mutation.spec.ts
@@ -22,7 +22,7 @@ import {
     SetGridlinesColorUndoMutationFactory,
 } from '../set-gridlines-color.mutation';
 import { SetWorksheetHideMutation, SetWorksheetHideMutationFactory } from '../set-worksheet-hide.mutation';
-import { SetWorksheetNameMutation, SetWorksheetNameMutationFactory } from '../set-worksheet-name.mutation';
+import { SetWorksheetNameMutation, SetWorksheetNameUndoMutationFactory } from '../set-worksheet-name.mutation';
 import {
     SetWorksheetRowAutoHeightMutation,
     SetWorksheetRowAutoHeightMutationFactory,
@@ -141,7 +141,7 @@ describe('worksheet meta mutations', () => {
         const worksheet = testBed.sheet.getSheetBySheetId('sheet-1')!;
 
         expect(
-            SetWorksheetNameMutationFactory(testBed, {
+            SetWorksheetNameUndoMutationFactory(testBed, {
                 unitId: 'unit-1',
                 subUnitId: 'sheet-1',
                 name: 'new-name',
@@ -150,14 +150,15 @@ describe('worksheet meta mutations', () => {
             unitId: 'unit-1',
             subUnitId: 'sheet-1',
             name: 'old-name',
+            oldName: 'new-name',
         });
 
         expect(SetWorksheetNameMutation.handler(testBed, { unitId: 'unit-1', subUnitId: 'sheet-1', name: 'new-name' })).toBe(true);
         expect(worksheet.getConfig().name).toBe('new-name');
         expect(SetWorksheetNameMutation.handler(testBed, { unitId: 'missing', subUnitId: 'sheet-1', name: 'new-name' })).toBe(false);
         expect(SetWorksheetNameMutation.handler(testBed, { unitId: 'unit-1', subUnitId: 'missing', name: 'new-name' })).toBe(false);
-        expect(() => SetWorksheetNameMutationFactory(testBed, { unitId: 'missing', subUnitId: 'sheet-1', name: 'new-name' }))
-            .toThrowError('[SetWorksheetNameMutationFactory]: worksheet is null error!');
+        expect(() => SetWorksheetNameUndoMutationFactory(testBed, { unitId: 'missing', subUnitId: 'sheet-1', name: 'new-name' }))
+            .toThrowError('[SetWorksheetNameUndoMutationFactory]: worksheet is null error!');
     });
 
     it('row height mutations should update height, auto-height flag, and measured auto height', () => {

--- a/packages/sheets/src/commands/mutations/set-worksheet-name.mutation.ts
+++ b/packages/sheets/src/commands/mutations/set-worksheet-name.mutation.ts
@@ -20,23 +20,26 @@ import { getSheetMutationTarget } from '../commands/utils/target-util';
 
 export interface ISetWorksheetNameMutationParams {
     name: string;
+    /** The worksheet name before the rename. */
+    oldName?: string;
     unitId: string;
     subUnitId: string;
 }
 
-export const SetWorksheetNameMutationFactory = (
+export const SetWorksheetNameUndoMutationFactory = (
     accessor: IAccessor,
     params: ISetWorksheetNameMutationParams
 ): ISetWorksheetNameMutationParams => {
     const target = getSheetMutationTarget(accessor.get(IUniverInstanceService), params);
     if (!target) {
-        throw new Error('[SetWorksheetNameMutationFactory]: worksheet is null error!');
+        throw new Error('[SetWorksheetNameUndoMutationFactory]: worksheet is null error!');
     }
 
     const { worksheet } = target;
     return {
         unitId: params.unitId,
         name: worksheet.getName(),
+        oldName: params.name,
         subUnitId: worksheet.getSheetId(),
     };
 };


### PR DESCRIPTION
Worksheet rename mutations currently omit the previous name. Capture `oldName` before executing the rename so collaboration transforms can identify references to the original worksheet name. Keep the field optional for historical mutation payloads, and record the reverse name transition for undo.

Rename the internal factory to `SetWorksheetNameUndoMutationFactory` to make its purpose explicit. Add coverage for the mutation payloads emitted during rename, undo, and redo, and update the existing mutation factory test.

Validation: both targeted Sheets test suites passed (7 tests), Sheets typecheck and package build with declarations passed, and changed-file ESLint passed.

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (no linked issue).
- [x] Naming convention is followed.
- [x] Unit tests have been added for the changes.
- [x] No breaking changes to the public package API; `oldName` is optional and the renamed factory is internal.
