### PR TITLE
fix(sheets-ui): restore formula bar after canceling edit

### DIFF
--- a/packages/sheets-ui/src/controllers/editor/__tests__/editing-render-business.spec.ts
+++ b/packages/sheets-ui/src/controllers/editor/__tests__/editing-render-business.spec.ts
@@ -166,6 +166,7 @@ function createController(initialDataStream = 'new value\r\n', isPercentFormat =
         getEditorDirty: vi.fn(() => true),
         isForceKeepVisible: vi.fn(() => false),
         disableForceKeepVisible: vi.fn(),
+        refreshEditCellState: vi.fn(),
         refreshEditCellPosition: vi.fn(),
         changeEditorDirty: vi.fn(),
     };
@@ -351,6 +352,19 @@ describe('EditingRenderController business methods', () => {
             keycode,
             direction,
         });
+    });
+
+    it('refreshes editor content when Esc cancels editing', async () => {
+        const { controller } = createController();
+
+        await controller._handleEditorInvisible({
+            visible: false,
+            eventType: DeviceInputEventType.Keyboard,
+            unitId: 'unit-1',
+            keycode: KeyCode.ESC,
+        });
+
+        expect(controller._editorBridgeService.refreshEditCellState).toHaveBeenCalledTimes(1);
     });
 
     it('moves the cursor inside the editor and resets editor state on exit', () => {

--- a/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
+++ b/packages/sheets-ui/src/controllers/editor/editing.render-controller.ts
@@ -731,6 +731,7 @@ export class EditingRenderController extends Disposable {
             if (this._editorBridgeService.isForceKeepVisible()) {
                 this._editorBridgeService.disableForceKeepVisible();
             }
+            this._editorBridgeService.refreshEditCellState();
             this._refreshCurrentSelections(sheetId);
             return;
         }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- Associate issues with the pull request if there is one. Separate them width commas. -->
<!-- Feel free to delete this if there is no related issue. -->
close #7651

<!-- A description of the proposed changes. -->

<!-- How to test them. -->

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [ ] Related tickets or issues have been linked in the PR description (or missing issue).
- [ ] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [ ] Unit tests have been added for the changes (if applicable).
- [ ] Breaking changes have been documented (or no breaking changes introduced in this PR).
