### PR TITLE
fix(docs-ui): preserve mobile plugin defaults at construction

### DIFF
--- a/packages/docs-ui/src/__tests__/mobile-plugin.spec.ts
+++ b/packages/docs-ui/src/__tests__/mobile-plugin.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2023-present DreamNum Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IConfigService, Univer, UniverInstanceType } from '@univerjs/core';
+import { UniverDocsPlugin } from '@univerjs/docs';
+import { UniverRenderEnginePlugin } from '@univerjs/engine-render';
+import { UniverMobileUIPlugin } from '@univerjs/ui';
+import { expect, it, onTestFinished } from 'vitest';
+import { DOCS_UI_PLUGIN_CONFIG_KEY } from '../config/config';
+import { UniverDocsMobileUIPlugin } from '../mobile-plugin';
+
+it.each([undefined, {}, { fitToWidth: { paddingX: 32 } }])('keeps mobile fit-to-width defaults when registered with %j', (config) => {
+    const univer = new Univer();
+    onTestFinished(() => univer.dispose());
+    univer.registerPlugin(UniverRenderEnginePlugin);
+    univer.registerPlugin(UniverMobileUIPlugin);
+    univer.registerPlugin(UniverDocsPlugin);
+    univer.registerPlugin(UniverDocsMobileUIPlugin, config);
+    univer.createUnit(UniverInstanceType.UNIVER_DOC, { id: 'doc-1' });
+    const configService = univer.__getInjector().get(IConfigService);
+    expect(configService.getConfig(DOCS_UI_PLUGIN_CONFIG_KEY)).toMatchObject({
+        fitToWidth: {
+            mode: 'fit-width',
+            target: 'viewport',
+            paddingX: config?.fitToWidth?.paddingX ?? 12,
+            minScale: 0,
+            maxScale: 1,
+            align: 'center',
+        },
+    });
+});

--- a/packages/docs-ui/src/config/config.ts
+++ b/packages/docs-ui/src/config/config.ts
@@ -63,3 +63,14 @@ export const defaultPluginConfig: IUniverDocsUIConfig = {
     placeholder: true,
     fitToWidth: DEFAULT_DOC_FIT_TO_WIDTH_OPTIONS,
 };
+
+export const defaultPluginMobileConfig: IUniverDocsUIConfig = {
+    ...defaultPluginConfig,
+    fitToWidth: {
+        ...DEFAULT_DOC_FIT_TO_WIDTH_OPTIONS,
+        mode: 'fit-width',
+        paddingX: 12,
+        minScale: 0,
+        maxScale: 1,
+    },
+};

--- a/packages/docs-ui/src/mobile-plugin.ts
+++ b/packages/docs-ui/src/mobile-plugin.ts
@@ -145,7 +145,7 @@ import { DocSectionSettingPanelOperation } from './commands/operations/doc-secti
 import { InsertDocumentColumnBreakOperation, InsertDocumentSectionBreakOperation } from './commands/operations/insert-break.operation';
 import { DocOpenPageSettingCommand } from './commands/operations/open-page-setting.operation';
 import { SetDocZoomRatioOperation } from './commands/operations/set-doc-zoom-ratio.operation';
-import { defaultPluginConfig, DOCS_UI_PLUGIN_CONFIG_KEY, DOCS_UI_PLUGIN_NAME } from './config/config';
+import { defaultPluginMobileConfig, DOCS_UI_PLUGIN_CONFIG_KEY, DOCS_UI_PLUGIN_NAME } from './config/config';
 import { DocAutoFormatController } from './controllers/doc-auto-format.controller';
 import { DocHeaderFooterController } from './controllers/doc-header-footer.controller';
 import { DocMoveCursorController } from './controllers/doc-move-cursor.controller';
@@ -205,10 +205,9 @@ export class UniverDocsMobileUIPlugin extends Plugin {
     static override pluginName = DOCS_UI_PLUGIN_NAME;
     static override packageName = pkg.name;
     static override version = pkg.version;
-    // static override type = UniverInstanceType.UNIVER_DOC;
 
     constructor(
-        private readonly _config: Partial<IUniverDocsUIConfig> = {},
+        private readonly _config: Partial<IUniverDocsUIConfig> = defaultPluginMobileConfig,
         @Inject(Injector) override _injector: Injector,
         @IRenderManagerService private readonly _renderManagerSrv: IRenderManagerService,
         @ICommandService private _commandService: ICommandService,
@@ -216,25 +215,11 @@ export class UniverDocsMobileUIPlugin extends Plugin {
     ) {
         super();
 
-        const mobileConfig: Partial<IUniverDocsUIConfig> = {
-            ...this._config,
-            fitToWidth: {
-                ...defaultPluginConfig.fitToWidth,
-                mode: 'fit-width',
-                target: 'viewport',
-                paddingX: 12,
-                minScale: 0,
-                maxScale: 1,
-                align: 'center',
-                ...this._config.fitToWidth,
-            },
-        };
-
         // Manage the plugin configuration.
         const { menu, ...rest } = merge(
             {},
-            defaultPluginConfig,
-            mobileConfig
+            defaultPluginMobileConfig,
+            this._config
         );
         if (menu) {
             this._configService.setConfig('menu', menu, { merge: true });


### PR DESCRIPTION
The mobile Docs plugin used an empty constructor default, which failed the plugin configuration convention check. Define a mobile-specific default configuration and merge caller overrides against it, preserving fit-to-width behavior for omitted, empty, and partial options.

Validation: all 988 docs-ui tests passed, package typecheck and touched-file ESLint passed, and the Pro convention check passed with no errors. Added plugin registration coverage for all three option forms.
