### PR TITLE
fix(sheets-formula): guard progress after locale disposal

### DIFF
--- a/packages/sheets-formula/src/controllers/__tests__/trigger-calculation.controller.spec.ts
+++ b/packages/sheets-formula/src/controllers/__tests__/trigger-calculation.controller.spec.ts
@@ -20,6 +20,7 @@ import {
     CommandType,
     ICommandService,
     IConfigService,
+    LocaleService,
     LocaleType,
 } from '@univerjs/core';
 import {
@@ -368,6 +369,64 @@ describe('TriggerCalculationController', () => {
         expect(progressValues).toContainEqual({ done: 3, count: 8, label: 'sheets-formula.progress.array-analysis' });
         expect(progressValues).toContainEqual({ done: 6, count: 8, label: 'sheets-formula.progress.array-calculation' });
         expect(progressValues).toContainEqual({ done: 1, count: 1, label: 'sheets-formula.progress.done' });
+
+        subscription.unsubscribe();
+        testBed.executedDisposable.dispose();
+        testBed.testBed.univer.dispose();
+    });
+
+    it('should ignore progress labels after locale service disposal', async () => {
+        const testBed = createControllerTestBed();
+        await settleInitialCalculation(testBed);
+        const subscription = testBed.controller.progress$.subscribe();
+
+        testBed.testBed.get(LocaleService).dispose();
+
+        await expect(testBed.commandService.executeCommand(SetFormulaCalculationNotificationMutation.id, {
+            stageInfo: {
+                stage: FormulaExecuteStageType.START,
+                totalFormulasToCalculate: 0,
+                completedFormulasCount: 0,
+                totalArrayFormulasToCalculate: 0,
+                completedArrayFormulasCount: 0,
+                formulaCycleIndex: 0,
+            } as IExecutionInProgressParams,
+        })).resolves.toBe(true);
+        await vi.advanceTimersByTimeAsync(1000);
+
+        await expect(testBed.commandService.executeCommand(SetFormulaCalculationNotificationMutation.id, {
+            stageInfo: {
+                stage: FormulaExecuteStageType.CURRENTLY_CALCULATING,
+                totalFormulasToCalculate: 1,
+                completedFormulasCount: 0,
+                totalArrayFormulasToCalculate: 0,
+                completedArrayFormulasCount: 0,
+                formulaCycleIndex: 0,
+            } as IExecutionInProgressParams,
+        })).resolves.toBe(true);
+        await expect(testBed.commandService.executeCommand(SetFormulaCalculationNotificationMutation.id, {
+            stageInfo: {
+                stage: FormulaExecuteStageType.START_DEPENDENCY_ARRAY_FORMULA,
+                totalFormulasToCalculate: 1,
+                completedFormulasCount: 0,
+                totalArrayFormulasToCalculate: 1,
+                completedArrayFormulasCount: 0,
+                formulaCycleIndex: 0,
+            } as IExecutionInProgressParams,
+        })).resolves.toBe(true);
+        await expect(testBed.commandService.executeCommand(SetFormulaCalculationNotificationMutation.id, {
+            stageInfo: {
+                stage: FormulaExecuteStageType.CURRENTLY_CALCULATING_ARRAY_FORMULA,
+                totalFormulasToCalculate: 1,
+                completedFormulasCount: 1,
+                totalArrayFormulasToCalculate: 1,
+                completedArrayFormulasCount: 0,
+                formulaCycleIndex: 0,
+            } as IExecutionInProgressParams,
+        })).resolves.toBe(true);
+        await expect(testBed.commandService.executeCommand(SetFormulaCalculationNotificationMutation.id, {
+            functionsExecutedState: FormulaExecutedStateType.SUCCESS,
+        })).resolves.toBe(true);
 
         subscription.unsubscribe();
         testBed.executedDisposable.dispose();

--- a/packages/sheets-formula/src/controllers/trigger-calculation.controller.ts
+++ b/packages/sheets-formula/src/controllers/trigger-calculation.controller.ts
@@ -76,11 +76,23 @@ export class TriggerCalculationController extends Disposable {
         this._progress$.next({ done: this._doneCalculationTaskCount, count: this._totalCalculationTaskCount, label });
     }
 
+    private _translateProgressLabel(key: LocaleKey): string | null {
+        if (!this._localeService.getLocales()) {
+            return null;
+        }
+
+        return this._localeService.t<LocaleKey>(key);
+    }
+
     private _startProgress(): void {
         this._doneCalculationTaskCount = 0;
         this._totalCalculationTaskCount = 1;
 
-        const analyzing = this._localeService.t<LocaleKey>('sheets-formula.progress.analyzing');
+        const analyzing = this._translateProgressLabel('sheets-formula.progress.analyzing');
+        if (analyzing === null) {
+            return;
+        }
+
         this._emitProgress(analyzing);
     }
 
@@ -106,7 +118,11 @@ export class TriggerCalculationController extends Disposable {
     private _completeProgress(): void {
         this._doneCalculationTaskCount = this._totalCalculationTaskCount = 1;
 
-        const done = this._localeService.t<LocaleKey>('sheets-formula.progress.done');
+        const done = this._translateProgressLabel('sheets-formula.progress.done');
+        if (done === null) {
+            return;
+        }
+
         this._emitProgress(done);
     }
 
@@ -217,21 +233,33 @@ export class TriggerCalculationController extends Disposable {
                         this._executionInProgressParams = params.stageInfo;
 
                         if (startDependencyTimer === null) {
-                            const calculating = this._localeService.t<LocaleKey>('sheets-formula.progress.calculating');
+                            const calculating = this._translateProgressLabel('sheets-formula.progress.calculating');
+                            if (calculating === null) {
+                                return;
+                            }
+
                             this._calculateProgress(calculating);
                         }
                     } else if (stage === FormulaExecuteStageType.START_DEPENDENCY_ARRAY_FORMULA) {
                         this._executionInProgressParams = params.stageInfo;
 
                         if (startDependencyTimer === null) {
-                            const arrayAnalysis = this._localeService.t<LocaleKey>('sheets-formula.progress.array-analysis');
+                            const arrayAnalysis = this._translateProgressLabel('sheets-formula.progress.array-analysis');
+                            if (arrayAnalysis === null) {
+                                return;
+                            }
+
                             this._calculateProgress(arrayAnalysis);
                         }
                     } else if (stage === FormulaExecuteStageType.CURRENTLY_CALCULATING_ARRAY_FORMULA) {
                         this._executionInProgressParams = params.stageInfo;
 
                         if (startDependencyTimer === null) {
-                            const arrayCalculation = this._localeService.t<LocaleKey>('sheets-formula.progress.array-calculation');
+                            const arrayCalculation = this._translateProgressLabel('sheets-formula.progress.array-calculation');
+                            if (arrayCalculation === null) {
+                                return;
+                            }
+
                             this._calculateProgress(arrayCalculation);
                         }
                     }


### PR DESCRIPTION
<!--
 Thank you for submitting a Pull Request.
 Please read our Pull Request guidelines:
 https://github.com/dream-num/univer/blob/dev/CONTRIBUTING.md#submitting-pull-requests
-->

<!-- No related issue. -->

<!-- A description of the proposed changes. -->
Formula progress notifications can still arrive after the `LocaleService` has been disposed. Those late notifications currently call `LocaleService.t(...)`, which throws when locale data has already been cleared during disposal.

This change routes formula progress labels through a small guard that checks `LocaleService.getLocales()` first. If locales are no longer available, the progress label update is skipped instead of throwing. Normal progress behavior is unchanged while the locale service is initialized.

<!-- How to test them. -->
- `pnpm --filter @univerjs/sheets-formula test -- src/controllers/__tests__/trigger-calculation.controller.spec.ts`
- `pnpm --filter @univerjs/sheets-formula typecheck`
- `pnpm exec eslint packages/sheets-formula/src/controllers/trigger-calculation.controller.ts packages/sheets-formula/src/controllers/__tests__/trigger-calculation.controller.spec.ts`

<!-- Uncomment the below lines if there are breaking changes introduced in this PR. -->
<!-- BREAKING CHANGE:
Before:

After: -->

## Pull Request Checklist

- [x] Related tickets or issues have been linked in the PR description (or missing issue).
- [x] [Naming convention](https://github.com/dream-num/univer/blob/dev/docs/NAMING_CONVENTION.md) is followed (**do please** check it especially when you created new plugins, commands and resources).
- [x] Unit tests have been added for the changes (if applicable).
- [x] Breaking changes have been documented (or no breaking changes introduced in this PR).
